### PR TITLE
Refactor: update anyerror to 0.1.4: by default do not generate backtrace. It can be very slow: 500ms

### DIFF
--- a/example-raft-kv/Cargo.toml
+++ b/example-raft-kv/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/bin/main.rs"
 
 [dependencies]
 actix-web = "4.0.0-rc.2"
-anyerror = { version = "0.1.1"}
+anyerror = { version = "0.1.4"}
 async-trait = "0.1.36"
 clap = { version = "3.0.13", features = ["derive", "env"] }
 env_logger = "0.9.0"

--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/datafuselabs/openraft"
 readme = "README.md"
 
 [dependencies]
-anyerror = { version = "0.1.1"}
+anyerror = { version = "0.1.4"}
 openraft = { version="0.6", path= "../openraft" }
 async-trait = "0.1.36"
 serde = { version="1.0.114", features=["derive"] }

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/datafuselabs/openraft"
 readme = "../README.md"
 
 [dependencies]
-anyerror = { version = "0.1.2", features = ["anyhow"]}
+anyerror = { version = "0.1.4", features = ["anyhow"]}
 async-trait = "0.1.36"
 byte-unit = "4.0.12"
 bytes = "1.0"


### PR DESCRIPTION

## Changelog

##### Refactor: update anyerror to 0.1.4: by default do not generate backtrace. It can be very slow: 500ms

---