### PR TITLE
Change: response types that only need NodeId instead of RaftTypeConfig as type param

### DIFF
--- a/example-raft-kv/src/network/raft_network_impl.rs
+++ b/example-raft-kv/src/network/raft_network_impl.rs
@@ -73,7 +73,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_append_entries(
         &mut self,
         req: AppendEntriesRequest<ExampleTypeConfig>,
-    ) -> Result<AppendEntriesResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, AppendEntriesError<ExampleNodeId>>>
+    ) -> Result<AppendEntriesResponse<ExampleNodeId>, RPCError<ExampleTypeConfig, AppendEntriesError<ExampleNodeId>>>
     {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-append", req).await
     }
@@ -81,17 +81,15 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_install_snapshot(
         &mut self,
         req: InstallSnapshotRequest<ExampleTypeConfig>,
-    ) -> Result<
-        InstallSnapshotResponse<ExampleTypeConfig>,
-        RPCError<ExampleTypeConfig, InstallSnapshotError<ExampleNodeId>>,
-    > {
+    ) -> Result<InstallSnapshotResponse<ExampleNodeId>, RPCError<ExampleTypeConfig, InstallSnapshotError<ExampleNodeId>>>
+    {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-snapshot", req).await
     }
 
     async fn send_vote(
         &mut self,
         req: VoteRequest<ExampleTypeConfig>,
-    ) -> Result<VoteResponse<ExampleTypeConfig>, RPCError<ExampleTypeConfig, VoteError<ExampleNodeId>>> {
+    ) -> Result<VoteResponse<ExampleNodeId>, RPCError<ExampleTypeConfig, VoteError<ExampleNodeId>>> {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-vote", req).await
     }
 }

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -23,7 +23,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(super) async fn handle_append_entries_request(
         &mut self,
         req: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse<C>, AppendEntriesError<C::NodeId>> {
+    ) -> Result<AppendEntriesResponse<C::NodeId>, AppendEntriesError<C::NodeId>> {
         tracing::debug!(last_log_id=?self.last_log_id, ?self.last_applied, msg=%req.summary(), "handle_append_entries_request");
 
         let msg_entries = req.entries.as_slice();
@@ -161,7 +161,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         prev_log_id: Option<LogId<C::NodeId>>,
         entries: &[Entry<C>],
         committed: Option<LogId<C::NodeId>>,
-    ) -> Result<AppendEntriesResponse<C>, StorageError<C::NodeId>> {
+    ) -> Result<AppendEntriesResponse<C::NodeId>, StorageError<C::NodeId>> {
         let mismatched = self.does_log_id_match(prev_log_id).await?;
 
         tracing::debug!(

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -32,7 +32,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(super) async fn handle_install_snapshot_request(
         &mut self,
         req: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C::NodeId>> {
+    ) -> Result<InstallSnapshotResponse<C::NodeId>, InstallSnapshotError<C::NodeId>> {
         if req.vote < self.vote {
             tracing::debug!(?self.vote, %req.vote, "InstallSnapshot RPC term is less than current term");
 
@@ -92,7 +92,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     async fn begin_installing_snapshot(
         &mut self,
         req: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C::NodeId>> {
+    ) -> Result<InstallSnapshotResponse<C::NodeId>, InstallSnapshotError<C::NodeId>> {
         let id = req.meta.snapshot_id.clone();
 
         if req.offset > 0 {
@@ -137,7 +137,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         req: InstallSnapshotRequest<C>,
         mut offset: u64,
         mut snapshot: Box<S::SnapshotData>,
-    ) -> Result<InstallSnapshotResponse<C>, InstallSnapshotError<C::NodeId>> {
+    ) -> Result<InstallSnapshotResponse<C::NodeId>, InstallSnapshotError<C::NodeId>> {
         let id = req.meta.snapshot_id.clone();
 
         // Always seek to the target offset if not an exact match.

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -23,7 +23,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(super) async fn handle_vote_request(
         &mut self,
         req: VoteRequest<C>,
-    ) -> Result<VoteResponse<C>, VoteError<C::NodeId>> {
+    ) -> Result<VoteResponse<C::NodeId>, VoteError<C::NodeId>> {
         tracing::debug!(
             %req.vote,
             ?self.vote,
@@ -97,7 +97,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Candida
     #[tracing::instrument(level = "debug", skip(self, res))]
     pub(super) async fn handle_vote_response(
         &mut self,
-        res: VoteResponse<C>,
+        res: VoteResponse<C::NodeId>,
         target: C::NodeId,
     ) -> Result<(), StorageError<C::NodeId>> {
         tracing::debug!(res=?res, target=display(target), "recv vote response");
@@ -145,7 +145,9 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Candida
 
     /// Spawn parallel vote requests to all cluster members.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub(super) async fn spawn_parallel_vote_requests(&mut self) -> mpsc::Receiver<(VoteResponse<C>, C::NodeId)> {
+    pub(super) async fn spawn_parallel_vote_requests(
+        &mut self,
+    ) -> mpsc::Receiver<(VoteResponse<C::NodeId>, C::NodeId)> {
         let all_nodes = self.core.effective_membership.all_members().clone();
         let (tx, rx) = mpsc::channel(all_nodes.len());
 

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -50,16 +50,19 @@ where C: RaftTypeConfig
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse<C>, RPCError<C, AppendEntriesError<C::NodeId>>>;
+    ) -> Result<AppendEntriesResponse<C::NodeId>, RPCError<C, AppendEntriesError<C::NodeId>>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C>, RPCError<C, InstallSnapshotError<C::NodeId>>>;
+    ) -> Result<InstallSnapshotResponse<C::NodeId>, RPCError<C, InstallSnapshotError<C::NodeId>>>;
 
     /// Send a RequestVote RPC to the target Raft node (§5).
-    async fn send_vote(&mut self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, RPCError<C, VoteError<C::NodeId>>>;
+    async fn send_vote(
+        &mut self,
+        rpc: VoteRequest<C>,
+    ) -> Result<VoteResponse<C::NodeId>, RPCError<C, VoteError<C::NodeId>>>;
 }
 
 /// A trait defining the interface for a Raft network factory to create connections between cluster members.

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -892,7 +892,7 @@ where
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
-    ) -> std::result::Result<AppendEntriesResponse<C>, RPCError<C, AppendEntriesError<C::NodeId>>> {
+    ) -> std::result::Result<AppendEntriesResponse<C::NodeId>, RPCError<C, AppendEntriesError<C::NodeId>>> {
         tracing::debug!("append_entries to id={} {:?}", self.target, rpc);
         self.owner.rand_send_delay().await;
 
@@ -911,7 +911,7 @@ where
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<C>,
-    ) -> std::result::Result<InstallSnapshotResponse<C>, RPCError<C, InstallSnapshotError<C::NodeId>>> {
+    ) -> std::result::Result<InstallSnapshotResponse<C::NodeId>, RPCError<C, InstallSnapshotError<C::NodeId>>> {
         self.owner.rand_send_delay().await;
 
         self.owner.check_reachable(rpc.vote.node_id, self.target)?;
@@ -927,7 +927,7 @@ where
     async fn send_vote(
         &mut self,
         rpc: VoteRequest<C>,
-    ) -> std::result::Result<VoteResponse<C>, RPCError<C, VoteError<C::NodeId>>> {
+    ) -> std::result::Result<VoteResponse<C::NodeId>, RPCError<C, VoteError<C::NodeId>>> {
         self.owner.rand_send_delay().await;
 
         self.owner.check_reachable(rpc.vote.node_id, self.target)?;


### PR DESCRIPTION

## Changelog

##### Change: response types that only need NodeId instead of RaftTypeConfig as type param
- `AppendEntriesResponse`
- `VoteResponse`
- `InstallSnapshotResponse`

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/276)
<!-- Reviewable:end -->
