### PR TITLE
Refactor: ReplicationMetrics.matched does not need to be an Option. A `LogId` is just enough

### DIFF
--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -109,7 +109,7 @@ async fn leader_metrics() -> Result<()> {
 
     router.assert_stable_cluster(Some(1), Some(log_index)).await; // Still in term 1, so leader is still node 0.
 
-    let ww = ReplicationMetrics::new(Some(LogId::new(LeaderId::new(1, 0), log_index)));
+    let ww = ReplicationMetrics::new(LogId::new(LeaderId::new(1, 0), log_index));
     let want_repl = hashmap! { 1=>ww.clone(), 2=>ww.clone(), 3=>ww.clone(), 4=>ww.clone(), };
     router
         .wait_for_metrics(
@@ -158,7 +158,7 @@ async fn leader_metrics() -> Result<()> {
 
     tracing::info!("--- replication metrics should reflect the replication state");
     {
-        let ww = ReplicationMetrics::new(Some(LogId::new(LeaderId::new(1, 0), log_index)));
+        let ww = ReplicationMetrics::new(LogId::new(LeaderId::new(1, 0), log_index));
         let want_repl = hashmap! { 1=>ww.clone(), 2=>ww.clone(), 3=>ww.clone()};
         router
             .wait_for_metrics(


### PR DESCRIPTION

## Changelog

##### Refactor: ReplicationMetrics.matched does not need to be an Option. A `LogId` is just enough
commit-id:79a9ac46

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/232)
<!-- Reviewable:end -->
