### PR TITLE
Change: Add support for GUID-like `NodeId`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
 ]
 exclude = [
     "example-raft-kv",
+    "test_guid_nodeid"
 ]

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = { version = "0.3.3",  features=["env-filter"] }
 
 [features]
 docinclude = [] # Used only for activating `doc(include="...")` on nightly.
+guid_nodeid = [] # Increase NodeId size to 16B to store GUIDs
 
 [package.metadata.docs.rs]
 features = ["docinclude"] # Activate `docinclude` during docs.rs build.

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -314,7 +314,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     ///
     /// Return true if removed.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn try_remove_replication(&mut self, target: u64) -> bool {
+    pub fn try_remove_replication(&mut self, target: NodeId) -> bool {
         tracing::debug!(target, "try_remove_replication");
 
         {

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -247,7 +247,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=display(self.core.id)))]
     pub async fn append_membership_log(
         &mut self,
         mem: Membership,
@@ -315,7 +315,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Return true if removed.
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn try_remove_replication(&mut self, target: NodeId) -> bool {
-        tracing::debug!(target, "try_remove_replication");
+        tracing::debug!(target = display(target), "try_remove_replication");
 
         {
             let n = self.nodes.get(&target);

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -147,11 +147,11 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             let (target, data) = match res {
                 Ok(Ok(res)) => res,
                 Ok(Err((target, err))) => {
-                    tracing::error!(target, error=%err, "timeout while confirming leadership for read request");
+                    tracing::error!(target=display(target), error=%err, "timeout while confirming leadership for read request");
                     continue;
                 }
                 Err((target, err)) => {
-                    tracing::error!(target, "{}", err);
+                    tracing::error!(target = display(target), "{}", err);
                     continue;
                 }
             };

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -85,7 +85,7 @@ pub struct EffectiveMembership {
 }
 
 impl EffectiveMembership {
-    pub fn new_initial(node_id: u64) -> Self {
+    pub fn new_initial(node_id: NodeId) -> Self {
         Self::new(LogId::new(LeaderId::default(), 0), Membership::new_initial(node_id))
     }
 

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -231,7 +231,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     }
 
     /// The main loop of the Raft protocol.
-    #[tracing::instrument(level="trace", skip(self), fields(id=self.id, cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="trace", skip(self), fields(id=display(self.id), cluster=%self.config.cluster_name))]
     async fn main(mut self) -> Result<(), Fatal> {
         let res = self.do_main().await;
         match res {
@@ -248,7 +248,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         }
     }
 
-    #[tracing::instrument(level="trace", skip(self), fields(id=self.id, cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="trace", skip(self), fields(id=display(self.id), cluster=%self.config.cluster_name))]
     async fn do_main(&mut self) -> Result<(), Fatal> {
         tracing::debug!("raft node is initializing");
 
@@ -380,7 +380,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         let res = self.tx_metrics.send(m);
 
         if let Err(err) = res {
-            tracing::error!(error=%err, id=self.id, "error reporting metrics");
+            tracing::error!(error=%err, id=display(self.id), "error reporting metrics");
         }
     }
 
@@ -391,9 +391,9 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     }
 
     /// Update core's target state, ensuring all invariants are upheld.
-    #[tracing::instrument(level = "trace", skip(self), fields(id=self.id))]
+    #[tracing::instrument(level = "trace", skip(self), fields(id=display(self.id)))]
     fn set_target_state(&mut self, target_state: State) {
-        tracing::debug!(id = self.id, ?target_state, "set_target_state");
+        tracing::debug!(id = display(self.id), ?target_state, "set_target_state");
 
         if target_state == State::Follower && !self.effective_membership.membership.is_member(&self.id) {
             self.target_state = State::Learner;
@@ -758,7 +758,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Transition to the Raft leader state.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="leader"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="leader"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         // Setup state as leader.
         self.core.last_heartbeat = None;
@@ -795,7 +795,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         Ok(())
     }
 
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id)))]
     pub(self) async fn leader_loop(mut self) -> Result<(), Fatal> {
         loop {
             if !self.core.target_state.is_leader() {
@@ -832,7 +832,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "leader", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "leader", id=display(self.core.id)))]
     pub async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
 
@@ -932,7 +932,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Run the candidate loop.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="candidate"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="candidate"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         // Each iteration of the outer loop represents a new term.
 
@@ -995,7 +995,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "candidate", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "candidate", id=display(self.core.id)))]
     pub async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
         match msg {
@@ -1041,7 +1041,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Run the follower loop.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="follower"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="follower"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         self.core.report_metrics(Update::Update(None));
 
@@ -1070,7 +1070,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "follower", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "follower", id=display(self.core.id)))]
     pub(crate) async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
 
@@ -1117,7 +1117,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Run the learner loop.
-    #[tracing::instrument(level="debug", skip(self), fields(id=self.core.id, raft_state="learner"))]
+    #[tracing::instrument(level="debug", skip(self), fields(id=display(self.core.id), raft_state="learner"))]
     pub(self) async fn run(mut self) -> Result<(), Fatal> {
         self.core.report_metrics(Update::Update(None));
 
@@ -1144,7 +1144,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     // TODO(xp): define a handle_msg method in RaftCore that decides what to do by current State.
-    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "learner", id=self.core.id))]
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(state = "learner", id=display(self.core.id)))]
     pub(crate) async fn handle_msg(&mut self, msg: RaftMsg<D, R>) -> Result<(), Fatal> {
         tracing::debug!("recv from rx_api: {}", msg.summary());
 

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -94,7 +94,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Handle response from a vote request sent to a peer.
     #[tracing::instrument(level = "debug", skip(self, res))]
     pub(super) async fn handle_vote_response(&mut self, res: VoteResponse, target: NodeId) -> Result<(), StorageError> {
-        tracing::debug!(res=?res, target, "recv vote response");
+        tracing::debug!(res=?res, target=display(target), "recv vote response");
 
         // If peer's vote is greater than current vote, revert to follower state.
 
@@ -157,10 +157,10 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
                         Ok(vote_resp) => {
                             let _ = tx_inner.send((vote_resp, member)).await;
                         }
-                        Err(err) => tracing::error!({error=%err, target=member}, "while requesting vote"),
+                        Err(err) => tracing::error!({error=%err, target=display(member)}, "while requesting vote"),
                     }
                 }
-                .instrument(tracing::debug_span!("send_vote_req", target = member)),
+                .instrument(tracing::debug_span!("send_vote_req", target = display(member))),
             );
         }
         rx

--- a/openraft/src/node/guid_nodeid.rs
+++ b/openraft/src/node/guid_nodeid.rs
@@ -1,0 +1,106 @@
+//! Module defining Raft node ID as a GUID.
+//!
+//! This depends on the configuration of the feature `guid_nodeid`. If set, then a larger, 16-byte
+//! NodeId storing a GUID will be used (defined here).
+
+use std::fmt::Debug;
+use std::fmt::Display;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// A Raft node's ID.
+///
+/// The node ID is encoded as a GUID (more concretely, UUID variant 1, big-endian).
+#[derive(Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct NodeId {
+    first: u64,
+    second: u64,
+}
+
+impl NodeId {
+    /// Create a new, invalid `NodeId`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a `NodeId` from raw values.
+    #[must_use]
+    pub const fn new_from_parts(first: u64, second: u64) -> Self {
+        Self {
+            first: first.to_be(),
+            second: second.to_be(),
+        }
+    }
+
+    /// Check if the `NodeId` is valid.
+    #[must_use]
+    pub const fn is_valid(&self) -> bool {
+        self.first != 0 || self.second != 0
+    }
+
+    /// Get the first 64 bits.
+    #[must_use]
+    pub const fn first(&self) -> u64 {
+        u64::from_be(self.first)
+    }
+
+    /// Get the second 64 bits.
+    #[must_use]
+    pub const fn second(&self) -> u64 {
+        u64::from_be(self.second)
+    }
+
+    /// Determine first and second parts of this `NodeId`.
+    #[must_use]
+    pub const fn into_parts(&self) -> (u64, u64) {
+        (self.first(), self.second())
+    }
+}
+
+impl Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (first, second) = self.into_parts();
+        f.write_fmt(format_args!(
+            "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+            first >> 32,
+            (first >> 16) & 0xffff,
+            first & 0xffff,
+            second >> 48,
+            second & 0xffff_ffff_ffff
+        ))
+    }
+}
+
+impl Debug for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let empty = NodeId::new();
+        assert_eq!(empty, NodeId::default());
+        assert!(!empty.is_valid());
+    }
+
+    #[test]
+    fn nonempty() {
+        let node_id = NodeId::new_from_parts(1, 2);
+        assert_ne!(node_id, NodeId::default());
+        assert_eq!(node_id, node_id);
+    }
+
+    #[test]
+    fn format() {
+        let node_id = NodeId::new_from_parts(0x0123_4567_89ab_8cde, 0xf123_def1_cccc_0ddd);
+        let str = format!("{}", node_id);
+        assert_eq!(str, "01234567-89ab-8cde-f123-def1cccc0ddd");
+    }
+}

--- a/openraft/src/node/mod.rs
+++ b/openraft/src/node/mod.rs
@@ -5,6 +5,16 @@ use std::fmt::Formatter;
 use serde::Deserialize;
 use serde::Serialize;
 
+// If GUID-based `NodeId` is activated, include the definition from submodule.
+//
+// NOTE: If you are using IDE with rust-analyzer with all-features turned on by default,
+// turn it off for the workspace to prevent showing errors in test files, which are not
+// adjusted to use `NodeId`, but rather use `u64` directly.
+#[cfg(feature = "guid_nodeid")]
+pub mod guid_nodeid;
+#[cfg(feature = "guid_nodeid")]
+pub use guid_nodeid::NodeId;
+#[cfg(not(feature = "guid_nodeid"))]
 /// A Raft node's ID.
 pub type NodeId = u64;
 

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -248,7 +248,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     /// The caller can attach additional info `node` to this node id.
     /// A `node` can be used to store the network address of a node. Thus an application does not need another store for
     /// mapping node-id to ip-addr when implementing the RaftNetwork.
-    #[tracing::instrument(level = "debug", skip(self, id), fields(target=id))]
+    #[tracing::instrument(level = "debug", skip(self, id), fields(target=display(id)))]
     pub async fn add_learner(
         &self,
         id: NodeId,

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use crate::LeaderId;
 use crate::MessageSummary;
+use crate::NodeId;
 
 /// The identity of a raft log.
 /// A term, node_id and an index identifies an log globally.
@@ -41,9 +42,11 @@ impl LogId {
                 leader_id, index
             );
             assert_eq!(
-                leader_id.node_id, 0,
+                leader_id.node_id,
+                NodeId::default(),
                 "zero-th log entry must be (0,0,0), but {} {}",
-                leader_id, index
+                leader_id,
+                index
             );
             assert_eq!(
                 index, 0,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -200,7 +200,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
         }
     }
 
-    #[tracing::instrument(level="trace", skip(self), fields(vote=%self.vote, target=self.target, cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="trace", skip(self), fields(vote=%self.vote, target=display(self.target), cluster=%self.config.cluster_name))]
     async fn main(mut self) {
         loop {
             // If it returns Ok(), always go back to LineRate state.

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -19,12 +19,13 @@ use crate::ErrorSubject;
 use crate::LeaderId;
 use crate::LogId;
 use crate::Membership;
+use crate::NodeId;
 use crate::RaftStorage;
 use crate::StorageError;
 use crate::Violation;
 use crate::Vote;
 
-const NODE_ID: u64 = 0;
+const NODE_ID: NodeId = 0;
 
 /// Test suite to ensure a `RaftStore` impl works as expected.
 ///
@@ -466,7 +467,7 @@ where
         let store = builder.build().await;
         Self::feed_10_logs_vote_self(&store).await?;
 
-        store.purge_logs_upto(LogId::new(LeaderId::new(0, 0), 0)).await?;
+        store.purge_logs_upto(LogId::new(LeaderId::new(0, NodeId::default()), 0)).await?;
 
         let ent = store.try_get_log_entry(3).await?;
         assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID), 3)), ent.map(|x| x.log_id));
@@ -511,7 +512,10 @@ where
             store.purge_logs_upto(LogId::new(LeaderId::new(0, NODE_ID), 0)).await?;
 
             let st = store.get_log_state().await?;
-            assert_eq!(Some(LogId::new(LeaderId::new(0, 0), 0)), st.last_purged_log_id);
+            assert_eq!(
+                Some(LogId::new(LeaderId::new(0, NodeId::default()), 0)),
+                st.last_purged_log_id
+            );
             assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID), 2)), st.last_log_id);
         }
 
@@ -1131,7 +1135,7 @@ where
 
         store.apply_to_state_machine(&[&blank(0, 0)]).await?;
 
-        store.purge_logs_upto(LogId::new(LeaderId::new(0, 0), 0)).await?;
+        store.purge_logs_upto(LogId::new(LeaderId::new(0, NodeId::default()), 0)).await?;
 
         store.get_log_entries(..).await?;
         store.get_log_entries(5..).await?;

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -21,14 +21,14 @@ impl std::fmt::Display for Vote {
 }
 
 impl Vote {
-    pub fn new(term: u64, node_id: u64) -> Self {
+    pub fn new(term: u64, node_id: NodeId) -> Self {
         Self {
             term,
             node_id,
             committed: false,
         }
     }
-    pub fn new_committed(term: u64, node_id: u64) -> Self {
+    pub fn new_committed(term: u64, node_id: NodeId) -> Self {
         Self {
             term,
             node_id,

--- a/test_guid_nodeid/Cargo.toml
+++ b/test_guid_nodeid/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test_guid_nodeid"
+version = "0.1.0"
+edition = "2021"
+description = "Helper crate to test whether GUID-based NodeId for openraft is compiling properly"
+
+[dependencies]
+openraft = { version="0.6", path = "../openraft", features = ["guid_nodeid"] }

--- a/test_guid_nodeid/src/lib.rs
+++ b/test_guid_nodeid/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ensure_guid_nodeid_works() {
+        let _guid_nodeid = openraft::NodeId::new_from_parts(1, 2);
+    }
+}


### PR DESCRIPTION
This adds support for 16-byte `NodeId` type, which can be used to store node GUIDs instead of simple `u64` which need additional mapping. In principle, it's also possible to store IPv6 address into the node ID, but currently it's meant to store GUIDs.

Note: This subsumes both https://github.com/datafuselabs/openraft/pull/190 and https://github.com/datafuselabs/openraft/pull/191, so please look only at the third commit.

Ideal implementation would parameterize the Raft on `NodeId`, but that's a breaking change and fairly complex. This way, the user can activate the feature `guid_nodeid` to enable the GUID-based `NodeId`.

The implementation is not perfect also in another respect: the test crate actually using the GUID `NodeId` is not part of the regular `cargo test`. Not sure how to enable testing without polluting all other tests with GUID `NodeId`, failing their compilation. Thus, it has to be tested manually.

This PR can be also seen as RFC. We do need to use 16-byte `NodeId`. If you accept it as-is, feel free to merge as-is, but I understand some additional work might be necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/192)
<!-- Reviewable:end -->
