### PR TITLE
Refactor: use Option<LogId> every where

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use crate::core::client::ClientRequestEntry;
-use crate::core::EffectiveMembership;
 use crate::core::LeaderState;
 use crate::core::LearnerState;
 use crate::core::State;
@@ -15,6 +14,7 @@ use crate::raft::AddLearnerResponse;
 use crate::raft::ClientWriteResponse;
 use crate::raft::EntryPayload;
 use crate::raft::RaftRespTx;
+use crate::raft_types::LogIdOptionExt;
 use crate::AppData;
 use crate::AppDataResponse;
 use crate::LogId;
@@ -31,10 +31,12 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         &mut self,
         mut members: BTreeSet<NodeId>,
     ) -> Result<(), InitializeError> {
-        if self.core.last_log_id.is_none() || self.core.current_term != 0 {
+        // TODO(xp): simplify this condition
+
+        if self.core.last_log_id.is_some() || self.core.current_term != 0 {
             tracing::error!(
-                { last_log_id=?self.core.last_log_id, self.core.current_term },
-                "rejecting init_with_config request as last_log_index is not None or current_term is 0");
+                last_log_id=?self.core.last_log_id, self.core.current_term,
+                "rejecting init_with_config request as last_log_index is not None or current_term is not 0");
             return Err(InitializeError::NotAllowed);
         }
 
@@ -43,17 +45,16 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             members.insert(self.core.id);
         }
 
-        // Build a new membership config from given init data & assign it as the new cluster
-        // membership config in memory only.
-        self.core.effective_membership = EffectiveMembership {
-            log_id: LogId { term: 1, index: 1 },
-            membership: Membership::new_single(members),
-        };
+        let membership = Membership::new_single(members);
+
+        let payload = EntryPayload::Membership(membership.clone());
+        let _ent = self.core.append_payload_to_log(payload).await?;
 
         // Become a candidate and start campaigning for leadership. If this node is the only node
         // in the cluster, then become leader without holding an election. If members len == 1, we
         // know it is our ID due to the above code where we ensure our own ID is present.
         if self.core.effective_membership.membership.all_nodes().len() == 1 {
+            // TODO(xp): remove this simplified shortcut.
             self.core.current_term += 1;
             self.core.voted_for = Some(self.core.id);
 
@@ -83,7 +84,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         if target == self.core.id {
             tracing::debug!("target node is this node");
             let _ = tx.send(Ok(AddLearnerResponse {
-                matched: self.core.last_log_id.expect("raft core is uninitialized."),
+                matched: self.core.last_log_id,
             }));
             return;
         }
@@ -102,9 +103,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             self.nodes.insert(target, state);
 
             // non-blocking mode, do not know about the replication stat.
-            let _ = tx.send(Ok(AddLearnerResponse {
-                matched: LogId::new(0, 0),
-            }));
+            let _ = tx.send(Ok(AddLearnerResponse { matched: None }));
         }
     }
 
@@ -125,7 +124,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
         // The last membership config is not committed yet.
         // Can not process the next one.
-        if self.core.committed < self.core.effective_membership.log_id {
+        if self.core.committed < Some(self.core.effective_membership.log_id) {
             let _ = tx.send(Err(ClientWriteError::ChangeMembershipError(
                 ChangeMembershipError::InProgress {
                     membership_log_id: self.core.effective_membership.log_id,
@@ -154,7 +153,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         for new_node in members.difference(curr.all_nodes()) {
             match self.nodes.get(new_node) {
                 Some(node) => {
-                    if node.is_line_rate(&self.core.last_log_id.unwrap_or_default(), &self.core.config) {
+                    if node.is_line_rate(&self.core.last_log_id, &self.core.config) {
                         // Node is ready to join.
                         continue;
                     }
@@ -165,7 +164,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
                             ChangeMembershipError::LearnerIsLagging {
                                 node_id: *new_node,
                                 matched: node.matched,
-                                distance: self.core.last_log_id.unwrap().index.saturating_sub(node.matched.index),
+                                distance: self.core.last_log_id.next_index().saturating_sub(node.matched.next_index()),
                             },
                         )));
                         return Ok(());
@@ -186,6 +185,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         Ok(())
     }
 
+    // TODO(xp): remove this
     #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=self.core.id))]
     pub async fn append_membership_log(
         &mut self,
@@ -193,13 +193,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         resp_tx: Option<RaftRespTx<ClientWriteResponse<R>, ClientWriteError>>,
     ) -> Result<(), StorageError> {
         let payload = EntryPayload::Membership(mem.clone());
-        let entry = self.append_payload_to_log(payload).await?;
-
-        // Caveat: membership must be updated before commit check is done with the new config.
-        self.core.effective_membership = EffectiveMembership {
-            log_id: entry.log_id,
-            membership: mem,
-        };
+        let entry = self.core.append_payload_to_log(payload).await?;
 
         self.leader_report_metrics();
 
@@ -268,7 +262,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
             if let Some(n) = n {
                 if let Some(since) = n.remove_since {
-                    if n.matched.index < since {
+                    if n.matched.index() < Some(since) {
                         return false;
                     }
                 } else {

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -24,7 +24,6 @@ use crate::raft::RaftRespTx;
 use crate::replication::RaftEvent;
 use crate::AppData;
 use crate::AppDataResponse;
-use crate::LogId;
 use crate::MessageSummary;
 use crate::RaftNetwork;
 use crate::RaftStorage;
@@ -52,21 +51,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Commit the initial entry which new leaders are obligated to create when first coming to power, per §8.
     #[tracing::instrument(level = "trace", skip(self))]
     pub(super) async fn commit_initial_leader_entry(&mut self) -> Result<(), StorageError> {
-        // If the cluster has just formed, and the current index is 0, then commit the current
-        // config, else a blank payload.
-        let req: ClientWriteRequest<D> =
-            if self.core.last_log_id.expect("leader's raft core is uninitialized.").index == 0 {
-                ClientWriteRequest::new_config(self.core.effective_membership.membership.clone())
-            } else {
-                ClientWriteRequest::new_blank()
-            };
-
-        // Commit the initial payload to the cluster.
-        let entry = self.append_payload_to_log(req.payload).await?;
-        self.core.last_log_id = self.core.last_log_id.map(|mut last_log_id| {
-            last_log_id.term = self.core.current_term;
-            last_log_id
-        }); // This only ever needs to be updated once per term.
+        let entry = self.core.append_payload_to_log(EntryPayload::Blank).await?;
 
         self.leader_report_metrics();
 
@@ -74,7 +59,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             entry: Arc::new(entry),
             tx: None,
         };
-        // TODO(xp): it should update the lost_log_id
+
         self.replicate_client_request(cr_entry).await?;
 
         Ok(())
@@ -187,7 +172,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         rpc: ClientWriteRequest<D>,
         tx: RaftRespTx<ClientWriteResponse<R>, ClientWriteError>,
     ) -> Result<(), StorageError> {
-        let entry = self.append_payload_to_log(rpc.payload).await?;
+        let entry = self.core.append_payload_to_log(rpc.payload).await?;
         let entry = ClientRequestEntry {
             entry: Arc::new(entry),
             tx: Some(tx),
@@ -197,27 +182,6 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
         self.replicate_client_request(entry).await?;
         Ok(())
-    }
-
-    /// Transform the given payload into an entry, assign an index and term, and append the entry to the log.
-    #[tracing::instrument(level = "debug", skip(self, payload))]
-    pub(super) async fn append_payload_to_log(&mut self, payload: EntryPayload<D>) -> Result<Entry<D>, StorageError> {
-        let entry = Entry {
-            log_id: LogId {
-                index: self.core.last_log_id.expect("raft core is uninitialized.").index + 1,
-                term: self.core.current_term,
-            },
-            payload,
-        };
-        self.core.storage.append_to_log(&[&entry]).await?;
-
-        tracing::debug!("append log: {}", entry.summary());
-        self.core.last_log_id = self.core.last_log_id.map(|mut log_id| {
-            log_id.index = entry.log_id.index;
-            log_id
-        });
-
-        Ok(entry)
     }
 
     /// Begin the process of replicating the given client request.
@@ -246,8 +210,8 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             self.awaiting_committed.push(req);
         } else {
             // Else, there are no voting nodes for replication, so the payload is now committed.
-            self.core.committed = entry_arc.log_id;
-            tracing::debug!(%self.core.committed, "update committed, no need to replicate");
+            self.core.committed = Some(entry_arc.log_id);
+            tracing::debug!(?self.core.committed, "update committed, no need to replicate");
 
             self.leader_report_metrics();
             self.client_request_post_commit(req).await?;
@@ -342,12 +306,16 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         let log_id = &entry.log_id;
         let index = log_id.index;
 
-        let expected_next_index = self.core.last_applied.index + 1;
+        let expected_next_index = match self.core.last_applied {
+            None => 0,
+            Some(log_id) => log_id.index + 1,
+        };
+
         if index != expected_next_index {
             let entries = self.core.storage.get_log_entries(expected_next_index..index).await?;
 
             if let Some(entry) = entries.last() {
-                self.core.last_applied = entry.log_id;
+                self.core.last_applied = Some(entry.log_id);
             }
 
             let data_entries: Vec<_> = entries.iter().collect();
@@ -370,7 +338,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         .await?;
 
         // TODO(xp): deal with partial apply.
-        self.core.last_applied = *log_id;
+        self.core.last_applied = Some(*log_id);
         self.leader_report_metrics();
 
         // TODO(xp) merge this function to replication_to_state_machine?

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -239,13 +239,13 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             delete_applied_logs(self.storage.clone(), &last_applied, self.config.max_applied_log_to_keep).await?;
 
             // snapshot is installed
-            self.last_applied = last_applied;
+            self.last_applied = Some(last_applied);
 
             if self.committed < self.last_applied {
                 self.committed = self.last_applied;
             }
-            if self.last_log_id < Some(self.last_applied) {
-                self.last_log_id = Some(self.last_applied);
+            if self.last_log_id < self.last_applied {
+                self.last_log_id = self.last_applied;
             }
 
             // There could be unknown membership in the snapshot.

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -39,14 +39,14 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             target,
             self.core.current_term,
             self.core.config.clone(),
-            self.core.last_log_id.expect("raft core is uninitialized."),
+            self.core.last_log_id,
             self.core.committed,
             self.core.network.clone(),
             self.core.storage.clone(),
             self.replication_tx.clone(),
         );
         ReplicationState {
-            matched: LogId { term: 0, index: 0 },
+            matched: None,
             repl_stream,
             remove_since: None,
             tx: caller_tx,
@@ -90,18 +90,18 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn handle_update_matched(&mut self, target: NodeId, matched: LogId) -> Result<(), StorageError> {
+    async fn handle_update_matched(&mut self, target: NodeId, matched: Option<LogId>) -> Result<(), StorageError> {
         // Update target's match index & check if it is awaiting removal.
 
         if let Some(state) = self.nodes.get_mut(&target) {
-            tracing::debug!("state.matched: {}, update to matched: {}", state.matched, matched);
+            tracing::debug!("state.matched: {:?}, update to matched: {:?}", state.matched, matched);
 
             assert!(matched >= state.matched, "the matched increments monotonically");
 
             state.matched = matched;
 
             // Issue a response on the learners response channel if needed.
-            if state.is_line_rate(&self.core.last_log_id.unwrap_or_default(), &self.core.config) {
+            if state.is_line_rate(&self.core.last_log_id, &self.core.config) {
                 // This replication became line rate.
 
                 // When adding a learner, it blocks until the replication becomes line-rate.
@@ -127,13 +127,13 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             return Ok(());
         }
 
-        let commit_index = self.calc_commit_log_id();
+        let commit_log_id = self.calc_commit_log_id();
 
         // Determine if we have a new commit index, accounting for joint consensus.
         // If a new commit index has been established, then update a few needed elements.
 
-        if commit_index > self.core.committed {
-            self.core.committed = commit_index;
+        if commit_log_id > self.core.committed {
+            self.core.committed = commit_log_id;
 
             // Update all replication streams based on new commit index.
             for node in self.nodes.values() {
@@ -150,7 +150,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
                 .awaiting_committed
                 .iter()
                 .enumerate()
-                .take_while(|(_idx, elem)| elem.entry.log_id <= self.core.committed)
+                .take_while(|(_idx, elem)| Some(elem.entry.log_id) <= self.core.committed)
                 .last()
                 .map(|(idx, _)| idx);
 
@@ -170,22 +170,25 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    fn update_leader_metrics(&mut self, target: NodeId, matched: LogId) {
-        tracing::debug!(%target, %matched, "update_leader_metrics");
+    fn update_leader_metrics(&mut self, target: NodeId, matched: Option<LogId>) {
+        tracing::debug!(%target, ?matched, "update_leader_metrics");
         self.leader_metrics.replication.insert(target, ReplicationMetrics { matched });
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    fn calc_commit_log_id(&self) -> LogId {
-        let repl_indexes = self.get_match_log_indexes();
+    fn calc_commit_log_id(&self) -> Option<LogId> {
+        let repl_indexes = self.get_match_log_ids();
 
         let committed = self.core.effective_membership.membership.greatest_majority_value(&repl_indexes);
 
-        *committed.unwrap_or(&self.core.committed)
+        // TODO(xp): remove this line
+        std::cmp::max(committed.cloned(), self.core.committed)
+
+        // *committed.unwrap_or(&self.core.committed)
     }
 
     /// Collect indexes of the greatest matching log on every replica(include the leader itself)
-    fn get_match_log_indexes(&self) -> BTreeMap<NodeId, LogId> {
+    fn get_match_log_ids(&self) -> BTreeMap<NodeId, LogId> {
         let node_ids = self.core.effective_membership.membership.all_nodes();
 
         let mut res = BTreeMap::new();
@@ -195,7 +198,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
                 self.core.last_log_id
             } else {
                 let repl_state = self.nodes.get(id);
-                Some(repl_state.map(|x| x.matched).unwrap_or_default())
+                repl_state.map(|x| x.matched).unwrap_or_default()
             };
 
             // Mismatching term can not prevent other replica with higher term log from being chosen as leader,

--- a/openraft/src/core/replication_state_test.rs
+++ b/openraft/src/core/replication_state_test.rs
@@ -4,33 +4,42 @@ use crate::LogId;
 
 #[test]
 fn test_is_line_rate() -> anyhow::Result<()> {
-    let m = LogId { term: 1, index: 10 };
+    let m = Some(LogId { term: 1, index: 10 });
+
+    let cfg = |n| Config {
+        replication_lag_threshold: n,
+        ..Default::default()
+    };
+
+    assert!(is_matched_upto_date(&None, &None, &cfg(0)), "matched, threshold=0");
     assert!(
-        is_matched_upto_date(&m, &LogId { term: 2, index: 10 }, &Config {
-            replication_lag_threshold: 0,
-            ..Default::default()
-        }),
+        is_matched_upto_date(&None, &Some(LogId { term: 2, index: 0 }), &cfg(1)),
+        "matched, threshold=1"
+    );
+    assert!(
+        !is_matched_upto_date(&None, &Some(LogId { term: 2, index: 0 }), &cfg(0)),
+        "not matched, threshold=1"
+    );
+
+    assert!(
+        is_matched_upto_date(&Some(LogId::new(0, 0)), &None, &cfg(0)),
+        "matched, threshold=0"
+    );
+
+    assert!(
+        is_matched_upto_date(&m, &Some(LogId { term: 2, index: 10 }), &cfg(0)),
         "matched, threshold=0"
     );
     assert!(
-        is_matched_upto_date(&m, &LogId { term: 2, index: 9 }, &Config {
-            replication_lag_threshold: 0,
-            ..Default::default()
-        }),
+        is_matched_upto_date(&m, &Some(LogId { term: 2, index: 9 }), &cfg(0)),
         "overflow, threshold=0"
     );
     assert!(
-        !is_matched_upto_date(&m, &LogId { term: 2, index: 11 }, &Config {
-            replication_lag_threshold: 0,
-            ..Default::default()
-        }),
+        !is_matched_upto_date(&m, &Some(LogId { term: 2, index: 11 }), &cfg(0)),
         "not caught up, threshold=0"
     );
     assert!(
-        is_matched_upto_date(&m, &LogId { term: 2, index: 11 }, &Config {
-            replication_lag_threshold: 1,
-            ..Default::default()
-        }),
+        is_matched_upto_date(&m, &Some(LogId { term: 2, index: 11 }), &cfg(1)),
         "caught up, threshold=1"
     );
     Ok(())

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -24,7 +24,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     #[tracing::instrument(level = "debug", skip(self, msg), fields(msg=%msg.summary()))]
     pub(super) async fn handle_vote_request(&mut self, msg: VoteRequest) -> Result<VoteResponse, VoteError> {
         tracing::debug!({candidate=msg.candidate_id, self.current_term, rpc_term=msg.term}, "start handle_vote_request");
-        let last_log_id = self.last_log_id.expect("raft core is uninitialized.");
+        let last_log_id = self.last_log_id;
 
         // If candidate's current term is less than this nodes current term, reject.
         if msg.term < self.current_term {
@@ -115,6 +115,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Handle response from a vote request sent to a peer.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn handle_vote_response(&mut self, res: VoteResponse, target: NodeId) -> Result<(), StorageError> {
+        // TODO(xp): change membership from 123 to 4 may hangs I guess. Because this function will not be called.
         // If peer's term is greater than current term, revert to follower state.
 
         if res.term > self.core.current_term {
@@ -127,7 +128,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             // TODO(xp): This is a simplified impl: revert to follower as soon as seeing a higher `last_log_id`.
             //           When reverted to follower, it waits for heartbeat for 2 second before starting a new round of
             //           election.
-            if self.core.last_log_id < Some(res.last_log_id) {
+            if self.core.last_log_id < res.last_log_id {
                 self.core.set_target_state(State::Follower);
                 tracing::debug!("reverting to follower state due to greater term observed in RequestVote RPC response");
             } else {
@@ -136,7 +137,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
                     self_term=%self.core.current_term,
                     res_term=%res.term,
                     self_last_log_id=?self.core.last_log_id,
-                    res_last_log_id=%res.last_log_id,
+                    res_last_log_id=?res.last_log_id,
                     "I have lower term but higher or euqal last_log_id, keep trying to elect"
                 );
             }
@@ -164,11 +165,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         let (tx, rx) = mpsc::channel(all_nodes.len());
 
         for member in all_nodes.into_iter().filter(|member| member != &self.core.id) {
-            let rpc = VoteRequest::new(
-                self.core.current_term,
-                self.core.id,
-                self.core.last_log_id.expect("raft core is uninitialized."),
-            );
+            let rpc = VoteRequest::new(self.core.current_term, self.core.id, self.core.last_log_id);
 
             let (network, tx_inner) = (self.core.network.clone(), tx.clone());
             let _ = tokio::spawn(

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -18,6 +18,9 @@ use crate::StorageError;
 pub enum Fatal {
     #[error(transparent)]
     StorageError(#[from] StorageError),
+
+    #[error("raft stopped")]
+    Stopped,
 }
 
 /// Extract Fatal from a Result.
@@ -108,10 +111,10 @@ pub enum ChangeMembershipError {
     LearnerNotFound { node_id: NodeId },
 
     // TODO(xp): 111 test it
-    #[error("replication to learner {node_id} is lagging {distance}, matched: {matched}, can not add as member")]
+    #[error("replication to learner {node_id} is lagging {distance}, matched: {matched:?}, can not add as member")]
     LearnerIsLagging {
         node_id: NodeId,
-        matched: LogId,
+        matched: Option<LogId>,
         distance: u64,
     },
 
@@ -227,9 +230,9 @@ pub enum ReplicationError {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("store has no log at: {index}")]
+#[error("store has no log at: {index:?}")]
 pub struct LackEntry {
-    pub index: u64,
+    pub index: Option<u64>,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -39,6 +39,7 @@ pub use crate::metrics::RaftMetrics;
 pub use crate::network::RaftNetwork;
 pub use crate::raft::Raft;
 pub use crate::raft_types::LogId;
+pub use crate::raft_types::LogIdOptionExt;
 pub use crate::raft_types::SnapshotId;
 pub use crate::raft_types::SnapshotSegmentId;
 pub use crate::raft_types::StateMachineChanges;

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -34,6 +34,58 @@ impl LogId {
     }
 }
 
+pub trait LogIdOptionExt {
+    fn index(&self) -> Option<u64>;
+    fn next_index(&self) -> u64;
+}
+
+impl LogIdOptionExt for Option<LogId> {
+    fn index(&self) -> Option<u64> {
+        self.map(|x| x.index)
+    }
+
+    fn next_index(&self) -> u64 {
+        match self {
+            None => 0,
+            Some(log_id) => log_id.index + 1,
+        }
+    }
+}
+
+pub trait LogIndexOptionExt {
+    fn next_index(&self) -> u64;
+    fn prev_index(&self) -> Self;
+    fn add(&self, v: u64) -> Self;
+}
+
+impl LogIndexOptionExt for Option<u64> {
+    fn next_index(&self) -> u64 {
+        match self {
+            None => 0,
+            Some(v) => v + 1,
+        }
+    }
+
+    fn prev_index(&self) -> Self {
+        match self {
+            None => {
+                panic!("None has no previous value");
+            }
+            Some(v) => {
+                if *v == 0 {
+                    None
+                } else {
+                    Some(*v - 1)
+                }
+            }
+        }
+    }
+
+    fn add(&self, v: u64) -> Self {
+        Some(self.next_index() + v).prev_index()
+    }
+}
+
 // Everytime a snapshot is created, it is assigned with a globally unique id.
 pub type SnapshotId = String;
 

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -108,11 +108,11 @@ pub enum Violation {
     #[error("all logs are removed. It requires at least one log to track continuity")]
     StoreLogsEmpty,
 
-    #[error("logs are not consecutive, prev: {prev}, next: {next}")]
-    LogsNonConsecutive { prev: LogId, next: LogId },
+    #[error("logs are not consecutive, prev: {prev:?}, next: {next}")]
+    LogsNonConsecutive { prev: Option<LogId>, next: LogId },
 
-    #[error("invalid next log to apply: prev: {prev}, next: {next}")]
-    ApplyNonConsecutive { prev: LogId, next: LogId },
+    #[error("invalid next log to apply: prev: {prev:?}, next: {next}")]
+    ApplyNonConsecutive { prev: Option<LogId>, next: LogId },
 }
 
 /// A storage error could be either a defensive check error or an error occurred when doing the actual io operation.

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -143,12 +143,7 @@ where
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn first_known_log_id(&self) -> Result<LogId, StorageError> {
-        self.inner().first_known_log_id().await
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    async fn last_applied_state(&self) -> Result<(LogId, Option<EffectiveMembership>), StorageError> {
+    async fn last_applied_state(&self) -> Result<(Option<LogId>, Option<EffectiveMembership>), StorageError> {
         self.inner().last_applied_state().await
     }
 

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
@@ -13,7 +14,7 @@ use openraft::MessageSummary;
 use openraft::RaftStorage;
 use openraft::State;
 
-use crate::fixtures::ent;
+use crate::fixtures::blank;
 use crate::fixtures::RaftRouter;
 
 /// Test append-entries response in every case.
@@ -29,29 +30,56 @@ async fn append_conflicts() -> Result<()> {
     let router = Arc::new(RaftRouter::new(config.clone()));
     router.new_raft_node(0).await;
 
-    let n_logs = 0;
-
     tracing::info!("--- wait for init node to ready");
 
-    router.wait_for_log(&btreeset![0], n_logs, None, "empty").await?;
-    router.wait_for_state(&btreeset![0], State::Learner, None, "empty").await?;
+    router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
+    router.wait_for_state(&btreeset![0], State::Learner, timeout(), "empty").await?;
 
     let (r0, sto0) = router.remove_node(0).await.unwrap();
-    check_logs(&sto0, vec![0]).await?;
+    check_logs(&sto0, vec![]).await?;
 
-    tracing::info!("--- case 0: prev_log_id.index == 0, no logs");
+    tracing::info!("--- case 0: prev_log_id == None, no logs");
 
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(0, 0),
+        prev_log_id: None,
         entries: vec![],
-        leader_commit: LogId::new(1, 2),
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req.clone()).await?;
-    assert!(resp.success());
-    assert_eq!(None, resp.conflict);
+
+    assert!(resp.success);
+    assert!(!resp.conflict);
+
+    tracing::info!("--- case 0: prev_log_id == None, 1 logs");
+
+    let req = AppendEntriesRequest {
+        term: 1,
+        leader_id: 0,
+        prev_log_id: None,
+        entries: vec![blank(0, 0)],
+        leader_commit: Some(LogId::new(1, 2)),
+    };
+
+    let resp = r0.append_entries(req.clone()).await?;
+    assert!(resp.success);
+    assert!(!resp.conflict);
+
+    tracing::info!("--- case 0: prev_log_id == 1-1, 0 logs");
+
+    let req = AppendEntriesRequest {
+        term: 1,
+        leader_id: 0,
+        prev_log_id: Some(LogId::new(0, 0)),
+        entries: vec![],
+        leader_commit: Some(LogId::new(1, 2)),
+    };
+
+    let resp = r0.append_entries(req.clone()).await?;
+    assert!(resp.success);
+    assert!(!resp.conflict);
 
     check_logs(&sto0, vec![0]).await?;
 
@@ -60,23 +88,23 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(0, 0),
-        entries: vec![ent(1, 1), ent(1, 2), ent(1, 3), ent(1, 4)],
+        prev_log_id: Some(LogId::new(0, 0)),
+        entries: vec![blank(1, 1), blank(1, 2), blank(1, 3), blank(1, 4)],
         // this set the last_applied to 2
-        leader_commit: LogId::new(1, 2),
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req.clone()).await?;
-    assert!(resp.success());
-    assert_eq!(None, resp.conflict);
+    assert!(resp.success);
+    assert!(!resp.conflict);
 
     check_logs(&sto0, vec![0, 1, 1, 1, 1]).await?;
 
     tracing::info!("--- case 0: prev_log_id.index == 0, last_log_id mismatch");
 
     let resp = r0.append_entries(req.clone()).await?;
-    assert!(resp.success());
-    assert_eq!(None, resp.conflict);
+    assert!(resp.success);
+    assert!(!resp.conflict);
 
     check_logs(&sto0, vec![0, 1, 1, 1, 1]).await?;
 
@@ -86,14 +114,14 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(1, 1),
-        entries: vec![ent(1, 2)],
-        leader_commit: LogId::new(1, 2),
+        prev_log_id: Some(LogId::new(1, 1)),
+        entries: vec![blank(1, 2)],
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req).await?;
-    assert!(resp.success());
-    assert_eq!(None, resp.conflict);
+    assert!(resp.success);
+    assert!(!resp.conflict);
 
     check_logs(&sto0, vec![0, 1, 1, 1, 1]).await?;
 
@@ -102,15 +130,15 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(1, 2),
-        entries: vec![ent(2, 3)],
+        prev_log_id: Some(LogId::new(1, 2)),
+        entries: vec![blank(2, 3)],
         // this set the last_applied to 2
-        leader_commit: LogId::new(1, 2),
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req).await?;
-    assert!(resp.success());
-    assert_eq!(None, resp.conflict);
+    assert!(resp.success);
+    assert!(!resp.conflict);
 
     check_logs(&sto0, vec![0, 1, 1, 2]).await?;
 
@@ -118,14 +146,14 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(1, 2000),
+        prev_log_id: Some(LogId::new(1, 2000)),
         entries: vec![],
-        leader_commit: LogId::new(1, 2),
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req).await?;
-    assert!(!resp.success());
-    assert_eq!(Some(LogId::new(1, 2000)), resp.conflict);
+    assert!(!resp.success);
+    assert!(resp.conflict);
 
     check_logs(&sto0, vec![0, 1, 1, 2]).await?;
 
@@ -134,15 +162,14 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(3, 3),
+        prev_log_id: Some(LogId::new(3, 3)),
         entries: vec![],
-        leader_commit: LogId::new(1, 2),
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req).await?;
-    assert!(!resp.success());
-    // returns the id just before prev_log_id.index
-    assert_eq!(Some(LogId::new(3, 3)), resp.conflict);
+    assert!(!resp.success);
+    assert!(resp.conflict);
 
     check_logs(&sto0, vec![0, 1, 1]).await?;
 
@@ -151,14 +178,14 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(1, 2),
-        entries: vec![ent(2, 3), ent(2, 4), ent(2, 5)],
-        leader_commit: LogId::new(1, 2),
+        prev_log_id: Some(LogId::new(1, 2)),
+        entries: vec![blank(2, 3), blank(2, 4), blank(2, 5)],
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req).await?;
-    assert!(resp.success());
-    assert_eq!(None, resp.conflict);
+    assert!(resp.success);
+    assert!(!resp.conflict);
 
     // check prepared store
     check_logs(&sto0, vec![0, 1, 1, 2, 2, 2]).await?;
@@ -167,14 +194,14 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(2, 3),
-        entries: vec![ent(3, 4)],
-        leader_commit: LogId::new(1, 2),
+        prev_log_id: Some(LogId::new(2, 3)),
+        entries: vec![blank(3, 4)],
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req).await?;
-    assert!(resp.success());
-    assert_eq!(None, resp.conflict);
+    assert!(resp.success);
+    assert!(!resp.conflict);
 
     check_logs(&sto0, vec![0, 1, 1, 2, 3]).await?;
 
@@ -184,14 +211,14 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         term: 1,
         leader_id: 0,
-        prev_log_id: LogId::new(1, 200),
+        prev_log_id: Some(LogId::new(1, 200)),
         entries: vec![],
-        leader_commit: LogId::new(1, 2),
+        leader_commit: Some(LogId::new(1, 2)),
     };
 
     let resp = r0.append_entries(req).await?;
-    assert!(!resp.success());
-    assert_eq!(Some(LogId::new(1, 200)), resp.conflict);
+    assert!(!resp.success);
+    assert!(resp.conflict);
 
     Ok(())
 }
@@ -209,10 +236,14 @@ where
         .iter()
         .skip(skip)
         .enumerate()
-        .map(|(i, term)| ent(*term, (i + skip) as u64))
+        .map(|(i, term)| blank(*term, (i + skip) as u64))
         .collect::<Vec<_>>();
 
     assert_eq!(want.as_slice().summary(), logs.as_slice().summary());
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -30,13 +30,13 @@ async fn append_entries_with_bigger_term() -> Result<()> {
     let req = AppendEntriesRequest::<memstore::ClientRequest> {
         term: 2,
         leader_id: 1,
-        prev_log_id: LogId::new(1, n_logs),
+        prev_log_id: Some(LogId::new(1, n_logs)),
         entries: vec![],
-        leader_commit: LogId::new(1, n_logs),
+        leader_commit: Some(LogId::new(1, n_logs)),
     };
 
     let resp = router.send_append_entries(0, req).await?;
-    assert!(resp.success());
+    assert!(resp.success);
 
     // after append entries, check hard state in term 2  and vote for node 1
     router

--- a/openraft/tests/client_api/t10_client_writes.rs
+++ b/openraft/tests/client_api/t10_client_writes.rs
@@ -41,7 +41,7 @@ async fn client_writes() -> Result<()> {
     let mut n_logs = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "empty").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0, 1, 2], State::Learner, None, "empty").await?;
     router.assert_pristine_cluster().await;
 
@@ -50,7 +50,7 @@ async fn client_writes() -> Result<()> {
     router.initialize_from_single_node(0).await?;
     n_logs += 1;
 
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "leader init log").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], Some(n_logs), None, "leader init log").await?;
     router.wait_for_state(&btreeset![0], State::Leader, None, "cluster leader").await?;
     router.wait_for_state(&btreeset![1, 2], State::Follower, None, "cluster follower").await?;
 
@@ -68,7 +68,7 @@ async fn client_writes() -> Result<()> {
     while clients.next().await.is_some() {}
 
     n_logs += 500 * 6;
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "sync logs").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], Some(n_logs), None, "sync logs").await?;
 
     router.assert_stable_cluster(Some(1), Some(n_logs)).await; // The extra 1 is from the leader's initial commit entry.
 
@@ -78,7 +78,7 @@ async fn client_writes() -> Result<()> {
             n_logs,
             Some(0),
             LogId::new(1, n_logs),
-            Some(((2000..2100).into(), 1)),
+            Some(((1999..2100).into(), 1)),
         )
         .await?;
 

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -29,7 +29,7 @@ async fn client_reads() -> Result<()> {
     let mut n_logs = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "empty node").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], None, None, "empty node").await?;
     router.wait_for_state(&btreeset![0, 1, 2], State::Learner, None, "empty node").await?;
     router.assert_pristine_cluster().await;
 
@@ -38,7 +38,7 @@ async fn client_reads() -> Result<()> {
     router.initialize_from_single_node(0).await?;
     n_logs += 1;
 
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "init leader").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], Some(n_logs), None, "init leader").await?;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Get the ID of the leader, and assert that client_read succeeds.

--- a/openraft/tests/concurrent_write_and_add_learner.rs
+++ b/openraft/tests/concurrent_write_and_add_learner.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use fixtures::RaftRouter;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::LogIdOptionExt;
 use openraft::State;
 use tracing_futures::Instrument;
 
@@ -149,7 +150,7 @@ async fn wait_log(
         router
             .wait_for_metrics(
                 i,
-                |x| x.last_applied == want_log,
+                |x| x.last_applied.index() == Some(want_log),
                 Some(timeout),
                 &format!("n{}.last_applied -> {}", i, want_log),
             )

--- a/openraft/tests/elect_compare_last_log.rs
+++ b/openraft/tests/elect_compare_last_log.rs
@@ -13,6 +13,8 @@ use openraft::Membership;
 use openraft::RaftStorage;
 use openraft::State;
 
+use crate::fixtures::blank;
+
 #[macro_use]
 mod fixtures;
 
@@ -40,7 +42,7 @@ async fn elect_compare_last_log() -> Result<()> {
         })
         .await?;
 
-        sto0.append_to_log(&[&Entry {
+        sto0.append_to_log(&[&blank(0, 0), &Entry {
             log_id: LogId { term: 2, index: 1 },
             payload: EntryPayload::Membership(Membership::new_single(btreeset! {0,1})),
         }])
@@ -56,14 +58,12 @@ async fn elect_compare_last_log() -> Result<()> {
         .await?;
 
         sto1.append_to_log(&[
+            &blank(0, 0),
             &Entry {
                 log_id: LogId { term: 1, index: 1 },
                 payload: EntryPayload::Membership(Membership::new_single(btreeset! {0,1})),
             },
-            &Entry {
-                log_id: LogId { term: 1, index: 2 },
-                payload: EntryPayload::Blank,
-            },
+            &blank(1, 2),
         ])
         .await?;
     }

--- a/openraft/tests/initialization.rs
+++ b/openraft/tests/initialization.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use fixtures::RaftRouter;
@@ -36,24 +37,24 @@ async fn initialization() -> Result<()> {
     router.new_raft_node(1).await;
     router.new_raft_node(2).await;
 
-    let mut n_logs = 0;
+    let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "empty").await?;
-    router.wait_for_state(&btreeset![0, 1, 2], State::Learner, None, "empty").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], None, timeout(), "empty").await?;
+    router.wait_for_state(&btreeset![0, 1, 2], State::Learner, timeout(), "empty").await?;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    n_logs += 1;
+    log_index += 1;
 
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "init").await?;
-    router.assert_stable_cluster(Some(1), Some(n_logs)).await;
+    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), timeout(), "init").await?;
+    router.assert_stable_cluster(Some(1), Some(log_index)).await;
 
     for i in 0..3 {
         let sto = router.get_storage_handle(&1).await?;
-        let first = sto.get_log_entries(1..2).await?.first().cloned();
+        let first = sto.get_log_entries(0..2).await?.first().cloned();
 
         tracing::info!("--- check membership is replicated: id: {}, first log: {:?}", i, first);
         let mem = match first.unwrap().payload {
@@ -67,7 +68,7 @@ async fn initialization() -> Result<()> {
         let sm_mem = sto.last_applied_state().await?.1;
         assert_eq!(
             Some(EffectiveMembership {
-                log_id: LogId { term: 1, index: 1 },
+                log_id: LogId { term: 0, index: 0 },
                 membership: Membership::new_single(btreeset! {0,1,2})
             }),
             sm_mem
@@ -75,4 +76,8 @@ async fn initialization() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/log_compaction/compaction.rs
+++ b/openraft/tests/log_compaction/compaction.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
-use openraft::raft::Entry;
-use openraft::raft::EntryPayload;
 use openraft::Config;
 use openraft::LogId;
 use openraft::RaftNetwork;
@@ -12,6 +11,7 @@ use openraft::RaftStorage;
 use openraft::SnapshotPolicy;
 use openraft::State;
 
+use crate::fixtures::blank;
 use crate::fixtures::RaftRouter;
 
 /// Compaction test.
@@ -40,48 +40,59 @@ async fn compaction() -> Result<()> {
     let router = Arc::new(RaftRouter::new(config.clone()));
     router.new_raft_node(0).await;
 
-    let mut n_logs = 0;
+    let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0], n_logs, None, "empty").await?;
-    router.wait_for_state(&btreeset![0], State::Learner, None, "empty").await?;
+    router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
+    router.wait_for_state(&btreeset![0], State::Learner, timeout(), "empty").await?;
 
     router.assert_pristine_cluster().await;
 
     tracing::info!("--- initializing cluster");
 
     router.initialize_from_single_node(0).await?;
-    n_logs += 1;
+    log_index += 1;
 
-    router.wait_for_log(&btreeset![0], n_logs, None, "init leader").await?;
+    router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init leader").await?;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Send enough requests to the cluster that compaction on the node should be triggered.
     // Puts us exactly at the configured snapshot policy threshold.
-    router.client_request_many(0, "0", (snapshot_threshold - n_logs) as usize).await;
-    n_logs = snapshot_threshold;
 
-    router.wait_for_log(&btreeset![0], n_logs, None, "write").await?;
-    router.assert_stable_cluster(Some(1), Some(n_logs)).await;
-    router.wait_for_snapshot(&btreeset![0], LogId { term: 1, index: n_logs }, None, "snapshot").await?;
+    // Log at 0 count as 1
+    router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await;
+    log_index = snapshot_threshold - 1;
+
+    router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "write").await?;
+    router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    router
+        .wait_for_snapshot(
+            &btreeset![0],
+            LogId {
+                term: 1,
+                index: log_index,
+            },
+            None,
+            "snapshot",
+        )
+        .await?;
 
     router
         .assert_storage_state(
             1,
-            n_logs,
+            log_index,
             Some(0),
-            LogId { term: 1, index: n_logs },
-            Some((n_logs.into(), 1)),
+            LogId {
+                term: 1,
+                index: log_index,
+            },
+            Some((log_index.into(), 1)),
         )
         .await?;
 
     // Add a new node and assert that it received the same snapshot.
     let sto1 = router.new_store(1).await;
-    sto1.append_to_log(&[&Entry {
-        log_id: LogId { term: 1, index: 1 },
-        payload: EntryPayload::Blank,
-    }])
-    .await?;
+    sto1.append_to_log(&[&blank(0, 0), &blank(1, 1)]).await?;
 
     router.new_raft_node_with_sto(1, sto1.clone()).await;
     router.add_learner(0, 1).await.expect("failed to add new node as learner");
@@ -89,26 +100,30 @@ async fn compaction() -> Result<()> {
     tracing::info!("--- add 1 log after snapshot");
     {
         router.client_request_many(0, "0", 1).await;
-        n_logs += 1;
+        log_index += 1;
     }
 
-    router.wait_for_log(&btreeset![0, 1], n_logs, None, "add follower").await?;
+    router.wait_for_log(&btreeset![0, 1], Some(log_index), timeout(), "add follower").await?;
 
     tracing::info!("--- logs should be deleted after installing snapshot; left only the last one");
     {
         let sto = router.get_storage_handle(&1).await?;
         let logs = sto.get_log_entries(..).await?;
         assert_eq!(1, logs.len());
-        assert_eq!(LogId { term: 1, index: 51 }, logs[0].log_id)
+        assert_eq!(LogId { term: 1, index: 50 }, logs[0].log_id)
     }
 
-    let expected_snap = Some((snapshot_threshold.into(), 1));
+    // log 0 counts
+    let expected_snap = Some(((snapshot_threshold - 1).into(), 1));
     router
         .assert_storage_state(
             1,
-            n_logs,
+            log_index,
             None, /* learner does not vote */
-            LogId { term: 1, index: n_logs },
+            LogId {
+                term: 1,
+                index: log_index,
+            },
             expected_snap,
         )
         .await?;
@@ -121,15 +136,19 @@ async fn compaction() -> Result<()> {
             .send_append_entries(1, AppendEntriesRequest {
                 term: 1,
                 leader_id: 0,
-                prev_log_id: LogId::new(1, 2),
+                prev_log_id: Some(LogId::new(1, 2)),
                 entries: vec![],
-                leader_commit: LogId::new(0, 0),
+                leader_commit: Some(LogId::new(0, 0)),
             })
             .await?;
 
-        assert!(res.success());
-        assert_eq!(None, res.conflict);
+        assert!(res.success);
+        assert!(!res.conflict);
     }
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -34,7 +34,7 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
         router.client_request_many(0, "non_voter_add", 100 - n_logs as usize).await;
         n_logs = 100;
 
-        router.wait(&0, timeout()).await?.log(n_logs, "received 100 logs").await?;
+        router.wait(&0, timeout()).await?.log(Some(n_logs), "received 100 logs").await?;
     }
 
     tracing::info!("--- change membership without adding-learner");
@@ -75,7 +75,7 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
     );
     let router = Arc::new(RaftRouter::new(config.clone()));
 
-    let mut n_logs = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
 
     tracing::info!("--- stop replication by isolating node 1");
     {
@@ -84,10 +84,10 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
 
     tracing::info!("--- write up to 100 logs");
     {
-        router.client_request_many(0, "non_voter_add", 500 - n_logs as usize).await;
-        n_logs = 500;
+        router.client_request_many(0, "non_voter_add", 500 - log_index as usize).await;
+        log_index = 500;
 
-        router.wait(&0, timeout()).await?.log(n_logs, "received 500 logs").await?;
+        router.wait(&0, timeout()).await?.log(Some(log_index), "received 500 logs").await?;
     }
 
     tracing::info!("--- restore replication and change membership at once, expect NonVoterIsLagging");

--- a/openraft/tests/membership/t25_elect_with_new_config.rs
+++ b/openraft/tests/membership/t25_elect_with_new_config.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use futures::stream::StreamExt;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::LogIdOptionExt;
 use openraft::State;
 use tokio::time::sleep;
 
@@ -35,7 +36,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     let mut n_logs = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0], n_logs, None, "empty").await?;
+    router.wait_for_log(&btreeset![0], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0], State::Learner, None, "empty").await?;
     router.assert_pristine_cluster().await;
 
@@ -44,7 +45,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     router.initialize_from_single_node(0).await?;
     n_logs += 1;
 
-    router.wait_for_log(&btreeset![0], n_logs, None, "init").await?;
+    router.wait_for_log(&btreeset![0], Some(n_logs), None, "init").await?;
     router.assert_stable_cluster(Some(1), Some(n_logs)).await;
 
     // Sync some new nodes.
@@ -67,7 +68,9 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     router.change_membership(0, btreeset![0, 1, 2, 3, 4]).await?;
     n_logs += 2;
 
-    router.wait_for_log(&btreeset![0, 1, 2, 3, 4], n_logs, None, "cluster of 5 candidates").await?;
+    router
+        .wait_for_log(&btreeset![0, 1, 2, 3, 4], Some(n_logs), None, "cluster of 5 candidates")
+        .await?;
     router.assert_stable_cluster(Some(1), Some(n_logs)).await; // Still in term 1, so leader is still node 0.
 
     // Isolate old leader and assert that a new leader takes over.
@@ -92,7 +95,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     let applied = metrics.last_applied;
     let leader_id = metrics.current_leader;
 
-    router.assert_stable_cluster(Some(term), Some(applied)).await;
+    router.assert_stable_cluster(Some(term), applied.index()).await;
     let leader = router.leader().await.expect("expected new leader");
     assert!(leader != 0, "expected new leader to be different from the old leader");
 
@@ -107,7 +110,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
         )
         .await?;
 
-    router.assert_stable_cluster(Some(term), Some(applied)).await;
+    router.assert_stable_cluster(Some(term), applied.index()).await;
 
     let current_leader = router.leader().await.expect("expected to find current leader");
     assert_eq!(leader, current_leader, "expected cluster leadership to stay the same");

--- a/openraft/tests/membership/t40_removed_follower.rs
+++ b/openraft/tests/membership/t40_removed_follower.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::LogIdOptionExt;
 
 use crate::fixtures::RaftRouter;
 
@@ -55,7 +56,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
             router
                 .wait(i, timeout())
                 .await?
-                .metrics(|x| x.last_applied >= n_logs, "new cluster recv new logs")
+                .metrics(|x| x.last_applied.index() >= Some(n_logs), "new cluster recv new logs")
                 .await?;
         }
     }
@@ -64,7 +65,10 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
         router
             .wait(i, timeout())
             .await?
-            .metrics(|x| x.last_applied < n_logs, "old cluster does not recv new logs")
+            .metrics(
+                |x| x.last_applied.index() < Some(n_logs),
+                "old cluster does not recv new logs",
+            )
             .await?;
     }
 

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -44,7 +44,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     tracing::info!("--- wait for log to sync");
     let n_logs = 2u64;
     for node_id in 0..2 {
-        router.wait_for_log(&btreeset![node_id], n_logs, None, "write one log").await?;
+        router.wait_for_log(&btreeset![node_id], Some(n_logs), None, "write one log").await?;
         let sto = router.get_storage_handle(&node_id).await?;
         assert!(sto.get_state_machine().await.client_status.get("foo").is_some());
     }

--- a/openraft/tests/metrics/t40_metrics_wait.rs
+++ b/openraft/tests/metrics/t40_metrics_wait.rs
@@ -28,13 +28,13 @@ async fn metrics_wait() -> Result<()> {
     let cluster = btreeset![0];
     router.new_raft_node(0).await;
     router.initialize_with(0, cluster.clone()).await?;
-    router.wait_for_state(&cluster, State::Leader, None, "init").await?;
+    router.wait_for_state(&cluster, State::Leader, timeout(), "init").await?;
     router.wait(&0, None).await?.current_leader(0, "become leader").await?;
-    router.wait_for_log(&cluster, 1, None, "initial log").await?;
+    router.wait_for_log(&cluster, Some(1), None, "initial log").await?;
 
     tracing::info!("--- wait and timeout");
 
-    let rst = router.wait(&0, Some(Duration::from_millis(200))).await?.log(2, "timeout waiting for log 2").await;
+    let rst = router.wait(&0, timeout()).await?.log(Some(2), "timeout waiting for log 2").await;
 
     match rst {
         Ok(_) => {
@@ -53,4 +53,8 @@ async fn metrics_wait() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/shutdown.rs
+++ b/openraft/tests/shutdown.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::anyhow;
 use anyhow::Result;
@@ -29,28 +30,36 @@ async fn initialization() -> Result<()> {
     router.new_raft_node(1).await;
     router.new_raft_node(2).await;
 
-    let mut n_logs = 0;
+    let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "empty").await?;
-    router.wait_for_state(&btreeset![0, 1, 2], State::Learner, None, "empty").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], None, timeout(), "empty").await?;
+    router.wait_for_state(&btreeset![0, 1, 2], State::Learner, timeout(), "empty").await?;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    n_logs += 1;
+    log_index += 1;
 
-    router.wait_for_log(&btreeset![0, 1, 2], n_logs, None, "init").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "init").await?;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     tracing::info!("--- performing node shutdowns");
-    let (node0, _) = router.remove_node(0).await.ok_or_else(|| anyhow!("failed to find node 0 in router"))?;
-    node0.shutdown().await?;
-    let (node1, _) = router.remove_node(1).await.ok_or_else(|| anyhow!("failed to find node 1 in router"))?;
-    node1.shutdown().await?;
-    let (node2, _) = router.remove_node(2).await.ok_or_else(|| anyhow!("failed to find node 2 in router"))?;
-    node2.shutdown().await?;
+    {
+        let (node0, _) = router.remove_node(0).await.ok_or_else(|| anyhow!("failed to find node 0 in router"))?;
+        node0.shutdown().await?;
+
+        let (node1, _) = router.remove_node(1).await.ok_or_else(|| anyhow!("failed to find node 1 in router"))?;
+        node1.shutdown().await?;
+
+        let (node2, _) = router.remove_node(2).await.ok_or_else(|| anyhow!("failed to find node 2 in router"))?;
+        node2.shutdown().await?;
+    }
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/snapshot/snapshot_chunk_size.rs
+++ b/openraft/tests/snapshot/snapshot_chunk_size.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
@@ -33,31 +34,59 @@ async fn snapshot_chunk_size() -> Result<()> {
     );
     let router = Arc::new(RaftRouter::new(config.clone()));
 
-    let mut n_logs = 0;
+    let mut log_index = 0;
 
     tracing::info!("--- initializing cluster");
     {
         router.new_raft_node(0).await;
 
-        router.wait_for_log(&btreeset![0], n_logs, None, "empty").await?;
-        router.wait_for_state(&btreeset![0], State::Learner, None, "empty").await?;
+        router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
+        router.wait_for_state(&btreeset![0], State::Learner, timeout(), "empty").await?;
 
         router.initialize_from_single_node(0).await?;
-        n_logs += 1;
+        log_index += 1;
 
-        router.wait_for_log(&btreeset![0], n_logs, None, "init leader").await?;
+        router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init leader").await?;
     }
 
     tracing::info!("--- send just enough logs to trigger snapshot");
     {
-        router.client_request_many(0, "0", (snapshot_threshold - n_logs) as usize).await;
-        n_logs = snapshot_threshold;
+        router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await;
+        log_index = snapshot_threshold - 1;
 
-        let want_snap = Some((n_logs.into(), 1));
+        let want_snap = Some((log_index.into(), 1));
 
-        router.wait_for_log(&btreeset![0], n_logs, None, "send log to trigger snapshot").await?;
-        router.wait_for_snapshot(&btreeset![0], LogId { term: 1, index: n_logs }, None, "snapshot").await?;
-        router.assert_storage_state(1, n_logs, Some(0), LogId { term: 1, index: n_logs }, want_snap).await?;
+        router
+            .wait_for_log(
+                &btreeset![0],
+                Some(log_index),
+                timeout(),
+                "send log to trigger snapshot",
+            )
+            .await?;
+        router
+            .wait_for_snapshot(
+                &btreeset![0],
+                LogId {
+                    term: 1,
+                    index: log_index,
+                },
+                None,
+                "snapshot",
+            )
+            .await?;
+        router
+            .assert_storage_state(
+                1,
+                log_index,
+                Some(0),
+                LogId {
+                    term: 1,
+                    index: log_index,
+                },
+                want_snap,
+            )
+            .await?;
     }
 
     tracing::info!("--- add learner to receive snapshot and logs");
@@ -65,20 +94,37 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.new_raft_node(1).await;
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
 
-        let want_snap = Some((n_logs.into(), 1));
+        let want_snap = Some((log_index.into(), 1));
 
-        router.wait_for_log(&btreeset![0, 1], n_logs, None, "add learner").await?;
-        router.wait_for_snapshot(&btreeset![1], LogId { term: 1, index: n_logs }, None, "").await?;
+        router.wait_for_log(&btreeset![0, 1], Some(log_index), timeout(), "add learner").await?;
+        router
+            .wait_for_snapshot(
+                &btreeset![1],
+                LogId {
+                    term: 1,
+                    index: log_index,
+                },
+                None,
+                "",
+            )
+            .await?;
         router
             .assert_storage_state(
                 1,
-                n_logs,
+                log_index,
                 None, /* learner does not vote */
-                LogId { term: 1, index: n_logs },
+                LogId {
+                    term: 1,
+                    index: log_index,
+                },
                 want_snap,
             )
             .await?;
     }
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use futures::stream::StreamExt;
@@ -6,6 +7,7 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::EffectiveMembership;
 use openraft::LogId;
+use openraft::LogIdOptionExt;
 use openraft::Membership;
 use openraft::RaftStorage;
 use openraft::State;
@@ -29,26 +31,26 @@ async fn state_machine_apply_membership() -> Result<()> {
     let router = Arc::new(RaftRouter::new(config.clone()));
     router.new_raft_node(0).await;
 
-    let mut n_logs = 0;
+    let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0], n_logs, None, "empty").await?;
+    router.wait_for_log(&btreeset![0], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0], State::Learner, None, "empty").await?;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    n_logs += 1;
+    log_index += 1;
 
-    router.wait_for_log(&btreeset![0], n_logs, None, "init").await?;
-    router.assert_stable_cluster(Some(1), Some(n_logs)).await;
+    router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init").await?;
+    router.assert_stable_cluster(Some(1), Some(log_index)).await;
 
     for i in 0..=0 {
         let sto = router.get_storage_handle(&i).await?;
         assert_eq!(
             Some(EffectiveMembership {
-                log_id: LogId { term: 1, index: 1 },
+                log_id: LogId { term: 0, index: 0 },
                 membership: Membership::new_single(btreeset! {0})
             }),
             sto.last_applied_state().await?.1
@@ -73,18 +75,24 @@ async fn state_machine_apply_membership() -> Result<()> {
 
     tracing::info!("--- changing cluster config");
     router.change_membership(0, btreeset![0, 1, 2]).await?;
-    n_logs += 2;
-
-    // router.wait_for_log(&btreeset![0, 1, 2, 3, 4], want, None, "cluster of 5 candidates").await?;
+    log_index += 2;
 
     tracing::info!("--- every node receives joint log");
     for i in 0..5 {
-        router.wait(&i, None).await?.metrics(|x| x.last_applied >= n_logs - 1, "joint log applied").await?;
+        router
+            .wait(&i, None)
+            .await?
+            .metrics(|x| x.last_applied.index() >= Some(log_index - 1), "joint log applied")
+            .await?;
     }
 
     tracing::info!("--- only 3 node applied membership config");
     for i in 0..3 {
-        router.wait(&i, None).await?.metrics(|x| x.last_applied == n_logs, "uniform log applied").await?;
+        router
+            .wait(&i, None)
+            .await?
+            .metrics(|x| x.last_applied.index() == Some(log_index), "uniform log applied")
+            .await?;
 
         let sto = router.get_storage_handle(&i).await?;
         let (_, last_membership) = sto.last_applied_state().await?;
@@ -98,4 +106,8 @@ async fn state_machine_apply_membership() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/state_machine/t40_clean_applied_logs.rs
+++ b/openraft/tests/state_machine/t40_clean_applied_logs.rs
@@ -28,9 +28,9 @@ async fn clean_applied_logs() -> Result<()> {
     );
     let router = Arc::new(RaftRouter::new(config.clone()));
 
-    let mut n_logs = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
 
-    let count = (10 - n_logs) as usize;
+    let count = (10 - log_index) as usize;
     for idx in 0..count {
         router.client_request(0, "0", idx as u64).await;
         // raft commit at once with a single leader cluster.
@@ -38,9 +38,9 @@ async fn clean_applied_logs() -> Result<()> {
         // Then it triggers snapshot replication, which is not expected.
         sleep(Duration::from_millis(50)).await;
     }
-    n_logs = 10;
+    log_index = 10;
 
-    router.wait_for_log(&btreeset! {0,1}, n_logs, timeout(), "write upto 10 logs").await?;
+    router.wait_for_log(&btreeset! {0,1}, Some(log_index), timeout(), "write upto 10 logs").await?;
 
     tracing::info!("--- logs before max_applied_log_to_keep should be cleaned");
     {


### PR DESCRIPTION

## Changelog

##### Refactor: use Option<LogId> every where
- Change: when initialize, append a membership log entry.
  This removes the special case that initialization does not follow
  normal voting process.

- Fix: first_known_log_id() should returns `last_applied_log_id` if it
  is not None.

- Refactor: move `append_payload_to_log` to RaftCore.
  It is not only used by LeaderState.

- Change: AppendEntriesResponse does not need to reply with matching log
  id or conflict log id. The caller already knows them.

---