### PR TITLE
Refactor: replace the trait bound RaftTypeConfig of LeaderId with NodeId

### DIFF
--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -12,7 +12,7 @@ use crate::RaftTypeConfig;
 /// A term, node_id and an index identifies an log globally.
 #[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LogId<C: RaftTypeConfig> {
-    pub leader_id: LeaderId<C>,
+    pub leader_id: LeaderId<C::NodeId>,
     pub index: u64,
 }
 
@@ -34,7 +34,7 @@ impl<C: RaftTypeConfig> MessageSummary for Option<LogId<C>> {
 }
 
 impl<C: RaftTypeConfig> LogId<C> {
-    pub fn new(leader_id: LeaderId<C>, index: u64) -> Self {
+    pub fn new(leader_id: LeaderId<C::NodeId>, index: u64) -> Self {
         if leader_id.term == 0 || index == 0 {
             assert_eq!(
                 leader_id.term, 0,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -52,7 +52,7 @@ use crate::Vote;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct ReplicationMetrics<C: RaftTypeConfig> {
-    pub(crate) matched_leader_id: Option<LeaderId<C>>,
+    pub(crate) matched_leader_id: Option<LeaderId<C::NodeId>>,
     pub(crate) matched_index: AtomicU64,
 }
 

--- a/openraft/src/vote/leader_id.rs
+++ b/openraft/src/vote/leader_id.rs
@@ -3,7 +3,7 @@ use std::fmt::Formatter;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::RaftTypeConfig;
+use crate::NodeId;
 
 /// LeaderId is identifier of a `leader`.
 ///
@@ -14,19 +14,23 @@ use crate::RaftTypeConfig;
 /// But under this(dirty and stupid) simplification, a `Leader` is actually identified by `(term, node_id)`.
 /// By introducing `LeaderId {term, node_id}`, things become easier to understand.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct LeaderId<C: RaftTypeConfig> {
+// Clear the bound so that serde will generate required bounds.
+#[serde(bound = "")]
+pub struct LeaderId<NID>
+where NID: NodeId
+{
     pub term: u64,
-    pub node_id: C::NodeId,
+    pub node_id: NID,
 }
 
-impl<C: RaftTypeConfig> std::fmt::Display for LeaderId<C> {
+impl<NID: NodeId> std::fmt::Display for LeaderId<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}-{}", self.term, self.node_id)
     }
 }
 
-impl<C: RaftTypeConfig> LeaderId<C> {
-    pub fn new(term: u64, node_id: C::NodeId) -> Self {
+impl<NID: NodeId> LeaderId<NID> {
+    pub fn new(term: u64, node_id: NID) -> Self {
         Self { term, node_id }
     }
 }

--- a/openraft/src/vote/leader_id_test.rs
+++ b/openraft/src/vote/leader_id_test.rs
@@ -1,16 +1,15 @@
-use crate::testing::DummyConfig as Config;
 use crate::vote::leader_id::LeaderId;
 
 #[test]
 fn test_leader_id() -> anyhow::Result<()> {
-    let l11 = LeaderId::<Config>::new(1, 1);
-    let l12 = LeaderId::<Config>::new(1, 2);
-    let l21 = LeaderId::<Config>::new(2, 1);
+    let l11 = LeaderId::<u64>::new(1, 1);
+    let l12 = LeaderId::<u64>::new(1, 2);
+    let l21 = LeaderId::<u64>::new(2, 1);
 
     assert!(l11 < l12);
     assert!(l12 < l21);
 
-    assert_eq!(l12, LeaderId::<Config>::new(1, 2));
+    assert_eq!(l12, LeaderId::<u64>::new(1, 2));
 
     Ok(())
 }

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -40,7 +40,7 @@ impl<C: RaftTypeConfig> Vote<C> {
         self.committed = true
     }
 
-    pub fn leader_id(&self) -> LeaderId<C> {
+    pub fn leader_id(&self) -> LeaderId<C::NodeId> {
         LeaderId::new(self.term, self.node_id)
     }
 


### PR DESCRIPTION
## Changelog

##### Refactor: replace the trait bound RaftTypeConfig of LeaderId with NodeId

@schreter 
What about avoiding using `RaftTypeConfig` if possible?
For some of the basic type such as `LogId` and `LeaderId`, it seems a trait bound `NodeId` is quite enough:

```rust
#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
// Clear the bound so that serde will generate required bounds.
#[serde(bound = "")]
pub struct LeaderId<NID>
where NID: NodeId
{
    pub term: u64,
    pub node_id: NID,
}
```

It seems working for now, 
But I do not know if there are any concerns in the future we will have to use `RaftTypeConfig` for these basic types.





---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/221)
<!-- Reviewable:end -->
