### PR TITLE
Change: learner-related errors do not need RaftTypeConfig

### DIFF
--- a/example-raft-kv/src/client.rs
+++ b/example-raft-kv/src/client.rs
@@ -95,7 +95,7 @@ impl ExampleClient {
     pub async fn add_learner(
         &self,
         req: (ExampleNodeId, String),
-    ) -> Result<AddLearnerResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, AddLearnerError<ExampleTypeConfig>>>
+    ) -> Result<AddLearnerResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, AddLearnerError<ExampleNodeId>>>
     {
         self.send_rpc_to_leader("add-learner", Some(&req)).await
     }
@@ -181,7 +181,7 @@ impl ExampleClient {
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,
-        Err: std::error::Error + Serialize + DeserializeOwned + TryInto<ForwardToLeader<ExampleTypeConfig>> + Clone,
+        Err: std::error::Error + Serialize + DeserializeOwned + TryInto<ForwardToLeader<ExampleNodeId>> + Clone,
     {
         // Retry at most 3 times to find a valid leader.
         let mut n_retry = 3;
@@ -196,7 +196,7 @@ impl ExampleClient {
 
             if let RPCError::RemoteError(remote_err) = &rpc_err {
                 let forward_err_res =
-                    <Err as TryInto<ForwardToLeader<ExampleTypeConfig>>>::try_into(remote_err.source.clone());
+                    <Err as TryInto<ForwardToLeader<ExampleNodeId>>>::try_into(remote_err.source.clone());
 
                 if let Ok(ForwardToLeader {
                     leader_id: Some(leader_id),

--- a/example-raft-kv/tests/cluster/test_cluster.rs
+++ b/example-raft-kv/tests/cluster/test_cluster.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use example_raft_key_value::client::ExampleClient;
 use example_raft_key_value::start_example_raft_node;
 use example_raft_key_value::store::ExampleRequest;
-use example_raft_key_value::ExampleTypeConfig;
+use example_raft_key_value::ExampleNodeId;
 use maplit::btreemap;
 use maplit::btreeset;
 use openraft::error::NodeNotFound;
@@ -26,7 +26,7 @@ async fn test_cluster() -> anyhow::Result<()> {
             2 => "127.0.0.1:21002".to_string(),
             3 => "127.0.0.1:21003".to_string(),
             _ => {
-                return Err(NodeNotFound::<ExampleTypeConfig> {
+                return Err(NodeNotFound::<ExampleNodeId> {
                     node_id,
                     source: AnyError::error("node not found"),
                 });

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -108,7 +108,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         &mut self,
         target: C::NodeId,
         node: Option<Node>,
-        tx: RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C>>,
+        tx: RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C::NodeId>>,
         blocking: bool,
     ) {
         tracing::debug!("add target node {} as learner {:?}", target, self.nodes.keys());
@@ -133,7 +133,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         let exist = match exist {
             Ok(x) => x,
             Err(e) => {
-                let _ = tx.send(Err(AddLearnerError::<C>::from(e)));
+                let _ = tx.send(Err(AddLearnerError::<C::NodeId>::from(e)));
                 return;
             }
         };

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -587,7 +587,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// Reject a request due to the Raft node being in a state which prohibits the request.
     #[tracing::instrument(level = "trace", skip(self, tx))]
     fn reject_with_forward_to_leader<T, E>(&self, tx: RaftRespTx<T, E>)
-    where E: From<ForwardToLeader<C>> {
+    where E: From<ForwardToLeader<C::NodeId>> {
         let l = self.current_leader();
         let err = ForwardToLeader {
             leader_id: l,
@@ -947,7 +947,7 @@ struct ReplicationState<C: RaftTypeConfig> {
     pub repl_stream: ReplicationStream<C>,
 
     /// The response channel to use for when this node has successfully synced with the cluster.
-    pub tx: Option<RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C>>>,
+    pub tx: Option<RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C::NodeId>>>,
 }
 
 impl<C: RaftTypeConfig> MessageSummary for ReplicationState<C> {

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -31,7 +31,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     pub(super) async fn spawn_replication_stream(
         &mut self,
         target: C::NodeId,
-        caller_tx: Option<RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C>>>,
+        caller_tx: Option<RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C::NodeId>>>,
     ) -> ReplicationState<C> {
         let target_node = self.core.effective_membership.get_node(&target);
         let repl_stream = ReplicationStream::new::<N, S>(

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -315,7 +315,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         id: C::NodeId,
         node: Option<Node>,
         blocking: bool,
-    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C>> {
+    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C::NodeId>> {
         let (tx, rx) = oneshot::channel();
         self.call_core(RaftMsg::AddLearner { id, node, blocking, tx }, rx).await
     }
@@ -609,7 +609,7 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
         blocking: bool,
 
         /// Send the log id when the replication becomes line-rate.
-        tx: RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C>>,
+        tx: RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C::NodeId>>,
     },
     ChangeMembership {
         members: ChangeMembers<C>,

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -373,7 +373,7 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub fn get_raft_handle(&self, node_id: &C::NodeId) -> std::result::Result<MemRaft<C, S>, NodeNotFound<C>> {
+    pub fn get_raft_handle(&self, node_id: &C::NodeId) -> std::result::Result<MemRaft<C, S>, NodeNotFound<C::NodeId>> {
         let rt = self.routing_table.lock().unwrap();
         let raft_and_sto = rt.get(node_id).ok_or_else(|| NodeNotFound {
             node_id: *node_id,
@@ -514,7 +514,7 @@ where
         &self,
         leader: C::NodeId,
         target: C::NodeId,
-    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C>> {
+    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C::NodeId>> {
         let node = self.get_raft_handle(&leader).unwrap();
         node.add_learner(target, None, true).await
     }
@@ -524,7 +524,7 @@ where
         leader: C::NodeId,
         target: C::NodeId,
         blocking: bool,
-    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C>> {
+    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C::NodeId>> {
         let node = {
             let rt = self.routing_table.lock().unwrap();
             rt.get(&leader).unwrap_or_else(|| panic!("node with ID {} does not exist", leader)).clone()

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
+use memstore::MemNodeId;
 use openraft::error::ChangeMembershipError;
 use openraft::Config;
 use openraft::RaftLogReader;
@@ -99,7 +100,7 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
         tracing::info!("--- got res: {:?}", res);
 
         let err = res.unwrap_err();
-        let err: ChangeMembershipError<memstore::Config> = err.try_into().unwrap();
+        let err: ChangeMembershipError<MemNodeId> = err.try_into().unwrap();
 
         match err {
             ChangeMembershipError::LearnerIsLagging(e) => {


### PR DESCRIPTION

## Changelog

##### Change: learner-related errors do not need RaftTypeConfig
Changed Errors type parameter from `RaftTypeConfig` to `NodeId`:

- `AddLearnerError<NodeId>`
- `ChangeMembershipError<NodeId>`
- `ForwardToLeader<NodeId>`
- `InProgress<NodeId>`
- `LearnerIsLagging<NodeId>`
- `LearnerNotFound<NodeId>`

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/267)
<!-- Reviewable:end -->
