### PR TITLE
Refactor: error system; add Fatal and API errors

### DIFF
--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/datafuselabs/openraft"
 readme = "README.md"
 
 [dependencies]
+anyerror = { version = "0.1.1", features=["anyhow"]}
 anyhow = "1.0.32"
 openraft = { version="0.6", path= "../openraft" }
 async-trait = "0.1.36"

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -17,6 +17,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1.0.32"
+anyerror = { version = "0.1.1", features=["anyhow"]}
 async-trait = "0.1.36"
 byte-unit = "4.0.12"
 bytes = "1.0"

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -1,5 +1,6 @@
 use std::io::SeekFrom;
 
+use anyerror::AnyError;
 use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWriteExt;
 
@@ -8,16 +9,20 @@ use crate::core::RaftCore;
 use crate::core::SnapshotState;
 use crate::core::State;
 use crate::core::UpdateCurrentLeader;
-use crate::error::RaftResult;
+use crate::error::InstallSnapshotError;
+use crate::error::SnapshotMismatch;
 use crate::raft::InstallSnapshotRequest;
 use crate::raft::InstallSnapshotResponse;
 use crate::AppData;
 use crate::AppDataResponse;
+use crate::ErrorSubject;
+use crate::ErrorVerb;
 use crate::MessageSummary;
-use crate::RaftError;
 use crate::RaftNetwork;
 use crate::RaftStorage;
 use crate::SnapshotSegmentId;
+use crate::StorageError;
+use crate::StorageIOError;
 use crate::Update;
 
 impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> RaftCore<D, R, N, S> {
@@ -30,7 +35,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     pub(super) async fn handle_install_snapshot_request(
         &mut self,
         req: InstallSnapshotRequest,
-    ) -> RaftResult<InstallSnapshotResponse> {
+    ) -> Result<InstallSnapshotResponse, InstallSnapshotError> {
         // If message's term is less than most recent term, then we do not honor the request.
         if req.term < self.current_term {
             return Ok(InstallSnapshotResponse {
@@ -86,34 +91,45 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
                     return self.begin_installing_snapshot(req).await;
                 }
 
-                Err(RaftError::SnapshotMismatch {
+                Err(SnapshotMismatch {
                     expect: SnapshotSegmentId { id: id.clone(), offset },
                     got: SnapshotSegmentId {
                         id: req.meta.snapshot_id.clone(),
                         offset: req.offset,
                     },
-                })
+                }
+                .into())
             }
         }
     }
 
     #[tracing::instrument(level = "debug", skip(self, req), fields(req=%req.summary()))]
-    async fn begin_installing_snapshot(&mut self, req: InstallSnapshotRequest) -> RaftResult<InstallSnapshotResponse> {
+    async fn begin_installing_snapshot(
+        &mut self,
+        req: InstallSnapshotRequest,
+    ) -> Result<InstallSnapshotResponse, InstallSnapshotError> {
         let id = req.meta.snapshot_id.clone();
 
         if req.offset > 0 {
-            return Err(RaftError::SnapshotMismatch {
+            return Err(SnapshotMismatch {
                 expect: SnapshotSegmentId {
                     id: id.clone(),
                     offset: 0,
                 },
                 got: SnapshotSegmentId { id, offset: req.offset },
-            });
+            }
+            .into());
         }
 
         // Create a new snapshot and begin writing its contents.
-        let mut snapshot = self.storage.begin_receiving_snapshot().await.map_err(|err| self.map_storage_error(err))?;
-        snapshot.as_mut().write_all(&req.data).await?;
+        let mut snapshot = self.storage.begin_receiving_snapshot().await?;
+        snapshot.as_mut().write_all(&req.data).await.map_err(|e| StorageError::IO {
+            source: StorageIOError::new(
+                ErrorSubject::Snapshot(req.meta.clone()),
+                ErrorVerb::Write,
+                AnyError::new(&e),
+            ),
+        })?;
 
         // If this was a small snapshot, and it is already done, then finish up.
         if req.done {
@@ -140,14 +156,19 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         req: InstallSnapshotRequest,
         mut offset: u64,
         mut snapshot: Box<S::SnapshotData>,
-    ) -> RaftResult<InstallSnapshotResponse> {
+    ) -> Result<InstallSnapshotResponse, InstallSnapshotError> {
         let id = req.meta.snapshot_id.clone();
 
         // Always seek to the target offset if not an exact match.
         if req.offset != offset {
             if let Err(err) = snapshot.as_mut().seek(SeekFrom::Start(req.offset)).await {
                 self.snapshot_state = Some(SnapshotState::Streaming { offset, id, snapshot });
-                return Err(err.into());
+                return Err(StorageError::from_io_error(
+                    ErrorSubject::Snapshot(req.meta.clone()),
+                    ErrorVerb::Seek,
+                    err,
+                )
+                .into());
             }
             offset = req.offset;
         }
@@ -155,7 +176,9 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         // Write the next segment & update offset.
         if let Err(err) = snapshot.as_mut().write_all(&req.data).await {
             self.snapshot_state = Some(SnapshotState::Streaming { offset, id, snapshot });
-            return Err(err.into());
+            return Err(
+                StorageError::from_io_error(ErrorSubject::Snapshot(req.meta.clone()), ErrorVerb::Write, err).into(),
+            );
         }
         offset += req.data.len() as u64;
 
@@ -178,8 +201,14 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         &mut self,
         req: InstallSnapshotRequest,
         mut snapshot: Box<S::SnapshotData>,
-    ) -> RaftResult<()> {
-        snapshot.as_mut().shutdown().await.map_err(|err| self.map_fatal_storage_error(err.into()))?;
+    ) -> Result<(), StorageError> {
+        snapshot.as_mut().shutdown().await.map_err(|e| StorageError::IO {
+            source: StorageIOError::new(
+                ErrorSubject::Snapshot(req.meta.clone()),
+                ErrorVerb::Write,
+                AnyError::new(&e),
+            ),
+        })?;
 
         // Caveat: All changes to state machine must be serialized
         //
@@ -197,11 +226,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         // TODO(xp): do not install if self.last_applied >= snapshot.meta.last_applied
 
-        let changes = self
-            .storage
-            .finalize_snapshot_installation(&req.meta, snapshot)
-            .await
-            .map_err(|e| self.map_storage_error(e))?;
+        let changes = self.storage.finalize_snapshot_installation(&req.meta, snapshot).await?;
 
         tracing::debug!("update after apply or install-snapshot: {:?}", changes);
 
@@ -211,9 +236,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         if let Some(last_applied) = changes.last_applied {
             // Applied logs are not needed.
-            delete_applied_logs(self.storage.clone(), &last_applied, self.config.max_applied_log_to_keep)
-                .await
-                .map_err(|e| self.map_storage_error(e))?;
+            delete_applied_logs(self.storage.clone(), &last_applied, self.config.max_applied_log_to_keep).await?;
 
             // snapshot is installed
             self.last_applied = last_applied;
@@ -226,14 +249,14 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             }
 
             // There could be unknown membership in the snapshot.
-            let membership = self.storage.get_membership().await.map_err(|err| self.map_storage_error(err))?;
+            let membership = self.storage.get_membership().await?;
             tracing::debug!("storage membership: {:?}", membership);
 
             assert!(membership.is_some());
 
             let membership = membership.unwrap();
 
-            self.update_membership(membership)?;
+            self.update_membership(membership);
 
             self.snapshot_last_log_id = self.last_applied;
             self.report_metrics(Update::Ignore);

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -4,37 +4,183 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::time::Duration;
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use crate::raft_types::SnapshotSegmentId;
 use crate::LogId;
 use crate::Membership;
 use crate::NodeId;
 use crate::StorageError;
 
-/// A result type where the error variant is always a `RaftError`.
-pub type RaftResult<T> = std::result::Result<T, RaftError>;
+/// Fatal is unrecoverable and shuts down raft at once.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Fatal {
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
+}
 
-/// Error variants related to the internals of Raft.
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum RaftError {
-    // Streaming-snapshot encountered mismatched snapshot_id/offset
-    #[error("expect: {expect}, got: {got}")]
-    SnapshotMismatch {
-        expect: SnapshotSegmentId,
-        got: SnapshotSegmentId,
+/// Extract Fatal from a Result.
+///
+/// Fatal will shutdown the raft and needs to be dealt separately,
+/// such as StorageError.
+pub trait ExtractFatal
+where Self: Sized
+{
+    fn extract_fatal(self) -> Result<Self, Fatal>;
+}
+
+impl<T, E> ExtractFatal for Result<T, E>
+where E: TryInto<Fatal> + Clone
+{
+    fn extract_fatal(self) -> Result<Self, Fatal> {
+        if let Err(e) = &self {
+            let fatal = e.clone().try_into();
+            if let Ok(f) = fatal {
+                return Err(f);
+            }
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+pub enum AppendEntriesError {
+    #[error(transparent)]
+    Fatal(#[from] Fatal),
+}
+
+#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+pub enum VoteError {
+    #[error(transparent)]
+    Fatal(#[from] Fatal),
+}
+
+#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+pub enum InstallSnapshotError {
+    #[error(transparent)]
+    SnapshotMismatch(#[from] SnapshotMismatch),
+
+    #[error(transparent)]
+    Fatal(#[from] Fatal),
+}
+
+/// An error related to a client read request.
+#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+pub enum ClientReadError {
+    #[error(transparent)]
+    ForwardToLeader(#[from] ForwardToLeader),
+
+    #[error(transparent)]
+    QuorumNotEnough(#[from] QuorumNotEnough),
+
+    #[error(transparent)]
+    Fatal(#[from] Fatal),
+}
+
+/// An error related to a client write request.
+#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+pub enum ClientWriteError {
+    // #[error("{0}")]
+    // RaftError(#[from] RaftError),
+    #[error(transparent)]
+    ForwardToLeader(#[from] ForwardToLeader),
+
+    /// When writing a change-membership entry.
+    #[error(transparent)]
+    ChangeMembershipError(#[from] ChangeMembershipError),
+
+    #[error(transparent)]
+    Fatal(#[from] Fatal),
+}
+
+/// The set of errors which may take place when requesting to propose a config change.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ChangeMembershipError {
+    #[error("the cluster is already undergoing a configuration change at log {membership_log_id}")]
+    InProgress { membership_log_id: LogId },
+
+    #[error("new membership can not be empty")]
+    EmptyMembership,
+
+    // TODO(xp): 111 test it
+    #[error("to add a member {node_id} first need to add it as learner")]
+    LearnerNotFound { node_id: NodeId },
+
+    // TODO(xp): 111 test it
+    #[error("replication to learner {node_id} is lagging {distance}, matched: {matched}, can not add as member")]
+    LearnerIsLagging {
+        node_id: NodeId,
+        matched: LogId,
+        distance: u64,
     },
 
-    /// An error which has come from the `RaftStorage` layer.
-    #[error("{0}")]
-    RaftStorage(anyhow::Error),
+    // TODO(xp): test it in unittest
+    // TODO(xp): rename this error to some elaborated name.
+    // TODO(xp): 111 test it
+    #[error("now allowed to change from {curr:?} to {to:?}")]
+    Incompatible { curr: Membership, to: BTreeSet<NodeId> },
+}
 
-    /// An error which has come from the `RaftNetwork` layer.
-    #[error("{0}")]
-    RaftNetwork(anyhow::Error),
+#[derive(Debug, thiserror::Error)]
+pub enum AddLearnerError {
+    #[error(transparent)]
+    ForwardToLeader(#[from] ForwardToLeader),
 
-    /// An internal Raft error indicating that Raft is shutting down.
-    #[error("Raft is shutting down")]
-    ShuttingDown,
+    #[error("node {0} is already a learner")]
+    Exists(NodeId),
+
+    #[error(transparent)]
+    Fatal(#[from] Fatal),
+}
+
+/// The set of errors which may take place when initializing a pristine Raft node.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum InitializeError {
+    /// The requested action is not allowed due to the Raft node's current state.
+    #[error("the requested action is not allowed due to the Raft node's current state")]
+    NotAllowed,
+
+    #[error(transparent)]
+    Fatal(#[from] Fatal),
+}
+
+impl From<StorageError> for AppendEntriesError {
+    fn from(s: StorageError) -> Self {
+        let f: Fatal = s.into();
+        f.into()
+    }
+}
+impl From<StorageError> for VoteError {
+    fn from(s: StorageError) -> Self {
+        let f: Fatal = s.into();
+        f.into()
+    }
+}
+impl From<StorageError> for InstallSnapshotError {
+    fn from(s: StorageError) -> Self {
+        let f: Fatal = s.into();
+        f.into()
+    }
+}
+impl From<StorageError> for ClientReadError {
+    fn from(s: StorageError) -> Self {
+        let f: Fatal = s.into();
+        f.into()
+    }
+}
+impl From<StorageError> for InitializeError {
+    fn from(s: StorageError) -> Self {
+        let f: Fatal = s.into();
+        f.into()
+    }
+}
+impl From<StorageError> for AddLearnerError {
+    fn from(s: StorageError) -> Self {
+        let f: Fatal = s.into();
+        f.into()
+    }
 }
 
 /// Error variants related to the Replication.
@@ -80,97 +226,29 @@ pub enum ReplicationError {
     },
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 #[error("store has no log at: {index}")]
 pub struct LackEntry {
     pub index: u64,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 #[error("has to forward request to: {leader_id:?}")]
 pub struct ForwardToLeader {
     pub leader_id: Option<NodeId>,
 }
 
-impl From<tokio::io::Error> for RaftError {
-    fn from(src: tokio::io::Error) -> Self {
-        RaftError::RaftStorage(src.into())
-    }
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("snapshot segment id mismatch, expect: {expect}, got: {got}")]
+pub struct SnapshotMismatch {
+    pub expect: SnapshotSegmentId,
+    pub got: SnapshotSegmentId,
 }
 
-/// An error related to a client read request.
-#[derive(Debug, thiserror::Error)]
-pub enum ClientReadError {
-    #[error(transparent)]
-    RaftError(#[from] RaftError),
-
-    #[error(transparent)]
-    ForwardToLeader(#[from] ForwardToLeader),
-}
-
-/// An error related to a client write request.
-#[derive(thiserror::Error, Debug, derive_more::TryInto)]
-pub enum ClientWriteError {
-    #[error("{0}")]
-    RaftError(#[from] RaftError),
-
-    #[error(transparent)]
-    ForwardToLeader(#[from] ForwardToLeader),
-
-    /// When writing a change-membership entry.
-    #[error(transparent)]
-    ChangeMembershipError(#[from] ChangeMembershipError),
-}
-
-/// The set of errors which may take place when initializing a pristine Raft node.
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum InitializeError {
-    /// An internal error has taken place.
-    #[error("{0}")]
-    RaftError(#[from] RaftError),
-
-    /// The requested action is not allowed due to the Raft node's current state.
-    #[error("the requested action is not allowed due to the Raft node's current state")]
-    NotAllowed,
-}
-
-/// The set of errors which may take place when requesting to propose a config change.
-#[derive(Debug, thiserror::Error)]
-pub enum ChangeMembershipError {
-    #[error("the cluster is already undergoing a configuration change at log {membership_log_id}")]
-    InProgress { membership_log_id: LogId },
-
-    #[error("new membership can not be empty")]
-    EmptyMembership,
-
-    // TODO(xp): 111 test it
-    #[error("to add a member {node_id} first need to add it as learner")]
-    LearnerNotFound { node_id: NodeId },
-
-    // TODO(xp): 111 test it
-    #[error("replication to learner {node_id} is lagging {distance}, matched: {matched}, can not add as member")]
-    LearnerIsLagging {
-        node_id: NodeId,
-        matched: LogId,
-        distance: u64,
-    },
-
-    // TODO(xp): test it in unittest
-    // TODO(xp): rename this error to some elaborated name.
-    // TODO(xp): 111 test it
-    #[error("now allowed to change from {curr:?} to {to:?}")]
-    Incompatible { curr: Membership, to: BTreeSet<NodeId> },
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum AddLearnerError {
-    #[error("{0}")]
-    RaftError(#[from] RaftError),
-
-    #[error(transparent)]
-    ForwardToLeader(#[from] ForwardToLeader),
-
-    #[error("node {0} is already a learner")]
-    Exists(NodeId),
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("not enough for a quorum, cluster: {cluster}, got: {got}")]
+pub struct QuorumNotEnough {
+    pub cluster: String,
+    // TODO(xp): replace it with BTreeSet.
+    pub got: u64,
 }

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -33,7 +33,6 @@ pub use crate::defensive::DefensiveCheck;
 pub use crate::error::ChangeMembershipError;
 pub use crate::error::ClientWriteError;
 pub use crate::error::InitializeError;
-pub use crate::error::RaftError;
 pub use crate::error::ReplicationError;
 pub use crate::membership::Membership;
 pub use crate::metrics::RaftMetrics;

--- a/openraft/src/metrics_wait_test.rs
+++ b/openraft/src/metrics_wait_test.rs
@@ -176,6 +176,7 @@ async fn test_wait() -> anyhow::Result<()> {
 /// Returns init metrics, Wait, and the tx to send an updated metrics.
 fn init_wait_test() -> (RaftMetrics, Wait, watch::Sender<RaftMetrics>) {
     let init = RaftMetrics {
+        running_state: Ok(()),
         id: 0,
         state: State::Learner,
         current_term: 0,

--- a/openraft/tests/api_install_snapshot.rs
+++ b/openraft/tests/api_install_snapshot.rs
@@ -60,7 +60,10 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         let mut req = req0.clone();
         req.offset = 2;
         let res = n.0.install_snapshot(req).await;
-        assert_eq!("expect: ss1+0, got: ss1+2", res.unwrap_err().to_string());
+        assert_eq!(
+            "snapshot segment id mismatch, expect: ss1+0, got: ss1+2",
+            res.unwrap_err().to_string()
+        );
     }
 
     tracing::info!("--- install and write ss1:[0,3)");
@@ -75,7 +78,10 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         req.offset = 3;
         req.meta.snapshot_id = "ss2".into();
         let res = n.0.install_snapshot(req).await;
-        assert_eq!("expect: ss1+3, got: ss2+3", res.unwrap_err().to_string());
+        assert_eq!(
+            "snapshot segment id mismatch, expect: ss1+3, got: ss2+3",
+            res.unwrap_err().to_string()
+        );
     }
 
     tracing::info!("-- write from offset=0 with different id, create a new session");

--- a/openraft/tests/metrics/t40_metrics_wait.rs
+++ b/openraft/tests/metrics/t40_metrics_wait.rs
@@ -45,7 +45,7 @@ async fn metrics_wait() -> Result<()> {
                 WaitError::Timeout(_, _) => {
                     // ok
                 }
-                WaitError::RaftError(_) => {
+                WaitError::ShuttingDown => {
                     panic!("unexpected error")
                 }
             }


### PR DESCRIPTION

## Changelog

##### Refactor: error system; add Fatal and API errors
- Add: Fatal as a collection of all errors that will shutdown a raft
  node. Currently it has only one sub-error: StorageError.

- Add: error types for every API, such as AppendEntriesError or
  VoteError.

- Remove: `map_storage_error()` and `map_fatal_storage_error()`.
  A fatal error should be popped up and be dealt with at the top level.
  Avoid changing target state everywhere, which is hard to review or
  debug.

- Use crate anyerror as a wrapper of external error.

- Remove: RaftError, which is vague about what it is for.

- Makes API error serializable for transport.

---