### PR TITLE
Change: use NodeId instead of RaftTypeConfig if a type only needs node-id as type param.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1.0.6
+        with:
+          components: rustfmt, clippy
+
 
       - name: Test example-raft-kv
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --manifest-path example-raft-kv/Cargo.toml
+
+
+      - name: Format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets -- -D warnings -A clippy::bool-assert-comparison
 
 
   ut-on-stable-rust:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ fmt:
 
 lint:
 	cargo fmt
+	cargo fmt --manifest-path example-raft-kv/Cargo.toml
 	cargo clippy --all-targets -- -D warnings -A clippy::bool-assert-comparison
+	cargo clippy --manifest-path example-raft-kv/Cargo.toml --all-targets -- -D warnings -A clippy::bool-assert-comparison
 
 clean:
 	cargo clean

--- a/example-raft-kv/src/store/mod.rs
+++ b/example-raft-kv/src/store/mod.rs
@@ -18,7 +18,6 @@ use openraft::LogId;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftStorage;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StateMachineChanges;
 use openraft::StorageError;

--- a/memstore/src/test.rs
+++ b/memstore/src/test.rs
@@ -1,7 +1,7 @@
 use openraft::testing::Suite;
 use openraft::StorageError;
 
-use crate::Config;
+use crate::MemNodeId;
 use crate::MemStore;
 
 /// To customize a builder:
@@ -26,7 +26,7 @@ use crate::MemStore;
 /// }
 /// ```
 #[test]
-pub fn test_mem_store() -> Result<(), StorageError<Config>> {
+pub fn test_mem_store() -> Result<(), StorageError<MemNodeId>> {
     Suite::test_all(MemStore::new_async)?;
     Ok(())
 }

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -78,7 +78,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         &mut self,
         target: C::NodeId,
         node: Option<Node>,
-    ) -> Result<bool, MissingNodeInfo<C>> {
+    ) -> Result<bool, MissingNodeInfo<C::NodeId>> {
         tracing::debug!(
             "add_learner_into_membership target node {:?} into learner {:?}",
             target,
@@ -174,7 +174,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         blocking: bool,
         turn_to_learner: bool,
         tx: RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C>>,
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         let members = change_members.apply_to(self.core.effective_membership.membership.get_configs().last().unwrap());
         // Ensure cluster will have at least one node.
         if members.is_empty() {
@@ -268,9 +268,9 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=display(self.core.id)))]
     pub async fn append_membership_log(
         &mut self,
-        mem: Membership<C>,
+        mem: Membership<C::NodeId>,
         resp_tx: Option<RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C>>>,
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         let payload = EntryPayload::Membership(mem.clone());
         let entry = self.core.append_payload_to_log(payload).await?;
 

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -180,7 +180,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         &mut self,
         req: InstallSnapshotRequest<C>,
         mut snapshot: Box<S::SnapshotData>,
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         snapshot.as_mut().shutdown().await.map_err(|e| StorageError::IO {
             source: StorageIOError::new(
                 ErrorSubject::Snapshot(req.meta.clone()),

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -96,7 +96,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Candida
         &mut self,
         res: VoteResponse<C>,
         target: C::NodeId,
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         tracing::debug!(res=?res, target=display(target), "recv vote response");
 
         // If peer's vote is greater than current vote, revert to follower state.

--- a/openraft/src/defensive.rs
+++ b/openraft/src/defensive.rs
@@ -9,6 +9,7 @@ use crate::raft_types::LogIdOptionExt;
 use crate::DefensiveError;
 use crate::ErrorSubject;
 use crate::LogId;
+use crate::NodeId;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -18,7 +19,7 @@ use crate::Wrapper;
 
 /// Defines methods of defensive checks for RaftStorage independent of the storage type.
 // TODO This can be extended by other methods, as needed. Currently only moved the one for LogReader
-pub trait DefensiveCheckBase<C: RaftTypeConfig> {
+pub trait DefensiveCheckBase<NID: NodeId> {
     /// Enable or disable defensive check when calling storage APIs.
     fn set_defensive(&self, v: bool);
 
@@ -28,7 +29,7 @@ pub trait DefensiveCheckBase<C: RaftTypeConfig> {
     fn defensive_nonempty_range<RB: RangeBounds<u64> + Clone + Debug + Send>(
         &self,
         range: RB,
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<NID>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -58,7 +59,7 @@ pub trait DefensiveCheckBase<C: RaftTypeConfig> {
 
 /// Defines methods of defensive checks for RaftStorage.
 #[async_trait]
-pub trait DefensiveCheck<C, T>: DefensiveCheckBase<C>
+pub trait DefensiveCheck<C, T>: DefensiveCheckBase<C::NodeId>
 where
     C: RaftTypeConfig,
     T: RaftStorage<C>,
@@ -66,7 +67,7 @@ where
 {
     /// Ensure that logs that have greater index than last_applied should have greater log_id.
     /// Invariant must hold: `log.log_id.index > last_applied.index` implies `log.log_id > last_applied`.
-    async fn defensive_no_dirty_log(&mut self) -> Result<(), StorageError<C>> {
+    async fn defensive_no_dirty_log(&mut self) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -89,7 +90,7 @@ where
 
     /// Ensure that current_term must increment for every update, and for every term there could be only one value for
     /// voted_for.
-    async fn defensive_incremental_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>> {
+    async fn defensive_incremental_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -114,7 +115,7 @@ where
     }
 
     /// The log entries fed into a store must be consecutive otherwise it is a bug.
-    async fn defensive_consecutive_input(&self, entries: &[&Entry<C>]) -> Result<(), StorageError<C>> {
+    async fn defensive_consecutive_input(&self, entries: &[&Entry<C>]) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -143,7 +144,7 @@ where
     /// Trying to feed in emtpy entries slice is an inappropriate action.
     ///
     /// The impl has to avoid this otherwise it may be a bug.
-    async fn defensive_nonempty_input(&self, entries: &[&Entry<C>]) -> Result<(), StorageError<C>> {
+    async fn defensive_nonempty_input(&self, entries: &[&Entry<C>]) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -159,7 +160,7 @@ where
     async fn defensive_append_log_index_is_last_plus_one(
         &mut self,
         entries: &[&Entry<C>],
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -181,7 +182,7 @@ where
     }
 
     /// The entries to append has to be greater than any known log ids
-    async fn defensive_append_log_id_gt_last(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C>> {
+    async fn defensive_append_log_id_gt_last(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -204,7 +205,10 @@ where
         Ok(())
     }
 
-    async fn defensive_purge_applied_le_last_applied(&mut self, upto: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
+    async fn defensive_purge_applied_le_last_applied(
+        &mut self,
+        upto: LogId<C::NodeId>,
+    ) -> Result<(), StorageError<C::NodeId>> {
         let (last_applied, _) = self.inner().last_applied_state().await?;
         if Some(upto.index) > last_applied.index() {
             return Err(
@@ -221,7 +225,7 @@ where
     async fn defensive_delete_conflict_gt_last_applied(
         &mut self,
         since: LogId<C::NodeId>,
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         let (last_applied, _) = self.inner().last_applied_state().await?;
         if Some(since.index) <= last_applied.index() {
             return Err(
@@ -239,7 +243,7 @@ where
     async fn defensive_apply_index_is_last_applied_plus_one(
         &mut self,
         entries: &[&Entry<C>],
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -265,7 +269,7 @@ where
     async fn defensive_half_open_range<RB: RangeBounds<u64> + Clone + Debug + Send>(
         &self,
         range: RB,
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -290,7 +294,7 @@ where
         &self,
         range: RB,
         logs: &[Entry<C>],
-    ) -> Result<(), StorageError<C>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -300,7 +304,7 @@ where
     }
 
     /// The log id of the entries to apply has to be greater than the last known one.
-    async fn defensive_apply_log_id_gt_last(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C>> {
+    async fn defensive_apply_log_id_gt_last(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -326,7 +330,7 @@ where
 pub fn check_range_matches_entries<C: RaftTypeConfig, RB: RangeBounds<u64> + Debug + Send>(
     range: RB,
     entries: &[Entry<C>],
-) -> Result<(), StorageError<C>> {
+) -> Result<(), StorageError<C::NodeId>> {
     let want_first = match range.start_bound() {
         Bound::Included(i) => Some(*i),
         Bound::Excluded(i) => Some(*i + 1),

--- a/openraft/src/defensive.rs
+++ b/openraft/src/defensive.rs
@@ -9,7 +9,6 @@ use crate::raft_types::LogIdOptionExt;
 use crate::DefensiveError;
 use crate::ErrorSubject;
 use crate::LogId;
-use crate::NodeId;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -19,7 +18,7 @@ use crate::Wrapper;
 
 /// Defines methods of defensive checks for RaftStorage independent of the storage type.
 // TODO This can be extended by other methods, as needed. Currently only moved the one for LogReader
-pub trait DefensiveCheckBase<NID: NodeId> {
+pub trait DefensiveCheckBase<C: RaftTypeConfig> {
     /// Enable or disable defensive check when calling storage APIs.
     fn set_defensive(&self, v: bool);
 
@@ -29,7 +28,7 @@ pub trait DefensiveCheckBase<NID: NodeId> {
     fn defensive_nonempty_range<RB: RangeBounds<u64> + Clone + Debug + Send>(
         &self,
         range: RB,
-    ) -> Result<(), StorageError<NID>> {
+    ) -> Result<(), StorageError<C::NodeId>> {
         if !self.is_defensive() {
             return Ok(());
         }
@@ -59,7 +58,7 @@ pub trait DefensiveCheckBase<NID: NodeId> {
 
 /// Defines methods of defensive checks for RaftStorage.
 #[async_trait]
-pub trait DefensiveCheck<C, T>: DefensiveCheckBase<C::NodeId>
+pub trait DefensiveCheck<C, T>: DefensiveCheckBase<C>
 where
     C: RaftTypeConfig,
     T: RaftStorage<C>,

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -20,13 +20,13 @@ fn test_membership_summary() -> anyhow::Result<()> {
         })
     };
 
-    let m = Membership::<Config>::new(vec![btreeset! {1,2}, btreeset! {3}], None);
+    let m = Membership::<u64>::new(vec![btreeset! {1,2}, btreeset! {3}], None);
     assert_eq!("members:[{1,2},{3}],learners:[]", m.summary());
 
-    let m = Membership::<Config>::new(vec![btreeset! {1,2}, btreeset! {3}], Some(btreeset! {4}));
+    let m = Membership::<u64>::new(vec![btreeset! {1,2}, btreeset! {3}], Some(btreeset! {4}));
     assert_eq!("members:[{1,2},{3}],learners:[4]", m.summary());
 
-    let m = Membership::<Config>::with_nodes(vec![btreeset! {1,2}, btreeset! {3}], btreemap! {
+    let m = Membership::<u64>::with_nodes(vec![btreeset! {1,2}, btreeset! {3}], btreemap! {
         1=>node("127.0.0.1", "k1"),
         2=>node("127.0.0.2", "k2"),
         3=>node("127.0.0.3", "k3"),
@@ -43,9 +43,9 @@ fn test_membership_summary() -> anyhow::Result<()> {
 
 #[test]
 fn test_membership() -> anyhow::Result<()> {
-    let m1 = Membership::<Config>::new(vec![btreeset! {1}], None);
-    let m123 = Membership::<Config>::new(vec![btreeset! {1,2,3}], None);
-    let m123_345 = Membership::<Config>::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None);
+    let m1 = Membership::<u64>::new(vec![btreeset! {1}], None);
+    let m123 = Membership::<u64>::new(vec![btreeset! {1,2,3}], None);
+    let m123_345 = Membership::<u64>::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None);
 
     assert_eq!(Some(btreeset! {1}), m1.get_configs().get(0).cloned());
     assert_eq!(Some(btreeset! {1,2,3}), m123.get_configs().get(0).cloned());
@@ -74,7 +74,7 @@ fn test_membership() -> anyhow::Result<()> {
 fn test_membership_with_learners() -> anyhow::Result<()> {
     // test multi membership with learners
     {
-        let m1_2 = Membership::<Config>::new(vec![btreeset! {1}], Some(btreeset! {2}));
+        let m1_2 = Membership::<u64>::new(vec![btreeset! {1}], Some(btreeset! {2}));
         let m1_23 = m1_2.add_learner(3, None)?;
 
         // test learner and membership
@@ -101,7 +101,7 @@ fn test_membership_with_learners() -> anyhow::Result<()> {
 
     // overlapping members and learners
     {
-        let s1_2 = Membership::<Config>::new(vec![btreeset! {1,2,3}, btreeset! {5,6,7}], Some(btreeset! {3,4,5}));
+        let s1_2 = Membership::<u64>::new(vec![btreeset! {1,2,3}, btreeset! {5,6,7}], Some(btreeset! {3,4,5}));
         let x = s1_2.learner_ids().cloned().collect();
         assert_eq!(btreeset! {4}, x);
     }
@@ -116,7 +116,7 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
         data: Default::default(),
     };
 
-    let m_1_2 = Membership::<Config>::with_nodes(
+    let m_1_2 = Membership::<u64>::with_nodes(
         vec![btreeset! {1}, btreeset! {2}],
         btreemap! {1=>Some(node("1")), 2=>Some(node("2"))},
     )?;
@@ -130,7 +130,7 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
 
     let m_1_2_3 = m_1_2.add_learner(3, Some(node("3")))?;
     assert_eq!(
-        Membership::<Config>::with_nodes(
+        Membership::<u64>::with_nodes(
             vec![btreeset! {1}, btreeset! {2}],
             btreemap! {1=>Some(node("1")), 2=>Some(node("2")), 3=>Some(node("3"))}
         )?,
@@ -151,7 +151,7 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
 
     // Illegal to add node id with node info into cluster without node info.
     {
-        let m_1_2 = Membership::<Config>::new(vec![btreeset! {1}, btreeset! {2}], None);
+        let m_1_2 = Membership::<u64>::new(vec![btreeset! {1}, btreeset! {2}], None);
 
         let res = m_1_2.add_learner(3, Some(node("3")));
         assert_eq!(
@@ -173,7 +173,7 @@ fn test_membership_extend_nodes() -> anyhow::Result<()> {
         data: Default::default(),
     };
 
-    let ext = |a, b| Membership::<Config>::extend_nodes(a, &b);
+    let ext = |a, b| Membership::<u64>::extend_nodes(a, &b);
 
     assert_eq!(
         btreemap! {1=>None},
@@ -206,7 +206,7 @@ fn test_membership_extend_nodes() -> anyhow::Result<()> {
 #[test]
 fn test_membership_with_nodes() -> anyhow::Result<()> {
     let node = || Some(Node::default());
-    let m = |nodes| Membership::<Config>::with_nodes(vec![btreeset! {1}, btreeset! {2}], nodes);
+    let m = |nodes| Membership::<u64>::with_nodes(vec![btreeset! {1}, btreeset! {2}], nodes);
 
     let ns_12 = || btreemap! {1=>node(), 2=>node()};
     let ns_123 = || btreemap! {1=>node(), 2=>node(), 3=>node()};
@@ -248,7 +248,7 @@ fn test_membership_with_nodes() -> anyhow::Result<()> {
 #[test]
 fn test_membership_majority() -> anyhow::Result<()> {
     {
-        let m12345 = Membership::<Config>::new(vec![btreeset! {1,2,3,4,5}], None);
+        let m12345 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5}], None);
         assert!(!m12345.is_majority(&btreeset! {0}));
         assert!(!m12345.is_majority(&btreeset! {0,1,2}));
         assert!(!m12345.is_majority(&btreeset! {6,7,8}));
@@ -258,7 +258,7 @@ fn test_membership_majority() -> anyhow::Result<()> {
     }
 
     {
-        let m12345_678 = Membership::<Config>::new(vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}], None);
+        let m12345_678 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}], None);
         assert!(!m12345_678.is_majority(&btreeset! {0}));
         assert!(!m12345_678.is_majority(&btreeset! {0,1,2}));
         assert!(!m12345_678.is_majority(&btreeset! {6,7,8}));
@@ -273,7 +273,7 @@ fn test_membership_majority() -> anyhow::Result<()> {
 #[test]
 fn test_membership_greatest_majority_value() -> anyhow::Result<()> {
     {
-        let m123 = Membership::<Config>::new(vec![btreeset! {1,2,3}], None);
+        let m123 = Membership::<u64>::new(vec![btreeset! {1,2,3}], None);
         assert_eq!(
             None,
             m123.greatest_majority_value(&BTreeMap::<<Config as RaftTypeConfig>::NodeId, u64>::new())
@@ -288,7 +288,7 @@ fn test_membership_greatest_majority_value() -> anyhow::Result<()> {
     }
 
     {
-        let m123_678 = Membership::<Config>::new(vec![btreeset! {1,2,3}, btreeset! {6,7,8}], None);
+        let m123_678 = Membership::<u64>::new(vec![btreeset! {1,2,3}, btreeset! {6,7,8}], None);
         assert_eq!(None, m123_678.greatest_majority_value(&btreemap! {0=>10}));
         assert_eq!(None, m123_678.greatest_majority_value(&btreemap! {0=>10,1=>10}));
         assert_eq!(None, m123_678.greatest_majority_value(&btreemap! {0=>10,1=>10,2=>20}));
@@ -315,10 +315,10 @@ fn test_membership_is_safe_to() -> anyhow::Result<()> {
     let set345 = || btreeset! {3,4,5};
     let set789 = || btreeset! {7,8,9};
 
-    let m123 = Membership::<Config>::new(vec![set123()], None);
-    let m345 = Membership::<Config>::new(vec![set345()], None);
-    let m123_345 = Membership::<Config>::new(vec![set123(), set345()], None);
-    let m345_789 = Membership::<Config>::new(vec![set345(), set789()], None);
+    let m123 = Membership::<u64>::new(vec![set123()], None);
+    let m345 = Membership::<u64>::new(vec![set345()], None);
+    let m123_345 = Membership::<u64>::new(vec![set123(), set345()], None);
+    let m345_789 = Membership::<u64>::new(vec![set345(), set789()], None);
 
     assert!(m123.is_safe_to(&m123));
     assert!(!m123.is_safe_to(&m345));
@@ -349,10 +349,10 @@ fn test_membership_next_safe() -> anyhow::Result<()> {
     let c2 = || btreeset! {3,4,5};
     let c3 = || btreeset! {7,8,9};
 
-    let m1 = Membership::<Config>::new(vec![c1()], None);
-    let m2 = Membership::<Config>::new(vec![c2()], None);
-    let m12 = Membership::<Config>::new(vec![c1(), c2()], None);
-    let m23 = Membership::<Config>::new(vec![c2(), c3()], None);
+    let m1 = Membership::<u64>::new(vec![c1()], None);
+    let m2 = Membership::<u64>::new(vec![c2()], None);
+    let m12 = Membership::<u64>::new(vec![c1(), c2()], None);
+    let m23 = Membership::<u64>::new(vec![c2(), c3()], None);
 
     assert_eq!(m1, m1.next_safe(c1(), false)?);
     assert_eq!(m12, m1.next_safe(c2(), false)?);
@@ -364,8 +364,8 @@ fn test_membership_next_safe() -> anyhow::Result<()> {
 
     let old_learners = || btreeset! {1, 2};
     let learners = || btreeset! {1, 2, 3, 4, 5};
-    let m23_with_learners_old = Membership::<Config>::new(vec![c2(), c3()], Some(old_learners()));
-    let m23_with_learners_new = Membership::<Config>::new(vec![c3()], Some(learners()));
+    let m23_with_learners_old = Membership::<u64>::new(vec![c2(), c3()], Some(old_learners()));
+    let m23_with_learners_new = Membership::<u64>::new(vec![c3()], Some(learners()));
     assert_eq!(m23_with_learners_new, m23_with_learners_old.next_safe(c3(), true)?);
 
     Ok(())
@@ -383,7 +383,7 @@ fn test_membership_next_safe_with_nodes() -> anyhow::Result<()> {
 
     // change from a Membership without nodes
     {
-        let without_nodes = Membership::<Config>::new(vec![c1(), c2()], None);
+        let without_nodes = Membership::<u64>::new(vec![c1(), c2()], None);
 
         // next_safe() can not change node info type from None to Some
 
@@ -410,7 +410,7 @@ fn test_membership_next_safe_with_nodes() -> anyhow::Result<()> {
     // change from a Membership with nodes
     {
         let with_node_infos =
-            Membership::<Config>::with_nodes(vec![c1(), c2()], btreemap! {1=>Some(node("1")), 2=>Some(node("2"))})?;
+            Membership::<u64>::with_nodes(vec![c1(), c2()], btreemap! {1=>Some(node("1")), 2=>Some(node("2"))})?;
 
         // joint [{2}, {1,2}]
 

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -31,7 +31,7 @@ use crate::RaftTypeConfig;
 /// A set of metrics describing the current state of a Raft node.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RaftMetrics<C: RaftTypeConfig> {
-    pub running_state: Result<(), Fatal<C>>,
+    pub running_state: Result<(), Fatal<C::NodeId>>,
 
     /// The ID of the Raft node.
     pub id: C::NodeId,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -113,7 +113,7 @@ impl<C: RaftTypeConfig> ReplicationStream<C> {
     pub(crate) fn new<N: RaftNetworkFactory<C>, S: RaftStorage<C>>(
         target: C::NodeId,
         target_node: Option<Node>,
-        vote: Vote<C>,
+        vote: Vote<C::NodeId>,
         config: Arc<Config>,
         last_log: Option<LogId<C::NodeId>>,
         committed: Option<LogId<C::NodeId>>,
@@ -145,7 +145,7 @@ struct ReplicationCore<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStora
     target: C::NodeId,
 
     /// The vote of the leader.
-    vote: Vote<C>,
+    vote: Vote<C::NodeId>,
 
     /// A channel for sending events to the Raft node.
     raft_core_tx: mpsc::UnboundedSender<(ReplicaEvent<C, S::SnapshotData>, Span)>,
@@ -198,7 +198,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
     pub(self) fn spawn(
         target: C::NodeId,
         target_node: Option<Node>,
-        vote: Vote<C>,
+        vote: Vote<C::NodeId>,
         config: Arc<Config>,
         last_log: Option<LogId<C::NodeId>>,
         committed: Option<LogId<C::NodeId>>,
@@ -655,7 +655,7 @@ where
         target: C::NodeId,
 
         /// The new vote observed.
-        vote: Vote<C>,
+        vote: Vote<C::NodeId>,
     },
     /// An event from a replication stream requesting snapshot info.
     NeedsSnapshot {

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -6,22 +6,22 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::LogId;
-use crate::RaftTypeConfig;
+use crate::NodeId;
 use crate::SnapshotMeta;
 use crate::Vote;
 
 /// Convert error to StorageError::IO();
-pub trait ToStorageResult<C: RaftTypeConfig, T> {
+pub trait ToStorageResult<NID: NodeId, T> {
     /// Convert Result<T, E> to Result<T, StorageError::IO(StorageIOError)>
     ///
     /// `f` provides error context for building the StorageIOError.
-    fn sto_res<F>(self, f: F) -> Result<T, StorageError<C>>
-    where F: FnOnce() -> (ErrorSubject<C>, ErrorVerb);
+    fn sto_res<F>(self, f: F) -> Result<T, StorageError<NID>>
+    where F: FnOnce() -> (ErrorSubject<NID>, ErrorVerb);
 }
 
-impl<C: RaftTypeConfig, T> ToStorageResult<C, T> for Result<T, std::io::Error> {
-    fn sto_res<F>(self, f: F) -> Result<T, StorageError<C>>
-    where F: FnOnce() -> (ErrorSubject<C>, ErrorVerb) {
+impl<NID: NodeId, T> ToStorageResult<NID, T> for Result<T, std::io::Error> {
+    fn sto_res<F>(self, f: F) -> Result<T, StorageError<NID>>
+    where F: FnOnce() -> (ErrorSubject<NID>, ErrorVerb) {
         match self {
             Ok(x) => Ok(x),
             Err(e) => {
@@ -37,18 +37,18 @@ impl<C: RaftTypeConfig, T> ToStorageResult<C, T> for Result<T, std::io::Error> {
 /// E.g. re-applying an log entry is a violation that may be a potential bug.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct DefensiveError<C: RaftTypeConfig> {
+pub struct DefensiveError<NID: NodeId> {
     /// The subject that violates store defensive check, e.g. hard-state, log or state machine.
-    pub subject: ErrorSubject<C>,
+    pub subject: ErrorSubject<NID>,
 
     /// The description of the violation.
-    pub violation: Violation<C>,
+    pub violation: Violation<NID>,
 
     pub backtrace: Option<String>,
 }
 
-impl<C: RaftTypeConfig> DefensiveError<C> {
-    pub fn new(subject: ErrorSubject<C>, violation: Violation<C>) -> Self {
+impl<NID: NodeId> DefensiveError<NID> {
+    pub fn new(subject: ErrorSubject<NID>, violation: Violation<NID>) -> Self {
         Self {
             subject,
             violation,
@@ -57,7 +57,7 @@ impl<C: RaftTypeConfig> DefensiveError<C> {
     }
 }
 
-impl<C: RaftTypeConfig> std::fmt::Display for DefensiveError<C> {
+impl<NID: NodeId> std::fmt::Display for DefensiveError<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "'{:?}' violates: '{}'", self.subject, self.violation)
     }
@@ -65,7 +65,7 @@ impl<C: RaftTypeConfig> std::fmt::Display for DefensiveError<C> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub enum ErrorSubject<C: RaftTypeConfig> {
+pub enum ErrorSubject<NID: NodeId> {
     /// A general storage error
     Store,
 
@@ -76,19 +76,19 @@ pub enum ErrorSubject<C: RaftTypeConfig> {
     Logs,
 
     /// Error about a single log entry
-    Log(LogId<C::NodeId>),
+    Log(LogId<NID>),
 
     /// Error about a single log entry without knowing the log term.
     LogIndex(u64),
 
     /// Error happened when applying a log entry
-    Apply(LogId<C::NodeId>),
+    Apply(LogId<NID>),
 
     /// Error happened when operating state machine.
     StateMachine,
 
     /// Error happened when operating snapshot.
-    Snapshot(SnapshotMeta<C>),
+    Snapshot(SnapshotMeta<NID>),
 
     None,
 }
@@ -105,17 +105,17 @@ pub enum ErrorVerb {
 /// Violations a store would return when running defensive check.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub enum Violation<C: RaftTypeConfig> {
+pub enum Violation<NID: NodeId> {
     #[error("term can only be change to a greater value, current: {curr}, change to {to}")]
     TermNotAscending { curr: u64, to: u64 },
 
     #[error("voted_for can not change from Some() to other Some(), current: {curr:?}, change to {to:?}")]
-    NonIncrementalVote { curr: Vote<C>, to: Vote<C> },
+    NonIncrementalVote { curr: Vote<NID>, to: Vote<NID> },
 
     #[error("log at higher index is obsolete: {higher_index_log_id:?} should GT {lower_index_log_id:?}")]
     DirtyLog {
-        higher_index_log_id: LogId<C::NodeId>,
-        lower_index_log_id: LogId<C::NodeId>,
+        higher_index_log_id: LogId<NID>,
+        lower_index_log_id: LogId<NID>,
     },
 
     #[error("try to get log at index {want} but got {got:?}")]
@@ -135,40 +135,34 @@ pub enum Violation<C: RaftTypeConfig> {
     StoreLogsEmpty,
 
     #[error("logs are not consecutive, prev: {prev:?}, next: {next}")]
-    LogsNonConsecutive {
-        prev: Option<LogId<C::NodeId>>,
-        next: LogId<C::NodeId>,
-    },
+    LogsNonConsecutive { prev: Option<LogId<NID>>, next: LogId<NID> },
 
     #[error("invalid next log to apply: prev: {prev:?}, next: {next}")]
-    ApplyNonConsecutive {
-        prev: Option<LogId<C::NodeId>>,
-        next: LogId<C::NodeId>,
-    },
+    ApplyNonConsecutive { prev: Option<LogId<NID>>, next: LogId<NID> },
 
     #[error("applied log can not conflict, last_applied: {last_applied:?}, delete since: {first_conflict_log_id}")]
     AppliedWontConflict {
-        last_applied: Option<LogId<C::NodeId>>,
-        first_conflict_log_id: LogId<C::NodeId>,
+        last_applied: Option<LogId<NID>>,
+        first_conflict_log_id: LogId<NID>,
     },
 
     #[error("not allowed to purge non-applied logs, last_applied: {last_applied:?}, purge upto: {purge_upto}")]
     PurgeNonApplied {
-        last_applied: Option<LogId<C::NodeId>>,
-        purge_upto: LogId<C::NodeId>,
+        last_applied: Option<LogId<NID>>,
+        purge_upto: LogId<NID>,
     },
 }
 
 /// A storage error could be either a defensive check error or an error occurred when doing the actual io operation.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub enum StorageError<C: RaftTypeConfig> {
+pub enum StorageError<NID: NodeId> {
     /// An error raised by defensive check.
     #[error(transparent)]
     Defensive {
         #[from]
         #[cfg_attr(feature = "bt", backtrace)]
-        source: DefensiveError<C>,
+        source: DefensiveError<NID>,
     },
 
     /// An error raised by io operation.
@@ -176,26 +170,26 @@ pub enum StorageError<C: RaftTypeConfig> {
     IO {
         #[from]
         #[cfg_attr(feature = "bt", backtrace)]
-        source: StorageIOError<C>,
+        source: StorageIOError<NID>,
     },
 }
 
-impl<C: RaftTypeConfig> StorageError<C> {
-    pub fn into_defensive(self) -> Option<DefensiveError<C>> {
+impl<NID: NodeId> StorageError<NID> {
+    pub fn into_defensive(self) -> Option<DefensiveError<NID>> {
         match self {
             StorageError::Defensive { source } => Some(source),
             _ => None,
         }
     }
 
-    pub fn into_io(self) -> Option<StorageIOError<C>> {
+    pub fn into_io(self) -> Option<StorageIOError<NID>> {
         match self {
             StorageError::IO { source } => Some(source),
             _ => None,
         }
     }
 
-    pub fn from_io_error(subject: ErrorSubject<C>, verb: ErrorVerb, io_error: std::io::Error) -> Self {
+    pub fn from_io_error(subject: ErrorSubject<NID>, verb: ErrorVerb, io_error: std::io::Error) -> Self {
         let sto_io_err = StorageIOError::new(subject, verb, AnyError::new(&io_error));
         StorageError::IO { source: sto_io_err }
     }
@@ -204,21 +198,21 @@ impl<C: RaftTypeConfig> StorageError<C> {
 /// Error that occurs when operating the store.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct StorageIOError<C: RaftTypeConfig> {
-    subject: ErrorSubject<C>,
+pub struct StorageIOError<NID: NodeId> {
+    subject: ErrorSubject<NID>,
     verb: ErrorVerb,
     source: AnyError,
     backtrace: Option<String>,
 }
 
-impl<C: RaftTypeConfig> std::fmt::Display for StorageIOError<C> {
+impl<NID: NodeId> std::fmt::Display for StorageIOError<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "when {:?} {:?}: {}", self.verb, self.subject, self.source)
     }
 }
 
-impl<C: RaftTypeConfig> StorageIOError<C> {
-    pub fn new(subject: ErrorSubject<C>, verb: ErrorVerb, source: AnyError) -> Self {
+impl<NID: NodeId> StorageIOError<NID> {
+    pub fn new(subject: ErrorSubject<NID>, verb: ErrorVerb, source: AnyError) -> Self {
         Self {
             subject,
             verb,

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -66,7 +66,7 @@ where
     }
 }
 
-impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C> for StoreExt<C, T>
+impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C::NodeId> for StoreExt<C, T>
 where
     C: RaftTypeConfig,
     T: RaftStorage<C>,
@@ -111,37 +111,37 @@ where
     type SnapshotBuilder = SnapshotBuilderExt<C, T>;
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>> {
+    async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
         self.defensive_incremental_vote(vote).await?;
         self.inner().save_vote(vote).await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>> {
         self.inner().read_vote().await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C::NodeId>>, Option<EffectiveMembership<C>>), StorageError<C>> {
+    ) -> Result<(Option<LogId<C::NodeId>>, Option<EffectiveMembership<C>>), StorageError<C::NodeId>> {
         self.inner().last_applied_state().await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn delete_conflict_logs_since(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
+    async fn delete_conflict_logs_since(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
         self.defensive_delete_conflict_gt_last_applied(log_id).await?;
         self.inner().delete_conflict_logs_since(log_id).await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn purge_logs_upto(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
+    async fn purge_logs_upto(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
         self.defensive_purge_applied_le_last_applied(log_id).await?;
         self.inner().purge_logs_upto(log_id).await
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries), fields(entries=%entries.summary()))]
-    async fn append_to_log(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C>> {
+    async fn append_to_log(&mut self, entries: &[&Entry<C>]) -> Result<(), StorageError<C::NodeId>> {
         self.defensive_nonempty_input(entries).await?;
         self.defensive_consecutive_input(entries).await?;
         self.defensive_append_log_index_is_last_plus_one(entries).await?;
@@ -151,7 +151,7 @@ where
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries), fields(entries=%entries.summary()))]
-    async fn apply_to_state_machine(&mut self, entries: &[&Entry<C>]) -> Result<Vec<C::R>, StorageError<C>> {
+    async fn apply_to_state_machine(&mut self, entries: &[&Entry<C>]) -> Result<Vec<C::R>, StorageError<C::NodeId>> {
         self.defensive_nonempty_input(entries).await?;
         self.defensive_apply_index_is_last_applied_plus_one(entries).await?;
         self.defensive_apply_log_id_gt_last(entries).await?;
@@ -160,21 +160,23 @@ where
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError<C>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError<C::NodeId>> {
         self.inner().begin_receiving_snapshot().await
     }
 
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<C>,
+        meta: &SnapshotMeta<C::NodeId>,
         snapshot: Box<Self::SnapshotData>,
-    ) -> Result<StateMachineChanges<C>, StorageError<C>> {
+    ) -> Result<StateMachineChanges<C>, StorageError<C::NodeId>> {
         self.inner().install_snapshot(meta, snapshot).await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<C, Self::SnapshotData>>, StorageError<C>> {
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<C, Self::SnapshotData>>, StorageError<C::NodeId>> {
         self.inner().get_current_snapshot().await
     }
 
@@ -198,12 +200,12 @@ impl<C: RaftTypeConfig, T: RaftStorage<C>> RaftLogReader<C> for StoreExt<C, T> {
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<Entry<C>>, StorageError<C>> {
+    ) -> Result<Vec<Entry<C>>, StorageError<C::NodeId>> {
         self.defensive_nonempty_range(range.clone())?;
         self.inner().try_get_log_entries(range).await
     }
 
-    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>> {
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>> {
         self.defensive_no_dirty_log().await?;
         self.inner().get_log_state().await
     }
@@ -219,7 +221,7 @@ pub struct SnapshotBuilderExt<C: RaftTypeConfig, T: RaftStorage<C>> {
 #[async_trait]
 impl<C: RaftTypeConfig, T: RaftStorage<C>> RaftSnapshotBuilder<C, T::SnapshotData> for SnapshotBuilderExt<C, T> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C, T::SnapshotData>, StorageError<C>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C, T::SnapshotData>, StorageError<C::NodeId>> {
         self.inner.build_snapshot().await
     }
 }
@@ -238,12 +240,12 @@ impl<C: RaftTypeConfig, T: RaftStorage<C>> RaftLogReader<C> for LogReaderExt<C, 
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<Entry<C>>, StorageError<C>> {
+    ) -> Result<Vec<Entry<C>>, StorageError<C::NodeId>> {
         self.defensive_nonempty_range(range.clone())?;
         self.inner.try_get_log_entries(range).await
     }
 
-    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>> {
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>> {
         // TODO self.defensive_no_dirty_log().await?;
         // Log state via LogReader is requested exactly at one place in the replication loop.
         // Find a way how to either remove it there or assert here properly.
@@ -251,7 +253,7 @@ impl<C: RaftTypeConfig, T: RaftStorage<C>> RaftLogReader<C> for LogReaderExt<C, 
     }
 }
 
-impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C> for LogReaderExt<C, T>
+impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C::NodeId> for LogReaderExt<C, T>
 where
     C: RaftTypeConfig,
     T: RaftStorage<C>,

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -66,7 +66,7 @@ where
     }
 }
 
-impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C::NodeId> for StoreExt<C, T>
+impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C> for StoreExt<C, T>
 where
     C: RaftTypeConfig,
     T: RaftStorage<C>,
@@ -253,7 +253,7 @@ impl<C: RaftTypeConfig, T: RaftStorage<C>> RaftLogReader<C> for LogReaderExt<C, 
     }
 }
 
-impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C::NodeId> for LogReaderExt<C, T>
+impl<C: RaftTypeConfig, T: RaftStorage<C>> DefensiveCheckBase<C> for LogReaderExt<C, T>
 where
     C: RaftTypeConfig,
     T: RaftStorage<C>,

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -19,6 +19,7 @@ use crate::ErrorSubject;
 use crate::LeaderId;
 use crate::LogId;
 use crate::Membership;
+use crate::NodeId;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -62,7 +63,7 @@ where
     S: RaftStorage<C>,
     B: StoreBuilder<C, S>,
 {
-    pub fn test_all(builder: B) -> Result<(), StorageError<C>> {
+    pub fn test_all(builder: B) -> Result<(), StorageError<C::NodeId>> {
         Suite::test_store(&builder)?;
 
         let df_builder = DefensiveStoreBuilder::<C, S, B> {
@@ -76,7 +77,7 @@ where
         Ok(())
     }
 
-    pub fn test_store(builder: &B) -> Result<(), StorageError<C>> {
+    pub fn test_store(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         run_fut(Suite::last_membership_in_log_initial(builder))?;
         run_fut(Suite::last_membership_in_log(builder))?;
         run_fut(Suite::get_membership_initial(builder))?;
@@ -104,7 +105,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log_initial(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn last_membership_in_log_initial(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let membership = store.last_membership_in_log(0).await?;
@@ -114,7 +115,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn last_membership_in_log(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         tracing::info!("--- no log, do not read membership from state machine");
@@ -188,7 +189,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_initial(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_membership_initial(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let membership = store.get_membership().await?;
@@ -198,7 +199,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_log_and_sm(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_membership_from_log_and_sm(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         tracing::info!("--- no log, read membership from state machine");
@@ -257,7 +258,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_without_init(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_initial_state_without_init(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let initial = store.get_initial_state().await?;
@@ -265,7 +266,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_with_state(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_initial_state_with_state(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::default_vote(&mut store).await?;
 
@@ -307,7 +308,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_membership_from_log_and_sm(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_initial_state_membership_from_log_and_sm(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         // It should never return membership from logs that are included in state machine present.
 
         let mut store = builder.build().await;
@@ -375,7 +376,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_gt_sm(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_initial_state_last_log_gt_sm(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::default_vote(&mut store).await?;
 
@@ -409,7 +410,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_lt_sm(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_initial_state_last_log_lt_sm(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::default_vote(&mut store).await?;
 
@@ -427,7 +428,7 @@ where
         Ok(())
     }
 
-    pub async fn save_vote(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn save_vote(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         store
@@ -451,7 +452,7 @@ where
         Ok(())
     }
 
-    pub async fn get_log_entries(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_log_entries(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::feed_10_logs_vote_self(&mut store).await?;
 
@@ -473,7 +474,7 @@ where
         Ok(())
     }
 
-    pub async fn try_get_log_entry(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn try_get_log_entry(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::feed_10_logs_vote_self(&mut store).await?;
 
@@ -494,7 +495,7 @@ where
         Ok(())
     }
 
-    pub async fn initial_logs(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn initial_logs(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let ent = store.try_get_log_entry(0).await?;
@@ -503,7 +504,7 @@ where
         Ok(())
     }
 
-    pub async fn get_log_state(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_log_state(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let st = store.get_log_state().await?;
@@ -559,7 +560,7 @@ where
         Ok(())
     }
 
-    pub async fn get_log_id(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn get_log_id(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::feed_10_logs_vote_self(&mut store).await?;
 
@@ -580,7 +581,7 @@ where
         Ok(())
     }
 
-    pub async fn last_id_in_log(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn last_id_in_log(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let log_id = store.get_log_state().await?.last_log_id;
@@ -617,7 +618,7 @@ where
         Ok(())
     }
 
-    pub async fn last_applied_state(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn last_applied_state(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let (applied, membership) = store.last_applied_state().await?;
@@ -667,7 +668,7 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn delete_logs(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- delete (-oo, 0]");
         {
             let mut store = builder.build().await;
@@ -768,7 +769,7 @@ where
         Ok(())
     }
 
-    pub async fn append_to_log(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn append_to_log(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::feed_10_logs_vote_self(&mut store).await?;
 
@@ -788,7 +789,7 @@ where
         Ok(())
     }
 
-    // pub async fn apply_single(builder: &B) -> Result<(), StorageError<C>> {
+    // pub async fn apply_single(builder: &B) -> Result<(), StorageError<C::NodeId>> {
     //     let mut store = builder.build().await;
     //
     //     let entry = Entry {
@@ -825,7 +826,7 @@ where
     //     Ok(())
     // }
     //
-    // pub async fn apply_multi(builder: &B) -> Result<(), StorageError<C>> {
+    // pub async fn apply_multi(builder: &B) -> Result<(), StorageError<C::NodeId>> {
     //     let store = builder.build().await;
     //
     //     let req0 = ClientRequest {
@@ -902,7 +903,7 @@ where
     //     Ok(())
     // }
 
-    pub async fn feed_10_logs_vote_self(sto: &mut S) -> Result<(), StorageError<C>> {
+    pub async fn feed_10_logs_vote_self(sto: &mut S) -> Result<(), StorageError<C::NodeId>> {
         sto.append_to_log(&[&blank(0, 0)]).await?;
 
         for i in 1..=10 {
@@ -918,7 +919,7 @@ where
         Ok(())
     }
 
-    pub async fn default_vote(sto: &mut S) -> Result<(), StorageError<C>> {
+    pub async fn default_vote(sto: &mut S) -> Result<(), StorageError<C::NodeId>> {
         sto.save_vote(&Vote {
             term: 1,
             node_id: NODE_ID.into(),
@@ -942,7 +943,7 @@ where
     S: RaftStorage<C>,
     B: StoreBuilder<C, S>,
 {
-    pub fn test_store_defensive(builder: &B) -> Result<(), StorageError<C>> {
+    pub fn test_store_defensive(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         run_fut(Suite::df_get_membership_config_dirty_log(builder))?;
         run_fut(Suite::df_get_initial_state_dirty_log(builder))?;
         run_fut(Suite::df_save_vote_ascending(builder))?;
@@ -962,7 +963,7 @@ where
         Ok(())
     }
 
-    pub async fn df_get_membership_config_dirty_log(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_get_membership_config_dirty_log(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         tracing::info!("--- dirty log: log.index > last_applied.index && log < last_applied");
@@ -1014,7 +1015,7 @@ where
         Ok(())
     }
 
-    pub async fn df_get_initial_state_dirty_log(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_get_initial_state_dirty_log(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         tracing::info!("--- dirty log: log.index > last_applied.index && log < last_applied");
@@ -1067,7 +1068,7 @@ where
         Ok(())
     }
 
-    pub async fn df_save_vote_ascending(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_save_vote_ascending(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         store
@@ -1150,7 +1151,7 @@ where
         Ok(())
     }
 
-    pub async fn df_get_log_entries(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_get_log_entries(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
         Self::feed_10_logs_vote_self(&mut store).await?;
 
@@ -1214,7 +1215,7 @@ where
         Ok(())
     }
 
-    pub async fn df_append_to_log_nonempty_input(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_append_to_log_nonempty_input(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let res = store.append_to_log(Vec::<&Entry<_>>::new().as_slice()).await;
@@ -1226,7 +1227,7 @@ where
         Ok(())
     }
 
-    pub async fn df_append_to_log_nonconsecutive_input(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_append_to_log_nonconsecutive_input(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let res = store
@@ -1255,7 +1256,7 @@ where
         Ok(())
     }
 
-    pub async fn df_append_to_log_eq_last_plus_one(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_append_to_log_eq_last_plus_one(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         tracing::info!("-- log_id <= last_applied");
@@ -1284,7 +1285,7 @@ where
         Ok(())
     }
 
-    pub async fn df_append_to_log_eq_last_applied_plus_one(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_append_to_log_eq_last_applied_plus_one(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         // last_log: 1,1
         // last_applied: 1,2
         // append_to_log: 1,4
@@ -1316,7 +1317,7 @@ where
         Ok(())
     }
 
-    pub async fn df_append_to_log_gt_last_log_id(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_append_to_log_gt_last_log_id(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         // last_log: 2,2
         // append_to_log: 1,3: index == last + 1 but term is lower
         let mut store = builder.build().await;
@@ -1341,7 +1342,7 @@ where
         Ok(())
     }
 
-    pub async fn df_append_to_log_gt_last_applied_id(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_append_to_log_gt_last_applied_id(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         // last_log: 2,1
         // last_applied: 2,2
         // append_to_log: 1,3: index == last + 1 but term is lower
@@ -1371,7 +1372,7 @@ where
         Ok(())
     }
 
-    pub async fn df_apply_nonempty_input(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_apply_nonempty_input(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let res = store.apply_to_state_machine(Vec::<&Entry<_>>::new().as_slice()).await;
@@ -1383,7 +1384,7 @@ where
         Ok(())
     }
 
-    pub async fn df_apply_index_eq_last_applied_plus_one(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_apply_index_eq_last_applied_plus_one(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let entry = blank(3, 1);
@@ -1430,7 +1431,7 @@ where
         Ok(())
     }
 
-    pub async fn df_apply_gt_last_applied_id(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_apply_gt_last_applied_id(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         let entry = blank(3, 1);
@@ -1460,7 +1461,7 @@ where
         Ok(())
     }
 
-    pub async fn df_purge_applied_le_last_applied(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_purge_applied_le_last_applied(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         store.apply_to_state_machine(&[&blank(0, 0), &blank(3, 1)]).await?;
@@ -1486,7 +1487,7 @@ where
         Ok(())
     }
 
-    pub async fn df_delete_conflict_gt_last_applied(builder: &B) -> Result<(), StorageError<C>> {
+    pub async fn df_delete_conflict_gt_last_applied(builder: &B) -> Result<(), StorageError<C::NodeId>> {
         let mut store = builder.build().await;
 
         store.apply_to_state_machine(&[&blank(0, 0), &blank(3, 1)]).await?;
@@ -1524,8 +1525,8 @@ where C::NodeId: From<u64> {
 
 /// Block until a future is finished.
 /// The future will be running in a clean tokio runtime, to prevent an unfinished task affecting the test.
-pub fn run_fut<C: RaftTypeConfig, F>(f: F) -> Result<(), StorageError<C>>
-where F: Future<Output = Result<(), StorageError<C>>> {
+pub fn run_fut<NID: NodeId, F>(f: F) -> Result<(), StorageError<NID>>
+where F: Future<Output = Result<(), StorageError<NID>>> {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(f)?;
     Ok(())

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -4,31 +4,32 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::LeaderId;
-use crate::RaftTypeConfig;
+use crate::NodeId;
 
 /// `Vote` represent the privilege of a node.
 #[derive(Debug, Clone, Copy, Default, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Vote<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub struct Vote<NID: NodeId> {
     pub term: u64,
-    pub node_id: C::NodeId,
+    pub node_id: NID,
     pub committed: bool,
 }
 
-impl<C: RaftTypeConfig> std::fmt::Display for Vote<C> {
+impl<NID: NodeId> std::fmt::Display for Vote<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "vote:{}-{}", self.term, self.node_id)
     }
 }
 
-impl<C: RaftTypeConfig> Vote<C> {
-    pub fn new(term: u64, node_id: C::NodeId) -> Self {
+impl<NID: NodeId> Vote<NID> {
+    pub fn new(term: u64, node_id: NID) -> Self {
         Self {
             term,
             node_id,
             committed: false,
         }
     }
-    pub fn new_committed(term: u64, node_id: C::NodeId) -> Self {
+    pub fn new_committed(term: u64, node_id: NID) -> Self {
         Self {
             term,
             node_id,
@@ -40,14 +41,14 @@ impl<C: RaftTypeConfig> Vote<C> {
         self.committed = true
     }
 
-    pub fn leader_id(&self) -> LeaderId<C::NodeId> {
+    pub fn leader_id(&self) -> LeaderId<NID> {
         LeaderId::new(self.term, self.node_id)
     }
 
     /// Get the leader node id.
     ///
     /// Only when a committed vote is seen(granted by a quorum) the voted node id is a valid leader.
-    pub fn leader(&self) -> Option<C::NodeId> {
+    pub fn leader(&self) -> Option<NID> {
         if self.committed {
             Some(self.node_id)
         } else {


### PR DESCRIPTION

## Changelog

##### Change: use NodeId instead of RaftTypeConfig if a type only needs node-id as type param.
- Change: from `DefensiveError<C: RaftTypeConfig>` to `DefensiveError<NID: NodeId>`
- Change: from `ErrorSubject<C: RaftTypeConfig>` to `ErrorSubject<NID: NodeId>`
- Change: from `Membership<C: RaftTypeConfig>` to `Membership<NID: NodeId>`
- Change: from `MissingNodeInfo<C: RaftTypeConfig>` to `MissingNodeInfo<NID: NodeId>`
- Change: from `SnapshotMeta<C: RaftTypeConfig>` to `SnapshotMeta<NID: NodeId>`
- Change: from `StorageError<C: RaftTypeConfig>` to `StorageError<NID: NodeId>`
- Change: from `StorageIOError<C: RaftTypeConfig>` to `StorageIOError<NID: NodeId>`
- Change: from `Violation<C: RaftTypeConfig>` to `Violation<NID: NodeId>`
- Change: from `Vote<C: RaftTypeConfig>` to `Vote<NID: NodeId>`
- CI: lint example-raft-kv

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/261)
<!-- Reviewable:end -->
