### PR TITLE
Refactor: loosen state check in test "stepdown"

### DIFF
--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -206,7 +206,7 @@ impl Wait {
         .await
     }
 
-    /// Wait until applied upto `want_log`(inclusive) logs or timeout.
+    /// Wait until applied exactly `want_log`(inclusive) logs or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn log(&self, want_log: u64, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
         self.metrics(
@@ -218,6 +218,22 @@ impl Wait {
         self.metrics(
             |x| x.last_applied == want_log,
             &format!("{} .last_applied -> {}", msg.to_string(), want_log),
+        )
+        .await
+    }
+
+    /// Wait until applied at least `want_log`(inclusive) logs or timeout.
+    #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
+    pub async fn log_at_least(&self, want_log: u64, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
+        self.metrics(
+            |x| x.last_log_index >= want_log,
+            &format!("{} .last_log_index >= {}", msg.to_string(), want_log),
+        )
+        .await?;
+
+        self.metrics(
+            |x| x.last_applied >= want_log,
+            &format!("{} .last_applied >= {}", msg.to_string(), want_log),
         )
         .await
     }

--- a/openraft/src/metrics_wait_test.rs
+++ b/openraft/src/metrics_wait_test.rs
@@ -44,10 +44,19 @@ async fn test_wait() -> anyhow::Result<()> {
             assert!(rst.is_ok());
         });
         let got = w.log(3, "log").await?;
+        let got_least2 = w.log_at_least(2, "log").await?;
+        let got_least3 = w.log_at_least(3, "log").await?;
+        let got_least4 = w.log_at_least(4, "log").await;
         h.await?;
 
         assert_eq!(3, got.last_log_index);
         assert_eq!(3, got.last_applied);
+        assert_eq!(3, got_least2.last_log_index);
+        assert_eq!(3, got_least2.last_applied);
+        assert_eq!(3, got_least3.last_log_index);
+        assert_eq!(3, got_least3.last_applied);
+
+        assert!(got_least4.is_err());
     }
 
     {

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -316,6 +316,13 @@ impl RaftRouter {
         metrics
     }
 
+    pub async fn get_metrics(&self, node_id: &NodeId) -> Result<RaftMetrics> {
+        let rt = self.routing_table.read().await;
+        let x = rt.get(node_id).with_context(|| format!("could not find node {} in routing table", node_id))?;
+        let metrics = x.0.metrics().borrow().clone();
+        Ok(metrics)
+    }
+
     /// Get a handle to the storage backend for the target node.
     pub async fn get_storage_handle(&self, node_id: &NodeId) -> Result<Arc<StoreWithDefensive>> {
         let rt = self.routing_table.read().await;


### PR DESCRIPTION

## Changelog

##### Refactor: loosen state check in test "stepdown"
- Feature: add Metrix.Wait().log_at_least() to wait for last and applied
  log index to become equal or greater than specified value.

- In test "stepdown", the last log index of a non-leader node in the old
  cluster is unstable: because when change-membership, the second log
  just need the new cluster quorum to commit.

  Thus there is chance a node in old cluster does not have this log.

  The check on this value should be loosened: replace `Wait().log()`
  with `Wait().log_at_least()`.

---