### PR TITLE
Refactor: optimize `report_metrics` call, avoids call this function everywhere

### DIFF
--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -161,11 +161,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     }
 
     pub fn update_metrics_option(&mut self, option: UpdateMetricsOption) {
-        if self.update_metrics == Some(UpdateMetricsOption::Update) {
+        // cannot overwrite `update_metrics` if already in the `Update` option
+        if self.update_metrics == UpdateMetricsOption::Update {
             return;
         }
 
-        self.update_metrics = Some(option);
+        self.update_metrics = option;
     }
 
     /// Append logs only when the first entry(prev_log_id) matches local store

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -21,7 +21,7 @@ use crate::RaftTypeConfig;
 use crate::SnapshotSegmentId;
 use crate::StorageError;
 use crate::StorageIOError;
-use crate::UpdateMetricsOption;
+use crate::Update;
 
 impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C, N, S> {
     /// Invoked by leader to send chunks of a snapshot to a follower (§7).
@@ -52,7 +52,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 self.set_target_state(State::Follower); // State update will emit metrics.
             }
 
-            self.update_metrics_option(UpdateMetricsOption::AsIs);
+            self.update_other_metrics_option(Update::AsIs);
         }
 
         // Compare current snapshot state with received RPC and handle as needed.
@@ -240,7 +240,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         self.update_membership(membership);
 
         self.snapshot_last_log_id = self.last_applied;
-        self.update_metrics_option(UpdateMetricsOption::AsIs);
+        self.update_other_metrics_option(Update::AsIs);
 
         Ok(())
     }

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -21,7 +21,6 @@ use crate::RaftTypeConfig;
 use crate::SnapshotSegmentId;
 use crate::StorageError;
 use crate::StorageIOError;
-use crate::Update;
 
 impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C, N, S> {
     /// Invoked by leader to send chunks of a snapshot to a follower (§7).
@@ -52,7 +51,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 self.set_target_state(State::Follower); // State update will emit metrics.
             }
 
-            self.update_other_metrics_option(Update::AsIs);
+            self.update_other_metrics_option();
         }
 
         // Compare current snapshot state with received RPC and handle as needed.
@@ -240,7 +239,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         self.update_membership(membership);
 
         self.snapshot_last_log_id = self.last_applied;
-        self.update_other_metrics_option(Update::AsIs);
+        self.update_other_metrics_option();
 
         Ok(())
     }

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -21,7 +21,7 @@ use crate::RaftTypeConfig;
 use crate::SnapshotSegmentId;
 use crate::StorageError;
 use crate::StorageIOError;
-use crate::Update;
+use crate::UpdateMetricsOption;
 
 impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C, N, S> {
     /// Invoked by leader to send chunks of a snapshot to a follower (§7).
@@ -52,7 +52,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 self.set_target_state(State::Follower); // State update will emit metrics.
             }
 
-            self.report_metrics(Update::AsIs);
+            self.update_metrics_option(UpdateMetricsOption::AsIs);
         }
 
         // Compare current snapshot state with received RPC and handle as needed.
@@ -240,7 +240,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         self.update_membership(membership);
 
         self.snapshot_last_log_id = self.last_applied;
-        self.report_metrics(Update::AsIs);
+        self.update_metrics_option(UpdateMetricsOption::AsIs);
 
         Ok(())
     }

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -888,6 +888,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             let span = tracing::debug_span!("CHrx:LeaderState");
             let _ent = span.enter();
 
+            self.core.post_state_loop(&self);
             self.core.pre_state_loop();
 
             tokio::select! {
@@ -910,8 +911,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
                     self.core.set_target_state(State::Shutdown);
                 }
             }
-
-            self.core.post_state_loop(&self);
         }
     }
 
@@ -1043,6 +1042,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Candida
                 return Ok(());
             }
 
+            self.core.post_state_loop(&self);
             self.core.pre_state_loop();
 
             // Setup new term.
@@ -1096,8 +1096,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Candida
                     Ok(_) = &mut self.core.rx_shutdown => self.core.set_target_state(State::Shutdown),
                 }
             }
-
-            self.core.post_state_loop(&self);
         }
     }
 
@@ -1172,6 +1170,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Followe
                 return Ok(());
             }
 
+            self.core.post_state_loop(&self);
             self.core.pre_state_loop();
 
             let election_timeout = sleep_until(self.core.get_next_election_timeout()); // Value is updated as heartbeats are received.
@@ -1191,8 +1190,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Followe
 
                 Ok(_) = &mut self.core.rx_shutdown => self.core.set_target_state(State::Shutdown),
             }
-
-            self.core.post_state_loop(&self);
         }
     }
 
@@ -1267,7 +1264,9 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
                 return Ok(());
             }
 
+            self.core.post_state_loop(&self);
             self.core.pre_state_loop();
+
             let span = tracing::debug_span!("CHrx:LearnerState");
             let _ent = span.enter();
 
@@ -1282,8 +1281,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
 
                 Ok(_) = &mut self.core.rx_shutdown => self.core.set_target_state(State::Shutdown),
             }
-
-            self.core.post_state_loop(&self);
         }
     }
 

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -54,6 +54,7 @@ pub use crate::raft_types::SnapshotId;
 pub use crate::raft_types::SnapshotSegmentId;
 pub use crate::raft_types::StateMachineChanges;
 pub use crate::raft_types::Update;
+pub use crate::raft_types::UpdateMetricsOption;
 pub use crate::replication::ReplicationMetrics;
 pub use crate::storage::RaftLogReader;
 pub use crate::storage::RaftSnapshotBuilder;

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -146,6 +146,7 @@ pub enum Update<T> {
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UpdateMetricsOption {
+    NoUpdate,
     Update,
     AsIs,
 }

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -146,14 +146,14 @@ pub enum Update<T> {
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdateMetricsOption {
-    pub leader_metrics: Update<()>,
+    pub leader: Update<()>,
     pub other_metrics: Update<()>,
 }
 
 impl Default for UpdateMetricsOption {
     fn default() -> Self {
         UpdateMetricsOption {
-            leader_metrics: Update::AsIs,
+            leader: Update::AsIs,
             other_metrics: Update::AsIs,
         }
     }

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -144,10 +144,19 @@ pub enum Update<T> {
     AsIs,
 }
 
-#[derive(Debug, Clone, Default, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdateMetricsOption {
-    pub leader_metrics: Option<Update<()>>,
-    pub other_metrics: Option<Update<()>>,
+    pub leader_metrics: Update<()>,
+    pub other_metrics: Update<()>,
+}
+
+impl Default for UpdateMetricsOption {
+    fn default() -> Self {
+        UpdateMetricsOption {
+            leader_metrics: Update::AsIs,
+            other_metrics: Update::AsIs,
+        }
+    }
 }
 
 /// The changes of a state machine.

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -144,6 +144,12 @@ pub enum Update<T> {
     AsIs,
 }
 
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UpdateMetricsOption {
+    Update,
+    AsIs,
+}
+
 /// The changes of a state machine.
 /// E.g. when applying a log to state machine, or installing a state machine from snapshot.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -144,11 +144,10 @@ pub enum Update<T> {
     AsIs,
 }
 
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
-pub enum UpdateMetricsOption {
-    NoUpdate,
-    Update,
-    AsIs,
+#[derive(Debug, Clone, Default, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateMetricsOption {
+    pub leader_metrics: Option<Update<()>>,
+    pub other_metrics: Option<Update<()>>,
 }
 
 /// The changes of a state machine.

--- a/openraft/tests/append_entries/t40_append_updates_membership.rs
+++ b/openraft/tests/append_entries/t40_append_updates_membership.rs
@@ -80,7 +80,7 @@ async fn append_updates_membership() -> Result<()> {
         assert!(resp.is_success());
         assert!(!resp.is_conflict());
 
-        r0.wait(timeout()).members(btreeset! {1,2}, "deleting inconsistent lgos updates membership").await?;
+        r0.wait(timeout()).members(btreeset! {1,2}, "deleting inconsistent logs updates membership").await?;
     }
 
     Ok(())

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -256,5 +256,5 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_micros(1000))
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -256,5 +256,5 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_micros(500))
+    Some(Duration::from_micros(1000))
 }

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -182,5 +182,5 @@ async fn change_with_turn_not_exist_member_to_learner() -> anyhow::Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_micros(500))
+    Some(Duration::from_micros(1000))
 }

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -182,5 +182,5 @@ async fn change_with_turn_not_exist_member_to_learner() -> anyhow::Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_micros(1000))
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/singlenode.rs
+++ b/openraft/tests/singlenode.rs
@@ -48,8 +48,12 @@ async fn single_node() -> Result<()> {
 
     // Write some data to the single node cluster.
     router.client_request_many(0, "0", 1000).await;
-    router.assert_stable_cluster(Some(1), Some(1001)).await;
-    router.assert_storage_state(1, 1001, Some(0), LogId::new(LeaderId::new(1, 0), 1001), None).await?;
+    n_logs += 1000;
+    router.wait_for_log(&btreeset![0], Some(n_logs), timeout(), "client_request_many").await?;
+    router.assert_stable_cluster(Some(1), Some(n_logs)).await;
+    router
+        .assert_storage_state(1, n_logs, Some(0), LogId::new(LeaderId::new(1, 0), n_logs), None)
+        .await?;
 
     // Read some data from the single node cluster.
     router.is_leader(0).await?;


### PR DESCRIPTION
Refactor: optimize `report_metrics` call, avoids call this function everywhere

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/242)
<!-- Reviewable:end -->
