### PR TITLE
Change: Use a `RaftConfig` trait to configure common types

### DIFF
--- a/example-raft-kv/src/bin/main.rs
+++ b/example-raft-kv/src/bin/main.rs
@@ -2,12 +2,11 @@ use clap::Parser;
 use env_logger::Env;
 use example_raft_key_value::network::raft_network_impl::ExampleNetwork;
 use example_raft_key_value::start_example_raft_node;
-use example_raft_key_value::store::ExampleRequest;
-use example_raft_key_value::store::ExampleResponse;
 use example_raft_key_value::store::ExampleStore;
+use example_raft_key_value::ExampleConfig;
 use openraft::Raft;
 
-pub type ExampleRaft = Raft<ExampleRequest, ExampleResponse, ExampleNetwork, ExampleStore>;
+pub type ExampleRaft = Raft<ExampleConfig, ExampleNetwork, ExampleStore>;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/example-raft-kv/src/client.rs
+++ b/example-raft-kv/src/client.rs
@@ -19,8 +19,8 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::ExampleConfig;
 use crate::ExampleRequest;
-use crate::ExampleResponse;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Empty {}
@@ -54,7 +54,7 @@ impl ExampleClient {
     pub async fn write(
         &self,
         req: &ExampleRequest,
-    ) -> Result<ClientWriteResponse<ExampleResponse>, RPCError<ClientWriteError>> {
+    ) -> Result<ClientWriteResponse<ExampleConfig>, RPCError<ClientWriteError>> {
         self.send_rpc_to_leader("write", Some(req)).await
     }
 
@@ -91,7 +91,7 @@ impl ExampleClient {
     pub async fn change_membership(
         &self,
         req: &BTreeSet<NodeId>,
-    ) -> Result<ClientWriteResponse<ExampleResponse>, RPCError<ClientWriteError>> {
+    ) -> Result<ClientWriteResponse<ExampleConfig>, RPCError<ClientWriteError>> {
         self.send_rpc_to_leader("change-membership", Some(req)).await
     }
 

--- a/example-raft-kv/src/lib.rs
+++ b/example-raft-kv/src/lib.rs
@@ -8,6 +8,7 @@ use actix_web::HttpServer;
 use openraft::Config;
 use openraft::NodeId;
 use openraft::Raft;
+use openraft::RaftConfig;
 
 use crate::app::ExampleApp;
 use crate::network::api;
@@ -23,7 +24,14 @@ pub mod client;
 pub mod network;
 pub mod store;
 
-pub type ExampleRaft = Raft<ExampleRequest, ExampleResponse, ExampleNetwork, Arc<ExampleStore>>;
+pub struct ExampleConfig {}
+
+impl RaftConfig for ExampleConfig {
+    type D = ExampleRequest;
+    type R = ExampleResponse;
+}
+
+pub type ExampleRaft = Raft<ExampleConfig, ExampleNetwork, Arc<ExampleStore>>;
 
 pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std::io::Result<()> {
     // Create a configuration for the raft instance.

--- a/example-raft-kv/src/network/raft.rs
+++ b/example-raft-kv/src/network/raft.rs
@@ -8,7 +8,7 @@ use openraft::raft::VoteRequest;
 use web::Json;
 
 use crate::app::ExampleApp;
-use crate::store::ExampleRequest;
+use crate::ExampleConfig;
 
 // --- Raft communication
 
@@ -21,7 +21,7 @@ pub async fn vote(app: Data<ExampleApp>, req: Json<VoteRequest>) -> actix_web::R
 #[post("/raft-append")]
 pub async fn append(
     app: Data<ExampleApp>,
-    req: Json<AppendEntriesRequest<ExampleRequest>>,
+    req: Json<AppendEntriesRequest<ExampleConfig>>,
 ) -> actix_web::Result<impl Responder> {
     let res = app.raft.append_entries(req.0).await;
     Ok(Json(res))

--- a/example-raft-kv/src/network/raft_network_impl.rs
+++ b/example-raft-kv/src/network/raft_network_impl.rs
@@ -18,7 +18,7 @@ use openraft::RaftNetworkFactory;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::store::ExampleRequest;
+use crate::ExampleConfig;
 
 pub struct ExampleNetwork {}
 
@@ -50,7 +50,7 @@ impl ExampleNetwork {
 
 // NOTE: This could be implemented also on `Arc<ExampleNetwork>`, but since it's empty, implemented directly.
 #[async_trait]
-impl RaftNetworkFactory<ExampleRequest> for ExampleNetwork {
+impl RaftNetworkFactory<ExampleConfig> for ExampleNetwork {
     type Network = ExampleNetworkConnection;
 
     async fn connect(&mut self, target: NodeId, node: Option<&Node>) -> Self::Network {
@@ -69,10 +69,10 @@ pub struct ExampleNetworkConnection {
 }
 
 #[async_trait]
-impl RaftNetwork<ExampleRequest> for ExampleNetworkConnection {
+impl RaftNetwork<ExampleConfig> for ExampleNetworkConnection {
     async fn send_append_entries(
         &mut self,
-        req: AppendEntriesRequest<ExampleRequest>,
+        req: AppendEntriesRequest<ExampleConfig>,
     ) -> Result<AppendEntriesResponse, RPCError<AppendEntriesError>> {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-append", req).await
     }

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -12,11 +12,10 @@ use crate::error::InstallSnapshotError;
 use crate::error::SnapshotMismatch;
 use crate::raft::InstallSnapshotRequest;
 use crate::raft::InstallSnapshotResponse;
-use crate::AppData;
-use crate::AppDataResponse;
 use crate::ErrorSubject;
 use crate::ErrorVerb;
 use crate::MessageSummary;
+use crate::RaftConfig;
 use crate::RaftNetworkFactory;
 use crate::RaftStorage;
 use crate::SnapshotSegmentId;
@@ -24,7 +23,7 @@ use crate::StorageError;
 use crate::StorageIOError;
 use crate::Update;
 
-impl<D: AppData, R: AppDataResponse, N: RaftNetworkFactory<D>, S: RaftStorage<D, R>> RaftCore<D, R, N, S> {
+impl<C: RaftConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C, N, S> {
     /// Invoked by leader to send chunks of a snapshot to a follower (§7).
     ///
     /// Leaders always send chunks in order. It is important to note that, according to the Raft spec,

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -20,16 +20,15 @@ use crate::replication::ReplicationStream;
 use crate::storage::Snapshot;
 use crate::summary::MessageSummary;
 use crate::vote::Vote;
-use crate::AppData;
-use crate::AppDataResponse;
 use crate::LogId;
 use crate::NodeId;
+use crate::RaftConfig;
 use crate::RaftNetworkFactory;
 use crate::RaftStorage;
 use crate::ReplicationMetrics;
 use crate::StorageError;
 
-impl<'a, D: AppData, R: AppDataResponse, N: RaftNetworkFactory<D>, S: RaftStorage<D, R>> LeaderState<'a, D, R, N, S> {
+impl<'a, C: RaftConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderState<'a, C, N, S> {
     /// Spawn a new replication stream returning its replication state handle.
     #[tracing::instrument(level = "debug", skip(self, caller_tx))]
     pub(super) async fn spawn_replication_stream(
@@ -38,7 +37,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetworkFactory<D>, S: RaftStorag
         caller_tx: Option<RaftRespTx<AddLearnerResponse, AddLearnerError>>,
     ) -> ReplicationState {
         let target_node = self.core.effective_membership.get_node(target);
-        let repl_stream = ReplicationStream::new::<D, R, N, S>(
+        let repl_stream = ReplicationStream::new::<C, N, S>(
             target,
             target_node.cloned(),
             self.core.vote,

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -9,15 +9,14 @@ use crate::error::VoteError;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::summary::MessageSummary;
-use crate::AppData;
-use crate::AppDataResponse;
 use crate::NodeId;
+use crate::RaftConfig;
 use crate::RaftNetwork;
 use crate::RaftNetworkFactory;
 use crate::RaftStorage;
 use crate::StorageError;
 
-impl<D: AppData, R: AppDataResponse, N: RaftNetworkFactory<D>, S: RaftStorage<D, R>> RaftCore<D, R, N, S> {
+impl<C: RaftConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C, N, S> {
     /// An RPC invoked by candidates to gather votes (§5.2).
     ///
     /// See `receiver implementation: RequestVote RPC` in raft-essentials.md in this repo.
@@ -91,9 +90,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetworkFactory<D>, S: RaftStorage<D,
     }
 }
 
-impl<'a, D: AppData, R: AppDataResponse, N: RaftNetworkFactory<D>, S: RaftStorage<D, R>>
-    CandidateState<'a, D, R, N, S>
-{
+impl<'a, C: RaftConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> CandidateState<'a, C, N, S> {
     /// Handle response from a vote request sent to a peer.
     #[tracing::instrument(level = "debug", skip(self, res))]
     pub(super) async fn handle_vote_response(&mut self, res: VoteResponse, target: NodeId) -> Result<(), StorageError> {

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -43,6 +43,7 @@ pub use crate::network::RaftNetworkFactory;
 pub use crate::node::Node;
 pub use crate::node::NodeId;
 pub use crate::raft::Raft;
+pub use crate::raft::RaftConfig;
 pub use crate::raft_types::LogId;
 pub use crate::raft_types::LogIdOptionExt;
 pub use crate::raft_types::SnapshotId;

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -16,9 +16,9 @@ use crate::raft::InstallSnapshotRequest;
 use crate::raft::InstallSnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
-use crate::AppData;
 use crate::Node;
 use crate::NodeId;
+use crate::RaftConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RPCTypes {
@@ -44,13 +44,13 @@ impl std::fmt::Display for RPCTypes {
 /// A single network instance is used to connect to a single target node. The network instance is
 /// constructed by the [`RaftNetworkFactory`].
 #[async_trait]
-pub trait RaftNetwork<D>: Send + Sync + 'static
-where D: AppData
+pub trait RaftNetwork<C>: Send + Sync + 'static
+where C: RaftConfig
 {
     /// Send an AppendEntries RPC to the target Raft node (§5).
     async fn send_append_entries(
         &mut self,
-        rpc: AppendEntriesRequest<D>,
+        rpc: AppendEntriesRequest<C>,
     ) -> Result<AppendEntriesResponse, RPCError<AppendEntriesError>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
@@ -71,11 +71,11 @@ where D: AppData
 /// Typically, the network implementation as such will be hidden behind a `Box<T>` or `Arc<T>` and
 /// this interface implemented on the `Box<T>` or `Arc<T>`.
 #[async_trait]
-pub trait RaftNetworkFactory<D>: Send + Sync + 'static
-where D: AppData
+pub trait RaftNetworkFactory<C>: Send + Sync + 'static
+where C: RaftConfig
 {
     /// Actual type of the network handling a single connection.
-    type Network: RaftNetwork<D>;
+    type Network: RaftNetwork<C>;
 
     /// Create a new network instance sending RPCs to the target node.
     ///

--- a/openraft/src/store_wrapper.rs
+++ b/openraft/src/store_wrapper.rs
@@ -1,13 +1,11 @@
-use crate::AppData;
-use crate::AppDataResponse;
+use crate::RaftConfig;
 use crate::RaftStorage;
 
 /// A wrapper extends the APIs of a base RaftStore.
-pub trait Wrapper<D, R, T>
+pub trait Wrapper<C, T>
 where
-    D: AppData,
-    R: AppDataResponse,
-    T: RaftStorage<D, R>,
+    C: RaftConfig,
+    T: RaftStorage<C>,
 {
     fn inner(&mut self) -> &mut T;
 }

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -46,7 +46,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
 
     // Expect conflict even if the message contains no entries.
 
-    let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
+    let rpc = AppendEntriesRequest::<memstore::Config> {
         vote: Vote::new(1, 1),
         prev_log_id: Some(LogId::new(LeaderId::new(1, 0), 5)),
         entries: vec![],
@@ -59,7 +59,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
 
     // Feed logs
 
-    let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
+    let rpc = AppendEntriesRequest::<memstore::Config> {
         vote: Vote::new(1, 1),
         prev_log_id: None,
         entries: vec![blank(0, 0), blank(1, 1), Entry {
@@ -79,7 +79,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
 
     // Expect a conflict with prev_log_index == 3
 
-    let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
+    let rpc = AppendEntriesRequest::<memstore::Config> {
         vote: Vote::new(1, 1),
         prev_log_id: Some(LogId::new(LeaderId::new(1, 0), 3)),
         entries: vec![],

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -3,15 +3,13 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use memstore::ClientRequest;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::Entry;
-use openraft::AppData;
-use openraft::AppDataResponse;
 use openraft::Config;
 use openraft::LeaderId;
 use openraft::LogId;
 use openraft::MessageSummary;
+use openraft::RaftConfig;
 use openraft::RaftStorage;
 use openraft::State;
 use openraft::Vote;
@@ -215,15 +213,14 @@ async fn append_conflicts() -> Result<()> {
 }
 
 /// To check if logs is as expected.
-async fn check_logs<D, R, Sto>(sto: &mut Sto, terms: Vec<u64>) -> Result<()>
+async fn check_logs<C, Sto>(sto: &mut Sto, terms: Vec<u64>) -> Result<()>
 where
-    D: AppData,
-    R: AppDataResponse,
-    Sto: RaftStorage<D, R>,
+    C: RaftConfig,
+    Sto: RaftStorage<C>,
 {
     let logs = sto.get_log_entries(..).await?;
     let skip = 0;
-    let want: Vec<Entry<ClientRequest>> = terms
+    let want: Vec<Entry<memstore::Config>> = terms
         .iter()
         .skip(skip)
         .enumerate()

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -31,7 +31,7 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         .await?;
 
     // append entries with term 2 and leader_id, this MUST cause hard state changed in node 0
-    let req = AppendEntriesRequest::<memstore::ClientRequest> {
+    let req = AppendEntriesRequest::<memstore::Config> {
         vote: Vote::new(2, 1),
         prev_log_id: Some(LogId::new(LeaderId::new(1, 0), log_index)),
         entries: vec![],


### PR DESCRIPTION
Currently only the request and response type are configured, but other types can be now easily configured as well, such as `NodeId` (to be done in the next change) or `Runtime`.

Storage and network factory types are still provided as a separate type, since otherwise it would be hard to provide storage wrappers for testing.

This addresses https://github.com/datafuselabs/openraft/issues/204.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/211)
<!-- Reviewable:end -->
