### PR TITLE
Minor changes to `test-cluster.sh`

### DIFF
--- a/example-raft-kv/test-cluster.sh
+++ b/example-raft-kv/test-cluster.sh
@@ -5,13 +5,15 @@ set -o errexit
 cargo build
 
 kill() {
-    if [ "$(uname)" == "Darwin" ]; then
+    if [ "$(uname)" = "Darwin" ]; then
         SERVICE='raft-key-value'
         if pgrep -xq -- "${SERVICE}"; then
             pkill -f "${SERVICE}"
         fi
     else
+        set +e # killall will error if finds no process to kill
         killall raft-key-value
+        set -e
     fi
 }
 
@@ -22,13 +24,13 @@ rpc() {
     echo '---'" rpc(:$uri, $body)"
 
     {
-        if [ ".$body" == "." ]; then
+        if [ ".$body" = "." ]; then
             curl --silent "127.0.0.1:$uri"
         else
             curl --silent "127.0.0.1:$uri" -H "Content-Type: application/json" -d "$body"
         fi
     } | {
-        if which -s jq; then
+        if type jq > /dev/null 2>&1; then
             jq
         else
             cat


### PR DESCRIPTION
    - string comparison in the Bourne shell is done with `=` not `==`
    - `killall` will exit with non-zero status if it doesn't find any process to kill; so turned off errexit before invoking it, then turned it on again
    - which is not a built-in (and not present in my bash shell)-- `type` is.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.
