### PR TITLE
Feature: add default impl for RaftStorage::get_initial_state()

### DIFF
--- a/memstore/src/test.rs
+++ b/memstore/src/test.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 
 use async_trait::async_trait;
 use maplit::btreeset;
+use openraft::storage::InitialState;
 use openraft::DefensiveCheck;
 use openraft::DefensiveError;
 use openraft::Membership;
@@ -270,7 +271,7 @@ where
         let store = builder.build(NODE_ID).await;
 
         let initial = store.get_initial_state().await?;
-        assert!(initial.is_none(), "unexpected initial state");
+        assert_eq!(InitialState::default(), initial, "uninitialized state");
         Ok(())
     }
 
@@ -292,7 +293,7 @@ where
             }])
             .await?;
 
-        let initial = store.get_initial_state().await?.unwrap();
+        let initial = store.get_initial_state().await?;
 
         assert_eq!(
             initial.last_log_id,
@@ -338,11 +339,11 @@ where
                 ])
                 .await?;
 
-            let initial = store.get_initial_state().await?.unwrap();
+            let initial = store.get_initial_state().await?;
 
             assert_eq!(
                 Membership::new_single(btreeset! {3,4,5}),
-                initial.last_membership.membership,
+                initial.last_membership.unwrap().membership,
             );
         }
 
@@ -355,11 +356,11 @@ where
                 }])
                 .await?;
 
-            let initial = store.get_initial_state().await?.unwrap();
+            let initial = store.get_initial_state().await?;
 
             assert_eq!(
                 Membership::new_single(btreeset! {3,4,5}),
-                initial.last_membership.membership,
+                initial.last_membership.unwrap().membership,
             );
         }
 
@@ -372,11 +373,11 @@ where
                 }])
                 .await?;
 
-            let initial = store.get_initial_state().await?.unwrap();
+            let initial = store.get_initial_state().await?;
 
             assert_eq!(
                 Membership::new_single(btreeset! {1,2,3}),
-                initial.last_membership.membership,
+                initial.last_membership.unwrap().membership,
             );
         }
 
@@ -407,7 +408,7 @@ where
             ])
             .await?;
 
-        let initial = store.get_initial_state().await?.unwrap();
+        let initial = store.get_initial_state().await?;
 
         assert_eq!(
             initial.last_log_id,
@@ -435,7 +436,7 @@ where
             }])
             .await?;
 
-        let initial = store.get_initial_state().await?.unwrap();
+        let initial = store.get_initial_state().await?;
 
         assert_eq!(
             initial.last_log_id,

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -82,7 +82,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             }
 
             if report_metrics {
-                self.report_metrics(Update::Ignore);
+                self.report_metrics(Update::AsIs);
             }
         }
 
@@ -287,7 +287,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         self.replicate_to_state_machine_if_needed().await?;
 
-        self.report_metrics(Update::Ignore);
+        self.report_metrics(Update::AsIs);
 
         Ok(AppendEntriesResponse {
             term: self.current_term,
@@ -447,7 +447,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         self.last_applied = Some(last_log_id);
 
-        self.report_metrics(Update::Ignore);
+        self.report_metrics(Update::AsIs);
         self.trigger_log_compaction_if_needed(false);
 
         Ok(())
@@ -485,7 +485,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         apply_to_state_machine(storage, &data_entries, self.config.max_applied_log_to_keep).await?;
 
         self.last_applied = Some(new_last_applied.log_id);
-        self.report_metrics(Update::Ignore);
+        self.report_metrics(Update::AsIs);
         self.trigger_log_compaction_if_needed(false);
 
         Ok(())

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -198,6 +198,8 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         let quorum_granted = self.core.effective_membership.membership.is_majority(&btreeset! {self.core.id});
 
         if quorum_granted {
+            assert!(self.core.committed < Some(log_id));
+
             self.core.committed = Some(log_id);
             tracing::debug!(?self.core.committed, "update committed, no need to replicate");
 

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -66,7 +66,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         }
 
         if report_metrics {
-            self.report_metrics(Update::Ignore);
+            self.report_metrics(Update::AsIs);
         }
 
         // Compare current snapshot state with received RPC and handle as needed.
@@ -259,7 +259,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             self.update_membership(membership);
 
             self.snapshot_last_log_id = self.last_applied;
-            self.report_metrics(Update::Ignore);
+            self.report_metrics(Update::AsIs);
         } else {
             // snapshot not installed
         }

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -59,7 +59,6 @@ use crate::raft_types::LogIdOptionExt;
 use crate::replication::ReplicaEvent;
 use crate::replication::ReplicationStream;
 use crate::storage::HardState;
-use crate::storage::InitialState;
 use crate::AppData;
 use crate::AppDataResponse;
 use crate::LogId;
@@ -250,23 +249,18 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     async fn do_main(&mut self) -> Result<(), Fatal> {
         tracing::debug!("raft node is initializing");
 
-        // NOTE: get_initial_state will return None, if Raft node is first startup.
-        let state = if let Some(init_state) = self.storage.get_initial_state().await? {
-            init_state
-        } else {
-            let init_state = InitialState::new(self.id);
-            self.storage.save_hard_state(&init_state.hard_state).await?;
-            init_state
-        };
+        let state = self.storage.get_initial_state().await?;
+
+        // TODO(xp): this is not necessary.
+        self.storage.save_hard_state(&state.hard_state).await?;
 
         self.last_log_id = state.last_log_id;
         self.current_term = state.hard_state.current_term;
         self.voted_for = state.hard_state.voted_for;
-        self.effective_membership = state.last_membership.clone();
+        self.effective_membership = state.last_membership.unwrap_or_else(|| EffectiveMembership::new_initial(self.id));
         self.last_applied = state.last_applied;
 
-        // NOTE: this is repeated here for clarity. It is unsafe to initialize the node's commit
-        // index to any other value. The commit index must be determined by a leader after
+        // NOTE: The commit index must be determined by a leader after
         // successfully committing a new log to the cluster.
         self.committed = None;
 
@@ -276,30 +270,48 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             self.report_metrics(Update::AsIs);
         }
 
-        let has_log = self.last_log_id.is_some();
-        let single = self.effective_membership.membership.all_nodes().len() == 1;
-        let is_voter = self.effective_membership.membership.contains(&self.id);
+        let has_log = if self.last_log_id.is_some() {
+            "has_log"
+        } else {
+            "no_log"
+        };
+
+        let single = if self.effective_membership.membership.all_nodes().len() == 1 {
+            "single"
+        } else {
+            "multi"
+        };
+
+        let is_voter = if self.effective_membership.membership.contains(&self.id) {
+            "voter"
+        } else {
+            "learner"
+        };
 
         self.target_state = match (has_log, single, is_voter) {
             // A restarted raft that already received some logs but was not yet added to a cluster.
             // It should remain in Learner state, not Follower.
-            (true, true, false) => State::Learner,
-            (true, false, false) => State::Learner,
+            ("has_log", "single", "learner") => State::Learner,
+            ("has_log", "multi", "learner") => State::Learner,
 
-            (false, true, false) => State::Learner, // impossible: no logs but there are other members.
-            (false, false, false) => State::Learner, // impossible: no logs but there are other members.
+            ("no_log", "single", "learner") => State::Learner, // impossible: no logs but there are other members.
+            ("no_log", "multi", "learner") => State::Learner,  // impossible: no logs but there are other members.
 
             // If this is the only configured member and there is live state, then this is
             // a single-node cluster. Become leader.
-            (true, true, true) => State::Leader,
+            ("has_log", "single", "voter") => State::Leader,
 
             // The initial state when a raft is created from empty store.
-            (false, true, true) => State::Learner,
+            ("no_log", "single", "voter") => State::Learner,
 
             // Otherwise it is Follower.
-            (true, false, true) => State::Follower,
+            ("has_log", "multi", "voter") => State::Follower,
 
-            (false, false, true) => State::Follower, // impossible: no logs but there are other members.
+            ("no_log", "multi", "voter") => State::Follower, // impossible: no logs but there are other members.
+
+            _ => {
+                panic!("invalid state: {}, {}, {}", has_log, single, is_voter);
+            }
         };
 
         if self.target_state == State::Follower {

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -273,7 +273,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         // Fetch the most recent snapshot in the system.
         if let Some(snapshot) = self.storage.get_current_snapshot().await? {
             self.snapshot_last_log_id = Some(snapshot.meta.last_log_id);
-            self.report_metrics(Update::Ignore);
+            self.report_metrics(Update::AsIs);
         }
 
         let has_log = self.last_log_id.is_some();
@@ -336,7 +336,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     fn report_metrics(&mut self, leader_metrics: Update<Option<&LeaderMetrics>>) {
         let leader_metrics = match leader_metrics {
             Update::Update(v) => v.cloned(),
-            Update::Ignore => self.tx_metrics.borrow().leader_metrics.clone(),
+            Update::AsIs => self.tx_metrics.borrow().leader_metrics.clone(),
         };
 
         let m = RaftMetrics {
@@ -466,7 +466,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     fn update_snapshot_state(&mut self, update: SnapshotUpdate) {
         if let SnapshotUpdate::SnapshotComplete(log_id) = update {
             self.snapshot_last_log_id = Some(log_id);
-            self.report_metrics(Update::Ignore);
+            self.report_metrics(Update::AsIs);
         }
         // If snapshot state is anything other than streaming, then drop it.
         if let Some(state @ SnapshotState::Streaming { .. }) = self.snapshot_state.take() {

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -111,11 +111,11 @@ impl Display for SnapshotSegmentId {
     }
 }
 
-// An update action with option to update with some value or just ignore this update.
+// An update action with option to update with some value or just leave it as is.
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Update<T> {
     Update(T),
-    Ignore,
+    AsIs,
 }
 
 /// The changes of a state machine.

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -517,14 +517,14 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
         tracing::debug!(event=%event.summary(), "process_raft_event");
 
         match event {
-            RaftEvent::UpdateCommittedLogId {
-                committed: commit_index,
-            } => {
-                self.committed = commit_index;
+            RaftEvent::UpdateCommittedLogId { committed } => {
+                self.committed = committed;
             }
 
             RaftEvent::Replicate { appended, committed } => {
                 self.committed = committed;
+
+                assert!(self.last_log_id < Some(appended));
                 self.last_log_id = Some(appended);
             }
         }

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -86,12 +86,6 @@ where
     type SnapshotData = T::SnapshotData;
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn last_membership_in_log(&self, since_index: u64) -> Result<Option<EffectiveMembership>, StorageError> {
-        self.defensive_no_dirty_log().await?;
-        self.inner().last_membership_in_log(since_index).await
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
     async fn get_initial_state(&self) -> Result<Option<InitialState>, StorageError> {
         self.defensive_no_dirty_log().await?;
         self.inner().get_initial_state().await
@@ -139,6 +133,7 @@ where
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn get_log_state(&self) -> Result<(Option<LogId>, Option<LogId>), StorageError> {
+        self.defensive_no_dirty_log().await?;
         self.inner().get_log_state().await
     }
 

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -6,7 +6,6 @@ use std::sync::RwLock;
 use crate::async_trait::async_trait;
 use crate::raft::Entry;
 use crate::storage::HardState;
-use crate::storage::InitialState;
 use crate::storage::Snapshot;
 use crate::summary::MessageSummary;
 use crate::AppData;
@@ -84,12 +83,6 @@ where
     R: AppDataResponse,
 {
     type SnapshotData = T::SnapshotData;
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_initial_state(&self) -> Result<Option<InitialState>, StorageError> {
-        self.defensive_no_dirty_log().await?;
-        self.inner().get_initial_state().await
-    }
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn save_hard_state(&self, hs: &HardState) -> Result<(), StorageError> {

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -513,8 +513,6 @@ impl RaftRouter {
         node.0.client_write(ClientWriteRequest::new(payload)).await.map(|res| res.data)
     }
 
-    //////////////////////////////////////////////////////////////////////////////////////////////
-
     /// Assert that the cluster is in a pristine state, with all nodes as learners.
     pub async fn assert_pristine_cluster(&self) {
         let nodes = self.latest_metrics().await;


### PR DESCRIPTION

## Changelog

##### Feature: add default impl for RaftStorage::get_initial_state()
- `get_initial_state()` does not need to return None any more.
  Because the fields in it can be None.
  E.g. `last_membership` is None and it leaves the job building a
  default membership to its caller.

- Before this patch `get_initial_state()` returns None for
  `last_log_id`, when hard state is not found.

  Now it just returns the actual value of `last_log_id`, even though
  that logs without hard state is not possible.


##### Refactor: remove default impl method from StoreExt

##### Refactor: rename Update::Ignore to AsIs

---