### PR TITLE
Refactor: use Membership to check commit condition before replication

### DIFF
--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -742,13 +742,7 @@ impl<D: AppData> MessageSummary for ClientWriteRequest<D> {
 }
 
 impl<D: AppData> ClientWriteRequest<D> {
-    /// Create a new client payload instance with a normal entry type.
-    pub fn new(app_data: D) -> Self {
-        Self::new_base(EntryPayload::Normal(app_data))
-    }
-
-    /// Create a new instance.
-    pub(crate) fn new_base(entry: EntryPayload<D>) -> Self {
+    pub fn new(entry: EntryPayload<D>) -> Self {
         Self { payload: entry }
     }
 }

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -507,7 +507,10 @@ impl RaftRouter {
     ) -> std::result::Result<MemClientResponse, ClientWriteError> {
         let rt = self.routing_table.read().await;
         let node = rt.get(&target).unwrap_or_else(|| panic!("node '{}' does not exist in routing table", target));
-        node.0.client_write(ClientWriteRequest::new(req)).await.map(|res| res.data)
+
+        let payload = EntryPayload::Normal(req);
+
+        node.0.client_write(ClientWriteRequest::new(payload)).await.map(|res| res.data)
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION

## Changelog

##### Refactor: use Membership to check commit condition before replication

##### Refactor: remove redundant method in ClientWriteRequest

---