### PR TITLE
ci: skip slash-command-action if comment does not match

### DIFF
--- a/.github/workflows/issue-cmds.yml
+++ b/.github/workflows/issue-cmds.yml
@@ -7,6 +7,7 @@ jobs:
   assignme:
     name: /assignme
     runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '/assignme')
 
     steps:
       - uses: xt0rted/slash-command-action@v1
@@ -26,6 +27,7 @@ jobs:
   help:
     name: /help
     runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '/help')
 
     steps:
       - uses: xt0rted/slash-command-action@v1


### PR DESCRIPTION
Currently, `xt0rted/slash-command-action` will fail when a non-matching comment is created. Refer to https://github.com/xt0rted/slash-command-action/issues/124. This pr skips the entire job if the comment does not match.