### PR TITLE
Refactor: add consistent_read in example base on client_read API to provide consistent read from statemacine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ vendor
 # File Ignores ###############################################################
 **/*.rs.bk
 Cargo.lock
+*log
+perf.data*
+nohup*
+*svg

--- a/example-raft-kv/src/client.rs
+++ b/example-raft-kv/src/client.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use openraft::error::AddLearnerError;
+use openraft::error::CheckIsLeaderError;
 use openraft::error::ClientWriteError;
 use openraft::error::ForwardToLeader;
 use openraft::error::Infallible;
@@ -64,6 +65,16 @@ impl ExampleClient {
     /// This method may return stale value because it does not force to read on a legal leader.
     pub async fn read(&self, req: &String) -> Result<String, RPCError<ExampleTypeConfig, Infallible>> {
         self.do_send_rpc_to_leader("read", Some(req)).await
+    }
+
+    /// Consistent Read value by key, in an inconsistent mode.
+    ///
+    /// This method MUST return consitent value or CheckIsLeaderError.
+    pub async fn consistent_read(
+        &self,
+        req: &String,
+    ) -> Result<String, RPCError<ExampleTypeConfig, CheckIsLeaderError<ExampleTypeConfig>>> {
+        self.do_send_rpc_to_leader("consistent_read", Some(req)).await
     }
 
     // --- Cluster management API

--- a/example-raft-kv/src/lib.rs
+++ b/example-raft-kv/src/lib.rs
@@ -74,6 +74,7 @@ pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) 
             // application API
             .service(api::write)
             .service(api::read)
+            .service(api::consistent_read)
     });
 
     let x = server.bind(http_addr)?;

--- a/example-raft-kv/src/network/api.rs
+++ b/example-raft-kv/src/network/api.rs
@@ -3,6 +3,7 @@ use actix_web::web;
 use actix_web::web::Data;
 use actix_web::Responder;
 use openraft::error::Infallible;
+use openraft::error::ClientReadError;
 use openraft::raft::ClientWriteRequest;
 use openraft::raft::EntryPayload;
 use web::Json;
@@ -34,4 +35,23 @@ pub async fn read(app: Data<ExampleApp>, req: Json<String>) -> actix_web::Result
 
     let res: Result<String, Infallible> = Ok(value.unwrap_or_default());
     Ok(Json(res))
+}
+
+#[post("/consistent_read")]
+pub async fn consistent_read(app: Data<ExampleApp>, req: Json<String>) -> actix_web::Result<impl Responder> {
+    let ret = app.raft.client_read().await;
+
+    match ret {
+        Ok(_) => {
+            let state_machine = app.store.state_machine.read().await;
+            let key = req.0;
+            let value = state_machine.data.get(&key).cloned();
+            
+            let res: Result<String, ClientReadError> = Ok(value.unwrap_or_default());
+            Ok(Json(res))
+        }
+        Err(e) => {
+            Ok(Json(Err(e)))
+        }
+    }
 }

--- a/example-raft-kv/src/network/api.rs
+++ b/example-raft-kv/src/network/api.rs
@@ -10,6 +10,7 @@ use web::Json;
 
 use crate::app::ExampleApp;
 use crate::store::ExampleRequest;
+use crate::ExampleTypeConfig;
 
 /**
  * Application API
@@ -47,7 +48,7 @@ pub async fn consistent_read(app: Data<ExampleApp>, req: Json<String>) -> actix_
             let key = req.0;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, CheckIsLeaderError> = Ok(value.unwrap_or_default());
+            let res: Result<String, CheckIsLeaderError<ExampleTypeConfig>> = Ok(value.unwrap_or_default());
             Ok(Json(res))
         }
         Err(e) => Ok(Json(Err(e))),

--- a/example-raft-kv/tests/cluster/test_cluster.rs
+++ b/example-raft-kv/tests/cluster/test_cluster.rs
@@ -177,5 +177,21 @@ async fn test_cluster() -> anyhow::Result<()> {
     let x = client3.read(&("foo".to_string())).await?;
     assert_eq!("wow", x);
 
+    println!("=== consistent_read `foo` on node 1");
+    let x = client.consistent_read(&("foo".to_string())).await?;
+    assert_eq!("wow", x);
+
+    println!("=== consistent_read `foo` on node 2 MUST return CheckIsLeaderError");
+    let x = client2.consistent_read(&("foo".to_string())).await;
+    match x {
+        Err(e) => {
+            let s = e.to_string();
+            let expect_err:String = "error occur on remote peer 2: has to forward request to: Some(1), Some(Node { addr: \"127.0.0.1:21001\", data: {} })".to_string();
+
+            assert_eq!(s, expect_err);
+        }
+        Ok(_) => panic!("MUST return CheckIsLeaderError"),
+    }
+
     Ok(())
 }

--- a/guide/src/architecture.md
+++ b/guide/src/architecture.md
@@ -8,7 +8,7 @@
         !          |                      !
         !          |                      !
         !          | "client_write(impl AppData) -> impl AppDataResponse"
-        !          | "client_read()"      !
+        !          | "is_leader()"        !
         !          | "add_learner()"      !
         !          | "change_membership()"!
         !          v                      !

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -11,7 +11,7 @@ use tracing::Instrument;
 use crate::core::apply_to_state_machine;
 use crate::core::LeaderState;
 use crate::core::State;
-use crate::error::ClientReadError;
+use crate::error::CheckIsLeaderError;
 use crate::error::ClientWriteError;
 use crate::error::QuorumNotEnough;
 use crate::error::RPCError;
@@ -67,7 +67,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         Ok(())
     }
 
-    /// Handle client read requests.
+    /// Handle `is_leader` requests.
     ///
     /// Spawn requests to all members of the cluster, include members being added in joint
     /// consensus. Each request will have a timeout, and we respond once we have a majority
@@ -80,7 +80,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     /// handles this by having the leader exchange heartbeat messages with a majority of the
     /// cluster before responding to read-only requests.
     #[tracing::instrument(level = "trace", skip(self, tx))]
-    pub(super) async fn handle_client_read_request(&mut self, tx: RaftRespTx<(), ClientReadError>) {
+    pub(super) async fn handle_check_is_leader_request(&mut self, tx: RaftRespTx<(), CheckIsLeaderError>) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
         let mem = &self.core.effective_membership.membership;

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -842,8 +842,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
                 let res = self.core.handle_install_snapshot_request(rpc).await.extract_fatal()?;
                 let _ = tx.send(res);
             }
-            RaftMsg::ClientReadRequest { tx } => {
-                self.handle_client_read_request(tx).await;
+            RaftMsg::CheckIsLeaderRequest { tx } => {
+                self.handle_check_is_leader_request(tx).await;
             }
             RaftMsg::ClientWriteRequest { rpc, tx } => {
                 self.handle_client_write_request(rpc, tx).await?;
@@ -1001,7 +1001,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Candida
             RaftMsg::InstallSnapshot { rpc, tx } => {
                 let _ = tx.send(self.core.handle_install_snapshot_request(rpc).await.extract_fatal()?);
             }
-            RaftMsg::ClientReadRequest { tx } => {
+            RaftMsg::CheckIsLeaderRequest { tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
             RaftMsg::ClientWriteRequest { rpc: _, tx } => {
@@ -1077,7 +1077,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Followe
             RaftMsg::InstallSnapshot { rpc, tx } => {
                 let _ = tx.send(self.core.handle_install_snapshot_request(rpc).await.extract_fatal()?);
             }
-            RaftMsg::ClientReadRequest { tx } => {
+            RaftMsg::CheckIsLeaderRequest { tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
             RaftMsg::ClientWriteRequest { rpc: _, tx } => {
@@ -1151,7 +1151,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
             RaftMsg::InstallSnapshot { rpc, tx } => {
                 let _ = tx.send(self.core.handle_install_snapshot_request(rpc).await.extract_fatal()?);
             }
-            RaftMsg::ClientReadRequest { tx } => {
+            RaftMsg::CheckIsLeaderRequest { tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
             RaftMsg::ClientWriteRequest { rpc: _, tx } => {

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -72,9 +72,9 @@ pub enum InstallSnapshotError {
     Fatal(#[from] Fatal),
 }
 
-/// An error related to a client read request.
+/// An error related to a is_leader request.
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error, derive_more::TryInto)]
-pub enum ClientReadError {
+pub enum CheckIsLeaderError {
     #[error(transparent)]
     ForwardToLeader(#[from] ForwardToLeader),
 
@@ -166,7 +166,7 @@ impl From<StorageError> for InstallSnapshotError {
         f.into()
     }
 }
-impl From<StorageError> for ClientReadError {
+impl From<StorageError> for CheckIsLeaderError {
     fn from(s: StorageError) -> Self {
         let f: Fatal = s.into();
         f.into()

--- a/openraft/tests/append_entries/t60_large_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_large_heartbeat.rs
@@ -32,7 +32,7 @@ async fn large_heartbeat() -> Result<()> {
     router.client_request_many(0, "foo", 100).await;
     log_index += 100;
 
-    router.wait(&1, Some(Duration::from_millis(600))).await?.log(Some(log_index), "").await?;
+    router.wait(&1, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
 
     Ok(())
 }

--- a/openraft/tests/append_entries/t60_large_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_large_heartbeat.rs
@@ -32,7 +32,7 @@ async fn large_heartbeat() -> Result<()> {
     router.client_request_many(0, "foo", 100).await;
     log_index += 100;
 
-    router.wait(&1, Some(Duration::from_millis(500))).await?.log(Some(log_index), "").await?;
+    router.wait(&1, Some(Duration::from_millis(600))).await?.log(Some(log_index), "").await?;
 
     Ok(())
 }

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -12,8 +12,8 @@ use crate::fixtures::RaftRouter;
 /// What does this test do?
 ///
 /// - create a stable 3-node cluster.
-/// - call the client_read interface on the leader, and assert success.
-/// - call the client_read interface on the followers, and assert failure.
+/// - call the is_leader interface on the leader, and assert success.
+/// - call the is_leader interface on the followers, and assert failure.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn client_reads() -> Result<()> {
     let (_log_guard, ut_span) = init_ut!();
@@ -41,27 +41,27 @@ async fn client_reads() -> Result<()> {
     router.wait_for_log(&btreeset![0, 1, 2], Some(n_logs), None, "init leader").await?;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
-    // Get the ID of the leader, and assert that client_read succeeds.
+    // Get the ID of the leader, and assert that is_leader succeeds.
     let leader = router.leader().expect("leader not found");
     assert_eq!(leader, 0, "expected leader to be node 0, got {}", leader);
     router
-        .client_read(leader)
+        .is_leader(leader)
         .await
-        .unwrap_or_else(|_| panic!("expected client_read to succeed for cluster leader {}", leader));
+        .unwrap_or_else(|_| panic!("expected is_leader to succeed for cluster leader {}", leader));
 
-    router.client_read(1).await.expect_err("expected client_read on follower node 1 to fail");
-    router.client_read(2).await.expect_err("expected client_read on follower node 2 to fail");
+    router.is_leader(1).await.expect_err("expected is_leader on follower node 1 to fail");
+    router.is_leader(2).await.expect_err("expected is_leader on follower node 2 to fail");
 
-    tracing::info!("--- isolate node 1 then client read should work");
+    tracing::info!("--- isolate node 1 then is_leader should work");
 
     router.isolate_node(1).await;
-    router.client_read(leader).await?;
+    router.is_leader(leader).await?;
 
-    tracing::info!("--- isolate node 2 then client read should fail");
+    tracing::info!("--- isolate node 2 then is_leader should fail");
 
     router.isolate_node(2).await;
-    let rst = router.client_read(leader).await;
-    tracing::debug!(?rst, "client_read with majority down");
+    let rst = router.is_leader(leader).await;
+    tracing::debug!(?rst, "is_leader with majority down");
 
     assert!(rst.is_err());
 

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -25,7 +25,7 @@ use memstore::MemStore;
 use openraft::async_trait::async_trait;
 use openraft::error::AddLearnerError;
 use openraft::error::AppendEntriesError;
-use openraft::error::ClientReadError;
+use openraft::error::CheckIsLeaderError;
 use openraft::error::ClientWriteError;
 use openraft::error::InstallSnapshotError;
 use openraft::error::NetworkError;
@@ -526,13 +526,13 @@ impl RaftRouter {
         node.0.add_learner(target, None, blocking).await
     }
 
-    /// Send a client read request to the target node.
-    pub async fn client_read(&self, target: NodeId) -> Result<(), ClientReadError> {
+    /// Send a is_leader request to the target node.
+    pub async fn is_leader(&self, target: NodeId) -> Result<(), CheckIsLeaderError> {
         let node = {
             let rt = self.routing_table.lock().unwrap();
             rt.get(&target).unwrap_or_else(|| panic!("node with ID {} does not exist", target)).clone()
         };
-        node.0.client_read().await
+        node.0.is_leader().await
     }
 
     /// Send a client request to the target node, causing test failure on error.

--- a/openraft/tests/singlenode.rs
+++ b/openraft/tests/singlenode.rs
@@ -52,7 +52,7 @@ async fn single_node() -> Result<()> {
     router.assert_storage_state(1, 1001, Some(0), LogId::new(LeaderId::new(1, 0), 1001), None).await?;
 
     // Read some data from the single node cluster.
-    router.client_read(0).await?;
+    router.is_leader(0).await?;
 
     Ok(())
 }


### PR DESCRIPTION
1. Refactor: add consistent_read in example base on `is_leader` API to provide consistent read from statemacine"
2. rename API `client_read` to `is_leader`.
3. update gitignore file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/218)
<!-- Reviewable:end -->
