### PR TITLE
Feature: add ExampleClient to example-raft-kv

### DIFF
--- a/example-raft-kv/Cargo.toml
+++ b/example-raft-kv/Cargo.toml
@@ -33,6 +33,7 @@ tracing = "0.1.29"
 tracing-futures = "0.2.4"
 
 [dev-dependencies]
+anyhow = "1.0.32"
 maplit = "1.0.2"
 
 [features]

--- a/example-raft-kv/README.md
+++ b/example-raft-kv/README.md
@@ -12,13 +12,27 @@ Includes:
 
 - Client and `RaftNetwork`([rpc](./src/network/rpc.rs)) are built upon [reqwest](https://docs.rs/reqwest).
 
+  [ExampleClient](./src/client.rs) is a minimal raft client in rust to talk to a raft cluster.
+  - It includes application API `write()` and `read()`, and administrative API `init()`, `add_learner()`, `change_membership()`, `metrics()` and `list_nodes()`.
+  - This client tracks the last known leader id, a write operation(such as `write()` or `change_membership()`) will be redirected to the leader on client side.
+
 ## Run it
 
-If you want to see a simulation of 3 nodes running and sharing data, you can run the cluster demo:
+There is a example in bash script and an example in rust:
 
-```shell
-./test-cluster.sh
-```
+- [test-cluster.sh](./test-cluster.sh) shows a simulation of 3 nodes running and sharing data,
+  It only uses `curl` and shows the communication between a client and the cluster in plain HTTP messages.
+  You can run the cluster demo with:
+
+  ```shell
+  ./test-cluster.sh
+  ```
+
+- [test_cluster.rs](./tests/cluster/test_cluster.rs) does almost the same as `test-cluster.sh` but in rust
+  with the `ExampleClient`.
+
+  Run it with `cargo test`.
+
 
 if you want to compile the application, run:
 
@@ -28,6 +42,8 @@ cargo build
 
 (If you append `--release` to make it compile in production, but we don't recommend to use
 this project in production yet.)
+
+## What the test script does
 
 To run it, get the binary `raft-key-value` inside `target/debug` and run:
 

--- a/example-raft-kv/src/bin/main.rs
+++ b/example-raft-kv/src/bin/main.rs
@@ -1,21 +1,10 @@
-use std::sync::Arc;
-
-use actix_web::middleware;
-use actix_web::middleware::Logger;
-use actix_web::web::Data;
-use actix_web::App;
-use actix_web::HttpServer;
 use clap::Parser;
 use env_logger::Env;
-use example_raft_key_value::app::ExampleApp;
-use example_raft_key_value::network::api;
-use example_raft_key_value::network::management;
-use example_raft_key_value::network::raft;
 use example_raft_key_value::network::rpc::ExampleNetwork;
+use example_raft_key_value::start_example_raft_node;
 use example_raft_key_value::store::ExampleRequest;
 use example_raft_key_value::store::ExampleResponse;
 use example_raft_key_value::store::ExampleStore;
-use openraft::Config;
 use openraft::Raft;
 
 pub type ExampleRaft = Raft<ExampleRequest, ExampleResponse, ExampleNetwork, ExampleStore>;
@@ -37,52 +26,6 @@ async fn main() -> std::io::Result<()> {
 
     // Parse the parameters passed by arguments.
     let options = Opt::parse();
-    let node_id = options.id;
 
-    // Create a configuration for the raft instance.
-    let config = Arc::new(Config::default().validate().unwrap());
-
-    // Create a instance of where the Raft data will be stored.
-    let store = Arc::new(ExampleStore::default());
-
-    // Create the network layer that will connect and communicate the raft instances and
-    // will be used in conjunction with the store created above.
-    let network = Arc::new(ExampleNetwork { store: store.clone() });
-
-    // Create a local raft instance.
-    let raft = Raft::new(node_id, config.clone(), network, store.clone());
-
-    // Create an application that will store all the instances created above, this will
-    // be later used on the actix-web services.
-    let app = Data::new(ExampleApp {
-        id: options.id,
-        raft,
-        store,
-        config,
-    });
-
-    // Start the actix-web server.
-    HttpServer::new(move || {
-        App::new()
-            .wrap(Logger::default())
-            .wrap(Logger::new("%a %{User-Agent}i"))
-            .wrap(middleware::Compress::default())
-            .app_data(app.clone())
-            // raft internal RPC
-            .service(raft::append)
-            .service(raft::snapshot)
-            .service(raft::vote)
-            // admin API
-            .service(management::init)
-            .service(management::add_learner)
-            .service(management::change_membership)
-            .service(management::metrics)
-            .service(management::list_nodes)
-            // application API
-            .service(api::write)
-            .service(api::read)
-    })
-    .bind(options.http_addr)?
-    .run()
-    .await
+    start_example_raft_node(options.id, options.http_addr).await
 }

--- a/example-raft-kv/src/client.rs
+++ b/example-raft-kv/src/client.rs
@@ -1,0 +1,225 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use openraft::error::AddLearnerError;
+use openraft::error::ClientWriteError;
+use openraft::error::ForwardToLeader;
+use openraft::error::Infallible;
+use openraft::error::InitializeError;
+use openraft::error::NetworkError;
+use openraft::error::NodeNotFound;
+use openraft::error::RPCError;
+use openraft::error::RemoteError;
+use openraft::raft::AddLearnerResponse;
+use openraft::raft::ClientWriteResponse;
+use openraft::NodeId;
+use openraft::RaftMetrics;
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::ExampleRequest;
+use crate::ExampleResponse;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Empty {}
+
+#[async_trait]
+pub trait NodeManager {
+    async fn get_node_address(&self, node_id: NodeId) -> Result<String, NodeNotFound>;
+}
+
+#[async_trait]
+impl<T> NodeManager for T
+where T: Fn(NodeId) -> Result<String, NodeNotFound> + Sync
+{
+    async fn get_node_address(&self, node_id: NodeId) -> Result<String, NodeNotFound> {
+        self(node_id)
+    }
+}
+
+pub struct ExampleClient {
+    /// The leader node to send request to.
+    ///
+    /// All traffic should be sent to the leader in a cluster.
+    pub leader_id: Arc<Mutex<NodeId>>,
+
+    /// Raft itself does not store node addresses.
+    /// Thus when a `ForwardToLeader` error is returned, the client need to find the node address by itself.
+    pub node_manager: Arc<dyn NodeManager>,
+
+    pub inner: Client,
+}
+
+impl ExampleClient {
+    /// Create a client with a leader node id and a node manager to get node address by node id.
+    pub fn new(leader_id: NodeId, node_manager: Arc<dyn NodeManager>) -> Self {
+        Self {
+            leader_id: Arc::new(Mutex::new(leader_id)),
+            inner: reqwest::Client::new(),
+            node_manager,
+        }
+    }
+
+    // --- Application API
+
+    /// Submit a write request to the raft cluster.
+    ///
+    /// The request will be processed by raft protocol: it will be replicated to a quorum and then will be applied to
+    /// state machine.
+    ///
+    /// The result of applying the request will be returned.
+    pub async fn write(
+        &self,
+        req: &ExampleRequest,
+    ) -> Result<ClientWriteResponse<ExampleResponse>, RPCError<ClientWriteError>> {
+        self.send_rpc_to_leader("write", Some(req)).await
+    }
+
+    /// Read value by key, in an inconsistent mode.
+    ///
+    /// This method may return stale value because it does not force to read on a legal leader.
+    pub async fn read(&self, req: &String) -> Result<String, RPCError<Infallible>> {
+        let target = self.get_leader_id();
+        self.send_rpc(target, "read", Some(req)).await
+    }
+
+    // --- Cluster management API
+
+    /// Initialize a cluster of only the node that receives this request.
+    ///
+    /// This is the first step to initialize a cluster.
+    /// With a initialized cluster, new node can be added with [`write`].
+    /// Then setup replication with [`add_learner`].
+    /// Then make the new node a member with [`change_membership`].
+    pub async fn init(&self) -> Result<(), RPCError<InitializeError>> {
+        let target = self.get_leader_id();
+        self.send_rpc(target, "init", Some(&Empty {})).await
+    }
+
+    /// Add a node as learner.
+    ///
+    /// The node to add has to exist, i.e., being added with `write(ExampleRequest::AddNode{})`
+    pub async fn add_learner(&self, req: &NodeId) -> Result<AddLearnerResponse, RPCError<AddLearnerError>> {
+        self.send_rpc_to_leader("add-learner", Some(req)).await
+    }
+
+    /// Change membership to the specified set of nodes.
+    ///
+    /// All nodes in `req` have to be already added as learner with [`add_learner`],
+    /// or an error [`LearnerNotFound`] will be returned.
+    pub async fn change_membership(
+        &self,
+        req: &BTreeSet<NodeId>,
+    ) -> Result<ClientWriteResponse<ExampleResponse>, RPCError<ClientWriteError>> {
+        self.send_rpc_to_leader("change-membership", Some(req)).await
+    }
+
+    /// Get the metrics about the cluster.
+    pub async fn metrics(&self) -> Result<RaftMetrics, RPCError<Infallible>> {
+        let target = self.get_leader_id();
+        self.send_rpc(target, "metrics", None::<&()>).await
+    }
+
+    /// List all known nodes.
+    ///
+    /// A known node does not have to be a member or learner.
+    /// It is just a node that the cluster can use as learner or a member.
+    pub async fn list_nodes(&self) -> Result<BTreeMap<NodeId, String>, RPCError<Infallible>> {
+        let target = self.get_leader_id();
+        self.send_rpc(target, "list-nodes", None::<&()>).await
+    }
+
+    // --- Internal methods
+
+    /// Get the last known leader node id by this client.
+    fn get_leader_id(&self) -> NodeId {
+        let t = self.leader_id.lock().unwrap();
+        *t
+    }
+
+    /// Send RPC to specified node.
+    ///
+    /// It sends out a POST request if `req` is Some. Otherwise a GET request.
+    /// The remote endpoint must respond a reply in form of `Result<T, E>`.
+    /// An `Err` happened on remote will be wrapped in an [`RPCError::RemoteError`].
+    async fn send_rpc<Req, Resp, Err>(
+        &self,
+        target: NodeId,
+        uri: &str,
+        req: Option<&Req>,
+    ) -> Result<Resp, RPCError<Err>>
+    where
+        Req: Serialize + 'static,
+        Resp: DeserializeOwned,
+        Err: std::error::Error + DeserializeOwned,
+    {
+        let addr = self.node_manager.get_node_address(target).await?;
+
+        let url = format!("http://{}/{}", addr, uri);
+
+        let resp = if let Some(r) = req {
+            self.inner.post(url).json(r)
+        } else {
+            self.inner.get(url)
+        }
+        .send()
+        .await
+        .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+
+        let res: Result<Resp, Err> = resp.json().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+
+        res.map_err(|e| RPCError::RemoteError(RemoteError::new(target, e)))
+    }
+
+    /// Try the best to send a request to the leader.
+    ///
+    /// If the target node is not a leader, a `ForwardToLeader` error will be
+    /// returned and this client will retry at most 3 times to contact the updated leader.
+    async fn send_rpc_to_leader<Req, Resp, Err>(&self, uri: &str, req: Option<&Req>) -> Result<Resp, RPCError<Err>>
+    where
+        Req: Serialize + 'static,
+        Resp: DeserializeOwned,
+        Err: std::error::Error + DeserializeOwned + TryInto<ForwardToLeader> + Clone,
+    {
+        // Retry at most 3 times to find a valid leader.
+        let mut n_retry = 3;
+
+        loop {
+            let target = self.get_leader_id();
+
+            let res: Result<Resp, RPCError<Err>> = self.send_rpc(target, uri, req).await;
+
+            let rpc_err = match res {
+                Ok(x) => return Ok(x),
+                Err(rpc_err) => rpc_err,
+            };
+
+            if let RPCError::RemoteError(remote_err) = &rpc_err {
+                let forward_err_res = <Err as TryInto<ForwardToLeader>>::try_into(remote_err.source.clone());
+
+                if let Ok(ForwardToLeader {
+                    leader_id: Some(leader_id),
+                }) = forward_err_res
+                {
+                    // Update target to the new leader.
+                    {
+                        let mut t = self.leader_id.lock().unwrap();
+                        *t = leader_id;
+                    }
+
+                    n_retry -= 1;
+                    if n_retry > 0 {
+                        continue;
+                    }
+                }
+            }
+
+            return Err(rpc_err);
+        }
+    }
+}

--- a/example-raft-kv/src/lib.rs
+++ b/example-raft-kv/src/lib.rs
@@ -1,12 +1,76 @@
+use std::sync::Arc;
+
+use actix_web::middleware;
+use actix_web::middleware::Logger;
+use actix_web::web::Data;
+use actix_web::App;
+use actix_web::HttpServer;
+use openraft::Config;
+use openraft::NodeId;
 use openraft::Raft;
 
+use crate::app::ExampleApp;
+use crate::network::api;
+use crate::network::management;
+use crate::network::raft;
 use crate::network::rpc::ExampleNetwork;
 use crate::store::ExampleRequest;
 use crate::store::ExampleResponse;
 use crate::store::ExampleStore;
 
 pub mod app;
+pub mod client;
 pub mod network;
 pub mod store;
 
 pub type ExampleRaft = Raft<ExampleRequest, ExampleResponse, ExampleNetwork, ExampleStore>;
+
+pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std::io::Result<()> {
+    // Create a configuration for the raft instance.
+    let config = Arc::new(Config::default().validate().unwrap());
+
+    // Create a instance of where the Raft data will be stored.
+    let store = Arc::new(ExampleStore::default());
+
+    // Create the network layer that will connect and communicate the raft instances and
+    // will be used in conjunction with the store created above.
+    let network = Arc::new(ExampleNetwork { store: store.clone() });
+
+    // Create a local raft instance.
+    let raft = Raft::new(node_id, config.clone(), network, store.clone());
+
+    // Create an application that will store all the instances created above, this will
+    // be later used on the actix-web services.
+    let app = Data::new(ExampleApp {
+        id: node_id,
+        raft,
+        store,
+        config,
+    });
+
+    // Start the actix-web server.
+    let server = HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::default())
+            .wrap(Logger::new("%a %{User-Agent}i"))
+            .wrap(middleware::Compress::default())
+            .app_data(app.clone())
+            // raft internal RPC
+            .service(raft::append)
+            .service(raft::snapshot)
+            .service(raft::vote)
+            // admin API
+            .service(management::init)
+            .service(management::add_learner)
+            .service(management::change_membership)
+            .service(management::metrics)
+            .service(management::list_nodes)
+            // application API
+            .service(api::write)
+            .service(api::read)
+    });
+
+    let x = server.bind(http_addr)?;
+
+    x.run().await
+}

--- a/example-raft-kv/src/network/api.rs
+++ b/example-raft-kv/src/network/api.rs
@@ -2,6 +2,7 @@ use actix_web::post;
 use actix_web::web;
 use actix_web::web::Data;
 use actix_web::Responder;
+use openraft::error::Infallible;
 use openraft::raft::ClientWriteRequest;
 use openraft::raft::EntryPayload;
 use web::Json;
@@ -16,7 +17,7 @@ use crate::store::ExampleRequest;
  * API. The current implementation:
  *
  *  - `POST - /write` saves a value in a key and sync the nodes.
- *  - `GET - /read` attempt to find a value from a given key.
+ *  - `POST - /read` attempt to find a value from a given key.
  */
 #[post("/write")]
 pub async fn write(app: Data<ExampleApp>, req: Json<ExampleRequest>) -> actix_web::Result<impl Responder> {
@@ -30,5 +31,7 @@ pub async fn read(app: Data<ExampleApp>, req: Json<String>) -> actix_web::Result
     let state_machine = app.store.state_machine.read().await;
     let key = req.0;
     let value = state_machine.data.get(&key).cloned();
-    Ok(Json(value.unwrap_or_default()))
+
+    let res: Result<String, Infallible> = Ok(value.unwrap_or_default());
+    Ok(Json(res))
 }

--- a/example-raft-kv/tests/cluster/main.rs
+++ b/example-raft-kv/tests/cluster/main.rs
@@ -1,0 +1,1 @@
+mod test_cluster;

--- a/example-raft-kv/tests/cluster/test_cluster.rs
+++ b/example-raft-kv/tests/cluster/test_cluster.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use anyerror::AnyError;
+use example_raft_key_value::client::ExampleClient;
+use example_raft_key_value::start_example_raft_node;
+use example_raft_key_value::store::ExampleRequest;
+use maplit::btreeset;
+use openraft::error::NodeNotFound;
+use tokio::runtime::Runtime;
+
+/// Setup a cluster of 3 nodes.
+/// Write to it and read from it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_cluster() -> anyhow::Result<()> {
+    // --- The client itself does not store addresses for all nodes, but just node id.
+    //     Thus we need a supporting component to provide mapping from node id to node address.
+    //     This is only used by the client. A raft node in this example stores node addresses in its store.
+
+    let get_addr = |node_id| {
+        let addr = match node_id {
+            1 => "127.0.0.1:21001".to_string(),
+            2 => "127.0.0.1:21002".to_string(),
+            3 => "127.0.0.1:21003".to_string(),
+            _ => {
+                return Err(NodeNotFound {
+                    node_id,
+                    source: AnyError::error("node not found"),
+                });
+            }
+        };
+        Ok(addr)
+    };
+    let get_addr = Arc::new(get_addr);
+
+    // --- Start 3 raft node in 3 threads.
+
+    let _h1 = thread::spawn(|| {
+        let rt = Runtime::new().unwrap();
+        let x = rt.block_on(async move { start_example_raft_node(1, "127.0.0.1:21001".to_string()).await });
+        println!("x: {:?}", x);
+    });
+
+    let _h2 = thread::spawn(|| {
+        let rt = Runtime::new().unwrap();
+        let x = rt.block_on(async move { start_example_raft_node(2, "127.0.0.1:21002".to_string()).await });
+        println!("x: {:?}", x);
+    });
+
+    let _h3 = thread::spawn(|| {
+        let rt = Runtime::new().unwrap();
+        let x = rt.block_on(async move { start_example_raft_node(3, "127.0.0.1:21003".to_string()).await });
+        println!("x: {:?}", x);
+    });
+
+    // --- Create a client to the first node, as a control handle to the cluster.
+
+    let client = ExampleClient::new(1, get_addr.clone());
+
+    // --- 1. Initialize the target node as a cluster of only one node.
+    //        After init(), the single node cluster will be fully functional.
+
+    client.init().await?;
+
+    let m = client.metrics().await?;
+    println!("metrics after init: {:?}", m);
+
+    // --- 2. Before adding more members to the cluster, first we need to let the cluster know the address of every node
+    //        to add.
+    //        This is done with a regular raft protocol: replicate a log that contains node info and then apply the log
+    //        to state machine.
+    //        Then `RaftNetwork` will be able to read node address from its store.
+
+    let x = client
+        .write(&ExampleRequest::AddNode {
+            id: 1,
+            addr: "127.0.0.1:21001".to_string(),
+        })
+        .await?;
+    println!("add node 1 res: {:?}", x);
+
+    let x = client
+        .write(&ExampleRequest::AddNode {
+            id: 2,
+            addr: "127.0.0.1:21002".to_string(),
+        })
+        .await?;
+    println!("add node 2 res: {:?}", x);
+
+    let x = client
+        .write(&ExampleRequest::AddNode {
+            id: 3,
+            addr: "127.0.0.1:21003".to_string(),
+        })
+        .await?;
+    println!("add node 3 res: {:?}", x);
+
+    let x = client.list_nodes().await?;
+    println!("list-nodes: {:?}", x);
+
+    // --- 3. Add node 2 and 3 to the cluster as `Learner`, to let them start to receive log replication from the
+    //        leader.
+
+    let x = client.add_learner(&2).await?;
+    println!("add-learner 2: {:?}", x);
+
+    let x = client.add_learner(&3).await?;
+    println!("add-learner 3: {:?}", x);
+
+    // --- 4. Turn the two learners to members. A member node can vote or elect itself as leader.
+
+    let x = client.change_membership(&btreeset! {1,2,3}).await?;
+    println!("change-membership to 1,2,3: {:?}", x);
+
+    // --- After change-membership, some cluster state will be seen in the metrics.
+    //
+    // ```text
+    // metrics: RaftMetrics {
+    //   current_leader: Some(1),
+    //   membership_config: EffectiveMembership {
+    //        log_id: LogId { leader_id: LeaderId { term: 1, node_id: 1 }, index: 8 },
+    //        membership: Membership { learners: {}, configs: [{1, 2, 3}], all_members: {1, 2, 3} }
+    //   },
+    //   leader_metrics: Some(LeaderMetrics { replication: {
+    //     2: ReplicationMetrics { matched: Some(LogId { leader_id: LeaderId { term: 1, node_id: 1 }, index: 7 }) },
+    //     3: ReplicationMetrics { matched: Some(LogId { leader_id: LeaderId { term: 1, node_id: 1 }, index: 8 }) }} })
+    // }
+    // ```
+
+    let x = client.metrics().await?;
+    println!("metrics after change-member: {:?}", x);
+
+    // --- Try to write some application data through the leader.
+
+    let x = client
+        .write(&ExampleRequest::Set {
+            key: "foo".to_string(),
+            value: "bar".to_string(),
+        })
+        .await?;
+    println!("write `foo` res: {:?}", x);
+
+    // --- Wait for a while to let the replication get done.
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // --- Read it on every node.
+
+    let x = client.read(&("foo".to_string())).await?;
+    println!("read `foo` on node 1: {:?}", x);
+
+    let client2 = ExampleClient::new(2, get_addr.clone());
+    let x = client2.read(&("foo".to_string())).await?;
+    println!("read `foo` on node 2: {:?}", x);
+
+    let client3 = ExampleClient::new(3, get_addr.clone());
+    let x = client3.read(&("foo".to_string())).await?;
+    println!("read `foo` on node 3: {:?}", x);
+
+    // --- A write to non-leader will be automatically forwarded to a known leader
+
+    let x = client2
+        .write(&ExampleRequest::Set {
+            key: "foo".to_string(),
+            value: "wow".to_string(),
+        })
+        .await?;
+    println!("write `foo` to node-2 res: {:?}", x);
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // --- Read it on every node.
+
+    let x = client.read(&("foo".to_string())).await?;
+    println!("read `foo` on node 1: {:?}", x);
+
+    let client2 = ExampleClient::new(2, get_addr.clone());
+    let x = client2.read(&("foo".to_string())).await?;
+    println!("read `foo` on node 2: {:?}", x);
+
+    let client3 = ExampleClient::new(3, get_addr.clone());
+    let x = client3.read(&("foo".to_string())).await?;
+    println!("read `foo` on node 3: {:?}", x);
+
+    Ok(())
+}

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -115,7 +115,7 @@ pub enum ChangeMembershipError {
     LearnerIsLagging(#[from] LearnerIsLagging),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error, derive_more::TryInto)]
 pub enum AddLearnerError {
     #[error(transparent)]
     ForwardToLeader(#[from] ForwardToLeader),
@@ -197,6 +197,9 @@ pub enum ReplicationError {
     StorageError(#[from] StorageError),
 
     #[error(transparent)]
+    NodeNotFound(#[from] NodeNotFound),
+
+    #[error(transparent)]
     Timeout(#[from] Timeout),
 
     #[error(transparent)]
@@ -208,6 +211,9 @@ pub enum ReplicationError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 pub enum RPCError<T: Error> {
+    #[error(transparent)]
+    NodeNotFound(#[from] NodeNotFound),
+
     #[error(transparent)]
     Timeout(#[from] Timeout),
 
@@ -319,3 +325,14 @@ pub struct LearnerIsLagging {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 #[error("new membership can not be empty")]
 pub struct EmptyMembership {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("node not found: {node_id}, source: {source}")]
+pub struct NodeNotFound {
+    pub node_id: NodeId,
+    pub source: AnyError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("infallible")]
+pub enum Infallible {}

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -243,6 +243,9 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
                     let _ = self.raft_core_tx.send((ReplicaEvent::Shutdown, tracing::debug_span!("CH")));
                     return;
                 }
+                ReplicationError::NodeNotFound(err) => {
+                    unreachable!("programming bug: {}", err)
+                }
                 ReplicationError::Timeout { .. } => {
                     // nothing to do
                 }
@@ -364,6 +367,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
                 Err(err) => {
                     tracing::warn!(error=%err, "error sending AppendEntries RPC to target");
                     let repl_err = match err {
+                        RPCError::NodeNotFound(e) => ReplicationError::NodeNotFound(e),
                         RPCError::Timeout(e) => ReplicationError::Timeout(e),
                         RPCError::Network(e) => ReplicationError::Network(e),
                         RPCError::RemoteError(e) => ReplicationError::RemoteError(e),


### PR DESCRIPTION

## Changelog

##### Feature: add ExampleClient to example-raft-kv
Add raft client in rust `ExampleClient` to show how to talk to a raft
cluster.
It implements 2 application APIs and several administrative APIs for managing or
monitor a raft cluster.

This client also shows how to deal `ForwardToLeader` error when a
**write** request is sent to a non-leader.

Also a new demo `test_cluster.rs` of how to set up a raft cluster with `ExampleClient` is
added.

Other modification:
- All API replies are made into a uniform form: `Result<T, E>`.
- `openraft` adds new error `NodeNotFound` and `Infallible`.

- fix: #158

---