### PR TITLE
Refactor: let the initial effective membership be an empty set

### DIFF
--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -77,11 +77,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         //           initialized. Because a node always commit a membership log as the first log entry.
         let membership = self.storage.get_membership().await?;
 
-        // TODO(xp): This is a dirty patch:
-        //           When a node starts in a single-node mode, it does not append an initial log
-        //           but instead depends on storage.get_membership() to return a default one.
-        //           It would be better a node always append an initial log entry.
-        let membership = membership.unwrap_or_else(|| EffectiveMembership::new_initial(self.id));
+        // NOTE: the first log, i.e. log at index 0 can also conflict with the leader and is removed.
+        let membership = membership.unwrap_or_default();
 
         self.update_membership(membership);
 

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use maplit::btreemap;
-use maplit::btreeset;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -47,7 +46,7 @@ impl<NID: NodeId> IntoOptionNodes<NID> for BTreeMap<NID, Option<Node>> {
 ///
 /// It could be a joint of one, two or more configs, i.e., a quorum is a node set that is superset of a majority of
 /// every config.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct Membership<NID: NodeId> {
     /// Multi configs of members.
@@ -239,12 +238,6 @@ impl<NID: NodeId> Membership<NID> {
     #[allow(dead_code)]
     pub(crate) fn is_learner(&self, node_id: &NID) -> bool {
         self.contains(node_id) && !self.is_member(node_id)
-    }
-
-    // TODO(xp): rename this
-    /// Create a new initial config containing only the given node ID.
-    pub(crate) fn new_initial(node_id: NID) -> Self {
-        Membership::new(vec![btreeset! {node_id}], None)
     }
 
     /// Return true if the given set of ids constitutes a majority.

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -24,7 +24,6 @@ use crate::leader_metrics::LeaderMetrics;
 use crate::raft_types::LogIdOptionExt;
 use crate::versioned::Versioned;
 use crate::LogId;
-use crate::Membership;
 use crate::MessageSummary;
 use crate::RaftTypeConfig;
 
@@ -74,7 +73,6 @@ impl<C: RaftTypeConfig> MessageSummary for RaftMetrics<C> {
 
 impl<C: RaftTypeConfig> RaftMetrics<C> {
     pub(crate) fn new_initial(id: C::NodeId) -> Self {
-        let membership_config = Membership::new_initial(id);
         Self {
             running_state: Ok(()),
             id,
@@ -83,7 +81,7 @@ impl<C: RaftTypeConfig> RaftMetrics<C> {
             last_log_index: None,
             last_applied: None,
             current_leader: None,
-            membership_config: Arc::new(EffectiveMembership::new(LogId::default(), membership_config)),
+            membership_config: Arc::new(EffectiveMembership::default()),
             snapshot: None,
             leader_metrics: None,
         }

--- a/openraft/src/metrics.rs
+++ b/openraft/src/metrics.rs
@@ -224,6 +224,7 @@ impl<C: RaftTypeConfig> Wait<C> {
     }
 
     /// Wait for `membership_config.members` to become expected node set or timeout.
+    /// TODO(xp): this method wait for a uniform config. There should be method waiting for a generalized config.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn members(
         &self,
@@ -231,7 +232,11 @@ impl<C: RaftTypeConfig> Wait<C> {
         msg: impl ToString,
     ) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
-            |x| x.membership_config.membership.get_configs().get(0).cloned().unwrap() == want_members,
+            |x| {
+                let configs = x.membership_config.get_configs();
+                let first = configs.get(0);
+                first == Some(&want_members)
+            },
             &format!("{} .membership_config.members -> {:?}", msg.to_string(), want_members),
         )
         .await

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -190,6 +190,9 @@ where C: RaftTypeConfig
     type SnapshotBuilder: RaftSnapshotBuilder<C, Self::SnapshotData>;
 
     /// Returns the last membership config found in log or state machine.
+    /// TODO(xp): if there is no membership log, return `{log_id:None, membership: vec![]}`.
+    ///           The raft core should always have an effective_membership.
+    ///           Initially, it is empty.
     async fn get_membership(&mut self) -> Result<Option<EffectiveMembership<C>>, StorageError<C::NodeId>> {
         let (_, sm_mem) = self.last_applied_state().await?;
 

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -626,14 +626,10 @@ where
                 "node {} has last_log_index {:?}, expected None",
                 node.id, node.last_log_index
             );
-            let members = node.membership_config.get_configs()[0].clone();
-            assert_eq!(
-                members.iter().cloned().collect::<Vec<_>>(),
-                vec![node.id],
-                "node {0} has membership {1:?}, expected [{0}]",
-                node.id,
-                members
-            );
+
+            let configs = node.membership_config.get_configs();
+            assert_eq!(0, configs.len(), "expected empty configs, got: {:?}", configs);
+
             assert!(
                 !node.membership_config.membership.is_in_joint_consensus(),
                 "node {} is in joint consensus, expected uniform consensus",


### PR DESCRIPTION

## Changelog

##### Refactor: let the initial effective membership be an empty set

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/264)
<!-- Reviewable:end -->
