### PR TITLE
CI: move example-test and lint out of unit-test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,32 +34,11 @@ jobs:
           RAFT_STORE_DEFENSIVE: ${{ matrix.store_defensive }}
 
 
-      - name: Test example-raft-kv
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path example-raft-kv/Cargo.toml
-
-
       - name: Build | Release Mode
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --all-features
-
-
-      - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-
-      - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings -A clippy::bool-assert-comparison
 
 
       - name: Upload artifact
@@ -68,6 +47,20 @@ jobs:
         with:
           path: |
             openraft/_log/
+
+  test-example:
+    name: test example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1.0.6
+
+      - name: Test example-raft-kv
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path example-raft-kv/Cargo.toml
+
 
   ut-on-stable-rust:
     name: unittest on stable rust
@@ -82,7 +75,6 @@ jobs:
         with:
           toolchain: "stable"
           override: true
-          components: rustfmt, clippy
 
       - name: Unit Tests
         uses: actions-rs/cargo@v1
@@ -93,13 +85,6 @@ jobs:
           RUST_TEST_THREADS: 2
           RUST_LOG: debug
           RUST_BACKTRACE: full
-
-
-      - name: Test example-raft-kv
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path example-raft-kv/Cargo.toml
 
 
       - name: Build | Release Mode | No features
@@ -125,3 +110,42 @@ jobs:
         with:
           path: |
             openraft/_log/
+
+  test-example-on-stable-rust:
+    name: test example on stable rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: "stable"
+          override: true
+
+      - name: Test example-raft-kv
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path example-raft-kv/Cargo.toml
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          components: rustfmt, clippy
+
+      - name: Format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets -- -D warnings -A clippy::bool-assert-comparison


### PR DESCRIPTION

## Changelog

##### CI: move example-test and lint out of unit-test

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/257)
<!-- Reviewable:end -->
