### PR TITLE
Change: use `Vote` to define Leader and Candidate

### DIFF
--- a/guide/src/getting-started.md
+++ b/guide/src/getting-started.md
@@ -50,8 +50,8 @@ or a wrapper of a remote sql DB.
 
 - Read/write raft state, e.g., term or vote.
     ```rust
-    fn save_hard_state(hs:&HardState)
-    fn read_hard_state() -> Result<Option<HardState>>
+    fn save_vote(vote:&Vote)
+    fn read_vote() -> Result<Option<Vote>>
     ```
 
 - Read/write logs.

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -36,9 +36,9 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     ) -> Result<(), InitializeError> {
         // TODO(xp): simplify this condition
 
-        if self.core.last_log_id.is_some() || self.core.current_term != 0 {
+        if self.core.last_log_id.is_some() || self.core.vote.term != 0 {
             tracing::error!(
-                last_log_id=?self.core.last_log_id, self.core.current_term,
+                last_log_id=?self.core.last_log_id, %self.core.vote,
                 "rejecting init_with_config request as last_log_index is not None or current_term is not 0");
             return Err(InitializeError::NotAllowed);
         }
@@ -249,7 +249,6 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
             // TODO(xp): transfer leadership
             self.core.set_target_state(State::Learner);
-            self.core.current_leader = None;
             return;
         }
 

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -72,10 +72,11 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             }
 
             // Update current leader if needed.
-            if self.current_leader.as_ref() != Some(&msg.leader_id) {
-                self.current_leader = Some(msg.leader_id);
+            if self.current_leader != Some(msg.leader_id) {
                 report_metrics = true;
             }
+
+            self.current_leader = Some(msg.leader_id);
 
             if report_metrics {
                 self.report_metrics(Update::AsIs);

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -21,20 +21,22 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     /// An RPC invoked by the leader to replicate log entries (§5.3); also used as heartbeat (§5.2).
     ///
     /// See `receiver implementation: AppendEntries RPC` in raft-essentials.md in this repo.
-    #[tracing::instrument(level = "debug", skip(self, msg))]
+    #[tracing::instrument(level = "debug", skip(self, req))]
     pub(super) async fn handle_append_entries_request(
         &mut self,
-        msg: AppendEntriesRequest<D>,
+        req: AppendEntriesRequest<D>,
     ) -> Result<AppendEntriesResponse, AppendEntriesError> {
-        tracing::debug!(last_log_id=?self.last_log_id, ?self.last_applied, msg=%msg.summary(), "handle_append_entries_request");
+        tracing::debug!(last_log_id=?self.last_log_id, ?self.last_applied, msg=%req.summary(), "handle_append_entries_request");
 
-        let msg_entries = msg.entries.as_slice();
+        let msg_entries = req.entries.as_slice();
 
-        // If message's term is less than most recent term, then we do not honor the request.
-        if msg.term < self.current_term {
-            tracing::debug!({self.current_term, rpc_term=msg.term}, "AppendEntries RPC term is less than current term");
+        // Partial order compare: smaller than or incomparable
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        if !(req.vote >= self.vote) {
+            tracing::debug!(%self.vote, %req.vote, "AppendEntries RPC term is less than current term");
+
             return Ok(AppendEntriesResponse {
-                term: self.current_term,
+                vote: self.vote,
                 success: false,
                 conflict: false,
             });
@@ -42,51 +44,24 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         self.update_next_election_timeout(true);
 
-        // Caveat: Because we can not just delete `log[prev_log_id.index..]`, (which results in loss of committed
-        // entry), the commit index must be update only after append-entries
-        // and must point to a log entry that is consistent to leader.
-        // Or there would be chance applying an uncommitted entry:
-        //
-        // ```
-        // R0 1,1  1,2  3,3
-        // R1 1,1  1,2  2,3
-        // R2 1,1  1,2  3,3
-        // ```
-        //
-        // - R0 to R1 append_entries: entries=[{1,2}], prev_log_id = {1,1}, commit_index = 3
-        // - R1 accepted this append_entries request but was not aware of that entry {2,3} is inconsistent to leader.
-        //   Then it will update commit_index to 3 and apply {2,3}
+        tracing::debug!("start to check and update to latest term/leader");
+        if req.vote > self.vote {
+            self.vote = req.vote;
+            self.save_vote().await?;
+
+            // If not follower, become follower.
+            if !self.target_state.is_follower() && !self.target_state.is_learner() {
+                self.set_target_state(State::Follower); // State update will emit metrics.
+            }
+
+            self.report_metrics(Update::AsIs);
+        }
+
+        // Caveat: [commit-index must not advance the last known consistent log](https://datafuselabs.github.io/openraft/replication.html#caveat-commit-index-must-not-advance-the-last-known-consistent-log)
 
         // TODO(xp): cleanup commit index at sender side.
-        let valid_commit_index = msg_entries.last().map(|x| Some(x.log_id)).unwrap_or_else(|| msg.prev_log_id);
-        let valid_committed = std::cmp::min(msg.leader_commit, valid_commit_index);
-
-        tracing::debug!("start to check and update to latest term/leader");
-        {
-            let mut report_metrics = false;
-
-            if msg.term > self.current_term {
-                self.update_current_term(msg.term, Some(msg.leader_id));
-                self.save_hard_state().await?;
-                report_metrics = true;
-            }
-
-            // Update current leader if needed.
-            if self.current_leader != Some(msg.leader_id) {
-                report_metrics = true;
-            }
-
-            self.current_leader = Some(msg.leader_id);
-
-            if report_metrics {
-                self.report_metrics(Update::AsIs);
-            }
-        }
-
-        // Transition to follower state if needed.
-        if !self.target_state.is_follower() && !self.target_state.is_learner() {
-            self.set_target_state(State::Follower);
-        }
+        let valid_commit_index = msg_entries.last().map(|x| Some(x.log_id)).unwrap_or_else(|| req.prev_log_id);
+        let valid_committed = std::cmp::min(req.leader_commit, valid_commit_index);
 
         tracing::debug!("begin log consistency check");
 
@@ -95,7 +70,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         //              +----------------+------------------------+
         //              ` 0              ` last_applied           ` last_log_id
 
-        let res = self.append_apply_log_entries(msg.prev_log_id, msg_entries, valid_committed).await?;
+        let res = self.append_apply_log_entries(req.prev_log_id, msg_entries, valid_committed).await?;
 
         Ok(res)
     }
@@ -220,7 +195,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             }
 
             return Ok(AppendEntriesResponse {
-                term: self.current_term,
+                vote: self.vote,
                 success: false,
                 conflict: true,
             });
@@ -252,7 +227,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         self.report_metrics(Update::AsIs);
 
         Ok(AppendEntriesResponse {
-            term: self.current_term,
+            vote: self.vote,
             success: true,
             conflict: false,
         })

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -54,10 +54,11 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         }
 
         // Update current leader if needed.
-        if self.current_leader.as_ref() != Some(&req.leader_id) {
-            self.current_leader = Some(req.leader_id);
+        if self.current_leader != Some(req.leader_id) {
             report_metrics = true;
         }
+
+        self.current_leader = Some(req.leader_id);
 
         // If not follower, become follower.
         if !self.target_state.is_follower() && !self.target_state.is_learner() {

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -35,37 +35,25 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         &mut self,
         req: InstallSnapshotRequest,
     ) -> Result<InstallSnapshotResponse, InstallSnapshotError> {
-        // If message's term is less than most recent term, then we do not honor the request.
-        if req.term < self.current_term {
-            return Ok(InstallSnapshotResponse {
-                term: self.current_term,
-            });
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        if !(req.vote >= self.vote) {
+            tracing::debug!(%self.vote, %req.vote, "InstallSnapshot RPC term is less than current term");
+
+            return Ok(InstallSnapshotResponse { vote: self.vote });
         }
 
         // Update election timeout.
         self.update_next_election_timeout(true);
 
-        // Update current term if needed.
-        let mut report_metrics = false;
-        if self.current_term != req.term {
-            self.update_current_term(req.term, None);
-            self.save_hard_state().await?;
-            report_metrics = true;
-        }
+        if req.vote > self.vote {
+            self.vote = req.vote;
+            self.save_vote().await?;
 
-        // Update current leader if needed.
-        if self.current_leader != Some(req.leader_id) {
-            report_metrics = true;
-        }
+            // If not follower, become follower.
+            if !self.target_state.is_follower() && !self.target_state.is_learner() {
+                self.set_target_state(State::Follower); // State update will emit metrics.
+            }
 
-        self.current_leader = Some(req.leader_id);
-
-        // If not follower, become follower.
-        if !self.target_state.is_follower() && !self.target_state.is_learner() {
-            self.set_target_state(State::Follower); // State update will emit metrics.
-        }
-
-        if report_metrics {
             self.report_metrics(Update::AsIs);
         }
 
@@ -134,9 +122,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         // If this was a small snapshot, and it is already done, then finish up.
         if req.done {
             self.finalize_snapshot_installation(req, snapshot).await?;
-            return Ok(InstallSnapshotResponse {
-                term: self.current_term,
-            });
+            return Ok(InstallSnapshotResponse { vote: self.vote });
         }
 
         // Else, retain snapshot components for later segments & respond.
@@ -145,9 +131,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             id,
             snapshot,
         });
-        Ok(InstallSnapshotResponse {
-            term: self.current_term,
-        })
+        Ok(InstallSnapshotResponse { vote: self.vote })
     }
 
     #[tracing::instrument(level = "debug", skip(self, req, snapshot), fields(req=%req.summary()))]
@@ -188,9 +172,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         } else {
             self.snapshot_state = Some(SnapshotState::Streaming { offset, id, snapshot });
         }
-        Ok(InstallSnapshotResponse {
-            term: self.current_term,
-        })
+        Ok(InstallSnapshotResponse { vote: self.vote })
     }
 
     /// Finalize the installation of a new snapshot.

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -52,7 +52,7 @@ use crate::raft::VoteResponse;
 use crate::raft_types::LogIdOptionExt;
 use crate::replication::ReplicaEvent;
 use crate::replication::ReplicationStream;
-use crate::storage::HardState;
+use crate::vote::Vote;
 use crate::AppData;
 use crate::AppDataResponse;
 use crate::LogId;
@@ -124,21 +124,8 @@ pub struct RaftCore<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftSt
     /// The log id of the highest log entry which has been applied to the local state machine.
     last_applied: Option<LogId>,
 
-    /// The current term.
-    ///
-    /// Is initialized to 0 on first boot, and increases monotonically. This is normally based on
-    /// the leader's term which is communicated to other members via the AppendEntries protocol,
-    /// but this may also be incremented when a follower becomes a candidate.
-    current_term: u64,
-
-    /// The ID of the current leader of the Raft cluster.
-    current_leader: Option<NodeId>,
-
-    /// The ID of the candidate which received this node's vote for the current term.
-    ///
-    /// Each server will vote for at most one candidate in a given term, on a
-    /// first-come-first-served basis. See §5.4.1 for additional restriction on votes.
-    voted_for: Option<NodeId>,
+    /// The vote state of this node.
+    vote: Vote,
 
     /// The last entry to be appended to the log.
     last_log_id: Option<LogId>,
@@ -195,9 +182,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             target_state: State::Follower,
             committed: None,
             last_applied: None,
-            current_term: 0,
-            current_leader: None,
-            voted_for: None,
+            vote: Vote::new_uncommitted(0, None),
             last_log_id: None,
             snapshot_state: None,
             snapshot_last_log_id: None,
@@ -241,11 +226,10 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         let state = self.storage.get_initial_state().await?;
 
         // TODO(xp): this is not necessary.
-        self.storage.save_hard_state(&state.hard_state).await?;
+        self.storage.save_vote(&state.vote).await?;
 
         self.last_log_id = state.last_log_id;
-        self.current_term = state.hard_state.current_term;
-        self.voted_for = state.hard_state.voted_for;
+        self.vote = state.vote;
         self.effective_membership = state.last_membership.unwrap_or_else(|| EffectiveMembership::new_initial(self.id));
         self.last_applied = state.last_applied;
 
@@ -345,10 +329,10 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
             id: self.id,
             state: self.target_state,
-            current_term: self.current_term,
+            current_term: self.vote.term,
             last_log_index: self.last_log_id.map(|id| id.index),
             last_applied: self.last_applied,
-            current_leader: self.current_leader,
+            current_leader: self.current_leader(),
             membership_config: self.effective_membership.clone(),
             snapshot: self.snapshot_last_log_id,
             leader_metrics,
@@ -372,12 +356,8 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
     /// Save the Raft node's current hard state to disk.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_hard_state(&mut self) -> Result<(), StorageError> {
-        let hs = HardState {
-            current_term: self.current_term,
-            voted_for: self.voted_for,
-        };
-        self.storage.save_hard_state(&hs).await
+    async fn save_vote(&mut self) -> Result<(), StorageError> {
+        self.storage.save_vote(&self.vote).await
     }
 
     /// Update core's target state, ensuring all invariants are upheld.
@@ -420,15 +400,6 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         self.next_election_timeout = Some(now + t);
         if heartbeat {
             self.last_heartbeat = Some(now);
-        }
-    }
-
-    /// Encapsulate the process of updating the current term, as updating the `voted_for` state must also be updated.
-    #[tracing::instrument(level = "debug", skip(self))]
-    fn update_current_term(&mut self, new_term: u64, voted_for: Option<NodeId>) {
-        if new_term > self.current_term {
-            self.current_term = new_term;
-            self.voted_for = voted_for;
         }
     }
 
@@ -540,7 +511,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     fn reject_with_forward_to_leader<T, E>(&self, tx: RaftRespTx<T, E>)
     where E: From<ForwardToLeader> {
         let err = ForwardToLeader {
-            leader_id: self.current_leader,
+            leader_id: self.current_leader(),
         };
 
         let _ = tx.send(Err(err.into()));
@@ -548,7 +519,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
     #[tracing::instrument(level = "debug", skip(self, payload))]
     pub(super) async fn append_payload_to_log(&mut self, payload: EntryPayload<D>) -> Result<Entry<D>, StorageError> {
-        let log_id = LogId::new(self.current_term, self.last_log_id.next_index());
+        let log_id = LogId::new(self.vote.term, self.last_log_id.next_index());
 
         let entry = Entry { log_id, payload };
         self.storage.append_to_log(&[&entry]).await?;
@@ -564,6 +535,25 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         }
 
         Ok(entry)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub fn current_leader(&self) -> Option<NodeId> {
+        let l = self.vote.leader();
+
+        if let Some(id) = l {
+            if id == self.id {
+                if self.target_state == State::Leader {
+                    Some(id)
+                } else {
+                    None
+                }
+            } else {
+                Some(id)
+            }
+        } else {
+            None
+        }
     }
 }
 
@@ -759,7 +749,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         // Setup state as leader.
         self.core.last_heartbeat = None;
         self.core.next_election_timeout = None;
-        self.core.current_leader = Some(self.core.id);
+        self.core.vote = Vote::new_committed(self.core.vote.term, self.core.id);
 
         self.leader_report_metrics();
 
@@ -913,16 +903,16 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
             // Setup new term.
             self.core.update_next_election_timeout(false); // Generates a new rand value within range.
-            self.core.current_term += 1;
-            self.core.voted_for = Some(self.core.id);
-            self.core.current_leader = None;
-            self.core.save_hard_state().await?;
+
+            self.core.vote = Vote::new_uncommitted(self.core.vote.term + 1, Some(self.core.id));
+
+            self.core.save_vote().await?;
             self.core.report_metrics(Update::Update(None));
 
             // vote for itself.
             self.handle_vote_response(
                 VoteResponse {
-                    term: self.core.current_term,
+                    vote: self.core.vote,
                     vote_granted: true,
                     last_log_id: self.core.last_log_id,
                 },

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -9,6 +9,7 @@ use crate::error::VoteError;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::summary::MessageSummary;
+use crate::vote::Vote;
 use crate::AppData;
 use crate::AppDataResponse;
 use crate::NodeId;
@@ -23,23 +24,21 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     #[tracing::instrument(level = "debug", skip(self, req), fields(req=%req.summary()))]
     pub(super) async fn handle_vote_request(&mut self, req: VoteRequest) -> Result<VoteResponse, VoteError> {
         tracing::debug!(
-            candidate = req.candidate_id,
-            self.current_term,
-            req_term = req.term,
+            %req.vote,
+            %self.vote,
             "start handle_vote_request"
         );
         let last_log_id = self.last_log_id;
 
-        // If candidate's current term is less than this nodes current term, reject.
-        if req.term < self.current_term {
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        if !(req.vote >= self.vote) {
             tracing::debug!(
-                candidate = req.candidate_id,
-                self.current_term,
-                rpc_term = req.term,
+                %req.vote,
+                %self.vote,
                 "RequestVote RPC term is less than current term"
             );
             return Ok(VoteResponse {
-                term: self.current_term,
+                vote: self.vote,
                 vote_granted: false,
                 last_log_id,
             });
@@ -51,72 +50,54 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             let delta = now.duration_since(*inst);
             if self.config.election_timeout_min >= (delta.as_millis() as u64) {
                 tracing::debug!(
-                    { candidate = req.candidate_id },
+                    %req.vote,
+                    ?delta,
                     "rejecting vote request received within election timeout minimum"
                 );
                 return Ok(VoteResponse {
-                    term: self.current_term,
+                    vote: self.vote,
                     vote_granted: false,
                     last_log_id,
                 });
             }
         }
 
-        // Per spec, if we observe a term greater than our own outside of the election timeout
-        // minimum, then we must update term & immediately become follower. We still need to
-        // do vote checking after this.
-        if req.term > self.current_term {
-            self.update_current_term(req.term, None);
+        // Always save a higher term
+        if req.vote.term > self.vote.term {
             self.update_next_election_timeout(false);
+            self.vote = Vote::new_uncommitted(req.vote.term, None);
+            self.save_vote().await?;
+
             self.set_target_state(State::Follower);
-            self.save_hard_state().await?;
         }
 
         // Check if candidate's log is at least as up-to-date as this node's.
         // If candidate's log is not at least as up-to-date as this node, then reject.
         if req.last_log_id < last_log_id {
             tracing::debug!(
-                { candidate = req.candidate_id },
+                %req.vote,
                 "rejecting vote request as candidate's log is not up-to-date"
             );
             return Ok(VoteResponse {
-                term: self.current_term,
+                vote: self.vote,
                 vote_granted: false,
                 last_log_id,
             });
         }
 
-        // TODO: add hook for PreVote optimization here. If the RPC is a PreVote, then at this
-        // point we can respond to the candidate telling them that we would vote for them.
+        self.update_next_election_timeout(false);
+        self.vote = req.vote;
+        self.save_vote().await?;
 
-        // Candidate's log is up-to-date so handle voting conditions.
-        match &self.voted_for {
-            // This node has already voted for the candidate.
-            Some(candidate_id) if candidate_id == &req.candidate_id => Ok(VoteResponse {
-                term: self.current_term,
-                vote_granted: true,
-                last_log_id,
-            }),
-            // This node has already voted for a different candidate.
-            Some(_) => Ok(VoteResponse {
-                term: self.current_term,
-                vote_granted: false,
-                last_log_id,
-            }),
-            // This node has not yet voted for the current term, so vote for the candidate.
-            None => {
-                self.voted_for = Some(req.candidate_id);
-                self.set_target_state(State::Follower);
-                self.update_next_election_timeout(false);
-                self.save_hard_state().await?;
-                tracing::debug!({candidate=req.candidate_id, req.term}, "voted for candidate");
-                Ok(VoteResponse {
-                    term: self.current_term,
-                    vote_granted: true,
-                    last_log_id,
-                })
-            }
-        }
+        self.set_target_state(State::Follower);
+
+        tracing::debug!(%req.vote, "voted for candidate");
+
+        Ok(VoteResponse {
+            vote: self.vote,
+            vote_granted: true,
+            last_log_id,
+        })
     }
 }
 
@@ -126,11 +107,9 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     pub(super) async fn handle_vote_response(&mut self, res: VoteResponse, target: NodeId) -> Result<(), StorageError> {
         // If peer's term is greater than current term, revert to follower state.
 
-        if res.term > self.core.current_term {
-            self.core.update_current_term(res.term, None);
-            self.core.save_hard_state().await?;
-
-            self.core.current_leader = None;
+        if res.vote.term > self.core.vote.term {
+            self.core.vote = Vote::new_uncommitted(res.vote.term, None);
+            self.core.save_vote().await?;
 
             // If a quorum of nodes have higher `last_log_id`, I have no chance to become a leader.
             // TODO(xp): This is a simplified impl: revert to follower as soon as seeing a higher `last_log_id`.
@@ -142,8 +121,8 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             } else {
                 tracing::debug!(
                     id = %self.core.id,
-                    self_term=%self.core.current_term,
-                    res_term=%res.term,
+                    %self.core.vote,
+                    %res.vote,
                     self_last_log_id=?self.core.last_log_id,
                     res_last_log_id=?res.last_log_id,
                     "I have lower term but higher or euqal last_log_id, keep trying to elect"
@@ -173,7 +152,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         let (tx, rx) = mpsc::channel(all_nodes.len());
 
         for member in all_nodes.into_iter().filter(|member| member != &self.core.id) {
-            let rpc = VoteRequest::new(self.core.current_term, self.core.id, self.core.last_log_id);
+            let rpc = VoteRequest::new(self.core.vote, self.core.last_log_id);
 
             let (network, tx_inner) = (self.core.network.clone(), tx.clone());
             let _ = tokio::spawn(

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -11,6 +11,7 @@ mod storage_error;
 mod store_ext;
 mod store_wrapper;
 mod summary;
+mod vote;
 
 pub mod error;
 pub mod metrics;
@@ -57,6 +58,8 @@ pub use crate::storage_error::Violation;
 pub use crate::store_ext::StoreExt;
 pub use crate::store_wrapper::Wrapper;
 pub use crate::summary::MessageSummary;
+pub use crate::vote::CommittedState;
+pub use crate::vote::Vote;
 
 /// A Raft node's ID.
 pub type NodeId = u64;

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -36,6 +36,7 @@ use crate::NodeId;
 use crate::RaftNetwork;
 use crate::RaftStorage;
 use crate::SnapshotMeta;
+use crate::Vote;
 
 struct RaftInner<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> {
     tx_api: mpsc::UnboundedSender<(RaftMsg<D, R>, Span)>,
@@ -487,11 +488,7 @@ where
 /// An RPC sent by a cluster leader to replicate log entries (§5.3), and as a heartbeat (§5.2).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppendEntriesRequest<D: AppData> {
-    /// The leader's current term.
-    pub term: u64,
-
-    /// The leader's ID. Useful in redirecting clients.
-    pub leader_id: u64,
+    pub vote: Vote,
 
     pub prev_log_id: Option<LogId>,
 
@@ -509,9 +506,8 @@ pub struct AppendEntriesRequest<D: AppData> {
 impl<D: AppData> MessageSummary for AppendEntriesRequest<D> {
     fn summary(&self) -> String {
         format!(
-            "leader={}-{}, prev_log_id={}, leader_commit={}, entries={}",
-            self.term,
-            self.leader_id,
+            "vote={}, prev_log_id={}, leader_commit={}, entries={}",
+            self.vote,
             self.prev_log_id.summary(),
             self.leader_commit.summary(),
             self.entries.as_slice().summary()
@@ -522,9 +518,7 @@ impl<D: AppData> MessageSummary for AppendEntriesRequest<D> {
 /// The response to an `AppendEntriesRequest`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppendEntriesResponse {
-    /// The responding node's current term, for leader to update itself.
-    pub term: u64,
-
+    pub vote: Vote,
     pub success: bool,
     pub conflict: bool,
 }
@@ -532,8 +526,8 @@ pub struct AppendEntriesResponse {
 impl MessageSummary for AppendEntriesResponse {
     fn summary(&self) -> String {
         format!(
-            "term:{}, success:{:?}, conflict:{:?}",
-            self.term, self.success, self.conflict
+            "vote:{}, success:{:?}, conflict:{:?}",
+            self.vote, self.success, self.conflict
         )
     }
 }
@@ -617,35 +611,26 @@ impl<D: AppData> MessageSummary for EntryPayload<D> {
 /// An RPC sent by candidates to gather votes (§5.2).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VoteRequest {
-    /// The candidate's current term.
-    pub term: u64,
-
-    pub candidate_id: u64,
-
+    pub vote: Vote,
     pub last_log_id: Option<LogId>,
 }
 
 impl MessageSummary for VoteRequest {
     fn summary(&self) -> String {
-        format!("{}-{}, last_log:{:?}", self.term, self.candidate_id, self.last_log_id)
+        format!("{}, last_log:{:?}", self.vote, self.last_log_id)
     }
 }
 
 impl VoteRequest {
-    pub fn new(term: u64, candidate_id: u64, last_log_id: Option<LogId>) -> Self {
-        Self {
-            term,
-            candidate_id,
-            last_log_id,
-        }
+    pub fn new(vote: Vote, last_log_id: Option<LogId>) -> Self {
+        Self { vote, last_log_id }
     }
 }
 
 /// The response to a `VoteRequest`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VoteResponse {
-    /// The current term of the responding node, for the candidate to update itself.
-    pub term: u64,
+    pub vote: Vote,
 
     /// Will be true if the candidate received a vote from the responder.
     pub vote_granted: bool,
@@ -659,10 +644,7 @@ pub struct VoteResponse {
 /// An RPC sent by the Raft leader to send chunks of a snapshot to a follower (§7).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InstallSnapshotRequest {
-    /// The leader's current term.
-    pub term: u64,
-    /// The leader's ID. Useful in redirecting clients.
-    pub leader_id: u64,
+    pub vote: Vote,
 
     /// Metadata of a snapshot: snapshot_id, last_log_ed membership etc.
     pub meta: SnapshotMeta,
@@ -679,9 +661,8 @@ pub struct InstallSnapshotRequest {
 impl MessageSummary for InstallSnapshotRequest {
     fn summary(&self) -> String {
         format!(
-            "term={}, leader_id={}, meta={:?}, offset={}, len={}, done={}",
-            self.term,
-            self.leader_id,
+            "vote={}, meta={:?}, offset={}, len={}, done={}",
+            self.vote,
             self.meta,
             self.offset,
             self.data.len(),
@@ -693,8 +674,7 @@ impl MessageSummary for InstallSnapshotRequest {
 /// The response to an `InstallSnapshotRequest`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InstallSnapshotResponse {
-    /// The receiving node's current term, for leader to update itself.
-    pub term: u64,
+    pub vote: Vote,
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -6,9 +6,9 @@ use anyerror::AnyError;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::storage::HardState;
 use crate::LogId;
 use crate::SnapshotMeta;
+use crate::Vote;
 
 /// Convert error to StorageError::IO();
 pub trait ToStorageResult<T> {
@@ -68,7 +68,7 @@ pub enum ErrorSubject {
     Store,
 
     /// HardState related error.
-    HardState,
+    Vote,
 
     /// Error that is happened when operating a series of log entries
     Logs,
@@ -107,7 +107,7 @@ pub enum Violation {
     TermNotAscending { curr: u64, to: u64 },
 
     #[error("voted_for can not change from Some() to other Some(), current: {curr:?}, change to {to:?}")]
-    VotedForChanged { curr: HardState, to: HardState },
+    NonIncrementalVote { curr: Vote, to: Vote },
 
     #[error("log at higher index is obsolete: {higher_index_log_id:?} should GT {lower_index_log_id:?}")]
     DirtyLog {

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -5,7 +5,6 @@ use std::sync::RwLock;
 
 use crate::async_trait::async_trait;
 use crate::raft::Entry;
-use crate::storage::HardState;
 use crate::storage::LogState;
 use crate::storage::Snapshot;
 use crate::summary::MessageSummary;
@@ -19,6 +18,7 @@ use crate::RaftStorageDebug;
 use crate::SnapshotMeta;
 use crate::StateMachineChanges;
 use crate::StorageError;
+use crate::Vote;
 use crate::Wrapper;
 
 /// Extended store backed by another impl.
@@ -91,14 +91,14 @@ where
     type SnapshotData = T::SnapshotData;
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_hard_state(&self, hs: &HardState) -> Result<(), StorageError> {
-        self.defensive_incremental_hard_state(hs).await?;
-        self.inner().save_hard_state(hs).await
+    async fn save_vote(&self, vote: &Vote) -> Result<(), StorageError> {
+        self.defensive_incremental_vote(vote).await?;
+        self.inner().save_vote(vote).await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn read_hard_state(&self) -> Result<Option<HardState>, StorageError> {
-        self.inner().read_hard_state().await
+    async fn read_vote(&self) -> Result<Option<Vote>, StorageError> {
+        self.inner().read_vote().await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/openraft/src/vote/mod.rs
+++ b/openraft/src/vote/mod.rs
@@ -1,0 +1,8 @@
+#[allow(clippy::module_inception)]
+mod vote;
+
+pub use vote::CommittedState;
+pub use vote::Vote;
+
+#[cfg(test)]
+mod vote_test;

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -1,0 +1,141 @@
+use std::cmp::Ordering;
+use std::fmt::Formatter;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::NodeId;
+
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommittedState {
+    Uncommitted,
+    Committed,
+}
+
+impl Default for CommittedState {
+    fn default() -> Self {
+        CommittedState::Uncommitted
+    }
+}
+
+/// `Vote` represent the privilege of a node.
+/// A `Vote` is basically a tuple of `(term, committed|uncommitted, node_id)`.
+///
+/// A uncommitted `Vote` is built to represent a Candidate when a node enters Candidate state.
+/// A committed `Vote`(that is granted by a quorum) represents a leader.
+///
+/// A node can grant at most one `Vote`, by persistently storing a `Vote` in its storage.
+///
+/// Once a node granted a `Vote`, the next `Vote` can be granted only when some conditions are satisfied.
+/// These conditions reflect the raft spec and it is a **partially ordered** relation between `Vote`s.
+/// That's why we just impl a `PartialOrd` for `Vote`, that covers all rules defined in raft.
+///
+/// To use it, a node with `vote_1` just check whether `vote_1 <= vote_2` is hold to determine if it can grant
+/// `vote_2`.
+///
+/// A `Vote` is uncommitted when it is firstly created.
+/// A `Vote` is committed when a quorum granted it(i.e., the node with this node becomes a `Leader`).
+///
+/// E.g.:
+///
+/// - A node with `(term=1,uncommitted,None)` is able to grant `(term=2, *,*)`, `(term=1,*,Some(*))`;
+///
+/// - A node with `(term=1,uncommitted,Some(3))` is able to grant `(term=2,*,*)`, `(term=1,committed,Some(4))`. But it
+///   can not grant `(term=1,uncommitted,Some(4))`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Vote {
+    pub term: u64,
+
+    /// Whether this vote is committed, e.g., a vote is granted by a quorum.
+    pub state: CommittedState,
+
+    /// The id and the state of last voted node.
+    pub voted_for: Option<NodeId>,
+}
+
+impl PartialOrd for Vote {
+    /// The relation between votes are defined by a partially ordered relation.
+    ///
+    /// See [`Vote`].
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let term_ord = self.term.cmp(&other.term);
+        if term_ord != Ordering::Equal {
+            // Higher term overrides lower term.
+            return Some(term_ord);
+        }
+
+        // Same term
+
+        let st_ord = self.state.cmp(&other.state);
+        if st_ord != Ordering::Equal {
+            // Committed override non-committed.
+            return Some(st_ord);
+        }
+
+        // Same term,state
+
+        if self.state == CommittedState::Committed {
+            assert_eq!(
+                self.voted_for, other.voted_for,
+                "Two committed votes have to be the same"
+            );
+
+            return Some(Ordering::Equal);
+        }
+
+        // Same term, both NonCommitted
+
+        if self.voted_for.is_some() && other.voted_for.is_some() {
+            if self.voted_for == other.voted_for {
+                Some(Ordering::Equal)
+            } else {
+                // Two different Some() are incomparable
+                None
+            }
+        } else {
+            // At least one of them is None, always comparable
+            Some(self.voted_for.cmp(&other.voted_for))
+        }
+    }
+}
+
+impl std::fmt::Display for Vote {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "vote:{}-{:?}-{:?}", self.term, self.state, self.voted_for)
+    }
+}
+
+impl Vote {
+    pub fn new_uncommitted(term: u64, node_id: Option<u64>) -> Self {
+        Self {
+            term,
+            state: CommittedState::Uncommitted,
+            voted_for: node_id,
+        }
+    }
+
+    pub fn new_committed(term: u64, node_id: u64) -> Self {
+        Self {
+            term,
+            state: CommittedState::Committed,
+            voted_for: Some(node_id),
+        }
+    }
+
+    // Mark this vote as committed
+    pub fn commit(&mut self) {
+        self.state = CommittedState::Committed;
+    }
+
+    /// Get the currently established Leader.
+    ///
+    /// If the vote is committed, the the `voted_for` may be a `Leader`, returns the leader id.
+    /// Otherwise, there is not an established leader.
+    pub fn leader(&self) -> Option<NodeId> {
+        if self.state == CommittedState::Uncommitted {
+            None
+        } else {
+            self.voted_for
+        }
+    }
+}

--- a/openraft/src/vote/vote_test.rs
+++ b/openraft/src/vote/vote_test.rs
@@ -1,0 +1,73 @@
+use crate::Vote;
+
+#[test]
+fn test_voting_state() -> anyhow::Result<()> {
+    let v1u0 = Vote::new_uncommitted(1, None);
+    let v1u1 = Vote::new_uncommitted(1, Some(1));
+    let v1u2 = Vote::new_uncommitted(1, Some(2));
+    let v2u1 = Vote::new_uncommitted(2, Some(1));
+
+    let v1c1 = Vote::new_committed(1, 1);
+    let v1c2 = Vote::new_committed(1, 2);
+    let v2c1 = Vote::new_committed(2, 1);
+
+    let yes = true;
+    let n__ = false;
+
+    assert_eq!(yes, v1u0 <= v1u0);
+    assert_eq!(yes, v1u0 <= v1u1);
+    assert_eq!(yes, v1u0 <= v1u2);
+    assert_eq!(yes, v1u0 <= v2u1);
+    assert_eq!(yes, v1u0 <= v1c1);
+    assert_eq!(yes, v1u0 <= v1c2);
+    assert_eq!(yes, v1u0 <= v2c1);
+
+    assert_eq!(n__, v1u1 <= v1u0);
+    assert_eq!(yes, v1u1 <= v1u1);
+    assert_eq!(n__, v1u1 <= v1u2);
+    assert_eq!(yes, v1u1 <= v2u1);
+    assert_eq!(yes, v1u1 <= v1c1);
+    assert_eq!(yes, v1u1 <= v1c2);
+    assert_eq!(yes, v1u1 <= v2c1);
+
+    assert_eq!(n__, v1u2 <= v1u0);
+    assert_eq!(n__, v1u2 <= v1u1);
+    assert_eq!(yes, v1u2 <= v1u2);
+    assert_eq!(yes, v1u2 <= v2u1);
+    assert_eq!(yes, v1u2 <= v1c1);
+    assert_eq!(yes, v1u2 <= v1c2);
+    assert_eq!(yes, v1u2 <= v2c1);
+
+    assert_eq!(n__, v2u1 <= v1u0);
+    assert_eq!(n__, v2u1 <= v1u1);
+    assert_eq!(n__, v2u1 <= v1u2);
+    assert_eq!(yes, v2u1 <= v2u1);
+    assert_eq!(n__, v2u1 <= v1c1);
+    assert_eq!(n__, v2u1 <= v1c2);
+    assert_eq!(yes, v2u1 <= v2c1);
+
+    assert_eq!(n__, v1c1 <= v1u0);
+    assert_eq!(n__, v1c1 <= v1u1);
+    assert_eq!(n__, v1c1 <= v1u2);
+    assert_eq!(yes, v1c1 <= v2u1);
+    assert_eq!(yes, v1c1 <= v1c1);
+    // assert_eq!(n, v1c1 <= v1c2); // panic
+    assert_eq!(yes, v1c1 <= v2c1);
+
+    assert_eq!(n__, v1c2 <= v1u0);
+    assert_eq!(n__, v1c2 <= v1u1);
+    assert_eq!(n__, v1c2 <= v1u2);
+    assert_eq!(yes, v1c2 <= v2u1);
+    // assert_eq!(n, v1c2 <= v1c1); // panic
+    assert_eq!(yes, v1c2 <= v1c2);
+    assert_eq!(yes, v1c2 <= v2c1);
+
+    assert_eq!(n__, v2c1 <= v1u0);
+    assert_eq!(n__, v2c1 <= v1u1);
+    assert_eq!(n__, v2c1 <= v1u2);
+    assert_eq!(n__, v2c1 <= v2u1);
+    assert_eq!(n__, v2c1 <= v1c1);
+    assert_eq!(n__, v2c1 <= v1c2);
+    assert_eq!(yes, v2c1 <= v2c1);
+    Ok(())
+}

--- a/openraft/tests/api_install_snapshot.rs
+++ b/openraft/tests/api_install_snapshot.rs
@@ -9,6 +9,7 @@ use openraft::Config;
 use openraft::LogId;
 use openraft::SnapshotMeta;
 use openraft::State;
+use openraft::Vote;
 
 #[macro_use]
 mod fixtures;
@@ -45,8 +46,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
 
     let n = router.remove_node(0).await.ok_or_else(|| anyhow::anyhow!("node not found"))?;
     let req0 = InstallSnapshotRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         meta: SnapshotMeta {
             snapshot_id: "ss1".into(),
             last_log_id: LogId { term: 1, index: 0 },

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -8,6 +8,7 @@ use openraft::raft::EntryPayload;
 use openraft::Config;
 use openraft::LogId;
 use openraft::RaftNetwork;
+use openraft::Vote;
 
 use crate::fixtures::blank;
 use crate::fixtures::RaftRouter;
@@ -44,8 +45,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
     // Expect conflict even if the message contains no entries.
 
     let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
-        term: 1,
-        leader_id: 1,
+        vote: Vote::new_committed(1, 1),
         prev_log_id: Some(LogId::new(1, 5)),
         entries: vec![],
         leader_commit: Some(LogId::new(1, 5)),
@@ -58,8 +58,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
     // Feed logs
 
     let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
-        term: 1,
-        leader_id: 1,
+        vote: Vote::new_committed(1, 1),
         prev_log_id: None,
         entries: vec![blank(0, 0), blank(1, 1), Entry {
             log_id: (1, 2).into(),
@@ -79,8 +78,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
     // Expect a conflict with prev_log_index == 3
 
     let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
-        term: 1,
-        leader_id: 1,
+        vote: Vote::new_committed(1, 1),
         prev_log_id: Some(LogId::new(1, 3)),
         entries: vec![],
         leader_commit: Some(LogId::new(1, 5)),

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -13,6 +13,7 @@ use openraft::LogId;
 use openraft::MessageSummary;
 use openraft::RaftStorage;
 use openraft::State;
+use openraft::Vote;
 
 use crate::fixtures::blank;
 use crate::fixtures::RaftRouter;
@@ -41,8 +42,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 0: prev_log_id == None, no logs");
 
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: None,
         entries: vec![],
         leader_commit: Some(LogId::new(1, 2)),
@@ -56,8 +56,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 0: prev_log_id == None, 1 logs");
 
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: None,
         entries: vec![blank(0, 0)],
         leader_commit: Some(LogId::new(1, 2)),
@@ -70,8 +69,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 0: prev_log_id == 1-1, 0 logs");
 
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(0, 0)),
         entries: vec![],
         leader_commit: Some(LogId::new(1, 2)),
@@ -86,8 +84,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 0: prev_log_id.index == 0, ");
 
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(0, 0)),
         entries: vec![blank(1, 1), blank(1, 2), blank(1, 3), blank(1, 4)],
         // this set the last_applied to 2
@@ -112,8 +109,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 1: 0 < prev_log_id.index < commit_index");
 
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(1, 1)),
         entries: vec![blank(1, 2)],
         leader_commit: Some(LogId::new(1, 2)),
@@ -128,8 +124,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 2:  prev_log_id.index == last_applied, inconsistent log should be removed");
 
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(1, 2)),
         entries: vec![blank(2, 3)],
         // this set the last_applied to 2
@@ -144,8 +139,7 @@ async fn append_conflicts() -> Result<()> {
 
     // check last_log_id is updated:
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(1, 2000)),
         entries: vec![],
         leader_commit: Some(LogId::new(1, 2)),
@@ -160,8 +154,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 3,4: prev_log_id.index <= last_log_id, prev_log_id mismatch, inconsistent log is removed");
 
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(3, 3)),
         entries: vec![],
         leader_commit: Some(LogId::new(1, 2)),
@@ -176,8 +169,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- case 3,4: prev_log_id.index <= last_log_id, prev_log_id matches, inconsistent log is removed");
     // refill logs
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(1, 2)),
         entries: vec![blank(2, 3), blank(2, 4), blank(2, 5)],
         leader_commit: Some(LogId::new(1, 2)),
@@ -192,8 +184,7 @@ async fn append_conflicts() -> Result<()> {
 
     // prev_log_id matches
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(2, 3)),
         entries: vec![blank(3, 4)],
         leader_commit: Some(LogId::new(1, 2)),
@@ -209,8 +200,7 @@ async fn append_conflicts() -> Result<()> {
 
     // refill logs
     let req = AppendEntriesRequest {
-        term: 1,
-        leader_id: 0,
+        vote: Vote::new_committed(1, 0),
         prev_log_id: Some(LogId::new(1, 200)),
         entries: vec![],
         leader_commit: Some(LogId::new(1, 2)),

--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -5,11 +5,12 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::Entry;
 use openraft::raft::EntryPayload;
-use openraft::storage::HardState;
+use openraft::CommittedState;
 use openraft::Config;
 use openraft::LogId;
 use openraft::RaftStorage;
 use openraft::State;
+use openraft::Vote;
 
 use crate::fixtures::RaftRouter;
 
@@ -65,14 +66,16 @@ async fn append_inconsistent_log() -> Result<()> {
         .await?;
     }
 
-    sto0.save_hard_state(&HardState {
-        current_term: 2,
+    sto0.save_vote(&Vote {
+        term: 2,
+        state: CommittedState::Uncommitted,
         voted_for: Some(0),
     })
     .await?;
 
-    sto2.save_hard_state(&HardState {
-        current_term: 3,
+    sto2.save_vote(&Vote {
+        term: 3,
+        state: CommittedState::Uncommitted,
         voted_for: Some(2),
     })
     .await?;

--- a/openraft/tests/append_entries/t40_append_updates_membership.rs
+++ b/openraft/tests/append_entries/t40_append_updates_membership.rs
@@ -10,6 +10,7 @@ use openraft::Config;
 use openraft::LogId;
 use openraft::Membership;
 use openraft::State;
+use openraft::Vote;
 
 use crate::fixtures::blank;
 use crate::fixtures::RaftRouter;
@@ -38,8 +39,7 @@ async fn append_updates_membership() -> Result<()> {
     tracing::info!("--- append-entries update membership");
     {
         let req = AppendEntriesRequest {
-            term: 1,
-            leader_id: 0,
+            vote: Vote::new_committed(1, 0),
             prev_log_id: None,
             entries: vec![
                 blank(0, 0),
@@ -68,8 +68,7 @@ async fn append_updates_membership() -> Result<()> {
     tracing::info!("--- delete inconsistent logs update membership");
     {
         let req = AppendEntriesRequest {
-            term: 1,
-            leader_id: 0,
+            vote: Vote::new_committed(1, 0),
             prev_log_id: Some(LogId::new(1, 2)),
             entries: vec![blank(2, 3)],
             leader_commit: Some(LogId::new(0, 0)),

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -6,6 +6,7 @@ use openraft::raft::AppendEntriesRequest;
 use openraft::Config;
 use openraft::LogId;
 use openraft::RaftNetwork;
+use openraft::Vote;
 
 use crate::fixtures::RaftRouter;
 
@@ -27,8 +28,7 @@ async fn append_entries_with_bigger_term() -> Result<()> {
 
     // append entries with term 2 and leader_id, this MUST cause hard state changed in node 0
     let req = AppendEntriesRequest::<memstore::ClientRequest> {
-        term: 2,
-        leader_id: 1,
+        vote: Vote::new_committed(2, 1),
         prev_log_id: Some(LogId::new(1, n_logs)),
         entries: vec![],
         leader_commit: Some(LogId::new(1, n_logs)),

--- a/openraft/tests/elect_compare_last_log.rs
+++ b/openraft/tests/elect_compare_last_log.rs
@@ -6,12 +6,13 @@ use fixtures::RaftRouter;
 use maplit::btreeset;
 use openraft::raft::Entry;
 use openraft::raft::EntryPayload;
-use openraft::storage::HardState;
+use openraft::CommittedState;
 use openraft::Config;
 use openraft::LogId;
 use openraft::Membership;
 use openraft::RaftStorage;
 use openraft::State;
+use openraft::Vote;
 
 use crate::fixtures::blank;
 
@@ -36,8 +37,9 @@ async fn elect_compare_last_log() -> Result<()> {
 
     tracing::info!("--- fake store: sto0: last log: 2,1");
     {
-        sto0.save_hard_state(&HardState {
-            current_term: 10,
+        sto0.save_vote(&Vote {
+            term: 10,
+            state: CommittedState::Uncommitted,
             voted_for: None,
         })
         .await?;
@@ -51,8 +53,9 @@ async fn elect_compare_last_log() -> Result<()> {
 
     tracing::info!("--- fake store: sto1: last log: 1,2");
     {
-        sto1.save_hard_state(&HardState {
-            current_term: 10,
+        sto1.save_vote(&Vote {
+            term: 10,
+            state: CommittedState::Uncommitted,
             voted_for: None,
         })
         .await?;

--- a/openraft/tests/log_compaction/compaction.rs
+++ b/openraft/tests/log_compaction/compaction.rs
@@ -13,6 +13,7 @@ use openraft::RaftNetwork;
 use openraft::RaftStorage;
 use openraft::SnapshotPolicy;
 use openraft::State;
+use openraft::Vote;
 
 use crate::fixtures::blank;
 use crate::fixtures::RaftRouter;
@@ -148,8 +149,7 @@ async fn compaction() -> Result<()> {
     {
         let res = router
             .send_append_entries(1, AppendEntriesRequest {
-                term: 1,
-                leader_id: 0,
+                vote: Vote::new_committed(1, 0),
                 prev_log_id: Some(LogId::new(1, 2)),
                 entries: vec![],
                 leader_commit: Some(LogId::new(0, 0)),

--- a/openraft/tests/snapshot/snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/snapshot_overrides_membership.rs
@@ -12,6 +12,7 @@ use openraft::Membership;
 use openraft::RaftNetwork;
 use openraft::RaftStorage;
 use openraft::SnapshotPolicy;
+use openraft::Vote;
 
 use crate::fixtures::blank;
 use crate::fixtures::RaftRouter;
@@ -91,8 +92,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
         tracing::info!("--- add a membership config log to the learner");
         {
             let req = AppendEntriesRequest {
-                term: 1,
-                leader_id: 0,
+                vote: Vote::new_committed(1, 0),
                 prev_log_id: None,
                 entries: vec![blank(0, 0), Entry {
                     log_id: LogId { term: 1, index: 1 },

--- a/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
@@ -82,7 +82,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         assert_eq!(Membership::new_single(btreeset! {0,1}), m.membership, "membership ");
 
         // TODO(xp): this assertion fails because when change-membership, a append-entries request does not update
-        //           voted_for and does not call save_hard_state.
+        //           voted_for and does not call save_vote.
         //           Thus the storage layer does not know about the leader==Some(0).
         //           Update voted_for whenever a new leader is seen would solve this issue.
         // router


### PR DESCRIPTION
## Changelog

##### Change: use `Vote` to define Leader and Candidate
`Vote` is a similar concept to Paxos proposer-id.
It is defined by a tuple of `(term, uncommitted|committed, node_id)`.

A Candidate creates an uncommitted `Vote` to identify it, as a
replacement of `(term, candidate_id)`.

A Leader has a `Vote` that is committed, i.e., the vote is granted by a
quorum.

The rule for overriding a `Vote` is defined by a **partially ordered**
relation: a node is only allowed to grant a greater vote.
The partial order relation covers all behavior of the `vote` in raft
spec. This way we make the test very easy to be done.

With `Vote`, checking the validity of a request is quite simple: just by
`self.vote <= rpc.vote`.

- Rename: save_hard_state() and read_hard_state() to save_vote() and read_vote().

- Replace `term, node_id` pair with `Vote` in RaftCore and RPC struct-s.

- Fix: request handler for append-entries and install-snapshot should
  save the vote they received.


##### Refactor: minor refinement

---