### PR TITLE
change: trait RaftStore: remove get_membership_config(), add last_membership_in_log() and get_membership() with default impl

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -54,6 +54,8 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         if self.core.effective_membership.membership.all_nodes().len() == 1 {
             self.core.current_term += 1;
             self.core.voted_for = Some(self.core.id);
+
+            // TODO(xp): it should always commit a initial log entry
             self.core.set_target_state(State::Leader);
             self.core.save_hard_state().await?;
         } else {

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -226,8 +226,12 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             }
 
             // There could be unknown membership in the snapshot.
-            let membership = self.storage.get_membership_config().await.map_err(|err| self.map_storage_error(err))?;
+            let membership = self.storage.get_membership().await.map_err(|err| self.map_storage_error(err))?;
             tracing::debug!("storage membership: {:?}", membership);
+
+            assert!(membership.is_some());
+
+            let membership = membership.unwrap();
 
             self.update_membership(membership)?;
 

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -83,6 +83,15 @@ pub struct EffectiveMembership {
     pub membership: Membership,
 }
 
+impl EffectiveMembership {
+    pub fn new_initial(node_id: u64) -> Self {
+        EffectiveMembership {
+            log_id: LogId::new(0, 0),
+            membership: Membership::new_initial(node_id),
+        }
+    }
+}
+
 impl MessageSummary for EffectiveMembership {
     fn summary(&self) -> String {
         format!("{{log_id:{} membership:{}}}", self.log_id, self.membership.summary())
@@ -1018,7 +1027,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Run the learner loop.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="non-voter"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="learner"))]
     pub(self) async fn run(mut self) -> RaftResult<()> {
         self.core.report_metrics(Update::Update(None));
         loop {

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -86,9 +86,9 @@ where
     type SnapshotData = T::SnapshotData;
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_membership_config(&self) -> Result<EffectiveMembership, StorageError> {
+    async fn last_membership_in_log(&self, since_index: u64) -> Result<Option<EffectiveMembership>, StorageError> {
         self.defensive_no_dirty_log().await?;
-        self.inner().get_membership_config().await
+        self.inner().last_membership_in_log(since_index).await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/openraft/tests/snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot_overrides_membership.rs
@@ -95,7 +95,10 @@ async fn snapshot_overrides_membership() -> Result<()> {
 
             tracing::info!("--- check that learner membership is affected");
             {
-                let m = sto.get_membership_config().await?;
+                let m = sto.get_membership().await?;
+
+                let m = m.unwrap();
+
                 assert_eq!(Membership::new_single(btreeset! {2,3}), m.membership);
             }
         }
@@ -121,7 +124,10 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 )
                 .await?;
 
-            let m = sto.get_membership_config().await?;
+            let m = sto.get_membership().await?;
+
+            let m = m.unwrap();
+
             assert_eq!(
                 Membership::new_single(btreeset! {0}),
                 m.membership,

--- a/openraft/tests/snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot_uses_prev_snap_membership.rs
@@ -84,7 +84,10 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             println!("{}", logs.as_slice().summary());
             assert_eq!(2, logs.len(), "only one applied log is kept");
         }
-        let m = sto0.get_membership_config().await?;
+        let m = sto0.get_membership().await?;
+
+        let m = m.unwrap();
+
         assert_eq!(Membership::new_single(btreeset! {0,1}), m.membership, "membership ");
 
         // TODO(xp): this assertion fails because when change-membership, a append-entries request does not update
@@ -120,7 +123,10 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             let logs = sto0.get_log_entries(..).await?;
             assert_eq!(2, logs.len(), "only one applied log");
         }
-        let m = sto0.get_membership_config().await?;
+        let m = sto0.get_membership().await?;
+
+        let m = m.unwrap();
+
         assert_eq!(Membership::new_single(btreeset! {0,1}), m.membership, "membership ");
     }
 


### PR DESCRIPTION

## Changelog

##### change: trait RaftStore: remove get_membership_config(), add last_membership_in_log() and get_membership() with default impl
Goal: minimize the work for users to implement a correct raft application.

Now RaftStorage provides default implementations for `get_membership()`
and `last_membership_in_log()`.

These two methods just can be implemented with other basic user impl
methods.

- fix: #59

---