### PR TITLE
refactor: reduce log output when integration test. "client_writes" fails if log outputs too many

### DIFF
--- a/async-raft/src/core/admin.rs
+++ b/async-raft/src/core/admin.rs
@@ -291,8 +291,10 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Remove a replication if the membership that does not include it has committed.
     ///
     /// Return true if removed.
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn try_remove_replication(&mut self, target: u64) -> bool {
+        tracing::debug!(target, "try_remove_replication");
+
         {
             let n = self.nodes.get(&target);
 

--- a/async-raft/src/core/append_entries.rs
+++ b/async-raft/src/core/append_entries.rs
@@ -21,12 +21,12 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     /// An RPC invoked by the leader to replicate log entries (§5.3); also used as heartbeat (§5.2).
     ///
     /// See `receiver implementation: AppendEntries RPC` in raft-essentials.md in this repo.
-    #[tracing::instrument(level="debug", skip(self, msg), fields(msg=%msg.summary()))]
+    #[tracing::instrument(level = "debug", skip(self, msg))]
     pub(super) async fn handle_append_entries_request(
         &mut self,
         msg: AppendEntriesRequest<D>,
     ) -> RaftResult<AppendEntriesResponse> {
-        tracing::debug!(%self.last_log_id, %self.last_applied);
+        tracing::debug!(%self.last_log_id, %self.last_applied, msg=%msg.summary(), "handle_append_entries_request");
 
         let msg_entries = msg.entries.as_slice();
 

--- a/async-raft/src/core/vote.rs
+++ b/async-raft/src/core/vote.rs
@@ -9,6 +9,7 @@ use crate::core::UpdateCurrentLeader;
 use crate::error::RaftResult;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
+use crate::summary::MessageSummary;
 use crate::AppData;
 use crate::AppDataResponse;
 use crate::NodeId;
@@ -19,7 +20,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     /// An RPC invoked by candidates to gather votes (§5.2).
     ///
     /// See `receiver implementation: RequestVote RPC` in raft-essentials.md in this repo.
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(msg=%msg.summary()))]
     pub(super) async fn handle_vote_request(&mut self, msg: VoteRequest) -> RaftResult<VoteResponse> {
         tracing::debug!({candidate=msg.candidate_id, self.current_term, rpc_term=msg.term}, "start handle_vote_request");
 

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -254,8 +254,9 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn save_hard_state(&self, hs: &HardState) -> Result<(), StorageError> {
+        tracing::debug!(?hs, "save_hard_state");
         let mut h = self.hs.write().await;
 
         *h = Some(hs.clone());


### PR DESCRIPTION

## Changelog

##### refactor: reduce log output when integration test. "client_writes" fails if log outputs too many

---




- Improvement