### PR TITLE
make last_log_id an Option<LogId>

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -31,8 +31,8 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         &mut self,
         mut members: BTreeSet<NodeId>,
     ) -> Result<(), InitializeError> {
-        if self.core.last_log_id.index != 0 || self.core.current_term != 0 {
-            tracing::error!({self.core.last_log_id.index, self.core.current_term}, "rejecting init_with_config request as last_log_index or current_term is 0");
+        if self.core.last_log_id.unwrap().index != 0 || self.core.current_term != 0 {
+            tracing::error!({"{} {}", self.core.last_log_id.unwrap(), self.core.current_term}, "rejecting init_with_config request as last_log_index or current_term is 0");
             return Err(InitializeError::NotAllowed);
         }
 
@@ -81,7 +81,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         if target == self.core.id {
             tracing::debug!("target node is this node");
             let _ = tx.send(Ok(AddLearnerResponse {
-                matched: self.core.last_log_id,
+                matched: self.core.last_log_id.expect("raft core last_log_id is uninitialized"),
             }));
             return;
         }
@@ -171,7 +171,10 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             match self.nodes.get(new_node) {
                 // Node is ready to join.
                 Some(node) => {
-                    if node.is_line_rate(&self.core.last_log_id, &self.core.config) {
+                    if node.is_line_rate(
+                        &self.core.last_log_id.expect("raft core last_log_id is uninitialized"),
+                        &self.core.config,
+                    ) {
                         continue;
                     }
 
@@ -181,7 +184,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
                             ChangeMembershipError::LearnerIsLagging {
                                 node_id: *new_node,
                                 matched: node.matched,
-                                distance: self.core.last_log_id.index.saturating_sub(node.matched.index),
+                                distance: self.core.last_log_id.unwrap().index.saturating_sub(node.matched.index),
                             },
                         )));
                         return;
@@ -217,7 +220,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
         // Caveat: membership must be updated before commit check is done with the new config.
         self.core.effective_membership = EffectiveMembership {
-            log_id: self.core.last_log_id,
+            log_id: self.core.last_log_id.expect("raft core last_log_id is uninitialized"),
             membership: mem,
         };
 

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -221,8 +221,8 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             if self.committed < self.last_applied {
                 self.committed = self.last_applied;
             }
-            if self.last_log_id < self.last_applied {
-                self.last_log_id = self.last_applied;
+            if self.last_log_id.expect("raft core is uninitialized") < self.last_applied {
+                self.last_log_id = Some(self.last_applied);
             }
 
             // There could be unknown membership in the snapshot.

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -39,7 +39,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             target,
             self.core.current_term,
             self.core.config.clone(),
-            self.core.last_log_id,
+            self.core.last_log_id.expect("raft core is uninitialized"),
             self.core.committed,
             self.core.network.clone(),
             self.core.storage.clone(),
@@ -95,7 +95,10 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             state.matched = matched;
 
             // Issue a response on the learners response channel if needed.
-            if state.is_line_rate(&self.core.last_log_id, &self.core.config) {
+            if state.is_line_rate(
+                &self.core.last_log_id.expect("raft core last_log_id is uninitialized"),
+                &self.core.config,
+            ) {
                 // This replication became line rate.
 
                 // When adding a learner, it blocks until the replication becomes line-rate.
@@ -185,7 +188,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
         for id in node_ids.iter() {
             let matched = if *id == self.core.id {
-                self.core.last_log_id
+                self.core.last_log_id.expect("raft core is uninitialized")
             } else {
                 let repl_state = self.nodes.get(id);
                 repl_state.map(|x| x.matched).unwrap_or_default()
@@ -223,7 +226,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             // of the configured snapshot threshold, else create a new snapshot.
             if snapshot_is_within_half_of_threshold(
                 &snapshot.meta.last_log_id.index,
-                &self.core.last_log_id.index,
+                &self.core.last_log_id.expect("raft core is uninitialized").index,
                 &threshold,
             ) {
                 let _ = tx.send(snapshot);


### PR DESCRIPTION
this pr fix #49 .
make struct `RaftCore`'s `last_log_id` into `Option<LogId>` to express an uninitialized state.
