### PR TITLE
Refactor: in membership test, there is a chance a node has no 2nd change-membership log keeps electing

### DIFF
--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -104,10 +104,23 @@ async fn change_from_to(old: BTreeSet<NodeId>, new: BTreeSet<NodeId>) -> anyhow:
         }
 
         for id in only_in_old.clone() {
+            // TODO(xp): There is a chance the older leader quits before replicating 2 membership logs to every node.
+            //           Thus a node in old cluster may start electing while a new leader already elected in the new
+            //           cluster. Such a node keeps electing but it has less logs thus will never succeed.
+            //
+            //           Error: timeout after 1s when node 2 only in old, from {0, 1, 2} to {4, 5, 6} .state -> Learner
+            //           latest: Metrics{id:2,Candidate, term:7, last_log:Some(109), last_applied:Some(LogId
+            //           { leader_id: LeaderId { term: 1, node_id: 0 }, index: 109 }), leader:None,
+            //           membership:{log_id:1-0-109 membership:members:[{0, 1, 2},{4, 5, 6}],learners:[]},
+            //           snapshot:None, replication:
+
             router
                 .wait(id, timeout())
                 .await?
-                .state(State::Learner, format!("node {} only in old, {}", id, mes))
+                .metrics(
+                    |x| x.state == State::Learner || x.state == State::Candidate,
+                    format!("node {} only in old, {}", id, mes),
+                )
                 .await?;
         }
     }


### PR DESCRIPTION

## Changelog

##### Refactor: in membership test, there is a chance a node has no 2nd change-membership log keeps electing
This is normal but sometimes fails the test.

Loosen the condition check: allows a node in the old cluster to stay in
Candidate state.

---