### PR TITLE
Refactor: add profile HTTP interface to dump flame graph and script in example

### DIFF
--- a/example-raft-kv/Cargo.toml
+++ b/example-raft-kv/Cargo.toml
@@ -31,6 +31,9 @@ serde_json = "1.0.57"
 tokio = { version="1.0", default-features=false, features=["sync"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.4"
+thiserror = "1.0.30"
+inferno = { version = "0.10" }
+pprof = { version = "0.6.2", features = ["flamegraph", "protobuf"] }
 
 [dev-dependencies]
 anyhow = "1.0.32"
@@ -41,3 +44,6 @@ docinclude = [] # Used only for activating `doc(include="...")` on nightly.
 
 [package.metadata.docs.rs]
 features = ["docinclude"] # Activate `docinclude` during docs.rs build.
+
+[profile.release]
+debug = true

--- a/example-raft-kv/README.md
+++ b/example-raft-kv/README.md
@@ -126,3 +126,18 @@ To add a node to a cluster, it includes 3 steps:
 - Write a `node` through raft protocol to the storage.
 - Add the node as a `Learner` to let it start receiving replication data from the leader.
 - Invoke `change-membership` to change the learner node to a member.
+
+## Profile
+Use 
+
+```shell
+./test-cluster-and-dump-flamegraph.sh
+```
+
+can to dump flame graph file.
+
+Before that, must turn on `perf_event_paranoid` kernel flag,such as:
+
+```
+echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
+```

--- a/example-raft-kv/src/lib.rs
+++ b/example-raft-kv/src/lib.rs
@@ -14,6 +14,7 @@ use crate::app::ExampleApp;
 use crate::network::api;
 use crate::network::management;
 use crate::network::raft;
+use crate::network::profile;
 use crate::network::raft_network_impl::ExampleNetwork;
 use crate::store::ExampleRequest;
 use crate::store::ExampleResponse;
@@ -73,6 +74,8 @@ pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std:
             .service(management::add_learner)
             .service(management::change_membership)
             .service(management::metrics)
+            // profile API
+            .service(profile::dump_flamegraph)
             // application API
             .service(api::write)
             .service(api::read)

--- a/example-raft-kv/src/network/mod.rs
+++ b/example-raft-kv/src/network/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
 pub mod management;
+pub mod profile;
 pub mod raft;
 pub mod raft_network_impl;

--- a/example-raft-kv/src/network/profile.rs
+++ b/example-raft-kv/src/network/profile.rs
@@ -1,0 +1,103 @@
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use std::num::NonZeroI32;
+use std::time::Duration;
+
+use actix_web::http::StatusCode;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::HttpResponse;
+use actix_web::HttpResponseBuilder;
+use actix_web::Responder;
+use actix_web::ResponseError;
+use inferno::flamegraph;
+use pprof::protos::Message;
+use thiserror::Error;
+
+use crate::app::ExampleApp;
+// --- Generate profile info, such as flamegraph
+
+pub struct Profiling {
+    duration: Duration,
+    frequency: i32,
+}
+
+#[derive(Error, Debug)]
+pub enum ProfileError {
+    #[error(transparent)]
+    InternalError(#[from] pprof::Error),
+}
+
+impl ResponseError for ProfileError {
+    fn error_response(&self) -> HttpResponse {
+        HttpResponseBuilder::new(self.status_code())
+            .insert_header(("Content-Type", "text/html; charset=utf-8"))
+            .body(self.to_string())
+    }
+
+    fn status_code(&self) -> StatusCode {
+        match *self {
+            ProfileError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+pub type ProfileResult<T> = std::result::Result<T, ProfileError>;
+
+impl Profiling {
+    pub fn create(duration: Duration, frequency: i32) -> Self {
+        Self { duration, frequency }
+    }
+
+    pub async fn report(&self) -> ProfileResult<pprof::Report> {
+        let guard = pprof::ProfilerGuard::new(self.frequency).map_err(ProfileError::InternalError)?;
+        tokio::time::sleep(self.duration).await;
+        guard.report().build().map_err(ProfileError::InternalError)
+    }
+
+    pub async fn dump_flamegraph(&self) -> ProfileResult<Vec<u8>> {
+        let mut body: Vec<u8> = Vec::new();
+
+        let report = self.report().await?;
+        let option = &mut flamegraph::Options::default();
+        option.font_size = 14;
+        option.image_width = Some(2500);
+        report.flamegraph_with_options(&mut body, option)?;
+
+        Ok(body)
+    }
+
+    pub async fn dump_proto(&self) -> ProfileResult<Vec<u8>> {
+        let mut body: Vec<u8> = Vec::new();
+
+        let report = self.report().await?;
+        let profile = report.pprof()?;
+        let _ret = profile.encode(&mut body);
+
+        Ok(body)
+    }
+}
+
+/// Dump flamegraph.
+#[post("/profile/dump_flamegraph")]
+pub async fn dump_flamegraph(
+    _app: Data<ExampleApp>,
+    req: Json<(u64, NonZeroI32)>,
+) -> actix_web::Result<impl Responder> {
+    let seconds: u64 = req.0 .0;
+    let frequency = req.0 .1;
+
+    let duration = Duration::from_secs(seconds);
+    tracing::info!("start pprof request second: {:?} frequency: {:?}", seconds, frequency);
+    let profile = Profiling::create(duration, i32::from(frequency));
+
+    let body = profile.dump_flamegraph().await?;
+
+    let filename = "flamegraph.svg";
+    let mut file = OpenOptions::new().create(true).write(true).open(filename)?;
+    let err = file.write(&body);
+
+    tracing::info!("save pprof flamegraph : {:?} {} in {}", err, body.len(), filename);
+    Ok(Json("OK"))
+}

--- a/example-raft-kv/test-cluster-and-dump-flamegraph.sh
+++ b/example-raft-kv/test-cluster-and-dump-flamegraph.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+
+set -o errexit
+
+cargo build
+
+kill() {
+    if [ "$(uname)" = "Darwin" ]; then
+        SERVICE='raft-key-value'
+        if pgrep -xq -- "${SERVICE}"; then
+            pkill -f "${SERVICE}"
+        fi
+    else
+        set +e # killall will error if finds no process to kill
+        killall raft-key-value
+        set -e
+    fi
+}
+
+rpc() {
+    local uri=$1
+    local body="$2"
+
+    echo '---'" rpc(:$uri, $body)"
+
+    {
+        if [ ".$body" = "." ]; then
+            curl --silent "127.0.0.1:$uri"
+        else
+            curl --silent "127.0.0.1:$uri" -H "Content-Type: application/json" -d "$body"
+        fi
+    } | {
+        if type jq > /dev/null 2>&1; then
+            jq
+        else
+            cat
+        fi
+    }
+
+    echo
+    echo
+}
+
+export RUST_LOG=debug 
+
+echo "Killing all running raft-key-value"
+
+#kill
+
+#sleep 1
+
+echo "Start 3 uninitialized raft-key-value servers..."
+
+
+nohup ./target/release/raft-key-value  --id 1 --http-addr 127.0.0.1:21001 > n1.log &
+sleep 1
+echo "Server 1 started"
+
+nohup ./target/release/raft-key-value  --id 2 --http-addr 127.0.0.1:21002 > n2.log &
+sleep 1
+echo "Server 2 started"
+
+nohup ./target/release/raft-key-value  --id 3 --http-addr 127.0.0.1:21003 > n3.log &
+sleep 1
+echo "Server 3 started"
+sleep 1
+
+echo "Initialize server 1 as a single-node cluster"
+sleep 2
+echo
+rpc 21001/init '{}'
+
+echo "Server 1 is a leader now"
+
+sleep 2
+
+echo "Get metrics from the leader"
+sleep 2
+echo
+rpc 21001/metrics
+sleep 1
+
+
+echo "Adding node 2 and node 3 as learners, to receive log from leader node 1"
+
+sleep 1
+echo
+rpc 21001/add-learner       '[2, "127.0.0.1:21002"]'
+echo "Node 2 added as leaner"
+sleep 1
+echo
+rpc 21001/add-learner       '[3, "127.0.0.1:21003"]'
+echo "Node 3 added as leaner"
+sleep 1
+
+echo "Get metrics from the leader, after adding 2 learners"
+sleep 2
+echo
+rpc 21001/metrics
+sleep 1
+
+echo "Changing membership from [1] to 3 nodes cluster: [1, 2, 3]"
+echo
+rpc 21001/change-membership '[1, 2, 3]'
+sleep 1
+echo "Membership changed"
+sleep 1
+
+echo "Get metrics from the leader again"
+sleep 1
+echo
+rpc 21001/metrics
+sleep 1
+
+echo "Write data on leader"
+sleep 1
+
+nohup curl 127.0.0.1:21001/profile/dump_flamegraph -H "Content-Type: application/json" -d  '[10,99]' &
+
+for i in `seq 1500`  
+do
+    arg='{"Set":{"key":"'$i'","value":"'$i'"}}'
+    echo $arg
+    rpc 21001/write $arg;
+done 
+
+echo "Killing all nodes in 3s..."
+sleep 1
+echo "Killing all nodes in 2s..."
+sleep 1
+echo "Killing all nodes in 1s..."
+
+sleep 1
+kill


### PR DESCRIPTION
Refactor: add profile HTTP interface to dump flame graph and script in example

after that, user can use `test-cluster-and-dump-flamegraph.sh` to dump flame graph file, which can use to profile `openraft` lib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/213)
<!-- Reviewable:end -->
