### PR TITLE
ci: limit NO threads for test to 2, to reduce timeout caused by starving

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: ci
 jobs:
   build-async-raft:
-    name: build async-raft
+    name: unittest
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,6 +27,8 @@ jobs:
         with:
           command: test
         env:
+          # Parallel tests block each other and result in timeout.
+          RUST_TEST_THREADS: 2
           RUST_LOG: debug
           RUST_BACKTRACE: full
           RAFT_STORE_DEFENSIVE: ${{ matrix.store_defensive }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,8 +3,8 @@ queue_rules:
     conditions:
       # - '#check-pending=0'
       - '#check-success>=2'
-      - check-success=build async-raft (on)
-      - check-success~=build async-raft
+      - check-success=unittest (on)
+      - check-success~=unittest
 
 pull_request_rules:
 


### PR DESCRIPTION

## Changelog

##### ci: limit NO threads for test to 2, to reduce timeout caused by starving

---





- Build/Testing/CI