### PR TITLE
Change: add sub error types of ReplicationError

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -237,7 +237,6 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         Ok(())
     }
 
-    // TODO(xp): remove this
     #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=self.core.id))]
     pub async fn append_membership_log(
         &mut self,

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -101,12 +101,6 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_conflict_logs_since(&mut self, start: LogId) -> Result<(), StorageError> {
-        // TODO(xp): add a StorageAdapter to provide auxiliary APIs.
-        //           e.g.:
-        //           - extract and manage membership config.
-        //           - keep track of last_log_id, first_log_id,
-        //           RaftStorage should only provides the least basic APIs.
-
         self.storage.delete_conflict_logs_since(start).await?;
 
         self.last_log_id = self.storage.get_log_state().await?.last_log_id;

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -51,6 +51,7 @@ pub use crate::storage_error::ErrorSubject;
 pub use crate::storage_error::ErrorVerb;
 pub use crate::storage_error::StorageError;
 pub use crate::storage_error::StorageIOError;
+pub use crate::storage_error::ToStorageResult;
 pub use crate::storage_error::Violation;
 pub use crate::store_ext::StoreExt;
 pub use crate::store_wrapper::Wrapper;

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -14,7 +14,7 @@ use crate::NodeId;
 
 /// A trait defining the interface for a Raft network between cluster members.
 ///
-/// See the [network chapter of the guide](https://datafuselabs.github.io/openraft/network.html)
+/// See the [network chapter of the guide](https://datafuselabs.github.io/openraft/getting-started.html#3-impl-raftnetwork)
 /// for details and discussion on this trait and how to implement it.
 #[async_trait]
 pub trait RaftNetwork<D>: Send + Sync + 'static


### PR DESCRIPTION

## Changelog

##### Change: add sub error types of ReplicationError
- Add sub errors such as Timeout and NetworkError.

- Remove ReplicationError::IO, use StorageError instead.

- Cleanup finished TODOs.

---