### PR TITLE
Change: InitialState use NodeId as type param instead of RaftTypeConfig

### DIFF
--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -51,25 +51,25 @@ where
 
 /// A struct used to represent the initial state which a Raft node needs when first starting.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct InitialState<C: RaftTypeConfig> {
+pub struct InitialState<NID: NodeId> {
     /// The vote state of this node.
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<NID>,
 
     /// The greatest log id that has been purged after being applied to state machine.
     /// The range of log entries that exist in storage is `(last_purged_log_id, last_log_id]`,
     /// left open and right close.
     ///
     /// `last_purged_log_id == last_log_id` means there is no log entry in the storage.
-    pub last_purged_log_id: Option<LogId<C::NodeId>>,
+    pub last_purged_log_id: Option<LogId<NID>>,
 
     /// The id of the last log entry.
-    pub last_log_id: Option<LogId<C::NodeId>>,
+    pub last_log_id: Option<LogId<NID>>,
 
     /// The LogId of the last log applied to the state machine.
-    pub last_applied: Option<LogId<C::NodeId>>,
+    pub last_applied: Option<LogId<NID>>,
 
     /// The latest cluster membership configuration found, in log or in state machine.
-    pub effective_membership: Arc<EffectiveMembership<C::NodeId>>,
+    pub effective_membership: Arc<EffectiveMembership<NID>>,
 }
 
 /// The state about logs.
@@ -249,7 +249,7 @@ where C: RaftTypeConfig
     ///
     /// When the Raft node is first started, it will call this interface to fetch the last known state from stable
     /// storage.
-    async fn get_initial_state(&mut self) -> Result<InitialState<C>, StorageError<C::NodeId>> {
+    async fn get_initial_state(&mut self) -> Result<InitialState<C::NodeId>, StorageError<C::NodeId>> {
         let vote = self.read_vote().await?;
         let st = self.get_log_state().await?;
         let mut last_purged_log_id = st.last_purged_log_id;

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -257,7 +257,7 @@ where
         let mut store = builder.build().await;
 
         let initial = store.get_initial_state().await?;
-        assert_eq!(InitialState::<C>::default(), initial, "uninitialized state");
+        assert_eq!(InitialState::default(), initial, "uninitialized state");
         Ok(())
     }
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -420,6 +420,11 @@ where
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 1)),
             "state machine has higher log"
         );
+        assert_eq!(
+            initial.last_purged_log_id,
+            Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 1)),
+            "state machine has higher log"
+        );
         Ok(())
     }
 


### PR DESCRIPTION

## Changelog

##### Change: InitialState use NodeId as type param instead of RaftTypeConfig

##### Feature: InitialState: add `last_purged_log_id`

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/274)
<!-- Reviewable:end -->
