### PR TITLE
Fix: Remove `From<u64>` from default-implemented `NodeId`

### DIFF
--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -49,7 +49,6 @@ impl<T> NodeId for T where T: Sized
         + Default
         + serde::Serialize
         + for<'a> serde::Deserialize<'a>
-        + From<u64>
         + 'static
 {
 }


### PR DESCRIPTION
By mistake, a temporary `From<u64>` requirement on `NodeId` type was left in the code, which was intended to make tests run.

The requirement was properly removed from the `NodeId` trait, but not from the requirements on `T` needed to default-implement the `NodeId`.

Remove this requirement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/238)
<!-- Reviewable:end -->
