### PR TITLE
refactor: record span id #xxx for logging

### DIFF
--- a/async-raft/src/core/append_entries.rs
+++ b/async-raft/src/core/append_entries.rs
@@ -172,9 +172,11 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     ///
     /// If log 5 is committed by R1, and log 3 is not removed, R5 in future could become a new leader and overrides log
     /// 5 on R3.
-    #[tracing::instrument(level="debug", skip(self, msg_entries), fields(msg_entries=%msg_entries.summary()))]
+    #[tracing::instrument(level="trace", skip(self, msg_entries), fields(msg_entries=%msg_entries.summary()))]
     async fn delete_inconsistent_log<'s, 'e>(&'s mut self, msg_entries: &'e [Entry<D>]) -> RaftResult<()> {
         // all msg_entries are inconsistent logs
+
+        tracing::debug!(msg_entries=%msg_entries.summary(), "try to delete_inconsistent_log");
 
         let l = msg_entries.len();
         if l == 0 {

--- a/async-raft/tests/fixtures/logging.rs
+++ b/async-raft/tests/fixtures/logging.rs
@@ -1,0 +1,90 @@
+use std::env;
+
+use tracing::Event;
+use tracing::Subscriber;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::RollingFileAppender;
+use tracing_appender::rolling::Rotation;
+use tracing_subscriber::fmt;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time::FormatTime;
+use tracing_subscriber::fmt::time::SystemTime;
+use tracing_subscriber::fmt::FmtContext;
+use tracing_subscriber::fmt::FormatEvent;
+use tracing_subscriber::fmt::FormatFields;
+use tracing_subscriber::fmt::FormattedFields;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Registry;
+
+pub struct EventFormatter {}
+
+impl<S, N> FormatEvent<S, N> for EventFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(&self, ctx: &FmtContext<'_, S, N>, mut writer: Writer<'_>, event: &Event<'_>) -> std::fmt::Result {
+        let meta = event.metadata();
+
+        SystemTime {}.format_time(&mut writer)?;
+        writer.write_char(' ')?;
+
+        let fmt_level = meta.level().as_str();
+        write!(writer, "{:>5} ", fmt_level)?;
+
+        write!(writer, "{:0>2?} ", std::thread::current().id())?;
+
+        if let Some(scope) = ctx.event_scope() {
+            let mut seen = false;
+
+            for span in scope.from_root() {
+                write!(writer, "{}", span.metadata().name())?;
+                write!(writer, "#{:x}", span.id().into_u64())?;
+
+                seen = true;
+
+                let ext = span.extensions();
+                if let Some(fields) = &ext.get::<FormattedFields<N>>() {
+                    if !fields.is_empty() {
+                        write!(writer, "{{{}}}", fields)?;
+                    }
+                }
+                write!(writer, ":")?;
+            }
+
+            if seen {
+                writer.write_char(' ')?;
+            }
+        };
+
+        ctx.format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
+
+pub fn init_file_logging(app_name: &str, dir: &str, level: &str) -> (WorkerGuard, impl Subscriber) {
+    // open log file
+
+    let f = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
+
+    // build subscriber
+
+    let (writer, writer_guard) = tracing_appender::non_blocking(f);
+
+    let f_layer = fmt::Layer::new()
+        .with_span_events(fmt::format::FmtSpan::FULL)
+        .with_writer(writer)
+        .with_ansi(false)
+        .event_format(EventFormatter {});
+
+    // Use env RUST_LOG to initialize log if present.
+    // Otherwise use the specified level.
+    let directives = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_x| level.to_string());
+    let env_filter = EnvFilter::new(directives);
+
+    let subscriber = Registry::default().with(env_filter).with(f_layer);
+
+    (writer_guard, subscriber)
+}


### PR DESCRIPTION
## Changelog

##### refactor: record span id #xxx for logging

before:
`ut{add_remove_voter}:initialize{members={0}}:call_core new`

after:
`ut#1{add_remove_voter}:initialize#10000000000004{members={0}}:call_core#10000000000005: new`

Having a span id in log makes it easier to filter a specific event.

---




- Improvement