### PR TITLE
Change: Make `NodeId` type configurable via `RaftTypeConfig`

### DIFF
--- a/example-raft-kv/src/app.rs
+++ b/example-raft-kv/src/app.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
 use openraft::Config;
-use openraft::NodeId;
 
+use crate::ExampleNodeId;
 use crate::ExampleRaft;
 use crate::ExampleStore;
 
 // Representation of an application state. This struct can be shared around to share
 // instances of raft, store and more.
 pub struct ExampleApp {
-    pub id: NodeId,
+    pub id: ExampleNodeId,
     pub addr: String,
     pub raft: ExampleRaft,
     pub store: Arc<ExampleStore>,

--- a/example-raft-kv/src/lib.rs
+++ b/example-raft-kv/src/lib.rs
@@ -6,9 +6,7 @@ use actix_web::web::Data;
 use actix_web::App;
 use actix_web::HttpServer;
 use openraft::Config;
-use openraft::NodeId;
 use openraft::Raft;
-use openraft::RaftTypeConfig;
 
 use crate::app::ExampleApp;
 use crate::network::api;
@@ -24,16 +22,16 @@ pub mod client;
 pub mod network;
 pub mod store;
 
-pub struct ExampleTypeConfig {}
+pub type ExampleNodeId = u64;
 
-impl RaftTypeConfig for ExampleTypeConfig {
-    type D = ExampleRequest;
-    type R = ExampleResponse;
-}
+openraft::declare_raft_types!(
+    /// Declare the type configuration for example K/V store.
+    pub ExampleTypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId
+);
 
 pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, Arc<ExampleStore>>;
 
-pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std::io::Result<()> {
+pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) -> std::io::Result<()> {
     // Create a configuration for the raft instance.
     let config = Arc::new(Config::default().validate().unwrap());
 

--- a/example-raft-kv/src/network/management.rs
+++ b/example-raft-kv/src/network/management.rs
@@ -8,11 +8,12 @@ use actix_web::web::Data;
 use actix_web::Responder;
 use openraft::error::Infallible;
 use openraft::Node;
-use openraft::NodeId;
 use openraft::RaftMetrics;
 use web::Json;
 
 use crate::app::ExampleApp;
+use crate::ExampleNodeId;
+use crate::ExampleTypeConfig;
 
 // --- Cluster management
 
@@ -22,7 +23,10 @@ use crate::app::ExampleApp;
 /// This should be done before adding a node as a member into the cluster
 /// (by calling `change-membership`)
 #[post("/add-learner")]
-pub async fn add_learner(app: Data<ExampleApp>, req: Json<(NodeId, String)>) -> actix_web::Result<impl Responder> {
+pub async fn add_learner(
+    app: Data<ExampleApp>,
+    req: Json<(ExampleNodeId, String)>,
+) -> actix_web::Result<impl Responder> {
     let node_id = req.0 .0;
     let node = Node {
         addr: req.0 .1.clone(),
@@ -36,7 +40,7 @@ pub async fn add_learner(app: Data<ExampleApp>, req: Json<(NodeId, String)>) -> 
 #[post("/change-membership")]
 pub async fn change_membership(
     app: Data<ExampleApp>,
-    req: Json<BTreeSet<NodeId>>,
+    req: Json<BTreeSet<ExampleNodeId>>,
 ) -> actix_web::Result<impl Responder> {
     let res = app.raft.change_membership(req.0, true, false).await;
     Ok(Json(res))
@@ -59,6 +63,6 @@ pub async fn init(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
 pub async fn metrics(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
     let metrics = app.raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<ExampleTypeConfig>, Infallible> = Ok(metrics);
     Ok(Json(res))
 }

--- a/example-raft-kv/src/network/raft.rs
+++ b/example-raft-kv/src/network/raft.rs
@@ -13,7 +13,10 @@ use crate::ExampleTypeConfig;
 // --- Raft communication
 
 #[post("/raft-vote")]
-pub async fn vote(app: Data<ExampleApp>, req: Json<VoteRequest>) -> actix_web::Result<impl Responder> {
+pub async fn vote(
+    app: Data<ExampleApp>,
+    req: Json<VoteRequest<ExampleTypeConfig>>,
+) -> actix_web::Result<impl Responder> {
     let res = app.raft.vote(req.0).await;
     Ok(Json(res))
 }
@@ -28,7 +31,10 @@ pub async fn append(
 }
 
 #[post("/raft-snapshot")]
-pub async fn snapshot(app: Data<ExampleApp>, req: Json<InstallSnapshotRequest>) -> actix_web::Result<impl Responder> {
+pub async fn snapshot(
+    app: Data<ExampleApp>,
+    req: Json<InstallSnapshotRequest<ExampleTypeConfig>>,
+) -> actix_web::Result<impl Responder> {
     let res = app.raft.install_snapshot(req.0).await;
     Ok(Json(res))
 }

--- a/example-raft-kv/tests/cluster/test_cluster.rs
+++ b/example-raft-kv/tests/cluster/test_cluster.rs
@@ -5,6 +5,7 @@ use anyerror::AnyError;
 use example_raft_key_value::client::ExampleClient;
 use example_raft_key_value::start_example_raft_node;
 use example_raft_key_value::store::ExampleRequest;
+use example_raft_key_value::ExampleTypeConfig;
 use maplit::btreemap;
 use maplit::btreeset;
 use openraft::error::NodeNotFound;
@@ -25,7 +26,7 @@ async fn test_cluster() -> anyhow::Result<()> {
             2 => "127.0.0.1:21002".to_string(),
             3 => "127.0.0.1:21003".to_string(),
             _ => {
-                return Err(NodeNotFound {
+                return Err(NodeNotFound::<ExampleTypeConfig> {
                     node_id,
                     source: AnyError::error("node not found"),
                 });

--- a/memstore/src/test.rs
+++ b/memstore/src/test.rs
@@ -1,6 +1,7 @@
 use openraft::testing::Suite;
 use openraft::StorageError;
 
+use crate::Config;
 use crate::MemStore;
 
 /// To customize a builder:
@@ -25,7 +26,7 @@ use crate::MemStore;
 /// }
 /// ```
 #[test]
-pub fn test_mem_store() -> Result<(), StorageError> {
-    Suite::test_all(MemStore::new_arc)?;
+pub fn test_mem_store() -> Result<(), StorageError<Config>> {
+    Suite::test_all(MemStore::new_async)?;
     Ok(())
 }

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -24,7 +24,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(super) async fn handle_append_entries_request(
         &mut self,
         req: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse, AppendEntriesError> {
+    ) -> Result<AppendEntriesResponse<C>, AppendEntriesError<C>> {
         tracing::debug!(last_log_id=?self.last_log_id, ?self.last_applied, msg=%req.summary(), "handle_append_entries_request");
 
         let msg_entries = req.entries.as_slice();
@@ -74,7 +74,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn delete_conflict_logs_since(&mut self, start: LogId) -> Result<(), StorageError> {
+    async fn delete_conflict_logs_since(&mut self, start: LogId<C>) -> Result<(), StorageError<C>> {
         self.storage.delete_conflict_logs_since(start).await?;
 
         self.last_log_id = self.storage.get_log_state().await?.last_log_id;
@@ -136,7 +136,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// If log 5 is committed by R1, and log 3 is not removeC5 in future could become a new leader and overrides log
     /// 5 on R3.
     #[tracing::instrument(level="trace", skip(self, msg_entries), fields(msg_entries=%msg_entries.summary()))]
-    async fn find_and_delete_conflict_logs(&mut self, msg_entries: &[Entry<C>]) -> Result<(), StorageError> {
+    async fn find_and_delete_conflict_logs(&mut self, msg_entries: &[Entry<C>]) -> Result<(), StorageError<C>> {
         // all msg_entries are inconsistent logs
 
         tracing::debug!(msg_entries=%msg_entries.summary(), "try to delete_inconsistent_log");
@@ -170,10 +170,10 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     #[tracing::instrument(level="trace", skip(self, entries), fields(entries=%entries.summary()))]
     async fn append_apply_log_entries(
         &mut self,
-        prev_log_id: Option<LogId>,
+        prev_log_id: Option<LogId<C>>,
         entries: &[Entry<C>],
-        committed: Option<LogId>,
-    ) -> Result<AppendEntriesResponse, StorageError> {
+        committed: Option<LogId<C>>,
+    ) -> Result<AppendEntriesResponse<C>, StorageError<C>> {
         let mismatched = self.does_log_id_match(prev_log_id).await?;
 
         tracing::debug!(
@@ -239,7 +239,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub async fn skip_matching_entries<'s, 'e>(
         &'s mut self,
         entries: &'e [Entry<C>],
-    ) -> Result<(usize, &'e [Entry<C>]), StorageError> {
+    ) -> Result<(usize, &'e [Entry<C>]), StorageError<C>> {
         let l = entries.len();
 
         for i in 0..l {
@@ -270,7 +270,10 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     ///
     /// This way to check if the entries in append-entries request is consecutive with local logs.
     /// Raft only accept consecutive logs to be appended.
-    pub async fn does_log_id_match(&mut self, remote_log_id: Option<LogId>) -> Result<Option<LogId>, StorageError> {
+    pub async fn does_log_id_match(
+        &mut self,
+        remote_log_id: Option<LogId<C>>,
+    ) -> Result<Option<LogId<C>>, StorageError<C>> {
         let log_id = match remote_log_id {
             None => {
                 return Ok(None);
@@ -306,7 +309,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// Configuration changes are also detected and applied here. See `configuration changes`
     /// in the raft-essentials.md in this repo.
     #[tracing::instrument(level = "trace", skip(self, entries), fields(entries=%entries.summary()))]
-    async fn append_log_entries(&mut self, entries: &[Entry<C>]) -> Result<(), StorageError> {
+    async fn append_log_entries(&mut self, entries: &[Entry<C>]) -> Result<(), StorageError<C>> {
         if entries.is_empty() {
             return Ok(());
         }
@@ -343,7 +346,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// Very importantly, this routine must not block the main control loop main task, else it
     /// may cause the Raft leader to timeout the requests to this node.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn replicate_to_state_machine_if_needed(&mut self) -> Result<(), StorageError> {
+    async fn replicate_to_state_machine_if_needed(&mut self) -> Result<(), StorageError<C>> {
         tracing::debug!(?self.last_applied, "replicate_to_sm_if_needed");
 
         // If we don't have any new entries to replicate, then do nothing.

--- a/openraft/src/core/replication_state_test.rs
+++ b/openraft/src/core/replication_state_test.rs
@@ -1,20 +1,24 @@
 use crate::core::is_matched_upto_date;
+use crate::testing::DummyConfig;
 use crate::Config;
 use crate::LeaderId;
 use crate::LogId;
 
 #[test]
 fn test_is_line_rate() -> anyhow::Result<()> {
-    let m = Some(LogId::new(LeaderId::new(1, 0), 10));
+    let m = Some(LogId::<DummyConfig>::new(LeaderId::new(1, 0), 10));
 
     let cfg = |n| Config {
         replication_lag_threshold: n,
         ..Default::default()
     };
 
-    assert!(is_matched_upto_date(&None, &None, &cfg(0)), "matched, threshold=0");
     assert!(
-        is_matched_upto_date(
+        is_matched_upto_date::<DummyConfig>(&None, &None, &cfg(0)),
+        "matched, threshold=0"
+    );
+    assert!(
+        is_matched_upto_date::<DummyConfig>(
             &None,
             &Some(LogId {
                 leader_id: LeaderId::new(2, 0),
@@ -25,7 +29,7 @@ fn test_is_line_rate() -> anyhow::Result<()> {
         "matched, threshold=1"
     );
     assert!(
-        !is_matched_upto_date(
+        !is_matched_upto_date::<DummyConfig>(
             &None,
             &Some(LogId {
                 leader_id: LeaderId::new(2, 0),
@@ -37,16 +41,16 @@ fn test_is_line_rate() -> anyhow::Result<()> {
     );
 
     assert!(
-        is_matched_upto_date(&Some(LogId::new(LeaderId::new(0, 0), 0)), &None, &cfg(0)),
+        is_matched_upto_date::<DummyConfig>(&Some(LogId::new(LeaderId::new(0, 0), 0)), &None, &cfg(0)),
         "matched, threshold=0"
     );
 
     assert!(
-        is_matched_upto_date(&m, &Some(LogId::new(LeaderId::new(2, 0), 10)), &cfg(0)),
+        is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 10)), &cfg(0)),
         "matched, threshold=0"
     );
     assert!(
-        is_matched_upto_date(&m, &Some(LogId::new(LeaderId::new(2, 0), 9)), &cfg(0)),
+        is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 9)), &cfg(0)),
         "overflow, threshold=0"
     );
     assert!(
@@ -54,7 +58,7 @@ fn test_is_line_rate() -> anyhow::Result<()> {
         "not caught up, threshold=0"
     );
     assert!(
-        is_matched_upto_date(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(1)),
+        is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(1)),
         "caught up, threshold=1"
     );
     Ok(())

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -77,7 +77,13 @@ pub use crate::vote::Vote;
 /// models as-is to Raft, Raft will present it to the application's `RaftStorage` impl when ready,
 /// and the application may then deal with the data directly in the storage engine without having
 /// to do a preliminary deserialization.
+///
+/// ## Note
+///
+/// The trait is automatically implemented for all types which satisfy its supertraits.
 pub trait AppData: Clone + Send + Sync + Serialize + DeserializeOwned + 'static {}
+
+impl<T> AppData for T where T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static {}
 
 /// A trait defining application specific response data.
 ///
@@ -92,4 +98,10 @@ pub trait AppData: Clone + Send + Sync + Serialize + DeserializeOwned + 'static 
 /// related to the success or failure of a client request — application specific validation logic,
 /// enforcing of data constraints, and anything of that nature — are expressly out of the realm of
 /// the Raft consensus protocol.
+///
+/// ## Note
+///
+/// The trait is automatically implemented for all types which satisfy its supertraits.
 pub trait AppDataResponse: Clone + Send + Sync + Serialize + DeserializeOwned + 'static {}
+
+impl<T> AppDataResponse for T where T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static {}

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -12,34 +12,34 @@ use crate::error::NodeIdNotInNodes;
 use crate::membership::quorum;
 use crate::MessageSummary;
 use crate::Node;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum EitherNodesOrIds {
-    Nodes(BTreeMap<NodeId, Node>),
-    NodeIds(BTreeSet<NodeId>),
+pub enum EitherNodesOrIds<C: RaftTypeConfig> {
+    Nodes(BTreeMap<C::NodeId, Node>),
+    NodeIds(BTreeSet<C::NodeId>),
 }
 
-impl From<BTreeSet<NodeId>> for EitherNodesOrIds {
-    fn from(node_ids: BTreeSet<NodeId>) -> Self {
+impl<C: RaftTypeConfig> From<BTreeSet<C::NodeId>> for EitherNodesOrIds<C> {
+    fn from(node_ids: BTreeSet<C::NodeId>) -> Self {
         Self::NodeIds(node_ids)
     }
 }
-impl From<BTreeMap<NodeId, Node>> for EitherNodesOrIds {
-    fn from(nodes: BTreeMap<NodeId, Node>) -> Self {
+impl<C: RaftTypeConfig> From<BTreeMap<C::NodeId, Node>> for EitherNodesOrIds<C> {
+    fn from(nodes: BTreeMap<C::NodeId, Node>) -> Self {
         Self::Nodes(nodes)
     }
 }
 
-impl EitherNodesOrIds {
-    pub fn node_ids(&self) -> BTreeSet<NodeId> {
+impl<C: RaftTypeConfig> EitherNodesOrIds<C> {
+    pub fn node_ids(&self) -> BTreeSet<C::NodeId> {
         match self {
             EitherNodesOrIds::NodeIds(ids) => ids.clone(),
             EitherNodesOrIds::Nodes(nodes) => nodes.keys().cloned().collect::<BTreeSet<_>>(),
         }
     }
 
-    pub fn nodes(&self) -> Option<BTreeMap<NodeId, Node>> {
+    pub fn nodes(&self) -> Option<BTreeMap<C::NodeId, Node>> {
         match self {
             EitherNodesOrIds::NodeIds(_ids) => None,
             EitherNodesOrIds::Nodes(nodes) => Some(nodes.clone()),
@@ -52,22 +52,22 @@ impl EitherNodesOrIds {
 /// It could be a joint of one, two or more configs, i.e., a quorum is a node set that is superset of a majority of
 /// every config.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Membership {
+pub struct Membership<C: RaftTypeConfig> {
     /// Learners set
-    learners: BTreeSet<NodeId>,
+    learners: BTreeSet<C::NodeId>,
 
     /// Multi configs of members.
     ///
     /// AKA a joint config in original raft paper.
-    configs: Vec<BTreeSet<NodeId>>,
+    configs: Vec<BTreeSet<C::NodeId>>,
 
     /// Nodes info, e.g. the connecting host and port.
     ///
     /// If it is Some, it has to contain all node id in `configs` and `learners`.
-    nodes: Option<BTreeMap<NodeId, Node>>,
+    nodes: Option<BTreeMap<C::NodeId, Node>>,
 }
 
-impl MessageSummary for Membership {
+impl<C: RaftTypeConfig> MessageSummary for Membership<C> {
     fn summary(&self) -> String {
         let nodes = self.get_nodes();
 
@@ -109,11 +109,11 @@ impl MessageSummary for Membership {
     }
 }
 
-impl Membership {
+impl<C: RaftTypeConfig> Membership<C> {
     /// Create a new Membership of multiple configs(joint) and optinally a set of learners
     ///
     /// A learner that is already in configs will be filtered out.
-    pub fn new(configs: Vec<BTreeSet<NodeId>>, learners: Option<BTreeSet<NodeId>>) -> Self {
+    pub fn new(configs: Vec<BTreeSet<C::NodeId>>, learners: Option<BTreeSet<C::NodeId>>) -> Self {
         let all_members = Self::build_all_members(&configs);
         let learners = learners.unwrap_or_default();
         let learners = learners.difference(&all_members).cloned().collect::<BTreeSet<_>>();
@@ -128,7 +128,7 @@ impl Membership {
     /// Attatch nodes info to a Membership and returns a new instance.
     ///
     /// The provided `nodes` has to contain every node-id presents in `configs` or `learners` if it is `Some`.
-    pub(crate) fn set_nodes(mut self, nodes: Option<BTreeMap<NodeId, Node>>) -> Result<Self, NodeIdNotInNodes> {
+    pub(crate) fn set_nodes(mut self, nodes: Option<BTreeMap<C::NodeId, Node>>) -> Result<Self, NodeIdNotInNodes<C>> {
         self.check_node_ids_in_nodes(&nodes)?;
 
         self.nodes = self.remove_unused_nodes(&nodes);
@@ -137,13 +137,13 @@ impl Membership {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn get_nodes(&self) -> &Option<BTreeMap<NodeId, Node>> {
+    pub(crate) fn get_nodes(&self) -> &Option<BTreeMap<C::NodeId, Node>> {
         &self.nodes
     }
 
     // TODO(xp)
     #[allow(dead_code)]
-    pub(crate) fn get_node(&self, node_id: NodeId) -> Option<&Node> {
+    pub(crate) fn get_node(&self, node_id: C::NodeId) -> Option<&Node> {
         if let Some(ns) = &self.nodes {
             return ns.get(&node_id);
         }
@@ -151,7 +151,10 @@ impl Membership {
         None
     }
 
-    pub(crate) fn remove_unused_nodes(&self, nodes: &Option<BTreeMap<NodeId, Node>>) -> Option<BTreeMap<NodeId, Node>> {
+    pub(crate) fn remove_unused_nodes(
+        &self,
+        nodes: &Option<BTreeMap<C::NodeId, Node>>,
+    ) -> Option<BTreeMap<C::NodeId, Node>> {
         let ns = match nodes {
             None => {
                 return None;
@@ -176,9 +179,9 @@ impl Membership {
     /// Node that present in `old` will not be replaced because changing the address of a node potentially breaks
     /// consensus guarantee.
     pub fn extend_nodes(
-        old: Option<BTreeMap<NodeId, Node>>,
-        new: &Option<BTreeMap<NodeId, Node>>,
-    ) -> Option<BTreeMap<NodeId, Node>> {
+        old: Option<BTreeMap<C::NodeId, Node>>,
+        new: &Option<BTreeMap<C::NodeId, Node>>,
+    ) -> Option<BTreeMap<C::NodeId, Node>> {
         let new_nodes = match new {
             None => return old,
             Some(x) => x,
@@ -199,8 +202,8 @@ impl Membership {
     /// Check if all member node-id and learner node id are included in `self.nodes`, if `self.nodes` is `Some`.
     pub(crate) fn check_node_ids_in_nodes(
         &self,
-        nodes: &Option<BTreeMap<NodeId, Node>>,
-    ) -> Result<(), NodeIdNotInNodes> {
+        nodes: &Option<BTreeMap<C::NodeId, Node>>,
+    ) -> Result<(), NodeIdNotInNodes<C>> {
         let ns = match nodes {
             None => return Ok(()),
             Some(x) => x,
@@ -212,7 +215,7 @@ impl Membership {
             if !ns.contains_key(node_id) {
                 let e = NodeIdNotInNodes {
                     node_id: *node_id,
-                    node_ids: ns.keys().cloned().collect::<BTreeSet<NodeId>>(),
+                    node_ids: ns.keys().cloned().collect::<BTreeSet<C::NodeId>>(),
                 };
                 return Err(e);
             }
@@ -221,7 +224,7 @@ impl Membership {
         Ok(())
     }
 
-    pub fn get_configs(&self) -> &Vec<BTreeSet<NodeId>> {
+    pub fn get_configs(&self) -> &Vec<BTreeSet<C::NodeId>> {
         &self.configs
     }
 
@@ -230,7 +233,7 @@ impl Membership {
         self.configs.len() > 1
     }
 
-    pub(crate) fn add_learner(&self, node_id: NodeId, node: Option<Node>) -> Result<Self, NodeIdNotInNodes> {
+    pub(crate) fn add_learner(&self, node_id: C::NodeId, node: Option<Node>) -> Result<Self, NodeIdNotInNodes<C>> {
         let extension = node.map(|n| btreemap! {node_id=>n});
 
         let configs = self.configs.clone();
@@ -246,24 +249,24 @@ impl Membership {
         Ok(m)
     }
 
-    pub(crate) fn all_learners(&self) -> &BTreeSet<NodeId> {
+    pub(crate) fn all_learners(&self) -> &BTreeSet<C::NodeId> {
         &self.learners
     }
 
-    pub(crate) fn all_members(&self) -> BTreeSet<NodeId> {
+    pub(crate) fn all_members(&self) -> BTreeSet<C::NodeId> {
         Self::build_all_members(&self.configs)
     }
 
-    pub(crate) fn get_ith_config(&self, i: usize) -> Option<&BTreeSet<NodeId>> {
+    pub(crate) fn get_ith_config(&self, i: usize) -> Option<&BTreeSet<C::NodeId>> {
         self.configs.get(i)
     }
 
-    pub(crate) fn contains(&self, target: &NodeId) -> bool {
+    pub(crate) fn contains(&self, target: &C::NodeId) -> bool {
         self.is_member(target) || self.is_learner(target)
     }
 
-    /// Check if the given NodeId exists in this membership config.
-    pub(crate) fn is_member(&self, x: &NodeId) -> bool {
+    /// Check if the given `NodeId` exists in this membership config.
+    pub(crate) fn is_member(&self, x: &C::NodeId) -> bool {
         for c in self.configs.iter() {
             if c.contains(x) {
                 return true;
@@ -272,20 +275,20 @@ impl Membership {
         false
     }
 
-    pub(crate) fn is_learner(&self, x: &NodeId) -> bool {
+    pub(crate) fn is_learner(&self, x: &C::NodeId) -> bool {
         self.learners.contains(x)
     }
 
     // TODO(xp): rename this
     /// Create a new initial config containing only the given node ID.
-    pub(crate) fn new_initial(id: NodeId) -> Self {
+    pub(crate) fn new_initial(id: C::NodeId) -> Self {
         Membership::new(vec![btreeset! {id}], None)
     }
 
     /// Return true if the given set of ids constitutes a majority.
     ///
     /// I.e. the id set includes a majority of every config.
-    pub(crate) fn is_majority(&self, granted: &BTreeSet<NodeId>) -> bool {
+    pub(crate) fn is_majority(&self, granted: &BTreeSet<C::NodeId>) -> bool {
         for config in self.configs.iter() {
             if !Self::is_majority_of_single_config(granted, config) {
                 return false;
@@ -301,7 +304,7 @@ impl Membership {
     /// `10` constitutes a majoirty in the first config {1,2,3}.
     /// `20` constitutes a majority in the second config {4,5,6}.
     /// Thus the minimal value `10` is the greatest joint majority for this membership config.
-    pub(crate) fn greatest_majority_value<'v, V>(&self, values: &'v BTreeMap<NodeId, V>) -> Option<&'v V>
+    pub(crate) fn greatest_majority_value<'v, V>(&self, values: &'v BTreeMap<C::NodeId, V>) -> Option<&'v V>
     where V: Ord {
         let mut res = vec![];
         for config in self.configs.iter() {
@@ -364,9 +367,9 @@ impl Membership {
     ///     curr = next;
     /// }
     /// ```
-    pub(crate) fn next_safe<T>(&self, goal: T, turn_to_learner: bool) -> Result<Self, NodeIdNotInNodes>
-    where T: Into<EitherNodesOrIds> {
-        let goal: EitherNodesOrIds = goal.into();
+    pub(crate) fn next_safe<T>(&self, goal: T, turn_to_learner: bool) -> Result<Self, NodeIdNotInNodes<C>>
+    where T: Into<EitherNodesOrIds<C>> {
+        let goal: EitherNodesOrIds<C> = goal.into();
 
         let goal_ids = goal.node_ids();
 
@@ -391,7 +394,7 @@ impl Membership {
         Ok(res)
     }
 
-    fn is_majority_of_single_config(granted: &BTreeSet<NodeId>, single_config: &BTreeSet<NodeId>) -> bool {
+    fn is_majority_of_single_config(granted: &BTreeSet<C::NodeId>, single_config: &BTreeSet<C::NodeId>) -> bool {
         let d = granted.intersection(single_config);
         let n_granted = d.fold(0, |a, _x| a + 1);
 
@@ -399,7 +402,7 @@ impl Membership {
         n_granted >= majority
     }
 
-    fn build_all_members(configs: &[BTreeSet<NodeId>]) -> BTreeSet<NodeId> {
+    fn build_all_members(configs: &[BTreeSet<C::NodeId>]) -> BTreeSet<C::NodeId> {
         let mut members = BTreeSet::new();
         for config in configs.iter() {
             members.extend(config)

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -25,16 +25,16 @@ use crate::raft_types::LogIdOptionExt;
 use crate::LogId;
 use crate::Membership;
 use crate::MessageSummary;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::ReplicationMetrics;
 
 /// A set of metrics describing the current state of a Raft node.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RaftMetrics {
-    pub running_state: Result<(), Fatal>,
+pub struct RaftMetrics<C: RaftTypeConfig> {
+    pub running_state: Result<(), Fatal<C>>,
 
     /// The ID of the Raft node.
-    pub id: NodeId,
+    pub id: C::NodeId,
     /// The state of the Raft node.
     pub state: State,
     /// The current term of the Raft node.
@@ -42,21 +42,21 @@ pub struct RaftMetrics {
     /// The last log index has been appended to this Raft node's log.
     pub last_log_index: Option<u64>,
     /// The last log index has been applied to this Raft node's state machine.
-    pub last_applied: Option<LogId>,
+    pub last_applied: Option<LogId<C>>,
     /// The current cluster leader.
-    pub current_leader: Option<NodeId>,
+    pub current_leader: Option<C::NodeId>,
     /// The current membership config of the cluster.
-    pub membership_config: Arc<EffectiveMembership>,
+    pub membership_config: Arc<EffectiveMembership<C>>,
 
     /// The id of the last log included in snapshot.
     /// If there is no snapshot, it is (0,0).
-    pub snapshot: Option<LogId>,
+    pub snapshot: Option<LogId<C>>,
 
     /// The metrics about the leader. It is Some() only when this node is leader.
-    pub leader_metrics: Option<Arc<LeaderMetrics>>,
+    pub leader_metrics: Option<Arc<LeaderMetrics<C>>>,
 }
 
-impl MessageSummary for RaftMetrics {
+impl<C: RaftTypeConfig> MessageSummary for RaftMetrics<C> {
     fn summary(&self) -> String {
         format!("Metrics{{id:{},{:?}, term:{}, last_log:{:?}, last_applied:{:?}, leader:{:?}, membership:{}, snapshot:{:?}, replication:{}",
             self.id,
@@ -74,12 +74,12 @@ impl MessageSummary for RaftMetrics {
 
 /// The metrics about the leader. It is Some() only when this node is leader.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LeaderMetrics {
+pub struct LeaderMetrics<C: RaftTypeConfig> {
     /// Replication metrics of all known replication target: voters and learners
-    pub replication: HashMap<NodeId, ReplicationMetrics>,
+    pub replication: HashMap<C::NodeId, ReplicationMetrics<C>>,
 }
 
-impl MessageSummary for LeaderMetrics {
+impl<C: RaftTypeConfig> MessageSummary for LeaderMetrics<C> {
     fn summary(&self) -> String {
         let mut res = vec!["LeaderMetrics{".to_string()];
         for (i, (k, v)) in self.replication.iter().enumerate() {
@@ -94,8 +94,8 @@ impl MessageSummary for LeaderMetrics {
     }
 }
 
-impl RaftMetrics {
-    pub(crate) fn new_initial(id: NodeId) -> Self {
+impl<C: RaftTypeConfig> RaftMetrics<C> {
+    pub(crate) fn new_initial(id: C::NodeId) -> Self {
         let membership_config = Membership::new_initial(id);
         Self {
             running_state: Ok(()),
@@ -123,16 +123,16 @@ pub enum WaitError {
 }
 
 /// Wait is a wrapper of RaftMetrics channel that impls several utils to wait for metrics to satisfy some condition.
-pub struct Wait {
+pub struct Wait<C: RaftTypeConfig> {
     pub timeout: Duration,
-    pub rx: watch::Receiver<RaftMetrics>,
+    pub rx: watch::Receiver<RaftMetrics<C>>,
 }
 
-impl Wait {
+impl<C: RaftTypeConfig> Wait<C> {
     /// Wait for metrics to satisfy some condition or timeout.
     #[tracing::instrument(level = "trace", skip(self, func), fields(msg=%msg.to_string()))]
-    pub async fn metrics<T>(&self, func: T, msg: impl ToString) -> Result<RaftMetrics, WaitError>
-    where T: Fn(&RaftMetrics) -> bool + Send {
+    pub async fn metrics<T>(&self, func: T, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError>
+    where T: Fn(&RaftMetrics<C>) -> bool + Send {
         let timeout_at = Instant::now() + self.timeout;
 
         let mut rx = self.rx.clone();
@@ -197,7 +197,7 @@ impl Wait {
 
     /// Wait for `current_leader` to become `Some(leader_id)` until timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn current_leader(&self, leader_id: NodeId, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
+    pub async fn current_leader(&self, leader_id: C::NodeId, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.current_leader == Some(leader_id),
             &format!("{} .current_leader -> {}", msg.to_string(), leader_id),
@@ -207,7 +207,7 @@ impl Wait {
 
     /// Wait until applied exactly `want_log`(inclusive) logs or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn log(&self, want_log_index: Option<u64>, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
+    pub async fn log(&self, want_log_index: Option<u64>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.last_log_index == want_log_index,
             &format!("{} .last_log_index -> {:?}", msg.to_string(), want_log_index),
@@ -223,7 +223,7 @@ impl Wait {
 
     /// Wait until applied at least `want_log`(inclusive) logs or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn log_at_least(&self, want_log: Option<u64>, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
+    pub async fn log_at_least(&self, want_log: Option<u64>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.last_log_index >= want_log,
             &format!("{} .last_log_index >= {:?}", msg.to_string(), want_log),
@@ -239,7 +239,7 @@ impl Wait {
 
     /// Wait for `state` to become `want_state` or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn state(&self, want_state: State, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
+    pub async fn state(&self, want_state: State, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.state == want_state,
             &format!("{} .state -> {:?}", msg.to_string(), want_state),
@@ -249,7 +249,11 @@ impl Wait {
 
     /// Wait for `membership_config.members` to become expected node set or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn members(&self, want_members: BTreeSet<NodeId>, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
+    pub async fn members(
+        &self,
+        want_members: BTreeSet<C::NodeId>,
+        msg: impl ToString,
+    ) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.membership_config.membership.get_ith_config(0).cloned().unwrap() == want_members,
             &format!("{} .membership_config.members -> {:?}", msg.to_string(), want_members),
@@ -262,9 +266,9 @@ impl Wait {
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn next_members(
         &self,
-        want_members: Option<BTreeSet<NodeId>>,
+        want_members: Option<BTreeSet<C::NodeId>>,
         msg: impl ToString,
-    ) -> Result<RaftMetrics, WaitError> {
+    ) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.membership_config.membership.get_ith_config(1) == want_members.as_ref(),
             &format!("{} .membership_config.next -> {:?}", msg.to_string(), want_members),
@@ -274,7 +278,7 @@ impl Wait {
 
     /// Wait for `snapshot` to become `want_snapshot` or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn snapshot(&self, want_snapshot: LogId, msg: impl ToString) -> Result<RaftMetrics, WaitError> {
+    pub async fn snapshot(&self, want_snapshot: LogId<C>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.snapshot == Some(want_snapshot),
             &format!("{} .snapshot -> {:?}", msg.to_string(), want_snapshot),

--- a/openraft/src/metrics_wait_test.rs
+++ b/openraft/src/metrics_wait_test.rs
@@ -10,10 +10,12 @@ use crate::core::EffectiveMembership;
 use crate::metrics::Wait;
 use crate::metrics::WaitError;
 use crate::raft_types::LogIdOptionExt;
+use crate::testing::DummyConfig as Config;
 use crate::LeaderId;
 use crate::LogId;
 use crate::Membership;
 use crate::RaftMetrics;
+use crate::RaftTypeConfig;
 use crate::State;
 
 /// Test wait for different state changes
@@ -21,7 +23,7 @@ use crate::State;
 async fn test_wait() -> anyhow::Result<()> {
     {
         // wait for leader
-        let (init, w, tx) = init_wait_test();
+        let (init, w, tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -37,7 +39,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for log
-        let (init, w, tx) = init_wait_test();
+        let (init, w, tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -65,7 +67,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for state
-        let (init, w, tx) = init_wait_test();
+        let (init, w, tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -82,7 +84,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for members
-        let (init, w, tx) = init_wait_test();
+        let (init, w, tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -105,7 +107,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for next_members
-        let (init, w, tx) = init_wait_test();
+        let (init, w, tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -128,7 +130,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     tracing::info!("--- wait for snapshot, Ok");
     {
-        let (init, w, tx) = init_wait_test();
+        let (init, w, tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -145,7 +147,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     tracing::info!("--- wait for snapshot, only index matches");
     {
-        let (init, w, tx) = init_wait_test();
+        let (init, w, tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -170,7 +172,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // timeout
-        let (_init, w, _tx) = init_wait_test();
+        let (_init, w, _tx) = init_wait_test::<Config>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(200)).await;
@@ -193,10 +195,10 @@ async fn test_wait() -> anyhow::Result<()> {
 
 /// Build a initial state for testing of Wait:
 /// Returns init metrics, Wait, and the tx to send an updated metrics.
-fn init_wait_test() -> (RaftMetrics, Wait, watch::Sender<RaftMetrics>) {
+fn init_wait_test<C: RaftTypeConfig>() -> (RaftMetrics<C>, Wait<C>, watch::Sender<RaftMetrics<C>>) {
     let init = RaftMetrics {
         running_state: Ok(()),
-        id: 0,
+        id: C::NodeId::default(),
         state: State::Learner,
         current_term: 0,
         last_log_index: None,

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -17,7 +17,6 @@ use crate::raft::InstallSnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::Node;
-use crate::NodeId;
 use crate::RaftTypeConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,16 +50,16 @@ where C: RaftTypeConfig
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse, RPCError<AppendEntriesError>>;
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C, AppendEntriesError<C>>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn send_install_snapshot(
         &mut self,
-        rpc: InstallSnapshotRequest,
-    ) -> Result<InstallSnapshotResponse, RPCError<InstallSnapshotError>>;
+        rpc: InstallSnapshotRequest<C>,
+    ) -> Result<InstallSnapshotResponse<C>, RPCError<C, InstallSnapshotError<C>>>;
 
     /// Send a RequestVote RPC to the target Raft node (§5).
-    async fn send_vote(&mut self, rpc: VoteRequest) -> Result<VoteResponse, RPCError<VoteError>>;
+    async fn send_vote(&mut self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, RPCError<C, VoteError<C>>>;
 }
 
 /// A trait defining the interface for a Raft network factory to create connections between cluster members.
@@ -84,5 +83,5 @@ where C: RaftTypeConfig
     ///
     /// The method is intentionally async to give the implementation a chance to use asynchronous
     /// sync primitives to serialize access to the common internal object, if needed.
-    async fn connect(&mut self, target: NodeId, node: Option<&Node>) -> Self::Network;
+    async fn connect(&mut self, target: C::NodeId, node: Option<&Node>) -> Self::Network;
 }

--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -1,12 +1,58 @@
 use std::collections::BTreeMap;
+use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::hash::Hash;
 
 use serde::Deserialize;
 use serde::Serialize;
 
 /// A Raft node's ID.
-pub type NodeId = u64;
+///
+/// A `NodeId` uniquely identifies a node in the Raft cluster.
+///
+/// ## Notes
+///
+/// Currently, `serde` support is not optional, so the `NodeId` must be serializable via `serde` as well.
+pub trait NodeId:
+    Sized
+    + Send
+    + Sync
+    + Eq
+    + PartialEq
+    + Ord
+    + PartialOrd
+    + Debug
+    + Display
+    + Hash
+    + Copy
+    + Clone
+    + Default
+    + serde::Serialize
+    + for<'a> serde::Deserialize<'a>
+    + 'static
+{
+}
+
+impl<T> NodeId for T where T: Sized
+        + Send
+        + Sync
+        + Eq
+        + PartialEq
+        + Ord
+        + PartialOrd
+        + Debug
+        + Display
+        + Hash
+        + Copy
+        + Clone
+        + Default
+        + serde::Serialize
+        + for<'a> serde::Deserialize<'a>
+        + From<u64>
+        + 'static
+{
+}
 
 /// Additional node information.
 ///

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -23,9 +23,9 @@ use crate::StorageError;
 use crate::Vote;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct SnapshotMeta {
+pub struct SnapshotMeta<C: RaftTypeConfig> {
     // Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: LogId,
+    pub last_log_id: LogId<C>,
 
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be different in bytes.
@@ -34,11 +34,13 @@ pub struct SnapshotMeta {
 
 /// The data associated with the current snapshot.
 #[derive(Debug)]
-pub struct Snapshot<S>
-where S: AsyncRead + AsyncSeek + Send + Unpin + 'static
+pub struct Snapshot<C, S>
+where
+    C: RaftTypeConfig,
+    S: AsyncRead + AsyncSeek + Send + Unpin + 'static,
 {
     /// metadata of a snapshot
-    pub meta: SnapshotMeta,
+    pub meta: SnapshotMeta<C>,
 
     /// A read handle to the associated snapshot.
     pub snapshot: Box<S>,
@@ -46,31 +48,31 @@ where S: AsyncRead + AsyncSeek + Send + Unpin + 'static
 
 /// A struct used to represent the initial state which a Raft node needs when first starting.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct InitialState {
+pub struct InitialState<C: RaftTypeConfig> {
     /// The last entry.
-    pub last_log_id: Option<LogId>,
+    pub last_log_id: Option<LogId<C>>,
 
     /// The LogId of the last log applied to the state machine.
-    pub last_applied: Option<LogId>,
+    pub last_applied: Option<LogId<C>>,
 
-    pub vote: Vote,
+    pub vote: Vote<C>,
 
     /// The latest cluster membership configuration found, in log or in state machine, else a new initial
     /// membership config consisting only of this node's ID.
-    pub last_membership: Option<EffectiveMembership>,
+    pub last_membership: Option<EffectiveMembership<C>>,
 }
 
 /// The state about logs.
 ///
 /// Invariance: last_purged_log_id <= last_applied <= last_log_id
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct LogState {
+pub struct LogState<C: RaftTypeConfig> {
     /// The greatest log id that has been purged after being applied to state machine.
-    pub last_purged_log_id: Option<LogId>,
+    pub last_purged_log_id: Option<LogId<C>>,
 
     /// The log id of the last present entry if there are any entries.
     /// Otherwise the same value as `last_purged_log_id`.
-    pub last_log_id: Option<LogId>,
+    pub last_log_id: Option<LogId<C>>,
 }
 
 /// A trait defining the interface for a Raft log subsystem.
@@ -91,7 +93,7 @@ where C: RaftTypeConfig
     async fn get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<Entry<C>>, StorageError> {
+    ) -> Result<Vec<Entry<C>>, StorageError<C>> {
         let res = self.try_get_log_entries(range.clone()).await?;
 
         check_range_matches_entries(range, &res)?;
@@ -102,7 +104,7 @@ where C: RaftTypeConfig
     /// Try to get an log entry.
     ///
     /// It does not return an error if the log entry at `log_index` is not found.
-    async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<Entry<C>>, StorageError> {
+    async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<Entry<C>>, StorageError<C>> {
         let mut res = self.try_get_log_entries(log_index..(log_index + 1)).await?;
         Ok(res.pop())
     }
@@ -113,7 +115,7 @@ where C: RaftTypeConfig
     /// The returned `last_log_id` could be the log id of the last present log entry, or the `last_purged_log_id` if
     /// there is no entry at all.
     // NOTE: This can be made into sync, provided all state machines will use atomic read or the like.
-    async fn get_log_state(&mut self) -> Result<LogState, StorageError>;
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>>;
 
     /// Get a series of log entries from storage.
     ///
@@ -123,7 +125,7 @@ where C: RaftTypeConfig
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<Entry<C>>, StorageError>;
+    ) -> Result<Vec<Entry<C>>, StorageError<C>>;
 }
 
 /// A trait defining the interface for a Raft state machine snapshot subsystem.
@@ -147,7 +149,7 @@ where
     /// Building snapshot can be done by:
     /// - Performing log compaction, e.g. merge log entries that operates on the same key, like a LSM-tree does,
     /// - or by fetching a snapshot from the state machine.
-    async fn build_snapshot(&mut self) -> Result<Snapshot<SD>, StorageError>;
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C, SD>, StorageError<C>>;
 
     // NOTES:
     // This interface is geared toward small file-based snapshots. However, not all snapshots can
@@ -186,7 +188,7 @@ where C: RaftTypeConfig
     type SnapshotBuilder: RaftSnapshotBuilder<C, Self::SnapshotData>;
 
     /// Returns the last membership config found in log or state machine.
-    async fn get_membership(&mut self) -> Result<Option<EffectiveMembership>, StorageError> {
+    async fn get_membership(&mut self) -> Result<Option<EffectiveMembership<C>>, StorageError<C>> {
         let (_, sm_mem) = self.last_applied_state().await?;
 
         let sm_mem_index = match &sm_mem {
@@ -208,7 +210,10 @@ where C: RaftTypeConfig
     /// This method should returns membership with the greatest log index which is `>=since_index`.
     /// If no such membership log is found, it returns `None`, e.g., when logs are cleaned after being applied.
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn last_membership_in_log(&mut self, since_index: u64) -> Result<Option<EffectiveMembership>, StorageError> {
+    async fn last_membership_in_log(
+        &mut self,
+        since_index: u64,
+    ) -> Result<Option<EffectiveMembership<C>>, StorageError<C>> {
         let st = self.get_log_state().await?;
 
         let mut end = st.last_log_id.next_index();
@@ -234,7 +239,7 @@ where C: RaftTypeConfig
     ///
     /// When the Raft node is first started, it will call this interface to fetch the last known state from stable
     /// storage.
-    async fn get_initial_state(&mut self) -> Result<InitialState, StorageError> {
+    async fn get_initial_state(&mut self) -> Result<InitialState<C>, StorageError<C>> {
         let vote = self.read_vote().await?;
         let st = self.get_log_state().await?;
         let mut last_log_id = st.last_log_id;
@@ -256,7 +261,7 @@ where C: RaftTypeConfig
     }
 
     /// Get the log id of the entry at `index`.
-    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId, StorageError> {
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C>, StorageError<C>> {
         let st = self.get_log_state().await?;
 
         if Some(log_index) == st.last_purged_log_id.index() {
@@ -270,9 +275,9 @@ where C: RaftTypeConfig
 
     // --- Vote
 
-    async fn save_vote(&mut self, vote: &Vote) -> Result<(), StorageError>;
+    async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>>;
 
-    async fn read_vote(&mut self) -> Result<Option<Vote>, StorageError>;
+    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>>;
 
     // --- Log
 
@@ -286,20 +291,22 @@ where C: RaftTypeConfig
     ///
     /// Though the entries will always be presented in order, each entry's index should be used to
     /// determine its location to be written in the log.
-    async fn append_to_log(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError>;
+    async fn append_to_log(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C>>;
 
     /// Delete conflict log entries since `log_id`, inclusive.
-    async fn delete_conflict_logs_since(&mut self, log_id: LogId) -> Result<(), StorageError>;
+    async fn delete_conflict_logs_since(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
 
     /// Delete applied log entries upto `log_id`, inclusive.
-    async fn purge_logs_upto(&mut self, log_id: LogId) -> Result<(), StorageError>;
+    async fn purge_logs_upto(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
 
     // --- State Machine
 
     /// Returns the last applied log id which is recorded in state machine, and the last applied membership log id and
     /// membership config.
     // NOTE: This can be made into sync, provided all state machines will use atomic read or the like.
-    async fn last_applied_state(&mut self) -> Result<(Option<LogId>, Option<EffectiveMembership>), StorageError>;
+    async fn last_applied_state(
+        &mut self,
+    ) -> Result<(Option<LogId<C>>, Option<EffectiveMembership<C>>), StorageError<C>>;
 
     /// Apply the given payload of entries to the state machine.
     ///
@@ -320,7 +327,7 @@ where C: RaftTypeConfig
     // then collect completions on this channel and update the client with the result once all
     // the preceding operations have been applied to the state machine. This way we'll reach
     // operation pipelining w/o the need to wait for the completion of each operation inline.
-    async fn apply_to_state_machine(&mut self, entries: &[&Entry<C>]) -> Result<Vec<C::R>, StorageError>;
+    async fn apply_to_state_machine(&mut self, entries: &[&Entry<C>]) -> Result<Vec<C::R>, StorageError<C>>;
 
     // --- Snapshot
 
@@ -337,7 +344,7 @@ where C: RaftTypeConfig
     /// ### implementation guide
     /// See the [storage chapter of the guide](https://datafuselabs.github.io/openraft/storage.html)
     /// for details on log compaction / snapshotting.
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError>;
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError<C>>;
 
     /// Install a snapshot which has finished streaming from the cluster leader.
     ///
@@ -347,9 +354,9 @@ where C: RaftTypeConfig
     /// A snapshot created from an earlier call to `begin_receiving_snapshot` which provided the snapshot.
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta,
+        meta: &SnapshotMeta<C>,
         snapshot: Box<Self::SnapshotData>,
-    ) -> Result<StateMachineChanges, StorageError>;
+    ) -> Result<StateMachineChanges<C>, StorageError<C>>;
 
     /// Get a readable handle to the current snapshot, along with its metadata.
     ///
@@ -362,7 +369,7 @@ where C: RaftTypeConfig
     ///
     /// A proper snapshot implementation will store the term, index and membership config as part
     /// of the snapshot, which should be decoded for creating this method's response data.
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<Self::SnapshotData>>, StorageError>;
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<C, Self::SnapshotData>>, StorageError<C>>;
 }
 
 /// APIs for debugging a store.

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -4,3 +4,9 @@ mod suite;
 pub use store_builder::DefensiveStoreBuilder;
 pub use store_builder::StoreBuilder;
 pub use suite::Suite;
+
+crate::declare_raft_types!(
+    /// Dummy Raft types for the purpose of testing internal structures requiring
+    /// `RaftTypeConfig`, like `MembershipConfig`.
+    pub(crate) DummyConfig: D = u64, R = u64, NodeId = u64
+);

--- a/openraft/src/vote/leader_id.rs
+++ b/openraft/src/vote/leader_id.rs
@@ -3,7 +3,7 @@ use std::fmt::Formatter;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// LeaderId is identifier of a `leader`.
 ///
@@ -14,19 +14,19 @@ use crate::NodeId;
 /// But under this(dirty and stupid) simplification, a `Leader` is actually identified by `(term, node_id)`.
 /// By introducing `LeaderId {term, node_id}`, things become easier to understand.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct LeaderId {
+pub struct LeaderId<C: RaftTypeConfig> {
     pub term: u64,
-    pub node_id: NodeId,
+    pub node_id: C::NodeId,
 }
 
-impl std::fmt::Display for LeaderId {
+impl<C: RaftTypeConfig> std::fmt::Display for LeaderId<C> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}-{}", self.term, self.node_id)
     }
 }
 
-impl LeaderId {
-    pub fn new(term: u64, node_id: NodeId) -> Self {
+impl<C: RaftTypeConfig> LeaderId<C> {
+    pub fn new(term: u64, node_id: C::NodeId) -> Self {
         Self { term, node_id }
     }
 }

--- a/openraft/src/vote/leader_id_test.rs
+++ b/openraft/src/vote/leader_id_test.rs
@@ -1,15 +1,16 @@
+use crate::testing::DummyConfig as Config;
 use crate::vote::leader_id::LeaderId;
 
 #[test]
 fn test_leader_id() -> anyhow::Result<()> {
-    let l11 = LeaderId::new(1, 1);
-    let l12 = LeaderId::new(1, 2);
-    let l21 = LeaderId::new(2, 1);
+    let l11 = LeaderId::<Config>::new(1, 1);
+    let l12 = LeaderId::<Config>::new(1, 2);
+    let l21 = LeaderId::<Config>::new(2, 1);
 
     assert!(l11 < l12);
     assert!(l12 < l21);
 
-    assert_eq!(l12, LeaderId::new(1, 2));
+    assert_eq!(l12, LeaderId::<Config>::new(1, 2));
 
     Ok(())
 }

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -4,31 +4,31 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::LeaderId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// `Vote` represent the privilege of a node.
 #[derive(Debug, Clone, Copy, Default, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Vote {
+pub struct Vote<C: RaftTypeConfig> {
     pub term: u64,
-    pub node_id: NodeId,
+    pub node_id: C::NodeId,
     pub committed: bool,
 }
 
-impl std::fmt::Display for Vote {
+impl<C: RaftTypeConfig> std::fmt::Display for Vote<C> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "vote:{}-{}", self.term, self.node_id)
     }
 }
 
-impl Vote {
-    pub fn new(term: u64, node_id: NodeId) -> Self {
+impl<C: RaftTypeConfig> Vote<C> {
+    pub fn new(term: u64, node_id: C::NodeId) -> Self {
         Self {
             term,
             node_id,
             committed: false,
         }
     }
-    pub fn new_committed(term: u64, node_id: NodeId) -> Self {
+    pub fn new_committed(term: u64, node_id: C::NodeId) -> Self {
         Self {
             term,
             node_id,
@@ -40,14 +40,14 @@ impl Vote {
         self.committed = true
     }
 
-    pub fn leader_id(&self) -> LeaderId {
+    pub fn leader_id(&self) -> LeaderId<C> {
         LeaderId::new(self.term, self.node_id)
     }
 
     /// Get the leader node id.
     ///
     /// Only when a committed vote is seen(granted by a quorum) the voted node id is a valid leader.
-    pub fn leader(&self) -> Option<NodeId> {
+    pub fn leader(&self) -> Option<C::NodeId> {
         if self.committed {
             Some(self.node_id)
         } else {

--- a/openraft/tests/benchmark/bench_cluster.rs
+++ b/openraft/tests/benchmark/bench_cluster.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 
 use maplit::btreeset;
 use openraft::Config;
-use openraft::NodeId;
 use tokio::runtime::Builder;
 
 use crate::fixtures::RaftRouter;
@@ -14,7 +13,7 @@ use crate::fixtures::RaftRouter;
 struct BenchConfig {
     pub worker_threads: usize,
     pub n_operations: usize,
-    pub members: BTreeSet<NodeId>,
+    pub members: BTreeSet<u64>,
 }
 
 impl Display for BenchConfig {

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -1,12 +1,15 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use memstore::IntoMemClientRequest;
 use openraft::Config;
 use openraft::LogIdOptionExt;
-use openraft::NodeId;
 use openraft::Raft;
+use openraft::RaftStorage;
+use openraft::RaftTypeConfig;
 use openraft::State;
 use tokio::time::sleep;
 
@@ -69,7 +72,17 @@ async fn learner_restart() -> Result<()> {
     Ok(())
 }
 
-fn assert_node_state(id: NodeId, node: &MemRaft, expected_term: u64, expected_log: u64, state: State) {
+fn assert_node_state<C: RaftTypeConfig, S: RaftStorage<C>>(
+    id: C::NodeId,
+    node: &MemRaft<C, S>,
+    expected_term: u64,
+    expected_log: u64,
+    state: State,
+) where
+    C::D: Debug + IntoMemClientRequest<C::D>,
+    C::R: Debug,
+    S: Default + Clone,
+{
     let m = node.metrics().borrow().clone();
     tracing::info!("node {} metrics: {:?}", id, m);
 

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
+use memstore::MemNodeId;
 use openraft::Config;
-use openraft::NodeId;
 use openraft::State;
 use tracing_futures::Instrument;
 
@@ -35,7 +35,7 @@ async fn change_membership_cases() -> anyhow::Result<()> {
 }
 
 #[tracing::instrument(level = "debug")]
-async fn change_from_to(old: BTreeSet<NodeId>, new: BTreeSet<NodeId>) -> anyhow::Result<()> {
+async fn change_from_to(old: BTreeSet<MemNodeId>, new: BTreeSet<MemNodeId>) -> anyhow::Result<()> {
     let mes = format!("from {:?} to {:?}", old, new);
 
     let only_in_old = old.difference(&new);

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -104,7 +104,7 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
         tracing::info!("--- got res: {:?}", res);
 
         let err = res.unwrap_err();
-        let err: ChangeMembershipError = err.try_into().unwrap();
+        let err: ChangeMembershipError<memstore::Config> = err.try_into().unwrap();
 
         match err {
             ChangeMembershipError::LearnerIsLagging(e) => {


### PR DESCRIPTION
This addresses https://github.com/datafuselabs/openraft/issues/217.

The change is huge, but it is mostly just adaptations to pass `RaftTypeConfig` to all required structures.

The most interesting part is in `raft.rs`, where the new `NodeId` type is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/220)
<!-- Reviewable:end -->
