### PR TITLE
Change: RaftStorage::get_log_state() returns last purge log id

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -5,7 +5,6 @@ use crate::core::client::ClientRequestEntry;
 use crate::core::LeaderState;
 use crate::core::LearnerState;
 use crate::core::State;
-use crate::core::UpdateCurrentLeader;
 use crate::error::AddLearnerError;
 use crate::error::ChangeMembershipError;
 use crate::error::ClientWriteError;
@@ -220,15 +219,14 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
             // TODO(xp): transfer leadership
             self.core.set_target_state(State::Learner);
-            self.core.update_current_leader(UpdateCurrentLeader::Unknown);
+            self.core.current_leader = None;
             return;
         }
 
         let membership = &self.core.effective_membership.membership;
 
-        let all = membership.all_nodes();
         for (id, state) in self.nodes.iter_mut() {
-            if all.contains(id) {
+            if membership.contains(id) {
                 continue;
             }
 

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -4,11 +4,10 @@ use anyerror::AnyError;
 use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWriteExt;
 
-use crate::core::delete_applied_logs;
+use crate::core::purge_applied_logs;
 use crate::core::RaftCore;
 use crate::core::SnapshotState;
 use crate::core::State;
-use crate::core::UpdateCurrentLeader;
 use crate::error::InstallSnapshotError;
 use crate::error::SnapshotMismatch;
 use crate::raft::InstallSnapshotRequest;
@@ -56,7 +55,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         // Update current leader if needed.
         if self.current_leader.as_ref() != Some(&req.leader_id) {
-            self.update_current_leader(UpdateCurrentLeader::OtherNode(req.leader_id));
+            self.current_leader = Some(req.leader_id);
             report_metrics = true;
         }
 
@@ -226,7 +225,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         // TODO(xp): do not install if self.last_applied >= snapshot.meta.last_applied
 
-        let changes = self.storage.finalize_snapshot_installation(&req.meta, snapshot).await?;
+        let changes = self.storage.install_snapshot(&req.meta, snapshot).await?;
 
         tracing::debug!("update after apply or install-snapshot: {:?}", changes);
 
@@ -236,7 +235,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         if let Some(last_applied) = changes.last_applied {
             // Applied logs are not needed.
-            delete_applied_logs(self.storage.clone(), &last_applied, self.config.max_applied_log_to_keep).await?;
+            purge_applied_logs(self.storage.clone(), &last_applied, self.config.max_applied_log_to_keep).await?;
 
             // snapshot is installed
             self.last_applied = Some(last_applied);

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -8,7 +8,6 @@ use crate::core::LeaderState;
 use crate::core::ReplicationState;
 use crate::core::SnapshotState;
 use crate::core::State;
-use crate::core::UpdateCurrentLeader;
 use crate::error::AddLearnerError;
 use crate::raft::AddLearnerResponse;
 use crate::raft::RaftRespTx;
@@ -83,7 +82,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         if term > self.core.current_term {
             self.core.update_current_term(term, None);
             self.core.save_hard_state().await?;
-            self.core.update_current_leader(UpdateCurrentLeader::Unknown);
+            self.core.current_leader = None;
             self.core.set_target_state(State::Follower);
         }
         Ok(())

--- a/openraft/src/core/startup_test.rs
+++ b/openraft/src/core/startup_test.rs
@@ -1,5 +1,0 @@
-#[test]
-fn test_raft_core_initial_state() -> anyhow::Result<()> {
-    // TODO(xp): test initial state decided by has_log, is single and is_voter
-    Ok(())
-}

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -5,7 +5,6 @@ use tracing_futures::Instrument;
 use crate::core::CandidateState;
 use crate::core::RaftCore;
 use crate::core::State;
-use crate::core::UpdateCurrentLeader;
 use crate::error::VoteError;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
@@ -122,7 +121,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             self.core.update_current_term(res.term, None);
             self.core.save_hard_state().await?;
 
-            self.core.update_current_leader(UpdateCurrentLeader::Unknown);
+            self.core.current_leader = None;
 
             // If a quorum of nodes have higher `last_log_id`, I have no chance to become a leader.
             // TODO(xp): This is a simplified impl: revert to follower as soon as seeing a higher `last_log_id`.

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -113,6 +113,18 @@ pub enum Violation {
 
     #[error("invalid next log to apply: prev: {prev:?}, next: {next}")]
     ApplyNonConsecutive { prev: Option<LogId>, next: LogId },
+
+    #[error("applied log can not conflict, last_applied: {last_applied:?}, delete since: {first_conflict_log_id}")]
+    AppliedWontConflict {
+        last_applied: Option<LogId>,
+        first_conflict_log_id: LogId,
+    },
+
+    #[error("not allowed to purge non-applied logs, last_applied: {last_applied:?}, purge upto: {purge_upto}")]
+    PurgeNonApplied {
+        last_applied: Option<LogId>,
+        purge_upto: LogId,
+    },
 }
 
 /// A storage error could be either a defensive check error or an error occurred when doing the actual io operation.

--- a/openraft/src/store_wrapper.rs
+++ b/openraft/src/store_wrapper.rs
@@ -1,5 +1,13 @@
+use crate::AppData;
+use crate::AppDataResponse;
+use crate::RaftStorage;
+
 /// A wrapper extends the APIs of a base RaftStore.
-pub trait Wrapper<T> // where
+pub trait Wrapper<D, R, T>
+where
+    D: AppData,
+    R: AppDataResponse,
+    T: RaftStorage<D, R>,
 {
     fn inner(&self) -> &T;
 }

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -656,9 +656,7 @@ impl RaftRouter {
         expect_sm_last_applied_log: LogId,
         expect_snapshot: &Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
-        let (sm_last_id, _) = storage.last_applied_state().await?;
-        let last_id_in_log = storage.last_id_in_log().await?;
-        let last_log_id = std::cmp::max(last_id_in_log, sm_last_id);
+        let last_log_id = storage.get_log_state().await?.last_log_id;
 
         assert_eq!(
             expect_last_log,


### PR DESCRIPTION

## Changelog

##### Change: RaftStorage::get_log_state() returns last purge log id
-   Change: `get_log_state()` returns the `last_purged_log_id` instead of the `first_log_id`.
    Because there are some cases in which log are empty:
    When a snapshot is install that covers all logs,
    or when `max_applied_log_to_keep` is 0.

    Returning `None` is not clear about if there are no logs at all or
    all logs are deleted.

    In such cases, raft still needs to maintain log continuity
    when repilcating. Thus the last log id that once existed is important.
    Previously this is done by checking the `last_applied_log_id`, which is
    dirty and buggy.

    Now an implementation of `RaftStorage` has to maintain the
    `last_purged_log_id` in its store.

-   Change: Remove `first_id_in_log()`, `last_log_id()`, `first_known_log_id()`,
    because concepts are changed.

-   Change: Split `delete_logs()` into two method for clarity:

    `delete_conflict_logs_since()` for deleting conflict logs when the
    replication receiving end find a conflict log.

    `purge_logs_upto()` for cleaning applied logs

-   Change: Rename `finalize_snapshot_installation()` to `install_snapshot()`.

-   Refactor: Remove `initial_replicate_to_state_machine()`, which does nothing
    more than a normal applying-logs.

-   Refactor: Remove `enum UpdateCurrentLeader`. It is just a wrapper of Option.

---