### PR TITLE
Change: errors that only need NodeId instead of RaftTypeConfig as type param

### DIFF
--- a/example-raft-kv/src/client.rs
+++ b/example-raft-kv/src/client.rs
@@ -55,7 +55,7 @@ impl ExampleClient {
     pub async fn write(
         &self,
         req: &ExampleRequest,
-    ) -> Result<ClientWriteResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, ClientWriteError<ExampleTypeConfig>>>
+    ) -> Result<ClientWriteResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, ClientWriteError<ExampleNodeId>>>
     {
         self.send_rpc_to_leader("write", Some(req)).await
     }
@@ -73,7 +73,7 @@ impl ExampleClient {
     pub async fn consistent_read(
         &self,
         req: &String,
-    ) -> Result<String, RPCError<ExampleTypeConfig, CheckIsLeaderError<ExampleTypeConfig>>> {
+    ) -> Result<String, RPCError<ExampleTypeConfig, CheckIsLeaderError<ExampleNodeId>>> {
         self.do_send_rpc_to_leader("consistent_read", Some(req)).await
     }
 
@@ -85,7 +85,7 @@ impl ExampleClient {
     /// With a initialized cluster, new node can be added with [`write`].
     /// Then setup replication with [`add_learner`].
     /// Then make the new node a member with [`change_membership`].
-    pub async fn init(&self) -> Result<(), RPCError<ExampleTypeConfig, InitializeError<ExampleTypeConfig>>> {
+    pub async fn init(&self) -> Result<(), RPCError<ExampleTypeConfig, InitializeError<ExampleNodeId>>> {
         self.do_send_rpc_to_leader("init", Some(&Empty {})).await
     }
 
@@ -106,7 +106,7 @@ impl ExampleClient {
     pub async fn change_membership(
         &self,
         req: &BTreeSet<ExampleNodeId>,
-    ) -> Result<ClientWriteResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, ClientWriteError<ExampleTypeConfig>>>
+    ) -> Result<ClientWriteResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, ClientWriteError<ExampleNodeId>>>
     {
         self.send_rpc_to_leader("change-membership", Some(req)).await
     }

--- a/example-raft-kv/src/network/api.rs
+++ b/example-raft-kv/src/network/api.rs
@@ -10,7 +10,7 @@ use web::Json;
 
 use crate::app::ExampleApp;
 use crate::store::ExampleRequest;
-use crate::ExampleTypeConfig;
+use crate::ExampleNodeId;
 
 /**
  * Application API
@@ -48,7 +48,7 @@ pub async fn consistent_read(app: Data<ExampleApp>, req: Json<String>) -> actix_
             let key = req.0;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, CheckIsLeaderError<ExampleTypeConfig>> = Ok(value.unwrap_or_default());
+            let res: Result<String, CheckIsLeaderError<ExampleNodeId>> = Ok(value.unwrap_or_default());
             Ok(Json(res))
         }
         Err(e) => Ok(Json(Err(e))),

--- a/example-raft-kv/src/network/raft_network_impl.rs
+++ b/example-raft-kv/src/network/raft_network_impl.rs
@@ -73,10 +73,8 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_append_entries(
         &mut self,
         req: AppendEntriesRequest<ExampleTypeConfig>,
-    ) -> Result<
-        AppendEntriesResponse<ExampleTypeConfig>,
-        RPCError<ExampleTypeConfig, AppendEntriesError<ExampleTypeConfig>>,
-    > {
+    ) -> Result<AppendEntriesResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, AppendEntriesError<ExampleNodeId>>>
+    {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-append", req).await
     }
 
@@ -85,7 +83,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
         req: InstallSnapshotRequest<ExampleTypeConfig>,
     ) -> Result<
         InstallSnapshotResponse<ExampleTypeConfig>,
-        RPCError<ExampleTypeConfig, InstallSnapshotError<ExampleTypeConfig>>,
+        RPCError<ExampleTypeConfig, InstallSnapshotError<ExampleNodeId>>,
     > {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-snapshot", req).await
     }
@@ -93,7 +91,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_vote(
         &mut self,
         req: VoteRequest<ExampleTypeConfig>,
-    ) -> Result<VoteResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, VoteError<ExampleTypeConfig>>> {
+    ) -> Result<VoteResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, VoteError<ExampleNodeId>>> {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-vote", req).await
     }
 }

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -23,7 +23,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(super) async fn handle_append_entries_request(
         &mut self,
         req: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse<C>, AppendEntriesError<C>> {
+    ) -> Result<AppendEntriesResponse<C>, AppendEntriesError<C::NodeId>> {
         tracing::debug!(last_log_id=?self.last_log_id, ?self.last_applied, msg=%req.summary(), "handle_append_entries_request");
 
         let msg_entries = req.entries.as_slice();

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -32,7 +32,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(super) async fn handle_install_snapshot_request(
         &mut self,
         req: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C>> {
+    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C::NodeId>> {
         if req.vote < self.vote {
             tracing::debug!(?self.vote, %req.vote, "InstallSnapshot RPC term is less than current term");
 
@@ -92,7 +92,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     async fn begin_installing_snapshot(
         &mut self,
         req: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C>> {
+    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C::NodeId>> {
         let id = req.meta.snapshot_id.clone();
 
         if req.offset > 0 {
@@ -137,7 +137,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         req: InstallSnapshotRequest<C>,
         mut offset: u64,
         mut snapshot: Box<S::SnapshotData>,
-    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C>> {
+    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C::NodeId>> {
         let id = req.meta.snapshot_id.clone();
 
         // Always seek to the target offset if not an exact match.

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -582,7 +582,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
     /// Reject an init config request due to the Raft node being in a state which prohibits the request.
     #[tracing::instrument(level = "trace", skip(self, tx))]
-    fn reject_init_with_config(&self, tx: oneshot::Sender<Result<(), InitializeError<C>>>) {
+    fn reject_init_with_config(&self, tx: oneshot::Sender<Result<(), InitializeError<C::NodeId>>>) {
         let _ = tx.send(Err(InitializeError::NotAllowed(NotAllowed {
             last_log_id: self.last_log_id,
             vote: self.vote,

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -20,7 +20,10 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     ///
     /// See `receiver implementation: RequestVote RPC` in raft-essentials.md in this repo.
     #[tracing::instrument(level = "debug", skip(self, req), fields(req=%req.summary()))]
-    pub(super) async fn handle_vote_request(&mut self, req: VoteRequest<C>) -> Result<VoteResponse<C>, VoteError<C>> {
+    pub(super) async fn handle_vote_request(
+        &mut self,
+        req: VoteRequest<C>,
+    ) -> Result<VoteResponse<C>, VoteError<C::NodeId>> {
         tracing::debug!(
             %req.vote,
             ?self.vote,

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -54,51 +54,56 @@ where E: TryInto<Fatal<NID>> + Clone
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error, derive_more::TryInto)]
-pub enum AppendEntriesError<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub enum AppendEntriesError<NID: NodeId> {
     #[error(transparent)]
-    Fatal(#[from] Fatal<C::NodeId>),
+    Fatal(#[from] Fatal<NID>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error, derive_more::TryInto)]
-pub enum VoteError<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub enum VoteError<NID: NodeId> {
     #[error(transparent)]
-    Fatal(#[from] Fatal<C::NodeId>),
+    Fatal(#[from] Fatal<NID>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error, derive_more::TryInto)]
-pub enum InstallSnapshotError<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub enum InstallSnapshotError<NID: NodeId> {
     #[error(transparent)]
     SnapshotMismatch(#[from] SnapshotMismatch),
 
     #[error(transparent)]
-    Fatal(#[from] Fatal<C::NodeId>),
+    Fatal(#[from] Fatal<NID>),
 }
 
 /// An error related to a is_leader request.
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error, derive_more::TryInto)]
-pub enum CheckIsLeaderError<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub enum CheckIsLeaderError<NID: NodeId> {
     #[error(transparent)]
-    ForwardToLeader(#[from] ForwardToLeader<C::NodeId>),
+    ForwardToLeader(#[from] ForwardToLeader<NID>),
 
     #[error(transparent)]
-    QuorumNotEnough(#[from] QuorumNotEnough<C>),
+    QuorumNotEnough(#[from] QuorumNotEnough<NID>),
 
     #[error(transparent)]
-    Fatal(#[from] Fatal<C::NodeId>),
+    Fatal(#[from] Fatal<NID>),
 }
 
 /// An error related to a client write request.
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error, derive_more::TryInto)]
-pub enum ClientWriteError<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub enum ClientWriteError<NID: NodeId> {
     #[error(transparent)]
-    ForwardToLeader(#[from] ForwardToLeader<C::NodeId>),
+    ForwardToLeader(#[from] ForwardToLeader<NID>),
 
     /// When writing a change-membership entry.
     #[error(transparent)]
-    ChangeMembershipError(#[from] ChangeMembershipError<C::NodeId>),
+    ChangeMembershipError(#[from] ChangeMembershipError<NID>),
 
     #[error(transparent)]
-    Fatal(#[from] Fatal<C::NodeId>),
+    Fatal(#[from] Fatal<NID>),
 }
 
 /// The set of errors which may take place when requesting to propose a config change.
@@ -151,44 +156,45 @@ impl<NID: NodeId> TryFrom<AddLearnerError<NID>> for ForwardToLeader<NID> {
 
 /// The set of errors which may take place when initializing a pristine Raft node.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
-pub enum InitializeError<C: RaftTypeConfig> {
+#[serde(bound = "")]
+pub enum InitializeError<NID: NodeId> {
     #[error(transparent)]
-    NotAllowed(#[from] NotAllowed<C::NodeId>),
+    NotAllowed(#[from] NotAllowed<NID>),
 
     #[error(transparent)]
-    MissingNodeInfo(#[from] MissingNodeInfo<C::NodeId>),
+    MissingNodeInfo(#[from] MissingNodeInfo<NID>),
 
     #[error(transparent)]
-    Fatal(#[from] Fatal<C::NodeId>),
+    Fatal(#[from] Fatal<NID>),
 }
 
-impl<C: RaftTypeConfig> From<StorageError<C::NodeId>> for AppendEntriesError<C> {
-    fn from(s: StorageError<C::NodeId>) -> Self {
-        let f: Fatal<C::NodeId> = s.into();
+impl<NID: NodeId> From<StorageError<NID>> for AppendEntriesError<NID> {
+    fn from(s: StorageError<NID>) -> Self {
+        let f: Fatal<NID> = s.into();
         f.into()
     }
 }
-impl<C: RaftTypeConfig> From<StorageError<C::NodeId>> for VoteError<C> {
-    fn from(s: StorageError<C::NodeId>) -> Self {
-        let f: Fatal<C::NodeId> = s.into();
+impl<NID: NodeId> From<StorageError<NID>> for VoteError<NID> {
+    fn from(s: StorageError<NID>) -> Self {
+        let f: Fatal<NID> = s.into();
         f.into()
     }
 }
-impl<C: RaftTypeConfig> From<StorageError<C::NodeId>> for InstallSnapshotError<C> {
-    fn from(s: StorageError<C::NodeId>) -> Self {
-        let f: Fatal<C::NodeId> = s.into();
+impl<NID: NodeId> From<StorageError<NID>> for InstallSnapshotError<NID> {
+    fn from(s: StorageError<NID>) -> Self {
+        let f: Fatal<NID> = s.into();
         f.into()
     }
 }
-impl<C: RaftTypeConfig> From<StorageError<C::NodeId>> for CheckIsLeaderError<C> {
-    fn from(s: StorageError<C::NodeId>) -> Self {
-        let f: Fatal<C::NodeId> = s.into();
+impl<NID: NodeId> From<StorageError<NID>> for CheckIsLeaderError<NID> {
+    fn from(s: StorageError<NID>) -> Self {
+        let f: Fatal<NID> = s.into();
         f.into()
     }
 }
-impl<C: RaftTypeConfig> From<StorageError<C::NodeId>> for InitializeError<C> {
-    fn from(s: StorageError<C::NodeId>) -> Self {
-        let f: Fatal<C::NodeId> = s.into();
+impl<NID: NodeId> From<StorageError<NID>> for InitializeError<NID> {
+    fn from(s: StorageError<NID>) -> Self {
+        let f: Fatal<NID> = s.into();
         f.into()
     }
 }
@@ -230,7 +236,7 @@ pub enum ReplicationError<C: RaftTypeConfig> {
     Network(#[from] NetworkError),
 
     #[error(transparent)]
-    RemoteError(#[from] RemoteError<C, AppendEntriesError<C>>),
+    RemoteError(#[from] RemoteError<C, AppendEntriesError<C::NodeId>>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
@@ -334,10 +340,11 @@ pub struct SnapshotMismatch {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[serde(bound = "")]
 #[error("not enough for a quorum, cluster: {cluster}, got: {got:?}")]
-pub struct QuorumNotEnough<C: RaftTypeConfig> {
+pub struct QuorumNotEnough<NID: NodeId> {
     pub cluster: String,
-    pub got: BTreeSet<C::NodeId>,
+    pub got: BTreeSet<NID>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -50,16 +50,16 @@ where C: RaftTypeConfig
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse<C>, RPCError<C, AppendEntriesError<C>>>;
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C, AppendEntriesError<C::NodeId>>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C>, RPCError<C, InstallSnapshotError<C>>>;
+    ) -> Result<InstallSnapshotResponse<C>, RPCError<C, InstallSnapshotError<C::NodeId>>>;
 
     /// Send a RequestVote RPC to the target Raft node (§5).
-    async fn send_vote(&mut self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, RPCError<C, VoteError<C>>>;
+    async fn send_vote(&mut self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, RPCError<C, VoteError<C::NodeId>>>;
 }
 
 /// A trait defining the interface for a Raft network factory to create connections between cluster members.

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -533,7 +533,7 @@ where
     }
 
     /// Send a is_leader request to the target node.
-    pub async fn is_leader(&self, target: C::NodeId) -> Result<(), CheckIsLeaderError<C>> {
+    pub async fn is_leader(&self, target: C::NodeId) -> Result<(), CheckIsLeaderError<C::NodeId>> {
         let node = {
             let rt = self.routing_table.lock().unwrap();
             rt.get(&target).unwrap_or_else(|| panic!("node with ID {} does not exist", target)).clone()
@@ -580,7 +580,7 @@ where
         &self,
         target: C::NodeId,
         req: C::D,
-    ) -> std::result::Result<C::R, ClientWriteError<C>> {
+    ) -> std::result::Result<C::R, ClientWriteError<C::NodeId>> {
         let node = {
             let rt = self.routing_table.lock().unwrap();
             rt.get(&target)
@@ -892,7 +892,7 @@ where
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
-    ) -> std::result::Result<AppendEntriesResponse<C>, RPCError<C, AppendEntriesError<C>>> {
+    ) -> std::result::Result<AppendEntriesResponse<C>, RPCError<C, AppendEntriesError<C::NodeId>>> {
         tracing::debug!("append_entries to id={} {:?}", self.target, rpc);
         self.owner.rand_send_delay().await;
 
@@ -911,7 +911,7 @@ where
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<C>,
-    ) -> std::result::Result<InstallSnapshotResponse<C>, RPCError<C, InstallSnapshotError<C>>> {
+    ) -> std::result::Result<InstallSnapshotResponse<C>, RPCError<C, InstallSnapshotError<C::NodeId>>> {
         self.owner.rand_send_delay().await;
 
         self.owner.check_reachable(rpc.vote.node_id, self.target)?;
@@ -927,7 +927,7 @@ where
     async fn send_vote(
         &mut self,
         rpc: VoteRequest<C>,
-    ) -> std::result::Result<VoteResponse<C>, RPCError<C, VoteError<C>>> {
+    ) -> std::result::Result<VoteResponse<C>, RPCError<C, VoteError<C::NodeId>>> {
         self.owner.rand_send_delay().await;
 
         self.owner.check_reachable(rpc.vote.node_id, self.target)?;


### PR DESCRIPTION

## Changelog

##### Change: errors that only need NodeId instead of RaftTypeConfig as type param
- `InitializeError`
- `ClientWriteError`
- `CheckIsLeaderError`
- `AppendEntriesError`
- `VoteError`
- `InstallSnapshotError`

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/275)
<!-- Reviewable:end -->
