### PR TITLE
refactor: remove RaftEvent::Replicate::entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 guide/book
 target
 vendor
+.idea
 
 # File Ignores ###############################################################
 **/*.rs.bk

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -283,7 +283,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         for node in self.nodes.values() {
             let _ = node.repl_stream.repl_tx.send((
                 RaftEvent::Replicate {
-                    entry: entry_arc.clone(),
+                    appended: entry_arc.log_id,
                     committed: self.core.committed,
                 },
                 tracing::debug_span!("CH"),

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -676,7 +676,7 @@ struct LeaderState<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: Raf
     pub(super) core: &'a mut RaftCore<D, R, N, S>,
 
     /// A mapping of node IDs the replication state of the target node.
-    pub(super) nodes: BTreeMap<NodeId, ReplicationState<D>>,
+    pub(super) nodes: BTreeMap<NodeId, ReplicationState>,
 
     /// The metrics about a leader
     pub leader_metrics: LeaderMetrics,
@@ -810,16 +810,16 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 }
 
 /// A struct tracking the state of a replication stream from the perspective of the Raft actor.
-struct ReplicationState<D: AppData> {
+struct ReplicationState {
     pub matched: LogId,
     pub remove_since: Option<u64>,
-    pub repl_stream: ReplicationStream<D>,
+    pub repl_stream: ReplicationStream,
 
     /// The response channel to use for when this node has successfully synced with the cluster.
     pub tx: Option<RaftRespTx<AddLearnerResponse, AddLearnerError>>,
 }
 
-impl<D: AppData> MessageSummary for ReplicationState<D> {
+impl MessageSummary for ReplicationState {
     fn summary(&self) -> String {
         format!(
             "matched: {}, remove_after_commit: {:?}",
@@ -828,8 +828,7 @@ impl<D: AppData> MessageSummary for ReplicationState<D> {
     }
 }
 
-impl<D> ReplicationState<D>
-where D: AppData
+impl ReplicationState
 {
     // TODO(xp): make this a method of Config?
 

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -828,8 +828,7 @@ impl MessageSummary for ReplicationState {
     }
 }
 
-impl ReplicationState
-{
+impl ReplicationState {
     // TODO(xp): make this a method of Config?
 
     /// Return true if the distance behind last_log_id is smaller than the threshold to join.

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -33,7 +33,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         &self,
         target: NodeId,
         caller_tx: Option<RaftRespTx<AddLearnerResponse, AddLearnerError>>,
-    ) -> ReplicationState<D> {
+    ) -> ReplicationState {
         let repl_stream = ReplicationStream::new(
             self.core.id,
             target,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -23,7 +23,6 @@ use crate::config::Config;
 use crate::config::SnapshotPolicy;
 use crate::error::LackEntry;
 use crate::raft::AppendEntriesRequest;
-use crate::raft::Entry;
 use crate::raft::InstallSnapshotRequest;
 use crate::storage::Snapshot;
 use crate::AppData;
@@ -47,16 +46,16 @@ impl MessageSummary for ReplicationMetrics {
 }
 
 /// The public handle to a spawned replication stream.
-pub(crate) struct ReplicationStream<D: AppData> {
+pub(crate) struct ReplicationStream {
     /// The spawn handle the `ReplicationCore` task.
     // pub handle: JoinHandle<()>,
     /// The channel used for communicating with the replication task.
-    pub repl_tx: mpsc::UnboundedSender<(RaftEvent<D>, Span)>,
+    pub repl_tx: mpsc::UnboundedSender<(RaftEvent, Span)>,
 }
 
-impl<D: AppData> ReplicationStream<D> {
+impl ReplicationStream {
     /// Create a new replication stream for the target peer.
-    pub(crate) fn new<R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>>(
+    pub(crate) fn new<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>>(
         id: NodeId,
         target: NodeId,
         term: u64,
@@ -100,7 +99,7 @@ struct ReplicationCore<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: Raf
     raft_core_tx: mpsc::UnboundedSender<(ReplicaEvent<S::SnapshotData>, Span)>,
 
     /// A channel for receiving events from the Raft node.
-    repl_rx: mpsc::UnboundedReceiver<(RaftEvent<D>, Span)>,
+    repl_rx: mpsc::UnboundedReceiver<(RaftEvent, Span)>,
 
     /// The `RaftNetwork` interface.
     network: Arc<N>,
@@ -157,7 +156,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
         network: Arc<N>,
         storage: Arc<S>,
         raft_core_tx: mpsc::UnboundedSender<(ReplicaEvent<S::SnapshotData>, Span)>,
-    ) -> ReplicationStream<D> {
+    ) -> ReplicationStream {
         // other component to ReplicationStream
         let (repl_tx, repl_rx) = mpsc::unbounded_channel();
         let heartbeat_timeout = Duration::from_millis(config.heartbeat_interval);
@@ -487,7 +486,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(event=%event.summary()))]
-    pub fn process_raft_event(&mut self, event: RaftEvent<D>) -> Result<(), ReplicationError> {
+    pub fn process_raft_event(&mut self, event: RaftEvent) -> Result<(), ReplicationError> {
         tracing::debug!(event=%event.summary(), "process_raft_event");
 
         match event {
@@ -497,10 +496,10 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
                 self.committed = commit_index;
             }
 
-            RaftEvent::Replicate { entry, committed } => {
+            RaftEvent::Replicate { appended, committed } => {
                 // TODO(xp): Message Replicate does not need to send an entry.
                 self.committed = committed;
-                self.last_log_index = entry.log_id.index;
+                self.last_log_index = appended.index;
             }
 
             RaftEvent::Terminate => {
@@ -530,13 +529,13 @@ enum TargetReplState {
 
 // TODO(xp): remove Replicate
 /// An event from the Raft node.
-pub(crate) enum RaftEvent<D: AppData> {
+pub(crate) enum RaftEvent {
     Replicate {
         /// The new entry which needs to be replicated.
         ///
-        /// This entry will always be the most recent entry to have been appended to the log, so its
-        /// index is the new last_log_index value.
-        entry: Arc<Entry<D>>,
+        /// The logId of the most recent entry to have been appended to the log, its index is the
+        /// new last_log_index value.
+        appended: LogId,
 
         /// The index of the highest log entry which is known to be committed in the cluster.
         committed: LogId,
@@ -549,10 +548,10 @@ pub(crate) enum RaftEvent<D: AppData> {
     Terminate,
 }
 
-impl<D: AppData> MessageSummary for RaftEvent<D> {
+impl MessageSummary for RaftEvent {
     fn summary(&self) -> String {
         match self {
-            RaftEvent::Replicate { entry: _, committed } => {
+            RaftEvent::Replicate { appended: _, committed } => {
                 format!("Replicate: committed: {}", committed)
             }
             RaftEvent::UpdateCommittedLogId {

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -497,7 +497,6 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
             }
 
             RaftEvent::Replicate { appended, committed } => {
-                // TODO(xp): Message Replicate does not need to send an entry.
                 self.committed = committed;
                 self.last_log_index = appended.index;
             }

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -18,8 +18,8 @@ use crate::fixtures::RaftRouter;
 ///
 /// - brings 2 nodes online: one leader and one learner.
 /// - write one log to the leader.
-/// - asserts that the leader was able to successfully commit its initial payload and that the learner has
-///   successfully replicated the payload.
+/// - asserts that the leader was able to successfully commit its initial payload and that the learner has successfully
+///   replicated the payload.
 /// - shutdown all and restart the learner node.
 /// - asserts the learner stays in non-vtoer state.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
Close #42 
Remove `RaftEvent::Replicate::entry`, add a new field `appended: LogId` instead.
