### PR TITLE
Refactor: replace generic type RaftTypeConfig with NodeId if possible

### DIFF
--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -364,7 +364,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
     /// Report a metrics payload on the current state of the Raft node.
     #[tracing::instrument(level = "trace", skip(self))]
-    fn report_metrics(&mut self, leader_metrics: Update<Option<&Versioned<LeaderMetrics<C>>>>) {
+    fn report_metrics(&mut self, leader_metrics: Update<Option<&Versioned<LeaderMetrics<C::NodeId>>>>) {
         let leader_metrics = match leader_metrics {
             Update::Update(v) => v.cloned(),
             Update::AsIs => self.tx_metrics.borrow().leader_metrics.clone(),
@@ -752,7 +752,7 @@ struct LeaderState<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStora
     pub(super) nodes: BTreeMap<C::NodeId, ReplicationState<C>>,
 
     /// The metrics about a leader
-    pub leader_metrics: Versioned<LeaderMetrics<C>>,
+    pub leader_metrics: Versioned<LeaderMetrics<C::NodeId>>,
 
     /// The stream of events coming from replication streams.
     pub(super) replication_rx: mpsc::UnboundedReceiver<(ReplicaEvent<C, S::SnapshotData>, Span)>,

--- a/openraft/src/leader_metrics.rs
+++ b/openraft/src/leader_metrics.rs
@@ -18,7 +18,7 @@ use crate::ReplicationMetrics;
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeaderMetrics<C: RaftTypeConfig> {
     /// Replication metrics of all known replication target: voters and learners
-    pub replication: BTreeMap<C::NodeId, ReplicationMetrics<C>>,
+    pub replication: BTreeMap<C::NodeId, ReplicationMetrics<C::NodeId>>,
 }
 
 impl<C: RaftTypeConfig> MessageSummary for LeaderMetrics<C> {

--- a/openraft/src/leader_metrics.rs
+++ b/openraft/src/leader_metrics.rs
@@ -11,17 +11,17 @@ use crate::versioned::UpdateError;
 use crate::LogId;
 use crate::MessageSummary;
 use crate::NodeId;
-use crate::RaftTypeConfig;
 use crate::ReplicationMetrics;
 
 /// The metrics about the leader. It is Some() only when this node is leader.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LeaderMetrics<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub struct LeaderMetrics<NID: NodeId> {
     /// Replication metrics of all known replication target: voters and learners
-    pub replication: BTreeMap<C::NodeId, ReplicationMetrics<C::NodeId>>,
+    pub replication: BTreeMap<NID, ReplicationMetrics<NID>>,
 }
 
-impl<C: RaftTypeConfig> MessageSummary for LeaderMetrics<C> {
+impl<NID: NodeId> MessageSummary for LeaderMetrics<NID> {
     fn summary(&self) -> String {
         let mut res = vec!["LeaderMetrics{".to_string()];
         for (i, (k, v)) in self.replication.iter().enumerate() {
@@ -42,9 +42,9 @@ pub struct UpdateMatchedLogId<NID: NodeId> {
     pub matched: LogId<NID>,
 }
 
-impl<C: RaftTypeConfig> Update<LeaderMetrics<C>> for UpdateMatchedLogId<C::NodeId> {
+impl<NID: NodeId> Update<LeaderMetrics<NID>> for UpdateMatchedLogId<NID> {
     /// If there is already a record for the target node. Just modify the atomic u64.
-    fn apply_in_place(&self, to: &Arc<LeaderMetrics<C>>) -> Result<(), UpdateError> {
+    fn apply_in_place(&self, to: &Arc<LeaderMetrics<NID>>) -> Result<(), UpdateError> {
         let target_metrics = to.replication.get(&self.target).ok_or(UpdateError::CanNotUpdateInPlace)?;
 
         if target_metrics.matched_leader_id == self.matched.leader_id {
@@ -56,7 +56,7 @@ impl<C: RaftTypeConfig> Update<LeaderMetrics<C>> for UpdateMatchedLogId<C::NodeI
     }
 
     /// To insert a new record always work.
-    fn apply_mut(&self, to: &mut LeaderMetrics<C>) {
+    fn apply_mut(&self, to: &mut LeaderMetrics<NID>) {
         to.replication.insert(self.target, ReplicationMetrics {
             matched_leader_id: self.matched.leader_id,
             matched_index: AtomicU64::new(self.matched.index),
@@ -69,13 +69,13 @@ pub struct RemoveTarget<NID: NodeId> {
     pub target: NID,
 }
 
-impl<C: RaftTypeConfig> Update<LeaderMetrics<C>> for RemoveTarget<C::NodeId> {
+impl<NID: NodeId> Update<LeaderMetrics<NID>> for RemoveTarget<NID> {
     /// Removing can not be done in place
-    fn apply_in_place(&self, _to: &Arc<LeaderMetrics<C>>) -> Result<(), UpdateError> {
+    fn apply_in_place(&self, _to: &Arc<LeaderMetrics<NID>>) -> Result<(), UpdateError> {
         Err(UpdateError::CanNotUpdateInPlace)
     }
 
-    fn apply_mut(&self, to: &mut LeaderMetrics<C>) {
+    fn apply_mut(&self, to: &mut LeaderMetrics<NID>) {
         to.replication.remove(&self.target);
     }
 }

--- a/openraft/src/leader_metrics_test.rs
+++ b/openraft/src/leader_metrics_test.rs
@@ -1,6 +1,5 @@
 use crate::leader_metrics::LeaderMetrics;
 use crate::leader_metrics::UpdateMatchedLogId;
-use crate::testing::DummyConfig;
 use crate::versioned::Updatable;
 use crate::versioned::Versioned;
 use crate::LeaderId;
@@ -9,7 +8,7 @@ use crate::MessageSummary;
 
 #[test]
 fn test_versioned() -> anyhow::Result<()> {
-    let mut a = Versioned::new(LeaderMetrics::<DummyConfig> {
+    let mut a = Versioned::new(LeaderMetrics::<u64> {
         replication: Default::default(),
     });
 
@@ -86,7 +85,7 @@ fn test_versioned() -> anyhow::Result<()> {
 
 #[test]
 fn test_versioned_methods() -> anyhow::Result<()> {
-    let mut a = Versioned::new(LeaderMetrics::<DummyConfig> {
+    let mut a = Versioned::new(LeaderMetrics::<u64> {
         replication: Default::default(),
     });
 

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -53,7 +53,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     pub snapshot: Option<LogId<C::NodeId>>,
 
     /// The metrics about the leader. It is Some() only when this node is leader.
-    pub leader_metrics: Option<Versioned<LeaderMetrics<C>>>,
+    pub leader_metrics: Option<Versioned<LeaderMetrics<C::NodeId>>>,
 }
 
 impl<C: RaftTypeConfig> MessageSummary for RaftMetrics<C> {


### PR DESCRIPTION

## Changelog

##### Refactor: LeaderMetrics: use NID::NodeId as generic arg
commit-id:e8bb9b9e


##### Refactor: ReplicationMetrics: simplify generic argument.
commit-id:484fe19d

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/237)
<!-- Reviewable:end -->
