### PR TITLE
Feature: Membership::is_safe_to() check membership change safety

### DIFF
--- a/guide/src/dynamic-membership.md
+++ b/guide/src/dynamic-membership.md
@@ -37,31 +37,67 @@ and immediately begin syncing logs from the leader.
 
 This method will initiate a membership change.
 
-If there are nodes in the given config that is not a learner, this method will add it
+If there are nodes in the given membership that is not a learner, this method will add it
 as Learner first.
 Thus it is recommended that application always call `Raft::add_learner` first.
 Otherwise `change_membership` may block for long before committing the
 given membership and return.
 
-The new membership config specified by this method will take effect at once.
+The new membership specified by this method will take effect at once.
 
-Once the new config is committed, a Voter that is not in the new config will
+Once the new membership is committed, a Voter that is not in the new membership will
 revert to a Learner and is ready to remove.
 
 Correctness constrains:
 
-- There is no uncommitted membership config on the leader.
+- There is no uncommitted membership on the leader.
 
-- The new config has to contains a group that is the same as one of the last
-    committed config.
+- The new membership has to contains a config that is the same as one of the last
+    committed membership.
 
-    E.g., the last committed one is `[{a, b, c}]`, then a legal new config may be:
-    a joint config: `[{a, b, c}, {x, y, z}]`.
+    E.g., the last committed one is `[{a, b, c}]`, then a legal new membership may be:
+    a joint membership: `[{a, b, c}, {x, y, z}]`.
 
-    If the last committed one is `[{a, b, c}, {x, y, z}]`, a legal new config
-    may be: `[{a, b, c}]`, or `[{x, y, z}]`.
+    If the last committed one is `[{a, b, c}, {x, y, z}]`, a legal new
+    membership may be: `[{a, b, c}]`, or `[{x, y, z}]`.
 
-If the constrains are not satisfied, an error is returned and nothing is done
+If the constraints are not satisfied, an error is returned and nothing is done
 except the learner will not be removed.
 
-TODO(xp): these constrains can be loosen, if raft stores the commit index.
+
+### The safe-to relation
+
+TL, DR
+
+According to the rule that every 2 quorums has to intersect each other,
+one membership `m1` is safe to change to another membership `m2` iff `m1` contains
+a config the same as one in `m2`.
+
+E.g.: given a joint membership of 3 config: `m1 = c1 * c2 * c3`(`cᵢ` is a set of
+nodes. `*` means joint), the following are safe with `m1`:
+- `c1`,
+- `c2`,
+- `c1 * c3`,
+- and `c2 * c4 * c5`.
+
+
+The `safe_to` relation is **commutative**, e.g., `m1` being safe with `m2` iff `m2` being safe with `m1`.
+
+E.g., one of the safe membership changing path is:
+`c1`  →  `c1 * c2 * c3`  →  `c3 * c4`  →  `c4`.
+Every step in it is safe.
+
+Another example with 6 memberships shows that it is always safe to change
+membership from one vertex to another along edges:
+
+```
+            c3
+          /   \
+         /     \
+        /       \
+   c1*c3 ------- c2*c3
+    /  \         /  \
+   /    \       /    \
+  /      \     /      \
+c1 ------ c1*c2 ------ c2
+```

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -157,6 +157,22 @@ impl Membership {
         min_greatest.unwrap_or(None)
     }
 
+    /// Check if the `other` membership is safe to change to.
+    ///
+    /// Read more about:
+    /// [safe-membership-change](https://datafuselabs.github.io/openraft/dynamic-membership.html#the_safe_to_relation)
+    pub fn is_safe_to(&self, other: &Self) -> bool {
+        for c in &self.configs {
+            for d in &other.configs {
+                if c == d {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
     fn is_majority_of_single_config(granted: &BTreeSet<NodeId>, single_config: &BTreeSet<NodeId>) -> bool {
         let d = granted.intersection(single_config);
         let n_granted = d.fold(0, |a, _x| a + 1);

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -132,3 +132,37 @@ fn test_membership_greatest_majority_value() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_membership_is_safe_to() -> anyhow::Result<()> {
+    let set123 = || btreeset! {1,2,3};
+    let set345 = || btreeset! {3,4,5};
+    let set789 = || btreeset! {7,8,9};
+
+    let m123 = Membership::new_single(set123());
+    let m345 = Membership::new_single(set345());
+    let m123_345 = Membership::new_multi(vec![set123(), set345()]);
+    let m345_789 = Membership::new_multi(vec![set345(), set789()]);
+
+    assert!(m123.is_safe_to(&m123));
+    assert!(!m123.is_safe_to(&m345));
+    assert!(m123.is_safe_to(&m123_345));
+    assert!(!m123.is_safe_to(&m345_789));
+
+    assert!(!m345.is_safe_to(&m123));
+    assert!(m345.is_safe_to(&m345));
+    assert!(m345.is_safe_to(&m123_345));
+    assert!(m345.is_safe_to(&m345_789));
+
+    assert!(m123_345.is_safe_to(&m123));
+    assert!(m123_345.is_safe_to(&m345));
+    assert!(m123_345.is_safe_to(&m123_345));
+    assert!(m123_345.is_safe_to(&m345_789));
+
+    assert!(!m345_789.is_safe_to(&m123));
+    assert!(m345_789.is_safe_to(&m345));
+    assert!(m345_789.is_safe_to(&m123_345));
+    assert!(m345_789.is_safe_to(&m345_789));
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### Feature: Membership::is_safe_to() check membership change safety
Define extended change-membership safety.
With this definition raft membership management becomes more flexible.

Joint-uniform-joint-... wont be the only choice.

---