### PR TITLE
Change: RaftNetwork return `RPCError` instead of anyhow::Error

### DIFF
--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -34,6 +34,7 @@ pub use crate::core::State;
 pub use crate::defensive::DefensiveCheck;
 pub use crate::membership::Membership;
 pub use crate::metrics::RaftMetrics;
+pub use crate::network::RPCTypes;
 pub use crate::network::RaftNetwork;
 pub use crate::raft::Raft;
 pub use crate::raft_types::LogId;

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -1,8 +1,15 @@
 //! The Raft network interface.
 
-use anyhow::Result;
-use async_trait::async_trait;
+use std::fmt::Formatter;
 
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::error::AppendEntriesError;
+use crate::error::InstallSnapshotError;
+use crate::error::RPCError;
+use crate::error::VoteError;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::InstallSnapshotRequest;
@@ -11,6 +18,19 @@ use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::AppData;
 use crate::NodeId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RPCTypes {
+    Vote,
+    AppendEntries,
+    InstallSnapshot,
+}
+
+impl std::fmt::Display for RPCTypes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
 
 /// A trait defining the interface for a Raft network between cluster members.
 ///
@@ -21,15 +41,19 @@ pub trait RaftNetwork<D>: Send + Sync + 'static
 where D: AppData
 {
     /// Send an AppendEntries RPC to the target Raft node (§5).
-    async fn send_append_entries(&self, target: NodeId, rpc: AppendEntriesRequest<D>) -> Result<AppendEntriesResponse>;
+    async fn send_append_entries(
+        &self,
+        target: NodeId,
+        rpc: AppendEntriesRequest<D>,
+    ) -> Result<AppendEntriesResponse, RPCError<AppendEntriesError>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn send_install_snapshot(
         &self,
         target: NodeId,
         rpc: InstallSnapshotRequest,
-    ) -> Result<InstallSnapshotResponse>;
+    ) -> Result<InstallSnapshotResponse, RPCError<InstallSnapshotError>>;
 
     /// Send a RequestVote RPC to the target Raft node (§5).
-    async fn send_vote(&self, target: NodeId, rpc: VoteRequest) -> Result<VoteResponse>;
+    async fn send_vote(&self, target: NodeId, rpc: VoteRequest) -> Result<VoteResponse, RPCError<VoteError>>;
 }


### PR DESCRIPTION

## Changelog

##### Change: RaftNetwork return `RPCError` instead of anyhow::Error
- When a remote error encountered when replication, the replication will
  be stopped at once.

- Fix: #140

---