### PR TITLE
Refactor: use crate async-entry to define async test functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 # Directory Ignores ##########################################################
 guide/book
 target
@@ -11,3 +12,4 @@ Cargo.lock
 perf.data*
 nohup*
 *svg
+.DS_Store

--- a/example-raft-kv/tests/cluster/test_cluster.rs
+++ b/example-raft-kv/tests/cluster/test_cluster.rs
@@ -14,7 +14,7 @@ use tokio::runtime::Runtime;
 
 /// Setup a cluster of 3 nodes.
 /// Write to it and read from it.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_cluster() -> anyhow::Result<()> {
     // --- The client itself does not store addresses for all nodes, but just node id.
     //     Thus we need a supporting component to provide mapping from node id to node address.

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -35,6 +35,7 @@ tracing-futures = "0.2.4"
 
 [dev-dependencies]
 anyhow = "1.0.32"
+async-entry = "0.2.0"
 lazy_static = "1.4.0"
 memstore = { version="0.2.0", path="../memstore" }
 pretty_assertions = "1.0.0"

--- a/openraft/src/metrics_wait_test.rs
+++ b/openraft/src/metrics_wait_test.rs
@@ -19,7 +19,7 @@ use crate::RaftTypeConfig;
 use crate::State;
 
 /// Test wait for different state changes
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_wait() -> anyhow::Result<()> {
     {
         // wait for leader

--- a/openraft/tests/api_install_snapshot.rs
+++ b/openraft/tests/api_install_snapshot.rs
@@ -12,6 +12,8 @@ use openraft::SnapshotMeta;
 use openraft::State;
 use openraft::Vote;
 
+use crate::fixtures::init_default_ut_tracing;
+
 #[macro_use]
 mod fixtures;
 
@@ -21,11 +23,8 @@ mod fixtures;
 ///
 /// - build a stable single node cluster.
 /// - send install_snapshot request with matched/mismatched id and offset
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn snapshot_ge_half_threshold() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -13,6 +13,7 @@ use openraft::RaftNetworkFactory;
 use openraft::Vote;
 
 use crate::fixtures::blank;
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Cluster conflict_with_empty_entries test.
@@ -33,11 +34,8 @@ use crate::fixtures::RaftRouter;
 ///
 /// - send `append_logs` message with conflicting prev_log_index and empty `entries`.
 /// - asserts that a response with ConflictOpt set.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn conflict_with_empty_entries() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -15,16 +15,14 @@ use openraft::State;
 use openraft::Vote;
 
 use crate::fixtures::blank;
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Test append-entries response in every case.
 ///
 /// - bring up a learner and send to it append_entries request. Check the response in every case.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_conflicts() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -13,6 +13,7 @@ use openraft::RaftStorage;
 use openraft::State;
 use openraft::Vote;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Too many inconsistent log should not block replication.
@@ -31,11 +32,8 @@ use crate::fixtures::RaftRouter;
 ///
 /// - Start the cluster and node 2 start to replicate logs.
 /// - test the log should be replicated to node 0.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_inconsistent_log() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/append_entries/t40_append_updates_membership.rs
+++ b/openraft/tests/append_entries/t40_append_updates_membership.rs
@@ -15,17 +15,15 @@ use openraft::State;
 use openraft::Vote;
 
 use crate::fixtures::blank;
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// append-entries should update membership correctly when adding new logs and deleting
 /// inconsistent logs.
 ///
 /// - bring up a learner and send to it append_entries request. Check the membership updated.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_updates_membership() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -10,16 +10,14 @@ use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
 use openraft::Vote;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// append-entries should update hard state when adding new logs with bigger term
 ///
 /// - bring up a learner and send to it append_entries request. Check the hard state updated.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_entries_with_bigger_term() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/append_entries/t60_large_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_large_heartbeat.rs
@@ -5,15 +5,13 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Large heartbeat should not block replication.
 /// I.e., replication should not be driven by heartbeat.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn large_heartbeat() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(
         Config {

--- a/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
+++ b/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
-use tracing::Instrument;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Ensures the stale value of ReplicationCore.last_log_id won't affect replication.
@@ -14,57 +14,51 @@ use crate::fixtures::RaftRouter;
 /// TODO(xp): `max_applied_log_to_keep` to be 0 makes it very easy to enter snapshot replication and it will keeps
 ///           replicating every log by snapshot and get timeout.
 ///           Thus it is disabled until we find another way to test it.
-#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 #[ignore]
 async fn stale_last_log_id() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
+    // Setup test dependencies.
+    let config = Arc::new(
+        Config {
+            heartbeat_interval: 50,
+            election_timeout_min: 500,
+            election_timeout_max: 1000,
+            max_payload_entries: 1,
+            max_applied_log_to_keep: 0,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+    router.network_send_delay(5);
 
-    async {
-        // Setup test dependencies.
-        let config = Arc::new(
-            Config {
-                heartbeat_interval: 50,
-                election_timeout_min: 500,
-                election_timeout_max: 1000,
-                max_payload_entries: 1,
-                max_applied_log_to_keep: 0,
-                ..Default::default()
+    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3,4}).await?;
+
+    let n_threads = 4;
+    let n_ops = 500;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+    for i in 0..n_threads {
+        tokio::spawn({
+            let router = router.clone();
+            let tx = tx.clone();
+
+            async move {
+                router.client_request_many(0, &format!("{}", i), n_ops).await;
+                let _ = tx.send(());
             }
-            .validate()?,
-        );
-        let mut router = RaftRouter::new(config.clone());
-        router.network_send_delay(5);
-
-        let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3,4}).await?;
-
-        let n_threads = 4;
-        let n_ops = 500;
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-
-        for i in 0..n_threads {
-            tokio::spawn({
-                let router = router.clone();
-                let tx = tx.clone();
-
-                async move {
-                    router.client_request_many(0, &format!("{}", i), n_ops).await;
-                    let _ = tx.send(());
-                }
-            });
-        }
-
-        for _i in 0..n_threads {
-            let _ = rx.recv().await;
-            log_index += n_ops as u64;
-        }
-
-        router.wait(&1, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
-        router.wait(&2, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
-        router.wait(&3, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
-        router.wait(&4, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
-
-        Ok(())
+        });
     }
-    .instrument(ut_span)
-    .await
+
+    for _i in 0..n_threads {
+        let _ = rx.recv().await;
+        log_index += n_ops as u64;
+    }
+
+    router.wait(&1, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
+    router.wait(&2, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
+    router.wait(&3, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
+    router.wait(&4, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
+
+    Ok(())
 }

--- a/openraft/tests/client_api/t10_client_writes.rs
+++ b/openraft/tests/client_api/t10_client_writes.rs
@@ -9,6 +9,7 @@ use openraft::LogId;
 use openraft::SnapshotPolicy;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Client write tests.
@@ -18,11 +19,8 @@ use crate::fixtures::RaftRouter;
 /// - create a stable 3-node cluster.
 /// - write a lot of data to it.
 /// - assert that the cluster stayed stable and has all of the expected data.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 4, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn client_writes() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(
         Config {

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Client read tests.
@@ -14,11 +15,8 @@ use crate::fixtures::RaftRouter;
 /// - create a stable 3-node cluster.
 /// - call the is_leader interface on the leader, and assert success.
 /// - call the is_leader interface on the followers, and assert failure.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn client_reads() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/client_api/t50_lagging_network_write.rs
+++ b/openraft/tests/client_api/t50_lagging_network_write.rs
@@ -6,6 +6,7 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Lagging network test.
@@ -16,11 +17,8 @@ use crate::fixtures::RaftRouter;
 /// - bring a single-node cluster online.
 /// - add two Learner and then try to commit one log.
 /// - change config to a 3 members cluster and commit another log.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn lagging_network_write() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let config = Arc::new(
         Config {
             heartbeat_interval: 100,

--- a/openraft/tests/concurrent_write_and_add_learner.rs
+++ b/openraft/tests/concurrent_write_and_add_learner.rs
@@ -8,7 +8,8 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::LogIdOptionExt;
 use openraft::State;
-use tracing_futures::Instrument;
+
+use crate::fixtures::init_default_ut_tracing;
 
 #[macro_use]
 mod fixtures;
@@ -36,11 +37,8 @@ mod fixtures;
 /// - brings a 3 candidates cluster online.
 /// - add another learner and at the same time write a log.
 /// - asserts that all of the leader, followers and the learner receives all logs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn concurrent_write_and_add_learner() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let timeout = Duration::from_millis(500);
     let candidates = btreeset![0, 1, 2];
 

--- a/openraft/tests/elect_compare_last_log.rs
+++ b/openraft/tests/elect_compare_last_log.rs
@@ -16,6 +16,7 @@ use openraft::State;
 use openraft::Vote;
 
 use crate::fixtures::blank;
+use crate::fixtures::init_default_ut_tracing;
 
 #[macro_use]
 mod fixtures;
@@ -24,11 +25,8 @@ mod fixtures;
 ///
 /// - Fake a cluster with two node: with last log {2,1} and {1,2}.
 /// - Bring up the cluster and only node 0 can become leader.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn elect_compare_last_log() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -70,33 +70,6 @@ use crate::fixtures::logging::init_file_logging;
 
 pub mod logging;
 
-#[allow(unused)]
-macro_rules! func_name {
-    () => {{
-        fn f() {}
-        fn type_name_of<T>(_: T) -> &'static str {
-            std::any::type_name::<T>()
-        }
-        let name = type_name_of(f);
-        let n = &name[..name.len() - 3];
-        let nn = n.replace("::{{closure}}", "");
-        nn
-    }};
-}
-
-#[allow(unused)]
-macro_rules! init_ut {
-    () => {{
-        let name = func_name!();
-        let last = name.split("::").last().unwrap();
-
-        let g = crate::fixtures::init_default_ut_tracing();
-
-        let span = tracing::debug_span!("ut", "{}", last);
-        (g, span)
-    }};
-}
-
 pub type StoreWithDefensive<C = MemConfig, S = Arc<MemStore>> = StoreExt<C, S>;
 
 /// A concrete Raft type used during testing.

--- a/openraft/tests/initialization.rs
+++ b/openraft/tests/initialization.rs
@@ -16,6 +16,8 @@ use openraft::RaftStorage;
 use openraft::State;
 use tokio::sync::oneshot;
 
+use crate::fixtures::init_default_ut_tracing;
+
 #[macro_use]
 mod fixtures;
 
@@ -29,11 +31,8 @@ mod fixtures;
 /// - asserts that the cluster was able to come online, elect a leader and maintain a stable state.
 /// - asserts that the leader was able to successfully commit its initial payload and that all followers have
 ///   successfully replicated the payload.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn initialization() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/log_compaction/compaction.rs
+++ b/openraft/tests/log_compaction/compaction.rs
@@ -20,6 +20,7 @@ use openraft::State;
 use openraft::Vote;
 
 use crate::fixtures::blank;
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Compaction test.
@@ -29,11 +30,8 @@ use crate::fixtures::RaftRouter;
 /// - build a stable single node cluster.
 /// - send enough requests to the node that log compaction will be triggered.
 /// - add new nodes and assert that they receive the snapshot.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn compaction() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let snapshot_threshold: u64 = 50;
 
     // Setup test dependencies.

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -13,6 +13,7 @@ use openraft::RaftTypeConfig;
 use openraft::State;
 use tokio::time::sleep;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::MemRaft;
 use crate::fixtures::RaftRouter;
 
@@ -26,11 +27,8 @@ use crate::fixtures::RaftRouter;
 ///   replicated the payload.
 /// - shutdown all and restart the learner node.
 /// - asserts the learner stays in non-vtoer state.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn learner_restart() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -13,17 +13,15 @@ use openraft::RaftLogReader;
 use openraft::RaftStorage;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn add_learner_basic() -> Result<()> {
     //
     // - Add leader, expect NoChange
     // - Add a learner, expect raft to block until catching up.
     // - Re-add should fail.
-
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
 
     let config = Arc::new(
         Config {
@@ -90,15 +88,12 @@ async fn add_learner_basic() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn add_learner_non_blocking() -> Result<()> {
     //
     // - Add leader, expect NoChange
     // - Add a learner, expect raft to block until catching up.
     // - Re-add should fail.
-
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
 
     let config = Arc::new(
         Config {
@@ -132,11 +127,8 @@ async fn add_learner_non_blocking() -> Result<()> {
 
 /// add a learner, then shutdown the leader to make leader transfered,
 /// check after new leader come, the learner can receive new log.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn check_learner_after_leader_transfered() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(
         Config {

--- a/openraft/tests/membership/t15_add_remove_follower.rs
+++ b/openraft/tests/membership/t15_add_remove_follower.rs
@@ -6,6 +6,7 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// When a node is removed from cluster, replication to it should be stopped.
@@ -15,11 +16,8 @@ use crate::fixtures::RaftRouter;
 ///   the payload.
 /// - remove one follower: node-4
 /// - asserts node-4 becomes learner and the leader stops sending logs to it.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn add_remove_voter() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let cluster_of_5 = btreeset![0, 1, 2, 3, 4];
     let cluster_of_4 = btreeset![0, 1, 2, 3];
 

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -8,64 +8,41 @@ use memstore::MemNodeId;
 use openraft::ChangeMembers;
 use openraft::Config;
 use openraft::State;
-use tracing_futures::Instrument;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn change_membership_cases() -> anyhow::Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-
-    async {
-        change_from_to(btreeset! {0}, ChangeMembers::Replace(btreeset! {1})).await?;
-        change_from_to(btreeset! {0}, ChangeMembers::Replace(btreeset! {1,2})).await?;
-        change_from_to(btreeset! {0}, ChangeMembers::Replace(btreeset! {1,2,3})).await?;
-        change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {1,2})).await?;
-        change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {1})).await?;
-        change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {2})).await?;
-        change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {3})).await?;
-        change_from_to(btreeset! {0, 1, 2}, ChangeMembers::Replace(btreeset! {4})).await?;
-        change_from_to(btreeset! {0, 1, 2}, ChangeMembers::Replace(btreeset! {4,5,6})).await?;
-        change_from_to(btreeset! {0, 1, 2, 3, 4}, ChangeMembers::Replace(btreeset! {0,1,2,3})).await?;
-
-        Ok::<(), anyhow::Error>(())
-    }
-    .instrument(ut_span)
-    .await?;
+    change_from_to(btreeset! {0}, ChangeMembers::Replace(btreeset! {1})).await?;
+    change_from_to(btreeset! {0}, ChangeMembers::Replace(btreeset! {1,2})).await?;
+    change_from_to(btreeset! {0}, ChangeMembers::Replace(btreeset! {1,2,3})).await?;
+    change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {1,2})).await?;
+    change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {1})).await?;
+    change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {2})).await?;
+    change_from_to(btreeset! {0, 1}, ChangeMembers::Replace(btreeset! {3})).await?;
+    change_from_to(btreeset! {0, 1, 2}, ChangeMembers::Replace(btreeset! {4})).await?;
+    change_from_to(btreeset! {0, 1, 2}, ChangeMembers::Replace(btreeset! {4,5,6})).await?;
+    change_from_to(btreeset! {0, 1, 2, 3, 4}, ChangeMembers::Replace(btreeset! {0,1,2,3})).await?;
 
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn add_members_cases() -> anyhow::Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-
-    async {
-        change_from_to(btreeset! {0}, ChangeMembers::Add(btreeset! {0,1})).await?;
-        change_from_to(btreeset! {0}, ChangeMembers::Add(btreeset! {1,2})).await?;
-        change_from_to(btreeset! {0,1}, ChangeMembers::Add(btreeset! {})).await?;
-        Ok::<(), anyhow::Error>(())
-    }
-    .instrument(ut_span)
-    .await?;
+    change_from_to(btreeset! {0}, ChangeMembers::Add(btreeset! {0,1})).await?;
+    change_from_to(btreeset! {0}, ChangeMembers::Add(btreeset! {1,2})).await?;
+    change_from_to(btreeset! {0,1}, ChangeMembers::Add(btreeset! {})).await?;
 
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn remove_members_cases() -> anyhow::Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-
-    async {
-        change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {0,1})).await?;
-        change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {3})).await?;
-        change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {})).await?;
-        change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {1,3})).await?;
-
-        Ok::<(), anyhow::Error>(())
-    }
-    .instrument(ut_span)
-    .await?;
+    change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {0,1})).await?;
+    change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {3})).await?;
+    change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {})).await?;
+    change_from_to(btreeset! {0,1,2}, ChangeMembers::Remove(btreeset! {1,3})).await?;
 
     Ok(())
 }

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -8,14 +8,12 @@ use openraft::Config;
 use openraft::RaftLogReader;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
     // Add a member without adding it as learner, in blocking mode it should finish successfully.
-
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
 
     let lag_threshold = 1;
 
@@ -62,12 +60,9 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
     // Add a learner into membership config, expect error NonVoterIsLagging.
-
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
 
     let lag_threshold = 1;
 
@@ -122,12 +117,9 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn change_with_turn_not_exist_member_to_learner() -> anyhow::Result<()> {
     // Add a member without adding it as learner, in blocking mode it should finish successfully.
-
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
 
     let config = Arc::new(Config { ..Default::default() }.validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/membership/t25_elect_with_new_config.rs
+++ b/openraft/tests/membership/t25_elect_with_new_config.rs
@@ -9,6 +9,7 @@ use openraft::LogIdOptionExt;
 use openraft::State;
 use tokio::time::sleep;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Dynamic membership test.
@@ -20,11 +21,8 @@ use crate::fixtures::RaftRouter;
 /// - propose a new config change where the old master is not present, and assert that it steps down.
 /// - temporarily isolate the new master, and assert that a new master takes over.
 /// - restore the isolated node and assert that it becomes a follower.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn leader_election_after_changing_0_to_01234() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let span = tracing::debug_span!("ut-dynamic_membership");
     let _ent = span.enter();
 

--- a/openraft/tests/membership/t30_commit_joint_config.rs
+++ b/openraft/tests/membership/t30_commit_joint_config.rs
@@ -5,8 +5,8 @@ use futures::stream::StreamExt;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::LogIdOptionExt;
-use tracing_futures::Instrument;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// A leader must wait for learner to commit member-change from [0] to [0,1,2].
@@ -16,11 +16,8 @@ use crate::fixtures::RaftRouter;
 /// - Init 1 leader and 2 learner.
 /// - Isolate learner.
 /// - Asserts that membership change won't success.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn commit_joint_config_during_0_to_012() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
@@ -87,11 +84,8 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
 /// - bring a cluster of node 0,1,2 online.
 /// - isolate 3,4; change config to 2,3,4
 /// - since new config can not form a quorum, the joint config should not be committed.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn commit_joint_config_during_012_to_234() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -8,17 +8,15 @@ use openraft::LeaderId;
 use openraft::LogId;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Change membership from {0,1} to {1,2,3}.
 ///
 /// - Then the leader should step down after joint log is committed.
 /// - Check logs on other node.
-#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn step_down() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(
         Config {

--- a/openraft/tests/membership/t40_removed_follower.rs
+++ b/openraft/tests/membership/t40_removed_follower.rs
@@ -6,14 +6,12 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::LogIdOptionExt;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Replication should stop after a follower is removed from membership.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn stop_replication_to_removed_follower() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -11,6 +11,7 @@ use openraft::Membership;
 use openraft::Raft;
 use openraft::RaftStorage;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Cluster members_leader_fix_partial test.
@@ -21,11 +22,8 @@ use crate::fixtures::RaftRouter;
 /// - manually append a joint config log.
 /// - shutdown and restart, it should NOT add another final config log to complete the partial
 /// membership changing
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn new_leader_auto_commit_uniform_config() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/metrics/t10_current_leader.rs
+++ b/openraft/tests/metrics/t10_current_leader.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Current leader tests.
@@ -12,11 +13,8 @@ use crate::fixtures::RaftRouter;
 ///
 /// - create a stable 3-node cluster.
 /// - call the current_leader interface on the all nodes, and assert success.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn current_leader() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -6,6 +6,7 @@ use openraft::Config;
 use openraft::RaftStorageDebug;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Cluster metrics_state_machine_consistency test.
@@ -15,11 +16,8 @@ use crate::fixtures::RaftRouter;
 /// - brings 2 nodes online: one leader and one learner.
 /// - write one log to the leader.
 /// - asserts that when metrics.last_applied is upto date, the state machine should be upto date too.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn metrics_state_machine_consistency() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -19,6 +19,7 @@ use pretty_assertions::assert_eq;
 #[allow(unused_imports)]
 use pretty_assertions::assert_ne;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Cluster leader_metrics test.
@@ -31,11 +32,8 @@ use crate::fixtures::RaftRouter;
 ///   the payload.
 /// - remove one follower: node-4
 /// - asserts node-4 becomes learner and the leader stops sending logs to it.
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn leader_metrics() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let span = tracing::debug_span!("leader_metrics");
     let _ent = span.enter();
 

--- a/openraft/tests/metrics/t40_metrics_wait.rs
+++ b/openraft/tests/metrics/t40_metrics_wait.rs
@@ -7,6 +7,7 @@ use openraft::metrics::WaitError;
 use openraft::Config;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Test wait() utils
@@ -16,11 +17,8 @@ use crate::fixtures::RaftRouter;
 /// - brings 1 nodes online:
 /// - wait for expected state.
 /// - wait for invalid state and expect a timeout error.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn metrics_wait() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/replication_1_voter_to_isolated_learner.rs
+++ b/openraft/tests/replication_1_voter_to_isolated_learner.rs
@@ -6,6 +6,8 @@ use fixtures::RaftRouter;
 use maplit::btreeset;
 use openraft::Config;
 
+use crate::fixtures::init_default_ut_tracing;
+
 #[macro_use]
 mod fixtures;
 
@@ -16,11 +18,8 @@ mod fixtures;
 /// - bring on a cluster of 1 voter and 1 learner.
 /// - isolate replication to node 1.
 /// - client write should not be blocked.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn replication_1_voter_to_isolated_learner() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 

--- a/openraft/tests/shutdown.rs
+++ b/openraft/tests/shutdown.rs
@@ -8,6 +8,8 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
+
 #[macro_use]
 mod fixtures;
 
@@ -18,11 +20,8 @@ mod fixtures;
 /// - this test builds upon the `initialization` test.
 /// - after the cluster has been initialize, it performs a shutdown routine on each node, asserting that the shutdown
 ///   routine succeeded.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn initialization() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/singlenode.rs
+++ b/openraft/tests/singlenode.rs
@@ -9,6 +9,8 @@ use openraft::LeaderId;
 use openraft::LogId;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
+
 #[macro_use]
 mod fixtures;
 
@@ -21,11 +23,8 @@ mod fixtures;
 /// - initializes the cluster with membership config including just the one node.
 /// - asserts that the cluster was able to come online, and that the one node became leader.
 /// - asserts that the leader was able to successfully commit its initial payload.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn single_node() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/snapshot/after_snapshot_add_learner_and_request_a_log.rs
+++ b/openraft/tests/snapshot/after_snapshot_add_learner_and_request_a_log.rs
@@ -8,6 +8,7 @@ use openraft::LeaderId;
 use openraft::LogId;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Test membership info is sync correctly along with snapshot.
@@ -17,11 +18,8 @@ use crate::fixtures::RaftRouter;
 /// - build a stable single node cluster.
 /// - send enough requests to the node that log compaction will be triggered.
 /// - ensure that snapshot overrides the existent membership on the learner.
-#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let snapshot_threshold: u64 = 10;
 
     let config = Arc::new(

--- a/openraft/tests/snapshot/snapshot_chunk_size.rs
+++ b/openraft/tests/snapshot/snapshot_chunk_size.rs
@@ -9,6 +9,7 @@ use openraft::LogId;
 use openraft::SnapshotPolicy;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Test transfer snapshot in small chnuks
@@ -18,11 +19,8 @@ use crate::fixtures::RaftRouter;
 /// - build a stable single node cluster.
 /// - send enough requests to the node that log compaction will be triggered.
 /// - add learner and assert that they receive the snapshot and logs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn snapshot_chunk_size() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let snapshot_threshold: u64 = 10;
 
     let config = Arc::new(

--- a/openraft/tests/snapshot/snapshot_ge_half_threshold.rs
+++ b/openraft/tests/snapshot/snapshot_ge_half_threshold.rs
@@ -7,6 +7,7 @@ use openraft::LeaderId;
 use openraft::LogId;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// A leader should create and send snapshot when snapshot is old and is not that old to trigger a snapshot, i.e.:
@@ -19,11 +20,8 @@ use crate::fixtures::RaftRouter;
 /// - send some other log after snapshot created, to make the `leader.last_log_index - snapshot.applied_index` big
 ///   enough.
 /// - add learner and assert that they receive the snapshot and logs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn snapshot_ge_half_threshold() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let snapshot_threshold: u64 = 10;
     let log_cnt = snapshot_threshold + 6;
 

--- a/openraft/tests/snapshot/snapshot_line_rate_to_snapshot.rs
+++ b/openraft/tests/snapshot/snapshot_line_rate_to_snapshot.rs
@@ -8,6 +8,7 @@ use openraft::LeaderId;
 use openraft::LogId;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Test replication when switching line rate to snapshotting.
@@ -20,11 +21,8 @@ use crate::fixtures::RaftRouter;
 ///   removed.
 /// - restore replication.
 /// - ensure that replication is switched from line-rate mode to snapshotting mode, on absence of logs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn snapshot_line_rate_to_snapshot() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let snapshot_threshold: u64 = 10;
 
     let config = Arc::new(

--- a/openraft/tests/snapshot/snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/snapshot_overrides_membership.rs
@@ -18,6 +18,7 @@ use openraft::SnapshotPolicy;
 use openraft::Vote;
 
 use crate::fixtures::blank;
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Test membership info is sync correctly along with snapshot.
@@ -27,11 +28,8 @@ use crate::fixtures::RaftRouter;
 /// - build a stable single node cluster.
 /// - send enough requests to the node that log compaction will be triggered.
 /// - ensure that snapshot overrides the existent membership on the learner.
-#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn snapshot_overrides_membership() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let snapshot_threshold: u64 = 10;
 
     let config = Arc::new(

--- a/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
@@ -12,6 +12,7 @@ use openraft::RaftLogReader;
 use openraft::RaftStorage;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Test a second compaction should not lose membership.
@@ -26,11 +27,8 @@ use crate::fixtures::RaftRouter;
 /// - send just enough request to trigger another snapshot.
 /// - ensure membership is still valid.
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn snapshot_uses_prev_snap_membership() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     let snapshot_threshold: u64 = 10;
 
     let config = Arc::new(

--- a/openraft/tests/state_machine/t10_total_order_apply.rs
+++ b/openraft/tests/state_machine/t10_total_order_apply.rs
@@ -9,14 +9,12 @@ use openraft::RaftStorage;
 use openraft::State;
 use tokio::sync::watch;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// The logs have to be applied in log index order.
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn total_order_apply() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate().expect("failed to build Raft config"));
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -14,6 +14,7 @@ use openraft::Membership;
 use openraft::RaftStorage;
 use openraft::State;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// All log should be applied to state machine.
@@ -23,11 +24,8 @@ use crate::fixtures::RaftRouter;
 /// - bring a cluster with 3 voter and 2 learner.
 /// - check last_membership in state machine.
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn state_machine_apply_membership() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/state_machine/t40_clean_applied_logs.rs
+++ b/openraft/tests/state_machine/t40_clean_applied_logs.rs
@@ -7,17 +7,15 @@ use openraft::Config;
 use openraft::RaftLogReader;
 use tokio::time::sleep;
 
+use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
 /// Logs should be deleted by raft after applying them, on leader and learner.
 ///
 /// - assert logs are deleted on leader after applying them.
 /// - assert logs are deleted on replication target after installing a snapshot.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn clean_applied_logs() -> Result<()> {
-    let (_log_guard, ut_span) = init_ut!();
-    let _ent = ut_span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(
         Config {


### PR DESCRIPTION

## Changelog

##### Refactor: use crate async-entry to define async test functions
`#[async_entry::test(tracing_span = "debug")]` creates tracing span that
covers the test case body.
The previous way `span.enter()` is an inappropriate usage in an async
function: it does not leave the span when `.await`.

`async_entry::test` transform async test function in the following way:

```
 #[async_entry::test(tracing_span="debug", init="g()", worker_threads=3)]
 async fn foo() {
     assert!(true);
 }

 // Will be expaneded to

 #[test]
 fn foo() {
     let _g = g(); // init a test case

     let body = async {
         assert!(true);
     };

     use tracing_futures::Instrument;
     let body_span = tracing::debug_span!("foo");
     let body = body.instrument(body_span); // install span

     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(3usize)
         .enable_all()
         .build()
         .expect("Failed building the Runtime");
     #[allow(clippy::expect_used)]
     rt.block_on(body);
 }
```

---