### PR TITLE
Change: do not store learners in Membership

### DIFF
--- a/example-raft-kv/tests/cluster/test_cluster.rs
+++ b/example-raft-kv/tests/cluster/test_cluster.rs
@@ -87,11 +87,11 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     let nodes_in_cluster = x.membership_config.get_nodes();
     assert_eq!(
-        Some(&btreemap! {
-            1 => Node::new("127.0.0.1:21001"),
-            2 => Node::new("127.0.0.1:21002"),
-            3 => Node::new("127.0.0.1:21003"),
-        }),
+        &btreemap! {
+            1 => Some(Node::new("127.0.0.1:21001")),
+            2 => Some(Node::new("127.0.0.1:21002")),
+            3 => Some(Node::new("127.0.0.1:21003")),
+        },
         nodes_in_cluster
     );
 

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -110,7 +110,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
             let my_id = self.core.id;
             let target = *target;
-            let target_node = self.core.effective_membership.get_node(target).cloned();
+            let target_node = self.core.effective_membership.get_node(&target).cloned();
             let mut network = self.core.network.connect(target, target_node.as_ref()).await;
 
             let ttl = Duration::from_millis(self.core.config.heartbeat_interval);

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -118,7 +118,8 @@ impl<C: RaftTypeConfig> EffectiveMembership<C> {
         &self.all_members
     }
 
-    pub(crate) fn all_learners(&self) -> &BTreeSet<C::NodeId> {
+    // TODO(xp): make it an iter
+    pub(crate) fn all_learners(&self) -> BTreeSet<C::NodeId> {
         self.membership.all_learners()
     }
 
@@ -127,12 +128,12 @@ impl<C: RaftTypeConfig> EffectiveMembership<C> {
         self.membership.get_configs()
     }
 
-    pub fn get_node(&self, node_id: C::NodeId) -> Option<&Node> {
+    pub fn get_node(&self, node_id: &C::NodeId) -> Option<&Node> {
         self.membership.get_node(node_id)
     }
 
-    pub fn get_nodes(&self) -> Option<&BTreeMap<C::NodeId, Node>> {
-        self.membership.get_nodes().as_ref()
+    pub fn get_nodes(&self) -> &BTreeMap<C::NodeId, Option<Node>> {
+        self.membership.get_nodes()
     }
 }
 
@@ -607,7 +608,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(crate) fn get_leader_node(&self, leader_id: Option<C::NodeId>) -> Option<Node> {
         match leader_id {
             None => None,
-            Some(id) => self.effective_membership.get_node(id).cloned(),
+            Some(id) => self.effective_membership.get_node(&id).cloned(),
         }
     }
 }

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -33,7 +33,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         target: C::NodeId,
         caller_tx: Option<RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C>>>,
     ) -> ReplicationState<C> {
-        let target_node = self.core.effective_membership.get_node(target);
+        let target_node = self.core.effective_membership.get_node(&target);
         let repl_stream = ReplicationStream::new::<N, S>(
             target,
             target_node.cloned(),

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -149,7 +149,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Candida
         for member in all_nodes.into_iter().filter(|member| member != &self.core.id) {
             let rpc = VoteRequest::new(self.core.vote, self.core.last_log_id);
 
-            let target_node = self.core.effective_membership.get_node(member).cloned();
+            let target_node = self.core.effective_membership.get_node(&member).cloned();
 
             let (mut network, tx_inner) = (
                 self.core.network.connect(member, target_node.as_ref()).await,

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -116,7 +116,7 @@ pub enum ChangeMembershipError<C: RaftTypeConfig> {
     LearnerIsLagging(#[from] LearnerIsLagging<C>),
 
     #[error(transparent)]
-    NodeNotInCluster(#[from] NodeIdNotInNodes<C>),
+    LackNodeInfo(#[from] LackNodeInfo<C>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
@@ -128,7 +128,7 @@ pub enum AddLearnerError<C: RaftTypeConfig> {
     Exists(C::NodeId),
 
     #[error(transparent)]
-    NodeNotInCluster(#[from] NodeIdNotInNodes<C>),
+    LackNodeInfo(#[from] LackNodeInfo<C>),
 
     #[error(transparent)]
     Fatal(#[from] Fatal<C>),
@@ -153,7 +153,7 @@ pub enum InitializeError<C: RaftTypeConfig> {
     NotAllowed,
 
     #[error(transparent)]
-    NodeNotInCluster(#[from] NodeIdNotInNodes<C>),
+    LackNodeInfo(#[from] LackNodeInfo<C>),
 
     #[error(transparent)]
     Fatal(#[from] Fatal<C>),
@@ -357,10 +357,10 @@ pub struct LearnerIsLagging<C: RaftTypeConfig> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
-#[error("node {node_id} not found in cluster: {node_ids:?}")]
-pub struct NodeIdNotInNodes<C: RaftTypeConfig> {
+#[error("node {node_id} {reason}")]
+pub struct LackNodeInfo<C: RaftTypeConfig> {
     pub node_id: C::NodeId,
-    pub node_ids: BTreeSet<C::NodeId>,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -4,7 +4,7 @@ use std::option::Option::None;
 use maplit::btreemap;
 use maplit::btreeset;
 
-use crate::error::NodeIdNotInNodes;
+use crate::error::LackNodeInfo;
 use crate::testing::DummyConfig as Config;
 use crate::Membership;
 use crate::MessageSummary;
@@ -13,9 +13,11 @@ use crate::RaftTypeConfig;
 
 #[test]
 fn test_membership_summary() -> anyhow::Result<()> {
-    let node = |addr: &str, k: &str| Node {
-        addr: addr.to_string(),
-        data: btreemap! {k.to_string() => k.to_string()},
+    let node = |addr: &str, k: &str| {
+        Some(Node {
+            addr: addr.to_string(),
+            data: btreemap! {k.to_string() => k.to_string()},
+        })
     };
 
     let m = Membership::<Config>::new(vec![btreeset! {1,2}, btreeset! {3}], None);
@@ -24,13 +26,13 @@ fn test_membership_summary() -> anyhow::Result<()> {
     let m = Membership::<Config>::new(vec![btreeset! {1,2}, btreeset! {3}], Some(btreeset! {4}));
     assert_eq!("members:[{1,2},{3}],learners:[4]", m.summary());
 
-    let m = m.set_nodes(Some(btreemap! {
+    let m = Membership::<Config>::with_nodes(vec![btreeset! {1,2}, btreeset! {3}], btreemap! {
         1=>node("127.0.0.1", "k1"),
         2=>node("127.0.0.2", "k2"),
         3=>node("127.0.0.3", "k3"),
         4=>node("127.0.0.4", "k4"),
 
-    }))?;
+    })?;
     assert_eq!(
         "members:[{1:{127.0.0.1; k1:k1},2:{127.0.0.2; k2:k2}},{3:{127.0.0.3; k3:k3}}],learners:[4:{127.0.0.4; k4:k4}]",
         m.summary()
@@ -45,13 +47,13 @@ fn test_membership() -> anyhow::Result<()> {
     let m123 = Membership::<Config>::new(vec![btreeset! {1,2,3}], None);
     let m123_345 = Membership::<Config>::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None);
 
-    assert_eq!(Some(btreeset! {1}), m1.get_ith_config(0).cloned());
-    assert_eq!(Some(btreeset! {1,2,3}), m123.get_ith_config(0).cloned());
-    assert_eq!(Some(btreeset! {1,2,3}), m123_345.get_ith_config(0).cloned());
+    assert_eq!(Some(btreeset! {1}), m1.get_configs().get(0).cloned());
+    assert_eq!(Some(btreeset! {1,2,3}), m123.get_configs().get(0).cloned());
+    assert_eq!(Some(btreeset! {1,2,3}), m123_345.get_configs().get(0).cloned());
 
-    assert_eq!(None, m1.get_ith_config(1).cloned());
-    assert_eq!(None, m123.get_ith_config(1).cloned());
-    assert_eq!(Some(btreeset! {3,4,5}), m123_345.get_ith_config(1).cloned());
+    assert_eq!(None, m1.get_configs().get(1).cloned());
+    assert_eq!(None, m123.get_configs().get(1).cloned());
+    assert_eq!(Some(btreeset! {3,4,5}), m123_345.get_configs().get(1).cloned());
 
     assert_eq!(btreeset! {1}, m1.all_members());
     assert_eq!(btreeset! {1,2,3}, m123.all_members());
@@ -77,11 +79,11 @@ fn test_membership_with_learners() -> anyhow::Result<()> {
 
         // test learner and membership
         assert_eq!(btreeset! {1}, m1_2.all_members());
-        assert_eq!(&btreeset! {2}, m1_2.all_learners());
+        assert_eq!(btreeset! {2}, m1_2.all_learners());
         assert!(m1_2.is_learner(&2));
 
         assert_eq!(btreeset! {1}, m1_23.all_members());
-        assert_eq!(&btreeset! {2,3}, m1_23.all_learners());
+        assert_eq!(btreeset! {2,3}, m1_23.all_learners());
         assert!(m1_23.is_learner(&2));
         assert!(m1_23.is_learner(&3));
 
@@ -94,14 +96,14 @@ fn test_membership_with_learners() -> anyhow::Result<()> {
 
         let m = m1_23.add_learner(3, None)?;
         assert_eq!(btreeset! {1}, m.all_members());
-        assert_eq!(&btreeset! {2,3}, m.all_learners());
+        assert_eq!(btreeset! {2,3}, m.all_learners());
     }
 
     // overlapping members and learners
     {
         let s1_2 = Membership::<Config>::new(vec![btreeset! {1,2,3}, btreeset! {5,6,7}], Some(btreeset! {3,4,5}));
         let x = s1_2.all_learners();
-        assert_eq!(&btreeset! {4}, x);
+        assert_eq!(btreeset! {4}, x);
     }
 
     Ok(())
@@ -114,8 +116,10 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
         data: Default::default(),
     };
 
-    let m_1_2 = Membership::<Config>::new(vec![btreeset! {1}, btreeset! {2}], None)
-        .set_nodes(Some(btreemap! {1=>node("1"), 2=>node("2")}))?;
+    let m_1_2 = Membership::<Config>::with_nodes(
+        vec![btreeset! {1}, btreeset! {2}],
+        btreemap! {1=>Some(node("1")), 2=>Some(node("2"))},
+    )?;
 
     // Add learner that presents in old cluster has no effect.
 
@@ -126,8 +130,10 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
 
     let m_1_2_3 = m_1_2.add_learner(3, Some(node("3")))?;
     assert_eq!(
-        Membership::<Config>::new(vec![btreeset! {1}, btreeset! {2}], Some(btreeset! {3}))
-            .set_nodes(Some(btreemap! {1=>node("1"), 2=>node("2"), 3=>node("3")}))?,
+        Membership::<Config>::with_nodes(
+            vec![btreeset! {1}, btreeset! {2}],
+            btreemap! {1=>Some(node("1")), 2=>Some(node("2")), 3=>Some(node("3"))}
+        )?,
         m_1_2_3
     );
 
@@ -135,9 +141,9 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
     {
         let res = m_1_2.add_learner(3, None);
         assert_eq!(
-            Err(NodeIdNotInNodes {
+            Err(LackNodeInfo {
                 node_id: 3,
-                node_ids: btreeset! {1,2},
+                reason: "is None".to_string(),
             }),
             res
         );
@@ -149,50 +155,13 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
 
         let res = m_1_2.add_learner(3, Some(node("3")));
         assert_eq!(
-            Err(NodeIdNotInNodes {
+            Err(LackNodeInfo {
                 node_id: 1,
-                node_ids: btreeset! {3},
+                reason: "is None".to_string(),
             }),
             res
         );
     }
-
-    Ok(())
-}
-
-#[test]
-fn test_membership_check_ndoe_ids_in_nodes() -> anyhow::Result<()> {
-    let node = Node::default;
-
-    let mem = |c1, c2, l| Membership::<Config>::new(vec![btreeset! {c1}, btreeset! {c2}], Some(btreeset! {l}));
-    let nodes = Some(btreemap! {1 => node(), 2=>node(), 3=>node()});
-    let all = || btreeset! {1,2,3};
-
-    assert_eq!(
-        Err(NodeIdNotInNodes {
-            node_id: 5,
-            node_ids: all()
-        }),
-        mem(5, 2, 3).check_node_ids_in_nodes(&nodes)
-    );
-
-    assert_eq!(
-        Err(NodeIdNotInNodes {
-            node_id: 6,
-            node_ids: all()
-        }),
-        mem(1, 6, 3).check_node_ids_in_nodes(&nodes)
-    );
-
-    assert_eq!(
-        Err(NodeIdNotInNodes {
-            node_id: 7,
-            node_ids: all()
-        }),
-        mem(1, 2, 7).check_node_ids_in_nodes(&nodes)
-    );
-
-    assert_eq!(Ok(()), mem(1, 2, 3).check_node_ids_in_nodes(&nodes));
 
     Ok(())
 }
@@ -206,79 +175,73 @@ fn test_membership_extend_nodes() -> anyhow::Result<()> {
 
     let ext = |a, b| Membership::<Config>::extend_nodes(a, &b);
 
-    assert_eq!(None, ext(None, None));
     assert_eq!(
-        Some(btreemap! {1=>node("1")}),
-        ext(None, Some(btreemap! {1=>node("1")}))
+        btreemap! {1=>None},
+        ext(btreemap! {1=>None}, btreemap! {1=>Some(node("1"))}),
+        "existent node will not change"
     );
-
     assert_eq!(
-        Some(btreemap! {1=>node("1")}),
-        ext(Some(btreemap! {1=>node("1")}), None)
+        btreemap! {1=>Some(node("1"))},
+        ext(btreemap! {1=>Some(node("1"))}, btreemap! {1=>None}),
+        "existent node will not change"
     );
-
     assert_eq!(
-        Some(btreemap! {1=>node("1")}),
-        ext(Some(btreemap! {1=>node("1")}), Some(btreemap! {1=>node("2")})),
+        btreemap! {1=>Some(node("1"))},
+        ext(btreemap! {1=>Some(node("1"))}, btreemap! {1=>Some(node("2"))}),
         "existent node will not change"
     );
 
     assert_eq!(
-        Some(btreemap! {1=>node("1"), 2=>node("2")}),
+        btreemap! {1=>Some(node("1")), 2=>Some(node("2"))},
         ext(
-            Some(btreemap! {1=>node("1")}),
-            Some(btreemap! {1=>node("2"), 2=>node("2")})
+            btreemap! {1=>Some(node("1"))},
+            btreemap! {1=>Some(node("2")), 2=>Some(node("2"))}
         ),
     );
 
     Ok(())
 }
 
+// TODO: rename
 #[test]
-fn test_membership_remove_unused_nodes() -> anyhow::Result<()> {
-    let node = Node::default;
+fn test_membership_with_nodes() -> anyhow::Result<()> {
+    let node = || Some(Node::default());
+    let m = |nodes| Membership::<Config>::with_nodes(vec![btreeset! {1}, btreeset! {2}], nodes);
 
-    let m = Membership::<Config>::new(vec![btreeset! {1,2}, btreeset! {3}], Some(btreeset! {4}));
+    let ns_12 = || btreemap! {1=>node(), 2=>node()};
+    let ns_123 = || btreemap! {1=>node(), 2=>node(), 3=>node()};
 
-    assert_eq!(None, m.remove_unused_nodes(&None));
+    let res = m(btreemap! {1=>None, 2=>None})?;
+    assert_eq!(&btreemap! {1=>None, 2=>None}, res.get_nodes());
 
-    assert_eq!(
-        Some(btreemap! {1=>node(), 2=>node(), 3=>node(), 4=>node(),}),
-        m.remove_unused_nodes(&Some(btreemap! {1=>node(), 2=>node(), 3=>node(),4=>node()}))
-    );
-    assert_eq!(
-        Some(btreemap! {1=>node(), 2=>node(), 3=>node(), 4=>node(),}),
-        m.remove_unused_nodes(&Some(btreemap! {1=>node(), 2=>node(), 3=>node(), 4=>node(),5=>node()}))
-    );
+    let res = m(btreemap! {1=>None, 2=>None,3=>None})?;
+    assert_eq!(&btreemap! {1=>None, 2=>None, 3=>None}, res.get_nodes());
 
-    Ok(())
-}
+    let res = m(ns_12())?;
+    assert_eq!(&ns_12(), res.get_nodes());
 
-#[test]
-fn test_membership_set_nodes() -> anyhow::Result<()> {
-    let node = Node::default;
-    let m = || Membership::<Config>::new(vec![btreeset! {1}, btreeset! {2}], Some(btreeset! {3}));
-    let ns_12 = || Some(btreemap! {1=>node(), 2=>node()});
-    let ns_123 = || Some(btreemap! {1=>node(), 2=>node(), 3=>node()});
-    let ns_1234 = || Some(btreemap! {1=>node(), 2=>node(), 3=>node(), 4=>node()});
-
-    let res = m().set_nodes(None)?;
-    assert_eq!(&None, res.get_nodes());
-
-    let res = m().set_nodes(ns_123())?;
+    let res = m(ns_123())?;
     assert_eq!(&ns_123(), res.get_nodes());
 
-    let res = m().set_nodes(ns_1234())?;
-    assert_eq!(&ns_123(), res.get_nodes());
-
-    let res = m().set_nodes(ns_12());
+    // errors:
+    let res = m(btreemap! {1=>None});
     assert_eq!(
-        Err(NodeIdNotInNodes {
-            node_id: 3,
-            node_ids: btreeset! {1,2},
+        Err(LackNodeInfo {
+            node_id: 2,
+            reason: "is not in cluster: [1]".to_string(),
         }),
         res
     );
+
+    let res = m(btreemap! {1=>None,2=>node()});
+    assert_eq!(
+        Err(LackNodeInfo {
+            node_id: 1,
+            reason: "is None".to_string(),
+        }),
+        res
+    );
+
     Ok(())
 }
 
@@ -422,18 +385,18 @@ fn test_membership_next_safe_with_nodes() -> anyhow::Result<()> {
     {
         let without_nodes = Membership::<Config>::new(vec![c1(), c2()], None);
 
-        // [{2}, {1,2}] has all nodes info provided.
+        // next_safe() can not change node info type from None to Some
 
         let res = without_nodes.next_safe(btreemap! {1=>node("1"), 2=>node("2")}, false)?;
-        assert_eq!(&Some(btreemap! {1=>node("1"), 2=>node("2")}), res.get_nodes());
+        assert_eq!(&btreemap! {1=>None, 2=>None}, res.get_nodes());
 
         // joint [{2}, {1,3}] requires node info for 2
 
         let res = without_nodes.next_safe(btreemap! {1=>node("1"), 3=>node("3")}, false);
         assert_eq!(
-            Err(NodeIdNotInNodes {
-                node_id: 2,
-                node_ids: btreeset! {1,3},
+            Err(LackNodeInfo {
+                node_id: 1,
+                reason: "is None".to_string(),
             }),
             res
         );
@@ -446,29 +409,29 @@ fn test_membership_next_safe_with_nodes() -> anyhow::Result<()> {
 
     // change from a Membership with nodes
     {
-        let with_nodes = Membership::<Config>::new(vec![c1(), c2()], None)
-            .set_nodes(Some(btreemap! {1=>node("1"), 2=>node("2")}))?;
+        let with_node_infos =
+            Membership::<Config>::with_nodes(vec![c1(), c2()], btreemap! {1=>Some(node("1")), 2=>Some(node("2"))})?;
 
         // joint [{2}, {1,2}]
 
-        let res = with_nodes.next_safe(btreeset! {1,2}, false)?;
-        assert_eq!(&Some(btreemap! {1=>node("1"), 2=>node("2")}), res.get_nodes());
+        let res = with_node_infos.next_safe(btreeset! {1,2}, false)?;
+        assert_eq!(&btreemap! {1=>Some(node("1")), 2=>Some(node("2"))}, res.get_nodes());
 
         // joint [{2}, {1,3}]
 
-        let res = with_nodes.next_safe(btreeset! {1,3}, false);
+        let res = with_node_infos.next_safe(btreeset! {1,3}, false);
         assert_eq!(
-            Err(NodeIdNotInNodes {
+            Err(LackNodeInfo {
                 node_id: 3,
-                node_ids: btreeset! {1,2},
+                reason: "is None".to_string(),
             }),
             res
         );
 
         // Removed to learner
 
-        let res = with_nodes.next_safe(btreeset! {1}, true)?;
-        assert_eq!(&Some(btreemap! {1=>node("1"), 2=>node("2")}), res.get_nodes());
+        let res = with_node_infos.next_safe(btreeset! {1}, true)?;
+        assert_eq!(&btreemap! {1=>Some(node("1")), 2=>Some(node("2"))}, res.get_nodes());
         assert_eq!(&vec![btreeset! {1}], res.get_configs());
     }
 

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -6,5 +6,5 @@ mod membership_test;
 
 pub mod quorum;
 
-pub use membership::EitherNodesOrIds;
+pub use membership::IntoOptionNodes;
 pub use membership::Membership;

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -233,7 +233,7 @@ impl<C: RaftTypeConfig> Wait<C> {
         msg: impl ToString,
     ) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
-            |x| x.membership_config.membership.get_ith_config(0).cloned().unwrap() == want_members,
+            |x| x.membership_config.membership.get_configs().get(0).cloned().unwrap() == want_members,
             &format!("{} .membership_config.members -> {:?}", msg.to_string(), want_members),
         )
         .await
@@ -248,7 +248,7 @@ impl<C: RaftTypeConfig> Wait<C> {
         msg: impl ToString,
     ) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
-            |x| x.membership_config.membership.get_ith_config(1) == want_members.as_ref(),
+            |x| x.membership_config.membership.get_configs().get(1) == want_members.as_ref(),
             &format!("{} .membership_config.next -> {:?}", msg.to_string(), want_members),
         )
         .await

--- a/openraft/src/metrics_wait_test.rs
+++ b/openraft/src/metrics_wait_test.rs
@@ -101,7 +101,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
         assert_eq!(
             btreeset![1, 2],
-            got.membership_config.membership.get_ith_config(0).unwrap().clone()
+            got.membership_config.membership.get_configs().get(0).unwrap().clone()
         );
     }
 
@@ -124,7 +124,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
         assert_eq!(
             Some(btreeset![1, 2]),
-            got.membership_config.membership.get_ith_config(1).cloned()
+            got.membership_config.membership.get_configs().get(1).cloned()
         );
     }
 

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -1,5 +1,6 @@
 //! Public Raft interface and data types.
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -25,7 +26,7 @@ use crate::error::Fatal;
 use crate::error::InitializeError;
 use crate::error::InstallSnapshotError;
 use crate::error::VoteError;
-use crate::membership::EitherNodesOrIds;
+use crate::membership::IntoOptionNodes;
 use crate::metrics::RaftMetrics;
 use crate::metrics::Wait;
 use crate::AppData;
@@ -272,27 +273,19 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     /// which will allow time for the initial members of the cluster to be discovered (by the
     /// parent application) for this call.
     ///
-    /// If successful, this routine will set the given config as the active config, only in memory,
-    /// and will start an election.
+    /// Once a node successfully initialized it will commit a new membership config
+    /// log entry to store.
+    /// Then it starts to work, i.e., entering Candidate state and try electing itself as the leader.
     ///
-    /// It is recommended that applications call this function based on an initial call to
-    /// `RaftStorage.get_initial_state`. If the initial state indicates that the hard state's
-    /// current term is `0` and the `last_log_index` is `0`, then this routine should be called
-    /// in order to initialize the cluster.
-    ///
-    /// Once a node becomes leader and detects that its index is 0, it will commit a new config
-    /// entry (instead of the normal blank entry created by new leaders).
-    ///
-    /// Every member of the cluster should perform these actions. This routine is race-condition
-    /// free, and Raft guarantees that the first node to become the cluster leader will propagate
-    /// only its own config.
+    /// More than one node performing `initialize()` with the same config is safe,
+    /// with different config will result in brain split.
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn initialize<T>(&self, members: T) -> Result<(), InitializeError<C>>
-    where T: Into<EitherNodesOrIds<C>> + Debug {
+    where T: IntoOptionNodes<C::NodeId> + Debug {
         let (tx, rx) = oneshot::channel();
         self.call_core(
             RaftMsg::Initialize {
-                members: members.into(),
+                members: members.into_option_nodes(),
                 tx,
             },
             rx,
@@ -554,7 +547,7 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
         tx: RaftRespTx<(), CheckIsLeaderError<C>>,
     },
     Initialize {
-        members: EitherNodesOrIds<C>,
+        members: BTreeMap<C::NodeId, Option<Node>>,
         tx: RaftRespTx<(), InitializeError<C>>,
     },
     // TODO(xp): make tx a field of a struct


### PR DESCRIPTION

## Changelog

##### Change: do not store learners in Membership
- Change: rename NodeIdNotInNodes to LackNodeInfo for letting it
  represent a more generalized error type.

- Change: remove struct `EitherNodesOrIds`, add trait `IntoOptionNodes` to
  convert types into internal type to store node infos.

  Because we do not need to store multiple types, but only need to
  convert them to our type.

- Change: Membership remove redundent field `learners`: the node ids that
  are in `Membership.nodes` but not in `Membership.configs` are
  learners.

  Some method signatures changed along:

    - Change: `EffectiveMembership.get_nodes()` and
      `Membership.get_nodes()` returns `&BTreeMap` instead of
      `Option<BTreeMap>`.

    - Change: `EffectiveMembership.get_node()` use `&node_id` instead of
      `node_id` for arg.

- Add: `Membership::with_nodes(configs, nodes)` to create a new instance with membership configs and optional node infos.

- fix: #225

commit-id:e0ff8a75

---