### PR TITLE
Fix: a Candidate should revert to Follower at once when a higher vote is seen

### DIFF
--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -156,5 +156,5 @@ async fn change_from_to(old: BTreeSet<NodeId>, new: BTreeSet<NodeId>) -> anyhow:
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(500))
+    Some(Duration::from_millis(1000))
 }


### PR DESCRIPTION

## Changelog

##### Fix: a Candidate should revert to Follower at once when a higher vote is seen
When a Candidate saw a higher vote, it store it at once.
Then no more further granted votes are valid to this candidate,
because vote they granted are changed.

Thus it was wrong to compare `last_log_id` before decide if to revert to
Follower.
The right way is to revert to Follower at once and stop the voting
procedure.

The test `leader_metrics()` sometimes fails because of this bug.

---