### PR TITLE
Refactor: openraft tests: remove async if a method is sync.

### DIFF
--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -114,7 +114,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     ///
     /// These RPCs are sent by the cluster leader to replicate log entries (§5.3), and are also
     /// used as heartbeats (§5.2).
-    #[tracing::instrument(level = "trace", skip(self, rpc), fields(rpc=%rpc.summary()))]
+    #[tracing::instrument(level = "debug", skip(self, rpc), fields(rpc=%rpc.summary()))]
     pub async fn append_entries(
         &self,
         rpc: AppendEntriesRequest<D>,

--- a/openraft/tests/client_api/t10_client_writes.rs
+++ b/openraft/tests/client_api/t10_client_writes.rs
@@ -58,7 +58,7 @@ async fn client_writes() -> Result<()> {
     router.assert_stable_cluster(Some(1), Some(log_index)).await;
 
     // Write a bunch of data and assert that the cluster stayes stable.
-    let leader = router.leader().await.expect("leader not found");
+    let leader = router.leader().expect("leader not found");
     let mut clients = futures::stream::FuturesUnordered::new();
     clients.push(router.client_request_many(leader, "0", 500));
     clients.push(router.client_request_many(leader, "1", 500));

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -42,7 +42,7 @@ async fn client_reads() -> Result<()> {
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Get the ID of the leader, and assert that client_read succeeds.
-    let leader = router.leader().await.expect("leader not found");
+    let leader = router.leader().expect("leader not found");
     assert_eq!(leader, 0, "expected leader to be node 0, got {}", leader);
     router
         .client_read(leader)

--- a/openraft/tests/concurrent_write_and_add_learner.rs
+++ b/openraft/tests/concurrent_write_and_add_learner.rs
@@ -79,7 +79,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
         router.assert_stable_cluster(Some(1), Some(n_logs)).await; // Still in term 1, so leader is still node 0.
     }
 
-    let leader = router.leader().await.unwrap();
+    let leader = router.leader().unwrap();
 
     tracing::info!("--- write one log");
     {

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -164,7 +164,7 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Submit a config change which adds two new nodes and removes the current leader.
-    let orig_leader = router.leader().await.expect("expected the cluster to have a leader");
+    let orig_leader = router.leader().expect("expected the cluster to have a leader");
     assert_eq!(0, orig_leader, "expected original leader to be node 0");
 
     // add a learner
@@ -236,7 +236,7 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
 
     tracing::info!("--- check learner in new cluster can receive new log");
     {
-        let new_leader = router.leader().await.expect("expected the cluster to have a new leader");
+        let new_leader = router.leader().expect("expected the cluster to have a new leader");
         router.client_request_many(new_leader, "0", 1).await;
         n_logs += 1;
         router

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -54,7 +54,7 @@ async fn change_from_to(old: BTreeSet<NodeId>, new: BTreeSet<NodeId>) -> anyhow:
         router.wait_for_log(&old, Some(log_index), timeout(), &format!("write 100 logs, {}", mes)).await?;
     }
 
-    let orig_leader = router.leader().await.expect("expected the cluster to have a leader");
+    let orig_leader = router.leader().expect("expected the cluster to have a leader");
 
     tracing::info!("--- change to {:?}", new);
     {
@@ -83,7 +83,7 @@ async fn change_from_to(old: BTreeSet<NodeId>, new: BTreeSet<NodeId>) -> anyhow:
             }
         }
 
-        let new_leader = router.leader().await.expect("expected the cluster to have a leader");
+        let new_leader = router.leader().expect("expected the cluster to have a leader");
         for id in new.iter() {
             // new leader may already elected and committed a blank log.
             router

--- a/openraft/tests/membership/t25_elect_with_new_config.rs
+++ b/openraft/tests/membership/t25_elect_with_new_config.rs
@@ -100,7 +100,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     let leader_id = metrics.current_leader;
 
     router.assert_stable_cluster(Some(term), applied.index()).await;
-    let leader = router.leader().await.expect("expected new leader");
+    let leader = router.leader().expect("expected new leader");
     assert!(leader != 0, "expected new leader to be different from the old leader");
 
     // Restore isolated node.
@@ -116,7 +116,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
 
     router.assert_stable_cluster(Some(term), applied.index()).await;
 
-    let current_leader = router.leader().await.expect("expected to find current leader");
+    let current_leader = router.leader().expect("expected to find current leader");
     assert_eq!(leader, current_leader, "expected cluster leadership to stay the same");
 
     Ok(())

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -33,7 +33,7 @@ async fn step_down() -> Result<()> {
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1}, btreeset! {}).await?;
 
     // Submit a config change which adds two new nodes and removes the current leader.
-    let orig_leader = router.leader().await.expect("expected the cluster to have a leader");
+    let orig_leader = router.leader().expect("expected the cluster to have a leader");
     assert_eq!(0, orig_leader, "expected original leader to be node 0");
     router.new_raft_node(2).await;
     router.new_raft_node(3).await;

--- a/openraft/tests/metrics/t10_current_leader.rs
+++ b/openraft/tests/metrics/t10_current_leader.rs
@@ -24,7 +24,7 @@ async fn current_leader() -> Result<()> {
     let _log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
 
     // Get the ID of the leader, and assert that current_leader succeeds.
-    let leader = router.leader().await.expect("leader not found");
+    let leader = router.leader().expect("leader not found");
     assert_eq!(leader, 0, "expected leader to be node 0, got {}", leader);
 
     for i in 0..3 {


### PR DESCRIPTION

## Changelog

##### Refactor: openraft tests: remove async if a method is sync.

---