### PR TITLE
Change: Format NodeId using `Display` for tracing

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -247,7 +247,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=display(self.core.id)))]
     pub async fn append_membership_log(
         &mut self,
         mem: Membership,
@@ -315,7 +315,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Return true if removed.
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn try_remove_replication(&mut self, target: NodeId) -> bool {
-        tracing::debug!(target, "try_remove_replication");
+        tracing::debug!(target = display(target), "try_remove_replication");
 
         {
             let n = self.nodes.get(&target);

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -147,11 +147,11 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             let (target, data) = match res {
                 Ok(Ok(res)) => res,
                 Ok(Err((target, err))) => {
-                    tracing::error!(target, error=%err, "timeout while confirming leadership for read request");
+                    tracing::error!(target=display(target), error=%err, "timeout while confirming leadership for read request");
                     continue;
                 }
                 Err((target, err)) => {
-                    tracing::error!(target, "{}", err);
+                    tracing::error!(target = display(target), "{}", err);
                     continue;
                 }
             };

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -231,7 +231,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     }
 
     /// The main loop of the Raft protocol.
-    #[tracing::instrument(level="trace", skip(self), fields(id=self.id, cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="trace", skip(self), fields(id=display(self.id), cluster=%self.config.cluster_name))]
     async fn main(mut self) -> Result<(), Fatal> {
         let res = self.do_main().await;
         match res {
@@ -248,7 +248,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         }
     }
 
-    #[tracing::instrument(level="trace", skip(self), fields(id=self.id, cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="trace", skip(self), fields(id=display(self.id), cluster=%self.config.cluster_name))]
     async fn do_main(&mut self) -> Result<(), Fatal> {
         tracing::debug!("raft node is initializing");
 
@@ -380,7 +380,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         let res = self.tx_metrics.send(m);
 
         if let Err(err) = res {
-            tracing::error!(error=%err, id=self.id, "error reporting metrics");
+            tracing::error!(error=%err, id=display(self.id), "error reporting metrics");
         }
     }
 
@@ -391,9 +391,9 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     }
 
     /// Update core's target state, ensuring all invariants are upheld.
-    #[tracing::instrument(level = "trace", skip(self), fields(id=self.id))]
+    #[tracing::instrument(level = "trace", skip(self), fields(id=display(self.id)))]
     fn set_target_state(&mut self, target_state: State) {
-        tracing::debug!(id = self.id, ?target_state, "set_target_state");
+        tracing::debug!(id = display(self.id), ?target_state, "set_target_state");
 
         if target_state == State::Follower && !self.effective_membership.membership.is_member(&self.id) {
             self.target_state = State::Learner;
@@ -758,7 +758,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Transition to the Raft leader state.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="leader"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="leader"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         // Setup state as leader.
         self.core.last_heartbeat = None;
@@ -795,7 +795,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         Ok(())
     }
 
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id)))]
     pub(self) async fn leader_loop(mut self) -> Result<(), Fatal> {
         loop {
             if !self.core.target_state.is_leader() {
@@ -832,7 +832,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "leader", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "leader", id=display(self.core.id)))]
     pub async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
 
@@ -932,7 +932,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Run the candidate loop.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="candidate"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="candidate"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         // Each iteration of the outer loop represents a new term.
 
@@ -995,7 +995,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "candidate", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "candidate", id=display(self.core.id)))]
     pub async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
         match msg {
@@ -1041,7 +1041,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Run the follower loop.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="follower"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="follower"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         self.core.report_metrics(Update::Update(None));
 
@@ -1070,7 +1070,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "follower", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "follower", id=display(self.core.id)))]
     pub(crate) async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
 
@@ -1117,7 +1117,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Run the learner loop.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="learner"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="learner"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         self.core.report_metrics(Update::Update(None));
 
@@ -1144,7 +1144,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     // TODO(xp): define a handle_msg method in RaftCore that decides what to do by current State.
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "learner", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "learner", id=display(self.core.id)))]
     pub(crate) async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
 

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -94,7 +94,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Handle response from a vote request sent to a peer.
     #[tracing::instrument(level = "debug", skip(self, res))]
     pub(super) async fn handle_vote_response(&mut self, res: VoteResponse, target: NodeId) -> Result<(), StorageError> {
-        tracing::debug!(res=?res, target, "recv vote response");
+        tracing::debug!(res=?res, target=display(target), "recv vote response");
 
         // If peer's vote is greater than current vote, revert to follower state.
 
@@ -157,10 +157,10 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
                         Ok(vote_resp) => {
                             let _ = tx_inner.send((vote_resp, member)).await;
                         }
-                        Err(err) => tracing::error!({error=%err, target=member}, "while requesting vote"),
+                        Err(err) => tracing::error!({error=%err, target=display(member)}, "while requesting vote"),
                     }
                 }
-                .instrument(tracing::debug_span!("send_vote_req", target = member)),
+                .instrument(tracing::debug_span!("send_vote_req", target = display(member))),
             );
         }
         rx

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -248,7 +248,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     /// The caller can attach additional info `node` to this node id.
     /// A `node` can be used to store the network address of a node. Thus an application does not need another store for
     /// mapping node-id to ip-addr when implementing the RaftNetwork.
-    #[tracing::instrument(level = "debug", skip(self, id), fields(target=id))]
+    #[tracing::instrument(level = "debug", skip(self, id), fields(target=display(id)))]
     pub async fn add_learner(
         &self,
         id: NodeId,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -200,7 +200,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
         }
     }
 
-    #[tracing::instrument(level="trace", skip(self), fields(vote=%self.vote, target=self.target, cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="trace", skip(self), fields(vote=%self.vote, target=display(self.target), cluster=%self.config.cluster_name))]
     async fn main(mut self) {
         loop {
             // If it returns Ok(), always go back to LineRate state.


### PR DESCRIPTION
Currently, traced node IDs are used directly, which works, since `NodeId` is a `u64`. If the `NodeId` is anything more complex, the formatting will fail. Use `Display` trait to format the `NodeId` in trace messages to allow replacing `NodeId` with a different type.

Note: This subsumes https://github.com/datafuselabs/openraft/pull/190, only look at the second commit.