### PR TITLE
Remove some overhead caused by unnecessary memory allocations (improving performance by 40%)

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -24,7 +24,7 @@ derive_more = { version="0.99.9" }
 futures = "0.3"
 maplit = "1.0.2"
 rand = "0.8"
-serde = { version="1", features=["derive"] }
+serde = { version="1", features=["derive", "rc"] }
 clap = { version = "3.0.7", features = ["derive", "env"] }
 thiserror = "1.0.29"
 tokio = { version="1.8", default-features=false, features=["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -9,6 +9,7 @@
 
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -45,14 +46,14 @@ pub struct RaftMetrics {
     /// The current cluster leader.
     pub current_leader: Option<NodeId>,
     /// The current membership config of the cluster.
-    pub membership_config: EffectiveMembership,
+    pub membership_config: Arc<EffectiveMembership>,
 
     /// The id of the last log included in snapshot.
     /// If there is no snapshot, it is (0,0).
     pub snapshot: Option<LogId>,
 
     /// The metrics about the leader. It is Some() only when this node is leader.
-    pub leader_metrics: Option<LeaderMetrics>,
+    pub leader_metrics: Option<Arc<LeaderMetrics>>,
 }
 
 impl MessageSummary for RaftMetrics {
@@ -104,7 +105,7 @@ impl RaftMetrics {
             last_log_index: None,
             last_applied: None,
             current_leader: None,
-            membership_config: EffectiveMembership::new(LogId::default(), membership_config),
+            membership_config: Arc::new(EffectiveMembership::new(LogId::default(), membership_config)),
             snapshot: None,
             leader_metrics: None,
         }

--- a/openraft/src/metrics_wait_test.rs
+++ b/openraft/src/metrics_wait_test.rs
@@ -1,4 +1,5 @@
 use std::option::Option::None;
+use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
@@ -86,8 +87,10 @@ async fn test_wait() -> anyhow::Result<()> {
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
             let mut update = init.clone();
-            update.membership_config =
-                EffectiveMembership::new(LogId::default(), Membership::new(vec![btreeset! {1,2}], None));
+            update.membership_config = Arc::new(EffectiveMembership::new(
+                LogId::default(),
+                Membership::new(vec![btreeset! {1,2}], None),
+            ));
             let rst = tx.send(update);
             assert!(rst.is_ok());
         });
@@ -107,10 +110,10 @@ async fn test_wait() -> anyhow::Result<()> {
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
             let mut update = init.clone();
-            update.membership_config = EffectiveMembership::new(
+            update.membership_config = Arc::new(EffectiveMembership::new(
                 LogId::default(),
                 Membership::new(vec![btreeset! {}, btreeset! {1,2}], None),
-            );
+            ));
             let rst = tx.send(update);
             assert!(rst.is_ok());
         });
@@ -199,7 +202,10 @@ fn init_wait_test() -> (RaftMetrics, Wait, watch::Sender<RaftMetrics>) {
         last_log_index: None,
         last_applied: None,
         current_leader: None,
-        membership_config: EffectiveMembership::new(LogId::default(), Membership::new(vec![btreeset! {}], None)),
+        membership_config: Arc::new(EffectiveMembership::new(
+            LogId::default(),
+            Membership::new(vec![btreeset! {}], None),
+        )),
 
         snapshot: None,
         leader_metrics: None,


### PR DESCRIPTION
The two commits address the unnecessary allocation of message summary for each message passed via Raft and unnecessary allocations of membership infos before publishing metrics.

This alone improved the performance (in ops/second) of an empty Raft with a dummy state machine by about 40%.