### PR TITLE
Feature: add error NotAllowed

### DIFF
--- a/guide/src/cluster-formation.md
+++ b/guide/src/cluster-formation.md
@@ -9,24 +9,45 @@ To form a cluster, application must call `Raft::initialize(membership)`.
 
 This method will:
 
-- Update the in-memory membership.
+- Append one membership log at index 0, the log id has to be `(leader_id=(0,0), index=0)`. 
+  The membership will take effect at once.
 
-- If there are more than one voters in the config, enter Candidate state and start vote to become leader.
+- Enter Candidate state and start vote to become leader.
 
-- If there is only one voters(itself) in the config, become leader at once and
-    will enter leader state.
-
-- The leader will commit a log contains the given membership config.
-
-TODO(xp): this procedure will be changed:  https://github.com/datafuselabs/openraft/issues/45
+- The leader will commit a blank log to commit all preceding logs.
 
 
-- Calling this method on an already initialized node just returns an error and is safe.
+### Errors and failures
+
+- Calling this method on an already initialized node just returns an error and is safe,
+  i.e. `last_log_id` on this node is not None, or `vote` on this node is not `(0,0)`.
 
 - Calling this method on more than one node at the same time:
 
-    - with the same `membership` is safe.
+    - with the same `membership`, it is safe.
       Because voting protocol guarantees consistency.
 
-    - with different `membership` is **ILLEGAL** and will result in a undefined
+    - with different `membership` it is **ILLEGAL** and will result in an undefined
         state, AKA the **split-brain** state.
+
+
+### Conditions for initialization
+
+The conditions for a legal initialization is as the above because:
+
+The first membership log with log id `(vote, index=0)` will be appended to initialize a node, without consensus.
+This has not to break the commit condition:
+
+1. Log id `(vote, index=0)` must not be greater than any committed log id.
+   if `vote` is not the smallest value, i.e. `(term=0, node_id=0)`, it has chance to be greater than some
+   committed log id. This is why the first log has to be the smallest: `((term=0, node_id=0), 0)`.
+
+2. And a node should not append a log that is smaller than its `vote`.
+   Otherwise, it is actually changing the **history** other nodes has seen.
+   This has chance to (but not certainly will) break the consensus, depending on the protocol.
+   E.g. if the cluster has been running a fast-paxos like protocol, appending a smaller log than `vote` is illegal.
+   By not allowing to append a smaller log than `vote`, it will always be safe.
+
+From these two reason, it is only allowed to append the first log if:
+`vote==(0,0)`. And this is why the initial value of `vote` has to be `(0,0)`.
+ 

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -41,6 +41,7 @@ use crate::error::ExtractFatal;
 use crate::error::Fatal;
 use crate::error::ForwardToLeader;
 use crate::error::InitializeError;
+use crate::error::NotAllowed;
 use crate::metrics::RaftMetrics;
 use crate::raft::AddLearnerResponse;
 use crate::raft::Entry;
@@ -581,7 +582,10 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// Reject an init config request due to the Raft node being in a state which prohibits the request.
     #[tracing::instrument(level = "trace", skip(self, tx))]
     fn reject_init_with_config(&self, tx: oneshot::Sender<Result<(), InitializeError<C>>>) {
-        let _ = tx.send(Err(InitializeError::NotAllowed));
+        let _ = tx.send(Err(InitializeError::NotAllowed(NotAllowed {
+            last_log_id: self.last_log_id,
+            vote: self.vote,
+        })));
     }
 
     /// Reject a request due to the Raft node being in a state which prohibits the request.

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -138,7 +138,7 @@ impl Display for SnapshotSegmentId {
 }
 
 // An update action with option to update with some value or just leave it as is.
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
 pub enum Update<T> {
     Update(T),
     AsIs,

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -257,6 +257,7 @@ where C: RaftTypeConfig
         Ok(InitialState {
             last_log_id,
             last_applied,
+            // TODO(xp): vote should be None if this node is not initialized.
             vote: vote.unwrap_or_default(),
             last_membership: membership,
         })


### PR DESCRIPTION

## Changelog

##### Feature: add error NotAllowed
- Feature: add error `NotAllowed{last_log_id, vote}` to explain why
  initialization is now allowed.

- Doc: explain the conditions to satisfied to initialize.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/269)
<!-- Reviewable:end -->
