### PR TITLE
Change: AddLearnerResponse and ChangeMembers do not need RaftTypeConfig

### DIFF
--- a/example-raft-kv/src/client.rs
+++ b/example-raft-kv/src/client.rs
@@ -95,8 +95,7 @@ impl ExampleClient {
     pub async fn add_learner(
         &self,
         req: (ExampleNodeId, String),
-    ) -> Result<AddLearnerResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, AddLearnerError<ExampleNodeId>>>
-    {
+    ) -> Result<AddLearnerResponse<ExampleNodeId>, RPCError<ExampleTypeConfig, AddLearnerError<ExampleNodeId>>> {
         self.send_rpc_to_leader("add-learner", Some(&req)).await
     }
 

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -108,7 +108,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         &mut self,
         target: C::NodeId,
         node: Option<Node>,
-        tx: RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C::NodeId>>,
+        tx: RaftRespTx<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>>,
         blocking: bool,
     ) {
         tracing::debug!("add target node {} as learner {:?}", target, self.nodes.keys());
@@ -117,7 +117,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         // config, in the set of new nodes already being synced, or in the nodes being removed.
         if target == self.core.id {
             tracing::debug!("target node is this node");
-            let _ = tx.send(Ok(AddLearnerResponse::<C> {
+            let _ = tx.send(Ok(AddLearnerResponse {
                 matched: self.core.last_log_id,
             }));
             return;
@@ -170,7 +170,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     #[tracing::instrument(level = "debug", skip(self, tx))]
     pub(super) async fn change_membership(
         &mut self,
-        change_members: ChangeMembers<C>,
+        change_members: ChangeMembers<C::NodeId>,
         blocking: bool,
         turn_to_learner: bool,
         tx: RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C>>,

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -947,7 +947,8 @@ struct ReplicationState<C: RaftTypeConfig> {
     pub repl_stream: ReplicationStream<C>,
 
     /// The response channel to use for when this node has successfully synced with the cluster.
-    pub tx: Option<RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C::NodeId>>>,
+    #[allow(clippy::type_complexity)]
+    pub tx: Option<RaftRespTx<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>>>,
 }
 
 impl<C: RaftTypeConfig> MessageSummary for ReplicationState<C> {

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -28,10 +28,11 @@ use crate::StorageError;
 impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderState<'a, C, N, S> {
     /// Spawn a new replication stream returning its replication state handle.
     #[tracing::instrument(level = "debug", skip(self, caller_tx))]
+    #[allow(clippy::type_complexity)]
     pub(super) async fn spawn_replication_stream(
         &mut self,
         target: C::NodeId,
-        caller_tx: Option<RaftRespTx<AddLearnerResponse<C>, AddLearnerError<C::NodeId>>>,
+        caller_tx: Option<RaftRespTx<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>>>,
     ) -> ReplicationState<C> {
         let target_node = self.core.effective_membership.get_node(&target);
         let repl_stream = ReplicationStream::new::<N, S>(

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -514,7 +514,7 @@ where
         &self,
         leader: C::NodeId,
         target: C::NodeId,
-    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C::NodeId>> {
+    ) -> Result<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>> {
         let node = self.get_raft_handle(&leader).unwrap();
         node.add_learner(target, None, true).await
     }
@@ -524,7 +524,7 @@ where
         leader: C::NodeId,
         target: C::NodeId,
         blocking: bool,
-    ) -> Result<AddLearnerResponse<C>, AddLearnerError<C::NodeId>> {
+    ) -> Result<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>> {
         let node = {
             let rt = self.routing_table.lock().unwrap();
             rt.get(&leader).unwrap_or_else(|| panic!("node with ID {} does not exist", leader)).clone()

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-use memstore::Config as MemConfig;
 use memstore::MemNodeId;
 use openraft::ChangeMembers;
 use openraft::Config;
@@ -48,7 +47,7 @@ async fn remove_members_cases() -> anyhow::Result<()> {
 }
 
 #[tracing::instrument(level = "debug")]
-async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<MemConfig>) -> anyhow::Result<()> {
+async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<MemNodeId>) -> anyhow::Result<()> {
     let new = change_members.apply_to(&old);
 
     let mes = format!("from {:?} to {:?}", old, new);


### PR DESCRIPTION

## Changelog

##### Change: AddLearnerResponse and ChangeMembers do not need RaftTypeConfig
- `AddLearnerResponse<NodeId>`
- `ChangeMembers<NodeId>`

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/268)
<!-- Reviewable:end -->
