### PR TITLE
Change: RaftStorage: use `EffectiveMembership` instead of `Option<_>`

### DIFF
--- a/example-raft-kv/src/store/mod.rs
+++ b/example-raft-kv/src/store/mod.rs
@@ -73,7 +73,7 @@ pub struct ExampleStateMachine {
     pub last_applied_log: Option<LogId<ExampleNodeId>>,
 
     // TODO: it should not be Option.
-    pub last_membership: Option<EffectiveMembership<ExampleTypeConfig>>,
+    pub last_membership: EffectiveMembership<ExampleTypeConfig>,
 
     /// Application data.
     pub data: BTreeMap<String, String>,
@@ -252,13 +252,8 @@ impl RaftStorage<ExampleTypeConfig> for Arc<ExampleStore> {
 
     async fn last_applied_state(
         &mut self,
-    ) -> Result<
-        (
-            Option<LogId<ExampleNodeId>>,
-            Option<EffectiveMembership<ExampleTypeConfig>>,
-        ),
-        StorageError<ExampleNodeId>,
-    > {
+    ) -> Result<(Option<LogId<ExampleNodeId>>, EffectiveMembership<ExampleTypeConfig>), StorageError<ExampleNodeId>>
+    {
         let state_machine = self.state_machine.read().await;
         Ok((state_machine.last_applied_log, state_machine.last_membership.clone()))
     }
@@ -288,7 +283,7 @@ impl RaftStorage<ExampleTypeConfig> for Arc<ExampleStore> {
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
-                    sm.last_membership = Some(EffectiveMembership::new(Some(entry.log_id), mem.clone()));
+                    sm.last_membership = EffectiveMembership::new(Some(entry.log_id), mem.clone());
                     res.push(ExampleResponse { value: None })
                 }
             };

--- a/example-raft-kv/src/store/mod.rs
+++ b/example-raft-kv/src/store/mod.rs
@@ -72,6 +72,7 @@ pub struct ExampleSnapshot {
 pub struct ExampleStateMachine {
     pub last_applied_log: Option<LogId<ExampleNodeId>>,
 
+    // TODO: it should not be Option.
     pub last_membership: Option<EffectiveMembership<ExampleTypeConfig>>,
 
     /// Application data.
@@ -287,7 +288,7 @@ impl RaftStorage<ExampleTypeConfig> for Arc<ExampleStore> {
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
-                    sm.last_membership = Some(EffectiveMembership::new(entry.log_id, mem.clone()));
+                    sm.last_membership = Some(EffectiveMembership::new(Some(entry.log_id), mem.clone()));
                     res.push(ExampleResponse { value: None })
                 }
             };

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -343,7 +343,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
                     res.push(ClientResponse(previous));
                 }
                 EntryPayload::Membership(ref mem) => {
-                    sm.last_membership = Some(EffectiveMembership::new(entry.log_id, mem.clone()));
+                    sm.last_membership = Some(EffectiveMembership::new(Some(entry.log_id), mem.clone()));
                     res.push(ClientResponse(None))
                 }
             };

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -90,7 +90,7 @@ pub struct MemStoreSnapshot {
 pub struct MemStoreStateMachine {
     pub last_applied_log: Option<LogId<MemNodeId>>,
 
-    pub last_membership: Option<EffectiveMembership<Config>>,
+    pub last_membership: EffectiveMembership<Config>,
 
     /// A mapping of client IDs to their state info.
     pub client_serial_responses: HashMap<String, (u64, Option<String>)>,
@@ -263,7 +263,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
 
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<MemNodeId>>, Option<EffectiveMembership<Config>>), StorageError<MemNodeId>> {
+    ) -> Result<(Option<LogId<MemNodeId>>, EffectiveMembership<Config>), StorageError<MemNodeId>> {
         let sm = self.sm.read().await;
         Ok((sm.last_applied_log, sm.last_membership.clone()))
     }
@@ -343,7 +343,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
                     res.push(ClientResponse(previous));
                 }
                 EntryPayload::Membership(ref mem) => {
-                    sm.last_membership = Some(EffectiveMembership::new(Some(entry.log_id), mem.clone()));
+                    sm.last_membership = EffectiveMembership::new(Some(entry.log_id), mem.clone());
                     res.push(ClientResponse(None))
                 }
             };

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -299,7 +299,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         let last_conf_change = entries
             .iter()
             .filter_map(|ent| match &ent.payload {
-                EntryPayload::Membership(conf) => Some(EffectiveMembership::new(ent.log_id, conf.clone())),
+                EntryPayload::Membership(conf) => Some(EffectiveMembership::new(Some(ent.log_id), conf.clone())),
                 _ => None,
             })
             .last();

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -77,9 +77,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         //           initialized. Because a node always commit a membership log as the first log entry.
         let membership = self.storage.get_membership().await?;
 
-        // NOTE: the first log, i.e. log at index 0 can also conflict with the leader and is removed.
-        let membership = membership.unwrap_or_default();
-
         self.update_membership(membership);
 
         tracing::debug!("Done update membership");

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -232,10 +232,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         let membership = self.storage.get_membership().await?;
         tracing::debug!("storage membership: {:?}", membership);
 
-        assert!(membership.is_some());
-
-        let membership = membership.unwrap();
-
         self.update_membership(membership);
 
         self.snapshot_last_log_id = self.last_applied;

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -77,8 +77,7 @@ use crate::Update;
 #[derive(Clone, Default, Eq, Serialize, Deserialize)]
 pub struct EffectiveMembership<C: RaftTypeConfig> {
     /// The id of the log that applies this membership config
-    /// TODO: this `log_id` should be an `Option<LogId>`.
-    pub log_id: LogId<C::NodeId>,
+    pub log_id: Option<LogId<C::NodeId>>,
 
     pub membership: Membership<C::NodeId>,
 
@@ -103,7 +102,7 @@ impl<C: RaftTypeConfig> PartialEq for EffectiveMembership<C> {
 }
 
 impl<C: RaftTypeConfig> EffectiveMembership<C> {
-    pub fn new(log_id: LogId<C::NodeId>, membership: Membership<C::NodeId>) -> Self {
+    pub fn new(log_id: Option<LogId<C::NodeId>>, membership: Membership<C::NodeId>) -> Self {
         let all_members = membership.build_member_ids();
         Self {
             log_id,
@@ -147,7 +146,7 @@ impl<C: RaftTypeConfig> EffectiveMembership<C> {
 
 impl<C: RaftTypeConfig> MessageSummary for EffectiveMembership<C> {
     fn summary(&self) -> String {
-        format!("{{log_id:{} membership:{}}}", self.log_id, self.membership.summary())
+        format!("{{log_id:{:?} membership:{}}}", self.log_id, self.membership.summary())
     }
 }
 
@@ -612,7 +611,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         self.last_log_id = Some(log_id);
 
         if let EntryPayload::Membership(mem) = &entry.payload {
-            self.effective_membership = Arc::new(EffectiveMembership::new(entry.log_id, mem.clone()));
+            self.effective_membership = Arc::new(EffectiveMembership::new(Some(entry.log_id), mem.clone()));
         }
 
         Ok(entry)

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -292,7 +292,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         self.last_log_id = state.last_log_id;
         self.vote = state.vote;
-        self.effective_membership = Arc::new(state.last_membership.unwrap_or_default());
+        self.effective_membership = Arc::new(state.last_membership);
         self.last_applied = state.last_applied;
 
         // NOTE: The commit index must be determined by a leader after

--- a/openraft/src/metrics_wait_test.rs
+++ b/openraft/src/metrics_wait_test.rs
@@ -90,7 +90,7 @@ async fn test_wait() -> anyhow::Result<()> {
             sleep(Duration::from_millis(10)).await;
             let mut update = init.clone();
             update.membership_config = Arc::new(EffectiveMembership::new(
-                LogId::default(),
+                None,
                 Membership::new(vec![btreeset! {1,2}], None),
             ));
             let rst = tx.send(update);
@@ -113,7 +113,7 @@ async fn test_wait() -> anyhow::Result<()> {
             sleep(Duration::from_millis(10)).await;
             let mut update = init.clone();
             update.membership_config = Arc::new(EffectiveMembership::new(
-                LogId::default(),
+                None,
                 Membership::new(vec![btreeset! {}, btreeset! {1,2}], None),
             ));
             let rst = tx.send(update);
@@ -205,7 +205,7 @@ fn init_wait_test<C: RaftTypeConfig>() -> (RaftMetrics<C>, Wait<C>, watch::Sende
         last_applied: None,
         current_leader: None,
         membership_config: Arc::new(EffectiveMembership::new(
-            LogId::default(),
+            None,
             Membership::new(vec![btreeset! {}], None),
         )),
 

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -196,12 +196,12 @@ where C: RaftTypeConfig
     async fn get_membership(&mut self) -> Result<Option<EffectiveMembership<C>>, StorageError<C::NodeId>> {
         let (_, sm_mem) = self.last_applied_state().await?;
 
-        let sm_mem_index = match &sm_mem {
+        let sm_mem_next_index = match &sm_mem {
             None => 0,
-            Some(mem) => mem.log_id.index,
+            Some(mem) => mem.log_id.next_index(),
         };
 
-        let log_mem = self.last_membership_in_log(sm_mem_index + 1).await?;
+        let log_mem = self.last_membership_in_log(sm_mem_next_index).await?;
 
         if log_mem.is_some() {
             return Ok(log_mem);
@@ -230,7 +230,7 @@ where C: RaftTypeConfig
 
             for ent in entries.iter().rev() {
                 if let EntryPayload::Membership(ref mem) = ent.payload {
-                    return Ok(Some(EffectiveMembership::new(ent.log_id, mem.clone())));
+                    return Ok(Some(EffectiveMembership::new(Some(ent.log_id), mem.clone())));
                 }
             }
 

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -124,7 +124,7 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C::NodeId>>, Option<EffectiveMembership<C>>), StorageError<C::NodeId>> {
+    ) -> Result<(Option<LogId<C::NodeId>>, EffectiveMembership<C>), StorageError<C::NodeId>> {
         self.inner().last_applied_state().await
     }
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -638,7 +638,7 @@ where
             assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 3)), applied);
             assert_eq!(
                 Some(EffectiveMembership::new(
-                    LogId::new(LeaderId::new(1, NODE_ID.into()), 3),
+                    Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 3)),
                     Membership::new(vec![btreeset! {1,2}], None)
                 )),
                 membership
@@ -658,7 +658,7 @@ where
             assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 5)), applied);
             assert_eq!(
                 Some(EffectiveMembership::new(
-                    LogId::new(LeaderId::new(1, NODE_ID.into()), 3),
+                    Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 3)),
                     Membership::new(vec![btreeset! {1,2}], None)
                 )),
                 membership

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -194,7 +194,7 @@ where
 
         let membership = store.get_membership().await?;
 
-        assert!(membership.is_none());
+        assert_eq!(EffectiveMembership::default(), membership);
 
         Ok(())
     }
@@ -218,7 +218,6 @@ where
                 .await?;
 
             let mem = store.get_membership().await?;
-            let mem = mem.unwrap();
 
             assert_eq!(Membership::new(vec![btreeset! {3,4,5}], None), mem.membership,);
         }
@@ -234,8 +233,6 @@ where
 
             let mem = store.get_membership().await?;
 
-            let mem = mem.unwrap();
-
             assert_eq!(Membership::new(vec![btreeset! {3, 4, 5}], None), mem.membership,);
         }
 
@@ -249,8 +246,6 @@ where
                 .await?;
 
             let mem = store.get_membership().await?;
-
-            let mem = mem.unwrap();
 
             assert_eq!(Membership::new(vec![btreeset! {7,8,9}], None), mem.membership,);
         }
@@ -335,7 +330,7 @@ where
 
             assert_eq!(
                 Membership::new(vec![btreeset! {3,4,5}], None),
-                initial.last_membership.unwrap().membership,
+                initial.last_membership.membership,
             );
         }
 
@@ -352,7 +347,7 @@ where
 
             assert_eq!(
                 Membership::new(vec![btreeset! {3,4,5}], None),
-                initial.last_membership.unwrap().membership,
+                initial.last_membership.membership,
             );
         }
 
@@ -369,7 +364,7 @@ where
 
             assert_eq!(
                 Membership::new(vec![btreeset! {1,2,3}], None),
-                initial.last_membership.unwrap().membership,
+                initial.last_membership.membership,
             );
         }
 
@@ -623,7 +618,7 @@ where
 
         let (applied, membership) = store.last_applied_state().await?;
         assert_eq!(None, applied);
-        assert_eq!(None, membership);
+        assert_eq!(EffectiveMembership::default(), membership);
 
         tracing::info!("--- with last_applied and last_membership");
         {
@@ -637,10 +632,10 @@ where
             let (applied, membership) = store.last_applied_state().await?;
             assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 3)), applied);
             assert_eq!(
-                Some(EffectiveMembership::new(
+                EffectiveMembership::new(
                     Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 3)),
                     Membership::new(vec![btreeset! {1,2}], None)
-                )),
+                ),
                 membership
             );
         }
@@ -657,10 +652,10 @@ where
             let (applied, membership) = store.last_applied_state().await?;
             assert_eq!(Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 5)), applied);
             assert_eq!(
-                Some(EffectiveMembership::new(
+                EffectiveMembership::new(
                     Some(LogId::new(LeaderId::new(1, NODE_ID.into()), 3)),
                     Membership::new(vec![btreeset! {1,2}], None)
-                )),
+                ),
                 membership
             );
         }

--- a/openraft/tests/initialization.rs
+++ b/openraft/tests/initialization.rs
@@ -88,7 +88,7 @@ async fn initialization() -> Result<()> {
         let sm_mem = sto.last_applied_state().await?.1;
         assert_eq!(
             Some(EffectiveMembership::new(
-                LogId::new(LeaderId::new(0, 0), 0),
+                Some(LogId::new(LeaderId::new(0, 0), 0)),
                 Membership::new(vec![btreeset! {0,1,2}], None)
             )),
             sm_mem

--- a/openraft/tests/initialization.rs
+++ b/openraft/tests/initialization.rs
@@ -87,10 +87,10 @@ async fn initialization() -> Result<()> {
 
         let sm_mem = sto.last_applied_state().await?.1;
         assert_eq!(
-            Some(EffectiveMembership::new(
+            EffectiveMembership::new(
                 Some(LogId::new(LeaderId::new(0, 0), 0)),
                 Membership::new(vec![btreeset! {0,1,2}], None)
-            )),
+            ),
             sm_mem
         );
     }

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -220,7 +220,6 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
     {
         let mut sto = router.get_storage_handle(&1)?;
         let m = sto.get_membership().await?;
-        let m = m.unwrap();
 
         assert_eq!(
             Membership::new(vec![btreeset! {1,3,4}], Some(btreeset! {2})),

--- a/openraft/tests/snapshot/snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/snapshot_overrides_membership.rs
@@ -101,8 +101,6 @@ async fn snapshot_overrides_membership() -> Result<()> {
             {
                 let m = sto.get_membership().await?;
 
-                let m = m.unwrap();
-
                 assert_eq!(Membership::new(vec![btreeset! {2,3}], None), m.membership);
             }
         }
@@ -132,8 +130,6 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 .await?;
 
             let m = sto.get_membership().await?;
-
-            let m = m.unwrap();
 
             assert_eq!(
                 Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),

--- a/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
@@ -75,8 +75,6 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         }
         let m = sto0.get_membership().await?;
 
-        let m = m.unwrap();
-
         assert_eq!(
             Membership::new(vec![btreeset! {0,1}], None),
             m.membership,
@@ -124,8 +122,6 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             assert_eq!(3, logs.len(), "only one applied log");
         }
         let m = sto0.get_membership().await?;
-
-        let m = m.unwrap();
 
         assert_eq!(
             Membership::new(vec![btreeset! {0,1}], None),

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -50,7 +50,7 @@ async fn state_machine_apply_membership() -> Result<()> {
         let mut sto = router.get_storage_handle(&i)?;
         assert_eq!(
             Some(EffectiveMembership::new(
-                LogId::new(LeaderId::new(0, 0), 0),
+                Some(LogId::new(LeaderId::new(0, 0), 0)),
                 Membership::new(vec![btreeset! {0}], None)
             )),
             sto.last_applied_state().await?.1
@@ -102,7 +102,7 @@ async fn state_machine_apply_membership() -> Result<()> {
         let (_, last_membership) = sto.last_applied_state().await?;
         assert_eq!(
             Some(EffectiveMembership::new(
-                LogId::new(LeaderId::new(1, 0), log_index),
+                Some(LogId::new(LeaderId::new(1, 0), log_index)),
                 Membership::new(vec![btreeset! {0, 1, 2}], Some(btreeset! {3,4}))
             )),
             last_membership

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -49,10 +49,10 @@ async fn state_machine_apply_membership() -> Result<()> {
     for i in 0..=0 {
         let mut sto = router.get_storage_handle(&i)?;
         assert_eq!(
-            Some(EffectiveMembership::new(
+            EffectiveMembership::new(
                 Some(LogId::new(LeaderId::new(0, 0), 0)),
                 Membership::new(vec![btreeset! {0}], None)
-            )),
+            ),
             sto.last_applied_state().await?.1
         );
     }
@@ -101,10 +101,10 @@ async fn state_machine_apply_membership() -> Result<()> {
         let mut sto = router.get_storage_handle(&i)?;
         let (_, last_membership) = sto.last_applied_state().await?;
         assert_eq!(
-            Some(EffectiveMembership::new(
+            EffectiveMembership::new(
                 Some(LogId::new(LeaderId::new(1, 0), log_index)),
                 Membership::new(vec![btreeset! {0, 1, 2}], Some(btreeset! {3,4}))
-            )),
+            ),
             last_membership
         );
     }


### PR DESCRIPTION

## Changelog

##### Change: RaftStorage: use `EffectiveMembership` instead of `Option<_>`
The value of membership config of an uninitialized raft-node should be:
```rust
EffectiveMembership {
    log_id: None,
    membership: Membership::default(),
}

```

I.e., there is always a membership config for either an initialized or
an uninitialized raft-node.
Because `EffectiveMembership` is not a value that could be `None`, but it is more like a container of values.

Changed struct:

```rust
struct InitialState {
    pub last_membership: EffectiveMembership<C>,
    ...
}
```

Changed methods:

```rust
RaftStorage::get_membership() -> Result<EffectiveMembership<C>, _>;
RaftStorage::last_applied_state() -> Result<(_, EffectiveMembership<C>), _>;
```


##### Change: EffectiveMembership.log_id to Option<LogId>

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/265)
<!-- Reviewable:end -->
