### PR TITLE
Refactor: LogId only needs a generic NodeId, not all of the RaftTypeConfig

### DIFF
--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -90,7 +90,7 @@ pub struct MemStoreSnapshot {
 /// The state machine of the `MemStore`.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct MemStoreStateMachine {
-    pub last_applied_log: Option<LogId<Config>>,
+    pub last_applied_log: Option<LogId<MemNodeId>>,
 
     pub last_membership: Option<EffectiveMembership<Config>>,
 
@@ -102,7 +102,7 @@ pub struct MemStoreStateMachine {
 
 /// An in-memory storage system implementing the `RaftStorage` trait.
 pub struct MemStore {
-    last_purged_log_id: RwLock<Option<LogId<Config>>>,
+    last_purged_log_id: RwLock<Option<LogId<MemNodeId>>>,
 
     /// The Raft log.
     log: RwLock<BTreeMap<u64, Entry<Config>>>,
@@ -265,13 +265,13 @@ impl RaftStorage<Config> for Arc<MemStore> {
 
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<Config>>, Option<EffectiveMembership<Config>>), StorageError<Config>> {
+    ) -> Result<(Option<LogId<MemNodeId>>, Option<EffectiveMembership<Config>>), StorageError<Config>> {
         let sm = self.sm.read().await;
         Ok((sm.last_applied_log, sm.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn delete_conflict_logs_since(&mut self, log_id: LogId<Config>) -> Result<(), StorageError<Config>> {
+    async fn delete_conflict_logs_since(&mut self, log_id: LogId<MemNodeId>) -> Result<(), StorageError<Config>> {
         tracing::debug!("delete_log: [{:?}, +oo)", log_id);
 
         {
@@ -287,7 +287,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn purge_logs_upto(&mut self, log_id: LogId<Config>) -> Result<(), StorageError<Config>> {
+    async fn purge_logs_upto(&mut self, log_id: LogId<MemNodeId>) -> Result<(), StorageError<Config>> {
         tracing::debug!("delete_log: [{:?}, +oo)", log_id);
 
         {

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -273,7 +273,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     ///
     /// This is ony called by leader.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub(super) fn handle_uniform_consensus_committed(&mut self, log_id: &LogId<C>) {
+    pub(super) fn handle_uniform_consensus_committed(&mut self, log_id: &LogId<C::NodeId>) {
         let index = log_id.index;
 
         // Step down if needed.

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -98,7 +98,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     async fn handle_update_matched(
         &mut self,
         target: C::NodeId,
-        matched: Option<LogId<C>>,
+        matched: Option<LogId<C::NodeId>>,
     ) -> Result<(), StorageError<C>> {
         // Update target's match index & check if it is awaiting removal.
 
@@ -179,7 +179,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    fn update_leader_metrics(&mut self, target: C::NodeId, matched: Option<LogId<C>>) {
+    fn update_leader_metrics(&mut self, target: C::NodeId, matched: Option<LogId<C::NodeId>>) {
         tracing::debug!(%target, ?matched, "update_leader_metrics");
         let (matched_leader_id, matched_index) = if let Some(log_id) = matched {
             (Some(log_id.leader_id), log_id.index)
@@ -204,7 +204,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    fn calc_commit_log_id(&self) -> Option<LogId<C>> {
+    fn calc_commit_log_id(&self) -> Option<LogId<C::NodeId>> {
         let repl_indexes = self.get_match_log_ids();
 
         let committed = self.core.effective_membership.membership.greatest_majority_value(&repl_indexes);
@@ -216,7 +216,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     }
 
     /// Collect indexes of the greatest matching log on every replica(include the leader itself)
-    fn get_match_log_ids(&self) -> BTreeMap<C::NodeId, LogId<C>> {
+    fn get_match_log_ids(&self) -> BTreeMap<C::NodeId, LogId<C::NodeId>> {
         let node_ids = self.core.effective_membership.membership.all_members();
 
         let mut res = BTreeMap::new();
@@ -248,7 +248,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     #[tracing::instrument(level = "debug", skip(self, tx))]
     async fn handle_needs_snapshot(
         &mut self,
-        must_include: Option<LogId<C>>,
+        must_include: Option<LogId<C::NodeId>>,
         tx: oneshot::Sender<Snapshot<C, S::SnapshotData>>,
     ) -> Result<(), StorageError<C>> {
         // Ensure snapshotting is configured, else do nothing.

--- a/openraft/src/core/replication_state_test.rs
+++ b/openraft/src/core/replication_state_test.rs
@@ -6,7 +6,7 @@ use crate::LogId;
 
 #[test]
 fn test_is_line_rate() -> anyhow::Result<()> {
-    let m = Some(LogId::<DummyConfig>::new(LeaderId::new(1, 0), 10));
+    let m = Some(LogId::<u64>::new(LeaderId::new(1, 0), 10));
 
     let cfg = |n| Config {
         replication_lag_threshold: n,
@@ -54,7 +54,7 @@ fn test_is_line_rate() -> anyhow::Result<()> {
         "overflow, threshold=0"
     );
     assert!(
-        !is_matched_upto_date(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(0)),
+        !is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(0)),
         "not caught up, threshold=0"
     );
     assert!(

--- a/openraft/src/defensive.rs
+++ b/openraft/src/defensive.rs
@@ -204,7 +204,7 @@ where
         Ok(())
     }
 
-    async fn defensive_purge_applied_le_last_applied(&mut self, upto: LogId<C>) -> Result<(), StorageError<C>> {
+    async fn defensive_purge_applied_le_last_applied(&mut self, upto: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
         let (last_applied, _) = self.inner().last_applied_state().await?;
         if Some(upto.index) > last_applied.index() {
             return Err(
@@ -218,7 +218,10 @@ where
         Ok(())
     }
 
-    async fn defensive_delete_conflict_gt_last_applied(&mut self, since: LogId<C>) -> Result<(), StorageError<C>> {
+    async fn defensive_delete_conflict_gt_last_applied(
+        &mut self,
+        since: LogId<C::NodeId>,
+    ) -> Result<(), StorageError<C>> {
         let (last_applied, _) = self.inner().last_applied_state().await?;
         if Some(since.index) <= last_applied.index() {
             return Err(

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -312,7 +312,7 @@ pub struct Timeout<C: RaftTypeConfig> {
 #[error("store has no log at: {index:?}, last purged: {last_purged_log_id:?}")]
 pub struct LackEntry<C: RaftTypeConfig> {
     pub index: Option<u64>,
-    pub last_purged_log_id: Option<LogId<C>>,
+    pub last_purged_log_id: Option<LogId<C::NodeId>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
@@ -339,7 +339,7 @@ pub struct QuorumNotEnough<C: RaftTypeConfig> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 #[error("the cluster is already undergoing a configuration change at log {membership_log_id}")]
 pub struct InProgress<C: RaftTypeConfig> {
-    pub membership_log_id: LogId<C>,
+    pub membership_log_id: LogId<C::NodeId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
@@ -352,7 +352,7 @@ pub struct LearnerNotFound<C: RaftTypeConfig> {
 #[error("replication to learner {node_id} is lagging {distance}, matched: {matched:?}, can not add as member")]
 pub struct LearnerIsLagging<C: RaftTypeConfig> {
     pub node_id: C::NodeId,
-    pub matched: Option<LogId<C>>,
+    pub matched: Option<LogId<C::NodeId>>,
     pub distance: u64,
 }
 

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -42,7 +42,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// The last log index has been appended to this Raft node's log.
     pub last_log_index: Option<u64>,
     /// The last log index has been applied to this Raft node's state machine.
-    pub last_applied: Option<LogId<C>>,
+    pub last_applied: Option<LogId<C::NodeId>>,
     /// The current cluster leader.
     pub current_leader: Option<C::NodeId>,
     /// The current membership config of the cluster.
@@ -50,7 +50,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
 
     /// The id of the last log included in snapshot.
     /// If there is no snapshot, it is (0,0).
-    pub snapshot: Option<LogId<C>>,
+    pub snapshot: Option<LogId<C::NodeId>>,
 
     /// The metrics about the leader. It is Some() only when this node is leader.
     pub leader_metrics: Option<Arc<LeaderMetrics<C>>>,
@@ -278,7 +278,11 @@ impl<C: RaftTypeConfig> Wait<C> {
 
     /// Wait for `snapshot` to become `want_snapshot` or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn snapshot(&self, want_snapshot: LogId<C>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
+    pub async fn snapshot(
+        &self,
+        want_snapshot: LogId<C::NodeId>,
+        msg: impl ToString,
+    ) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
             |x| x.snapshot == Some(want_snapshot),
             &format!("{} .snapshot -> {:?}", msg.to_string(), want_snapshot),

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -60,7 +60,7 @@ use crate::Vote;
 /// );
 /// ```
 pub trait RaftTypeConfig:
-    Sized + Send + Sync + Debug + Clone + Copy + Default + Eq + PartialEq + Ord + PartialOrd + serde::Serialize + 'static
+    Sized + Send + Sync + Debug + Clone + Copy + Default + Eq + PartialEq + Ord + PartialOrd + 'static
 {
     /// Application-specific request data passed to the state machine.
     type D: AppData;
@@ -509,7 +509,7 @@ pub(crate) type RaftRespRx<T, E> = oneshot::Receiver<Result<T, E>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AddLearnerResponse<C: RaftTypeConfig> {
-    pub matched: Option<LogId<C>>,
+    pub matched: Option<LogId<C::NodeId>>,
 }
 
 /// A message coming from the Raft API.
@@ -612,7 +612,7 @@ where C: RaftTypeConfig
 pub struct AppendEntriesRequest<C: RaftTypeConfig> {
     pub vote: Vote<C>,
 
-    pub prev_log_id: Option<LogId<C>>,
+    pub prev_log_id: Option<LogId<C::NodeId>>,
 
     /// The new log entries to store.
     ///
@@ -622,7 +622,7 @@ pub struct AppendEntriesRequest<C: RaftTypeConfig> {
     pub entries: Vec<Entry<C>>,
 
     /// The leader's committed log id.
-    pub leader_commit: Option<LogId<C>>,
+    pub leader_commit: Option<LogId<C::NodeId>>,
 }
 
 impl<C: RaftTypeConfig> Clone for AppendEntriesRequest<C> {
@@ -680,8 +680,9 @@ impl<C: RaftTypeConfig> MessageSummary for AppendEntriesResponse<C> {
 
 /// A Raft log entry.
 #[derive(Serialize, Deserialize)]
+// #[serde(bound = "")]
 pub struct Entry<C: RaftTypeConfig> {
-    pub log_id: LogId<C>,
+    pub log_id: LogId<C::NodeId>,
 
     /// This entry's payload.
     #[serde(bound = "C::D: AppData")]
@@ -765,6 +766,7 @@ pub enum EntryPayload<C: RaftTypeConfig> {
     Normal(C::D),
 
     /// A change-membership log entry.
+    #[serde(bound = "")]
     Membership(Membership<C>),
 }
 
@@ -806,7 +808,7 @@ impl<C: RaftTypeConfig> MessageSummary for EntryPayload<C> {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VoteRequest<C: RaftTypeConfig> {
     pub vote: Vote<C>,
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 }
 
 impl<C: RaftTypeConfig> MessageSummary for VoteRequest<C> {
@@ -816,7 +818,7 @@ impl<C: RaftTypeConfig> MessageSummary for VoteRequest<C> {
 }
 
 impl<C: RaftTypeConfig> VoteRequest<C> {
-    pub fn new(vote: Vote<C>, last_log_id: Option<LogId<C>>) -> Self {
+    pub fn new(vote: Vote<C>, last_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self { vote, last_log_id }
     }
 }
@@ -830,7 +832,7 @@ pub struct VoteResponse<C: RaftTypeConfig> {
     pub vote_granted: bool,
 
     /// The last log id stored on the remote voter.
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -906,7 +908,7 @@ impl<C: RaftTypeConfig> ClientWriteRequest<C> {
 /// The response to a `ClientRequest`.
 #[derive(Serialize, Deserialize)]
 pub struct ClientWriteResponse<C: RaftTypeConfig> {
-    pub log_id: LogId<C>,
+    pub log_id: LogId<C::NodeId>,
 
     /// Application specific response data.
     #[serde(bound = "C::R: AppDataResponse")]

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -6,23 +6,25 @@ use serde::Serialize;
 
 use crate::LeaderId;
 use crate::MessageSummary;
+use crate::NodeId;
 use crate::RaftTypeConfig;
 
 /// The identity of a raft log.
 /// A term, node_id and an index identifies an log globally.
 #[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LogId<C: RaftTypeConfig> {
-    pub leader_id: LeaderId<C::NodeId>,
+#[serde(bound = "")]
+pub struct LogId<NID: NodeId> {
+    pub leader_id: LeaderId<NID>,
     pub index: u64,
 }
 
-impl<C: RaftTypeConfig> Display for LogId<C> {
+impl<NID: NodeId> Display for LogId<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}-{}", self.leader_id, self.index)
     }
 }
 
-impl<C: RaftTypeConfig> MessageSummary for Option<LogId<C>> {
+impl<NID: NodeId> MessageSummary for Option<LogId<NID>> {
     fn summary(&self) -> String {
         match self {
             None => "None".to_string(),
@@ -33,8 +35,8 @@ impl<C: RaftTypeConfig> MessageSummary for Option<LogId<C>> {
     }
 }
 
-impl<C: RaftTypeConfig> LogId<C> {
-    pub fn new(leader_id: LeaderId<C::NodeId>, index: u64) -> Self {
+impl<NID: NodeId> LogId<NID> {
+    pub fn new(leader_id: LeaderId<NID>, index: u64) -> Self {
         if leader_id.term == 0 || index == 0 {
             assert_eq!(
                 leader_id.term, 0,
@@ -43,7 +45,7 @@ impl<C: RaftTypeConfig> LogId<C> {
             );
             assert_eq!(
                 leader_id.node_id,
-                C::NodeId::default(),
+                NID::default(),
                 "zero-th log entry must be (0,0,0), but {} {}",
                 leader_id,
                 index
@@ -58,12 +60,12 @@ impl<C: RaftTypeConfig> LogId<C> {
     }
 }
 
-pub trait LogIdOptionExt<C: RaftTypeConfig> {
+pub trait LogIdOptionExt {
     fn index(&self) -> Option<u64>;
     fn next_index(&self) -> u64;
 }
 
-impl<C: RaftTypeConfig> LogIdOptionExt<C> for Option<LogId<C>> {
+impl<NID: NodeId> LogIdOptionExt for Option<LogId<NID>> {
     fn index(&self) -> Option<u64> {
         self.map(|x| x.index)
     }
@@ -146,6 +148,6 @@ pub enum Update<T> {
 /// E.g. when applying a log to state machine, or installing a state machine from snapshot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StateMachineChanges<C: RaftTypeConfig> {
-    pub last_applied: LogId<C>,
+    pub last_applied: LogId<C::NodeId>,
     pub is_snapshot: bool,
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -75,7 +75,7 @@ impl<C: RaftTypeConfig> PartialEq for ReplicationMetrics<C> {
 impl<C: RaftTypeConfig> Eq for ReplicationMetrics<C> {}
 
 impl<C: RaftTypeConfig> ReplicationMetrics<C> {
-    pub fn new(log_id: Option<LogId<C>>) -> Self {
+    pub fn new(log_id: Option<LogId<C::NodeId>>) -> Self {
         if let Some(log_id) = log_id {
             Self {
                 matched_leader_id: Some(log_id.leader_id),
@@ -85,7 +85,7 @@ impl<C: RaftTypeConfig> ReplicationMetrics<C> {
             Self::default()
         }
     }
-    pub fn matched(&self) -> Option<LogId<C>> {
+    pub fn matched(&self) -> Option<LogId<C::NodeId>> {
         if let Some(leader_id) = self.matched_leader_id {
             let index = self.matched_index.load(Ordering::Relaxed);
             Some(LogId { leader_id, index })
@@ -116,8 +116,8 @@ impl<C: RaftTypeConfig> ReplicationStream<C> {
         target_node: Option<Node>,
         vote: Vote<C>,
         config: Arc<Config>,
-        last_log: Option<LogId<C>>,
-        committed: Option<LogId<C>>,
+        last_log: Option<LogId<C::NodeId>>,
+        committed: Option<LogId<C::NodeId>>,
         network: N::Network,
         log_reader: S::LogReader,
         replication_tx: mpsc::UnboundedSender<(ReplicaEvent<C, S::SnapshotData>, Span)>,
@@ -169,10 +169,10 @@ struct ReplicationCore<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStora
     target_repl_state: TargetReplState<C>,
 
     /// The id of the log entry to most recently be appended to the log by the leader.
-    last_log_id: Option<LogId<C>>,
+    last_log_id: Option<LogId<C::NodeId>>,
 
     /// The log id of the highest log entry which is known to be committed in the cluster.
-    committed: Option<LogId<C>>,
+    committed: Option<LogId<C::NodeId>>,
 
     /// The last know log to be successfully replicated on the target.
     ///
@@ -181,7 +181,7 @@ struct ReplicationCore<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStora
     /// behind. This is defined in §5.3.
     /// This will be initialized to the leader's (last_log_term, last_log_index), and will be updated as
     /// replication proceeds.
-    matched: Option<LogId<C>>,
+    matched: Option<LogId<C::NodeId>>,
 
     // The last possible matching entry on a follower.
     max_possible_matched_index: Option<u64>,
@@ -201,8 +201,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
         target_node: Option<Node>,
         vote: Vote<C>,
         config: Arc<Config>,
-        last_log: Option<LogId<C>>,
-        committed: Option<LogId<C>>,
+        last_log: Option<LogId<C::NodeId>>,
+        committed: Option<LogId<C::NodeId>>,
         network: N::Network,
         log_reader: S::LogReader,
         raft_core_tx: mpsc::UnboundedSender<(ReplicaEvent<C, S::SnapshotData>, Span)>,
@@ -474,7 +474,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
 
     /// max_possible_matched_index is the least index for `prev_log_id` to form a consecutive log sequence
     #[tracing::instrument(level = "trace", skip(self), fields(max_possible_matched_index=self.max_possible_matched_index))]
-    fn check_consecutive(&self, last_purged: Option<LogId<C>>) -> Result<(), ReplicationError<C>> {
+    fn check_consecutive(&self, last_purged: Option<LogId<C::NodeId>>) -> Result<(), ReplicationError<C>> {
         tracing::debug!(?last_purged, ?self.max_possible_matched_index, "check_consecutive");
 
         if last_purged.index() > self.max_possible_matched_index {
@@ -497,7 +497,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
     /// follower replication(the left and right cursor in a bsearch).
     /// And also report the matched log id to RaftCore to commit an entry etc.
     #[tracing::instrument(level = "trace", skip(self))]
-    fn update_matched(&mut self, new_matched: Option<LogId<C>>) {
+    fn update_matched(&mut self, new_matched: Option<LogId<C::NodeId>>) {
         tracing::debug!(
             self.max_possible_matched_index,
             ?self.matched,
@@ -604,7 +604,7 @@ enum TargetReplState<C: RaftTypeConfig> {
     LineRate,
 
     /// The replication stream is streaming a snapshot over to the target node.
-    Snapshotting { must_include: Option<LogId<C>> },
+    Snapshotting { must_include: Option<LogId<C::NodeId>> },
 
     /// The replication stream is shutting down.
     Shutdown,
@@ -618,15 +618,15 @@ pub(crate) enum RaftEvent<C: RaftTypeConfig> {
         ///
         /// The logId of the most recent entry to have been appended to the log, its index is the
         /// new last_log_index value.
-        appended: LogId<C>,
+        appended: LogId<C::NodeId>,
 
         /// The index of the highest log entry which is known to be committed in the cluster.
-        committed: Option<LogId<C>>,
+        committed: Option<LogId<C::NodeId>>,
     },
     /// A message from Raft indicating a new commit index value.
     UpdateCommittedLogId {
         /// The index of the highest log entry which is known to be committed in the cluster.
-        committed: Option<LogId<C>>,
+        committed: Option<LogId<C::NodeId>>,
     },
 }
 
@@ -656,7 +656,7 @@ where
         /// The ID of the target node for which the match index is to be updated.
         target: C::NodeId,
         /// The log of the most recent log known to have been successfully replicated on the target.
-        matched: Option<LogId<C>>,
+        matched: Option<LogId<C::NodeId>>,
     },
     /// An event indicating that the Raft node needs to revert to follower state.
     RevertToFollower {
@@ -671,7 +671,7 @@ where
         target: C::NodeId,
 
         /// The log id the caller requires the snapshot has to include.
-        must_include: Option<LogId<C>>,
+        must_include: Option<LogId<C::NodeId>>,
 
         /// The response channel for delivering the snapshot data.
         tx: oneshot::Sender<Snapshot<C, S>>,
@@ -782,7 +782,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
     #[tracing::instrument(level = "debug", skip(self), fields(state = "snapshotting"))]
     pub async fn replicate_snapshot(
         &mut self,
-        snapshot_must_include: Option<LogId<C>>,
+        snapshot_must_include: Option<LogId<C::NodeId>>,
     ) -> Result<(), ReplicationError<C>> {
         let snapshot = self.wait_for_snapshot(snapshot_must_include).await?;
         self.stream_snapshot(snapshot).await?;
@@ -797,7 +797,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
     #[tracing::instrument(level = "debug", skip(self))]
     async fn wait_for_snapshot(
         &mut self,
-        snapshot_must_include: Option<LogId<C>>,
+        snapshot_must_include: Option<LogId<C::NodeId>>,
     ) -> Result<Snapshot<C, S::SnapshotData>, ReplicationError<C>> {
         // Ask raft core for a snapshot.
         // - If raft core has a ready snapshot, it sends back through tx.

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -25,7 +25,7 @@ use crate::Vote;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SnapshotMeta<C: RaftTypeConfig> {
     // Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: LogId<C>,
+    pub last_log_id: LogId<C::NodeId>,
 
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be different in bytes.
@@ -50,10 +50,10 @@ where
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct InitialState<C: RaftTypeConfig> {
     /// The last entry.
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 
     /// The LogId of the last log applied to the state machine.
-    pub last_applied: Option<LogId<C>>,
+    pub last_applied: Option<LogId<C::NodeId>>,
 
     pub vote: Vote<C>,
 
@@ -68,11 +68,11 @@ pub struct InitialState<C: RaftTypeConfig> {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LogState<C: RaftTypeConfig> {
     /// The greatest log id that has been purged after being applied to state machine.
-    pub last_purged_log_id: Option<LogId<C>>,
+    pub last_purged_log_id: Option<LogId<C::NodeId>>,
 
     /// The log id of the last present entry if there are any entries.
     /// Otherwise the same value as `last_purged_log_id`.
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 }
 
 /// A trait defining the interface for a Raft log subsystem.
@@ -261,7 +261,7 @@ where C: RaftTypeConfig
     }
 
     /// Get the log id of the entry at `index`.
-    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C>, StorageError<C>> {
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C>> {
         let st = self.get_log_state().await?;
 
         if Some(log_index) == st.last_purged_log_id.index() {
@@ -294,10 +294,10 @@ where C: RaftTypeConfig
     async fn append_to_log(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C>>;
 
     /// Delete conflict log entries since `log_id`, inclusive.
-    async fn delete_conflict_logs_since(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
+    async fn delete_conflict_logs_since(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>>;
 
     /// Delete applied log entries upto `log_id`, inclusive.
-    async fn purge_logs_upto(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
+    async fn purge_logs_upto(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>>;
 
     // --- State Machine
 
@@ -306,7 +306,7 @@ where C: RaftTypeConfig
     // NOTE: This can be made into sync, provided all state machines will use atomic read or the like.
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C>>, Option<EffectiveMembership<C>>), StorageError<C>>;
+    ) -> Result<(Option<LogId<C::NodeId>>, Option<EffectiveMembership<C>>), StorageError<C>>;
 
     /// Apply the given payload of entries to the state machine.
     ///

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -124,18 +124,18 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C>>, Option<EffectiveMembership<C>>), StorageError<C>> {
+    ) -> Result<(Option<LogId<C::NodeId>>, Option<EffectiveMembership<C>>), StorageError<C>> {
         self.inner().last_applied_state().await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn delete_conflict_logs_since(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>> {
+    async fn delete_conflict_logs_since(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
         self.defensive_delete_conflict_gt_last_applied(log_id).await?;
         self.inner().delete_conflict_logs_since(log_id).await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn purge_logs_upto(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>> {
+    async fn purge_logs_upto(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
         self.defensive_purge_applied_le_last_applied(log_id).await?;
         self.inner().purge_logs_upto(log_id).await
     }

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -500,7 +500,7 @@ where
     pub async fn wait_for_snapshot(
         &self,
         node_ids: &BTreeSet<C::NodeId>,
-        want: LogId<C>,
+        want: LogId<C::NodeId>,
         timeout: Option<Duration>,
         msg: &str,
     ) -> Result<()> {
@@ -752,7 +752,7 @@ where
         expect_term: u64,
         expect_last_log: u64,
         expect_voted_for: Option<C::NodeId>,
-        expect_sm_last_applied_log: LogId<C>,
+        expect_sm_last_applied_log: LogId<C::NodeId>,
         expect_snapshot: &Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let last_log_id = storage.get_log_state().await?.last_log_id;
@@ -833,7 +833,7 @@ where
         expect_term: u64,
         expect_last_log: u64,
         expect_voted_for: Option<C::NodeId>,
-        expect_sm_last_applied_log: LogId<C>,
+        expect_sm_last_applied_log: LogId<C::NodeId>,
         expect_snapshot: Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let mut rt = self.routing_table.lock().unwrap();
@@ -865,7 +865,7 @@ where
         expect_term: u64,
         expect_last_log: u64,
         expect_voted_for: Option<C::NodeId>,
-        expect_sm_last_applied_log: LogId<C>,
+        expect_sm_last_applied_log: LogId<C::NodeId>,
         expect_snapshot: Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let mut rt = self.routing_table.lock().unwrap();


### PR DESCRIPTION
## Changelog

##### Refactor: LogId only needs a generic NodeId, not all of the RaftTypeConfig


- #222 

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/224)
<!-- Reviewable:end -->
