### PR TITLE
Refactor: move client-api tests to tests/client_api/

### DIFF
--- a/openraft/tests/client_api/main.rs
+++ b/openraft/tests/client_api/main.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+// The number indicate the preferred running order for these case.
+// The later tests may depend on the earlier ones.
+
+mod t10_client_writes;
+mod t20_client_reads;
+mod t50_lagging_network_write;

--- a/openraft/tests/client_api/t10_client_writes.rs
+++ b/openraft/tests/client_api/t10_client_writes.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use fixtures::RaftRouter;
 use futures::prelude::*;
 use maplit::btreeset;
 use openraft::Config;
@@ -9,8 +8,7 @@ use openraft::LogId;
 use openraft::SnapshotPolicy;
 use openraft::State;
 
-#[macro_use]
-mod fixtures;
+use crate::fixtures::RaftRouter;
 
 /// Client write tests.
 ///

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -1,13 +1,11 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use fixtures::RaftRouter;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::State;
 
-#[macro_use]
-mod fixtures;
+use crate::fixtures::RaftRouter;
 
 /// Client read tests.
 ///


### PR DESCRIPTION

## Changelog

##### Refactor: move client-api tests to tests/client_api/
- fix: #31

---