### PR TITLE
Fix: add unit test for save leader_id if a higher term is seen when handling append-entries RPC

### DIFF
--- a/openraft/tests/append_entries/main.rs
+++ b/openraft/tests/append_entries/main.rs
@@ -9,3 +9,4 @@ mod t10_conflict_with_empty_entries;
 mod t20_append_conflicts;
 mod t30_append_inconsistent_log;
 mod t40_append_updates_membership;
+mod t50_append_entries_with_bigger_term;

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::raft::AppendEntriesRequest;
+use openraft::Config;
+use openraft::LogId;
+use openraft::RaftNetwork;
+use openraft::State;
+
+use crate::fixtures::RaftRouter;
+
+/// append-entries should update hard state when adding new logs with bigger term
+///
+/// - bring up a learner and send to it append_entries request. Check the hard state updated.
+#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+async fn append_entries_with_bigger_term() -> Result<()> {
+  let (_log_guard, ut_span) = init_ut!();
+  let _ent = ut_span.enter();
+
+  // Setup test dependencies.
+  let config = Arc::new(Config::default().validate()?);
+  let router = Arc::new(RaftRouter::new(config.clone()));
+  router.new_raft_node(0).await;
+  router.new_raft_node(1).await;
+  router.new_raft_node(2).await;
+
+  let mut n_logs = 0;
+
+  // Assert all nodes are in learner state & have no entries.
+  router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "empty").await?;
+  router.wait_for_state(&btreeset![0, 1, 2], State::Learner, None, "empty").await?;
+  router.assert_pristine_cluster().await;
+
+  // Initialize the cluster, then assert that a stable cluster was formed & held.
+  tracing::info!("--- initializing cluster");
+  router.initialize_from_single_node(0).await?;
+  n_logs += 1;
+
+  router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "init").await?;
+  router.assert_stable_cluster(Some(1), Some(n_logs)).await;
+
+  // before append entries, check hard state in term 1
+  router.assert_storage_state(1, n_logs, Some(0), LogId { term: 1, index: n_logs }, None).await?;
+
+  tracing::info!("append-entries with bigger term");
+
+  let req = AppendEntriesRequest::<memstore::ClientRequest> {
+    term: 2,
+    leader_id: 1,
+    prev_log_id: LogId::new(1, n_logs),
+    entries: vec![],
+    leader_commit: LogId::new(1, n_logs),
+  };
+
+  let resp = router.send_append_entries(0, req).await?;
+  assert!(resp.success());
+
+  // before append entries, check hard state in term 2
+  router.assert_storage_state_in_node(0,2, n_logs, Some(1), LogId { term: 1, index: n_logs }, None).await?;
+
+  Ok(())
+}

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -6,7 +6,6 @@ use openraft::raft::AppendEntriesRequest;
 use openraft::Config;
 use openraft::LogId;
 use openraft::RaftNetwork;
-use openraft::State;
 
 use crate::fixtures::RaftRouter;
 
@@ -15,50 +14,34 @@ use crate::fixtures::RaftRouter;
 /// - bring up a learner and send to it append_entries request. Check the hard state updated.
 #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
 async fn append_entries_with_bigger_term() -> Result<()> {
-  let (_log_guard, ut_span) = init_ut!();
-  let _ent = ut_span.enter();
+    let (_log_guard, ut_span) = init_ut!();
+    let _ent = ut_span.enter();
 
-  // Setup test dependencies.
-  let config = Arc::new(Config::default().validate()?);
-  let router = Arc::new(RaftRouter::new(config.clone()));
-  router.new_raft_node(0).await;
-  router.new_raft_node(1).await;
-  router.new_raft_node(2).await;
+    // Setup test dependencies.
+    let config = Arc::new(Config::default().validate()?);
+    let router = Arc::new(RaftRouter::new(config.clone()));
+    let n_logs = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
 
-  let mut n_logs = 0;
+    // before append entries, check hard state in term 1 and vote for node 0
+    router.assert_storage_state(1, n_logs, Some(0), LogId { term: 1, index: n_logs }, None).await?;
 
-  // Assert all nodes are in learner state & have no entries.
-  router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "empty").await?;
-  router.wait_for_state(&btreeset![0, 1, 2], State::Learner, None, "empty").await?;
-  router.assert_pristine_cluster().await;
+    tracing::info!("append-entries with bigger term");
+    // append entries with term 2 and leader_id, this MUST cause hard state changed in node 0
+    let req = AppendEntriesRequest::<memstore::ClientRequest> {
+        term: 2,
+        leader_id: 1,
+        prev_log_id: LogId::new(1, n_logs),
+        entries: vec![],
+        leader_commit: LogId::new(1, n_logs),
+    };
 
-  // Initialize the cluster, then assert that a stable cluster was formed & held.
-  tracing::info!("--- initializing cluster");
-  router.initialize_from_single_node(0).await?;
-  n_logs += 1;
+    let resp = router.send_append_entries(0, req).await?;
+    assert!(resp.success());
 
-  router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "init").await?;
-  router.assert_stable_cluster(Some(1), Some(n_logs)).await;
+    // after append entries, check hard state in term 2  and vote for node 1
+    router
+        .assert_storage_state_in_node(0, 2, n_logs, Some(1), LogId { term: 1, index: n_logs }, None)
+        .await?;
 
-  // before append entries, check hard state in term 1 and vote for node 0
-  router.assert_storage_state(1, n_logs, Some(0), LogId { term: 1, index: n_logs }, None).await?;
-
-  tracing::info!("append-entries with bigger term");
-
-  // append entries with term 2 and leader_id, this MUST cause hard state changed in node 0
-  let req = AppendEntriesRequest::<memstore::ClientRequest> {
-    term: 2,
-    leader_id: 1,
-    prev_log_id: LogId::new(1, n_logs),
-    entries: vec![],
-    leader_commit: LogId::new(1, n_logs),
-  };
-
-  let resp = router.send_append_entries(0, req).await?;
-  assert!(resp.success());
-
-  // after append entries, check hard state in term 2  and vote for node 1
-  router.assert_storage_state_in_node(0,2, n_logs, Some(1), LogId { term: 1, index: n_logs }, None).await?;
-
-  Ok(())
+    Ok(())
 }

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -638,86 +638,85 @@ impl RaftRouter {
         }
     }
 
-   /// Assert against the state of the storage system one node in the cluster.
-   pub async fn assert_storage_state_with_sto(
-    &self,
-    storage: &Arc<StoreWithDefensive>,
-    id: &u64,
-    expect_term: u64,
-    expect_last_log: u64,
-    expect_voted_for: Option<u64>,
-    expect_sm_last_applied_log: LogId,
-    expect_snapshot: &Option<(ValueTest<u64>, u64)>,
+    /// Assert against the state of the storage system one node in the cluster.
+    pub async fn assert_storage_state_with_sto(
+        &self,
+        storage: &Arc<StoreWithDefensive>,
+        id: &u64,
+        expect_term: u64,
+        expect_last_log: u64,
+        expect_voted_for: Option<u64>,
+        expect_sm_last_applied_log: LogId,
+        expect_snapshot: &Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
+        let (sm_last_id, _) = storage.last_applied_state().await?;
+        let last_log_id = match storage.last_id_in_log().await? {
+            Some(log_last_id) => std::cmp::max(log_last_id, sm_last_id),
+            None => sm_last_id,
+        };
 
-            let (sm_last_id, _) = storage.last_applied_state().await?;
-            let last_log_id = match storage.last_id_in_log().await? {
-                Some(log_last_id) => std::cmp::max(log_last_id, sm_last_id),
-                None => sm_last_id,
-            };
+        assert_eq!(
+            expect_last_log, last_log_id.index,
+            "expected node {} to have last_log {}, got {}",
+            id, expect_last_log, last_log_id
+        );
 
+        let hs = storage.read_hard_state().await?.unwrap_or_else(|| panic!("no hard state found for node {}", id));
+
+        assert_eq!(
+            hs.current_term, expect_term,
+            "expected node {} to have term {}, got {:?}",
+            id, expect_term, hs
+        );
+
+        if let Some(voted_for) = &expect_voted_for {
             assert_eq!(
-                expect_last_log, last_log_id.index,
-                "expected node {} to have last_log {}, got {}",
-                id, expect_last_log, last_log_id
+                hs.voted_for.as_ref(),
+                Some(voted_for),
+                "expected node {} to have voted for {}, got {:?}",
+                id,
+                voted_for,
+                hs
             );
+        }
 
-            let hs = storage.read_hard_state().await?.unwrap_or_else(|| panic!("no hard state found for node {}", id));
+        if let Some((index_test, term)) = &expect_snapshot {
+            let snap = storage
+                .get_current_snapshot()
+                .await
+                .map_err(|err| panic!("{}", err))
+                .unwrap()
+                .unwrap_or_else(|| panic!("no snapshot present for node {}", id));
 
-            assert_eq!(
-                hs.current_term, expect_term,
-                "expected node {} to have term {}, got {:?}",
-                id, expect_term, hs
-            );
-
-            if let Some(voted_for) = &expect_voted_for {
-                assert_eq!(
-                    hs.voted_for.as_ref(),
-                    Some(voted_for),
-                    "expected node {} to have voted for {}, got {:?}",
+            match index_test {
+                ValueTest::Exact(index) => assert_eq!(
+                    &snap.meta.last_log_id.index, index,
+                    "expected node {} to have snapshot with index {}, got {}",
+                    id, index, snap.meta.last_log_id.index
+                ),
+                ValueTest::Range(range) => assert!(
+                    range.contains(&snap.meta.last_log_id.index),
+                    "expected node {} to have snapshot within range {:?}, got {}",
                     id,
-                    voted_for,
-                    hs
-                );
+                    range,
+                    snap.meta.last_log_id.index
+                ),
             }
-
-            if let Some((index_test, term)) = &expect_snapshot {
-                let snap = storage
-                    .get_current_snapshot()
-                    .await
-                    .map_err(|err| panic!("{}", err))
-                    .unwrap()
-                    .unwrap_or_else(|| panic!("no snapshot present for node {}", id));
-
-                match index_test {
-                    ValueTest::Exact(index) => assert_eq!(
-                        &snap.meta.last_log_id.index, index,
-                        "expected node {} to have snapshot with index {}, got {}",
-                        id, index, snap.meta.last_log_id.index
-                    ),
-                    ValueTest::Range(range) => assert!(
-                        range.contains(&snap.meta.last_log_id.index),
-                        "expected node {} to have snapshot within range {:?}, got {}",
-                        id,
-                        range,
-                        snap.meta.last_log_id.index
-                    ),
-                }
-
-                assert_eq!(
-                    &snap.meta.last_log_id.term, term,
-                    "expected node {} to have snapshot with term {}, got {}",
-                    id, term, snap.meta.last_log_id.term
-                );
-            }
-
-            let (last_applied, _) = storage.last_applied_state().await?;
 
             assert_eq!(
-                &last_applied, &expect_sm_last_applied_log,
-                "expected node {} to have state machine last_applied_log {}, got {}",
-                id, expect_sm_last_applied_log, last_applied
+                &snap.meta.last_log_id.term, term,
+                "expected node {} to have snapshot with term {}, got {}",
+                id, term, snap.meta.last_log_id.term
             );
+        }
+
+        let (last_applied, _) = storage.last_applied_state().await?;
+
+        assert_eq!(
+            &last_applied, &expect_sm_last_applied_log,
+            "expected node {} to have state machine last_applied_log {}, got {}",
+            id, expect_sm_last_applied_log, last_applied
+        );
 
         Ok(())
     }
@@ -738,7 +737,16 @@ impl RaftRouter {
             if *id != node_id {
                 continue;
             }
-            self.assert_storage_state_with_sto(storage, id, expect_term, expect_last_log, expect_voted_for, expect_sm_last_applied_log, &expect_snapshot).await?;
+            self.assert_storage_state_with_sto(
+                storage,
+                id,
+                expect_term,
+                expect_last_log,
+                expect_voted_for,
+                expect_sm_last_applied_log,
+                &expect_snapshot,
+            )
+            .await?;
 
             break;
         }
@@ -758,7 +766,16 @@ impl RaftRouter {
         let rt = self.routing_table.read().await;
 
         for (id, (_node, storage)) in rt.iter() {
-            self.assert_storage_state_with_sto(storage, id, expect_term, expect_last_log, expect_voted_for, expect_sm_last_applied_log, &expect_snapshot).await?;
+            self.assert_storage_state_with_sto(
+                storage,
+                id,
+                expect_term,
+                expect_last_log,
+                expect_voted_for,
+                expect_sm_last_applied_log,
+                &expect_snapshot,
+            )
+            .await?;
         }
 
         Ok(())


### PR DESCRIPTION
Fix: add unit test for save leader_id if a higher term is seen when handling append-entries RPC, related to pr https://github.com/datafuselabs/openraft/pull/95