### PR TITLE
Fix: Use NodeId where NodeId is meant, not u64

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -314,7 +314,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     ///
     /// Return true if removed.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn try_remove_replication(&mut self, target: u64) -> bool {
+    pub fn try_remove_replication(&mut self, target: NodeId) -> bool {
         tracing::debug!(target, "try_remove_replication");
 
         {

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -85,7 +85,7 @@ pub struct EffectiveMembership {
 }
 
 impl EffectiveMembership {
-    pub fn new_initial(node_id: u64) -> Self {
+    pub fn new_initial(node_id: NodeId) -> Self {
         Self::new(LogId::new(LeaderId::default(), 0), Membership::new_initial(node_id))
     }
 

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use crate::LeaderId;
 use crate::MessageSummary;
+use crate::NodeId;
 
 /// The identity of a raft log.
 /// A term, node_id and an index identifies an log globally.
@@ -41,9 +42,11 @@ impl LogId {
                 leader_id, index
             );
             assert_eq!(
-                leader_id.node_id, 0,
+                leader_id.node_id,
+                NodeId::default(),
                 "zero-th log entry must be (0,0,0), but {} {}",
-                leader_id, index
+                leader_id,
+                index
             );
             assert_eq!(
                 index, 0,

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -19,12 +19,13 @@ use crate::ErrorSubject;
 use crate::LeaderId;
 use crate::LogId;
 use crate::Membership;
+use crate::NodeId;
 use crate::RaftStorage;
 use crate::StorageError;
 use crate::Violation;
 use crate::Vote;
 
-const NODE_ID: u64 = 0;
+const NODE_ID: NodeId = 0;
 
 /// Test suite to ensure a `RaftStore` impl works as expected.
 ///
@@ -466,7 +467,7 @@ where
         let store = builder.build().await;
         Self::feed_10_logs_vote_self(&store).await?;
 
-        store.purge_logs_upto(LogId::new(LeaderId::new(0, 0), 0)).await?;
+        store.purge_logs_upto(LogId::new(LeaderId::new(0, NodeId::default()), 0)).await?;
 
         let ent = store.try_get_log_entry(3).await?;
         assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID), 3)), ent.map(|x| x.log_id));
@@ -511,7 +512,10 @@ where
             store.purge_logs_upto(LogId::new(LeaderId::new(0, NODE_ID), 0)).await?;
 
             let st = store.get_log_state().await?;
-            assert_eq!(Some(LogId::new(LeaderId::new(0, 0), 0)), st.last_purged_log_id);
+            assert_eq!(
+                Some(LogId::new(LeaderId::new(0, NodeId::default()), 0)),
+                st.last_purged_log_id
+            );
             assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID), 2)), st.last_log_id);
         }
 
@@ -1131,7 +1135,7 @@ where
 
         store.apply_to_state_machine(&[&blank(0, 0)]).await?;
 
-        store.purge_logs_upto(LogId::new(LeaderId::new(0, 0), 0)).await?;
+        store.purge_logs_upto(LogId::new(LeaderId::new(0, NodeId::default()), 0)).await?;
 
         store.get_log_entries(..).await?;
         store.get_log_entries(5..).await?;

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -21,14 +21,14 @@ impl std::fmt::Display for Vote {
 }
 
 impl Vote {
-    pub fn new(term: u64, node_id: u64) -> Self {
+    pub fn new(term: u64, node_id: NodeId) -> Self {
         Self {
             term,
             node_id,
             committed: false,
         }
     }
-    pub fn new_committed(term: u64, node_id: u64) -> Self {
+    pub fn new_committed(term: u64, node_id: NodeId) -> Self {
         Self {
             term,
             node_id,


### PR DESCRIPTION
Note: It would be ideal to wrap NodeId into a newtype to prevent wrong usage in the future, but that's a breaking change.

Further, NodeId should ideally be a generic argument of Raft type, but that's even bigger breaking change.

The fix in `suite.rs` is not perfect, since it's still using a literal (as are all the tests).

This change is in preparation for another PR that introduces a possibility to use `NodeId` as a GUID/128-bit entity (e.g., you could also code IPv6 address there directly).
