### PR TITLE
Refactor: use read_hard_state() to check hard state in storage test

### DIFF
--- a/memstore/src/test.rs
+++ b/memstore/src/test.rs
@@ -269,7 +269,7 @@ where
         let store = builder.build(NODE_ID).await;
 
         let initial = store.get_initial_state().await?;
-        assert_eq!(initial.is_none(), true, "unexpected initial state");
+        assert!(initial.is_none(), "unexpected initial state");
         Ok(())
     }
 
@@ -454,14 +454,14 @@ where
             })
             .await?;
 
-        let post = store.get_initial_state().await?.unwrap();
+        let got = store.read_hard_state().await?;
 
         assert_eq!(
-            HardState {
+            Some(HardState {
                 current_term: 100,
                 voted_for: Some(NODE_ID),
-            },
-            post.hard_state,
+            }),
+            got,
         );
         Ok(())
     }
@@ -1093,14 +1093,14 @@ where
                 ..
             }));
 
-            let state = store.get_initial_state().await?.unwrap();
+            let hs = store.read_hard_state().await?;
 
             assert_eq!(
-                HardState {
+                Some(HardState {
                     current_term: 10,
                     voted_for: Some(NODE_ID),
-                },
-                state.hard_state,
+                }),
+                hs,
             );
         }
 
@@ -1129,14 +1129,14 @@ where
                 ..
             }));
 
-            let state = store.get_initial_state().await?.unwrap();
+            let hs = store.read_hard_state().await?;
 
             assert_eq!(
-                HardState {
+                Some(HardState {
                     current_term: 10,
                     voted_for: Some(NODE_ID),
-                },
-                state.hard_state,
+                }),
+                hs,
             );
         }
 
@@ -1165,14 +1165,14 @@ where
                 ..
             }));
 
-            let state = store.get_initial_state().await?.unwrap();
+            let hs = store.read_hard_state().await?;
 
             assert_eq!(
-                HardState {
+                Some(HardState {
                     current_term: 10,
                     voted_for: Some(NODE_ID),
-                },
-                state.hard_state,
+                }),
+                hs
             );
         }
 

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -229,7 +229,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         {
             init_state
         } else {
-            let init_state = InitialState::new_initial(self.id);
+            let init_state = InitialState::new(self.id);
             self.storage
                 .save_hard_state(&init_state.hard_state)
                 .await

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -73,20 +73,16 @@ pub struct InitialState {
 }
 
 impl InitialState {
-    /// Create a new instance for a pristine Raft node.
-    ///
-    /// ### `id`
-    /// The ID of the Raft node.
-    pub fn new_initial(id: NodeId) -> Self {
+    pub fn new(id: NodeId) -> Self {
         Self {
-            last_log_id: LogId { term: 0, index: 0 },
-            last_applied: LogId { term: 0, index: 0 },
+            last_log_id: LogId::new(0, 0),
+            last_applied: LogId::new(0, 0),
             hard_state: HardState {
                 current_term: 0,
                 voted_for: None,
             },
             last_membership: EffectiveMembership {
-                log_id: LogId { term: 0, index: 0 },
+                log_id: LogId::new(0, 0),
                 membership: Membership::new_initial(id),
             },
         }


### PR DESCRIPTION

## Changelog

##### Refactor: use read_hard_state() to check hard state in storage test

##### Refactor: rename InitialState::new_initial() to new()

---