### PR TITLE
Refactor: replicate_client_request() does not need an entry, only log_id

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -285,7 +285,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
         self.core.metrics_flags.set_data_changed();
 
-        self.replicate_client_request(entry, resp_tx).await?;
+        self.replicate_client_request(entry.log_id, resp_tx).await?;
 
         Ok(())
     }

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -49,21 +49,21 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     // --- replication ---
     // ---
     /// The metrics about the leader. It is Some() only when this node is leader.
-    pub leader_metrics: Option<Versioned<ReplicationMetrics<C::NodeId>>>,
+    pub replication: Option<Versioned<ReplicationMetrics<C::NodeId>>>,
 }
 
 impl<C: RaftTypeConfig> MessageSummary for RaftMetrics<C> {
     fn summary(&self) -> String {
         format!("Metrics{{id:{},{:?}, term:{}, last_log:{:?}, last_applied:{:?}, leader:{:?}, membership:{}, snapshot:{:?}, replication:{}",
-            self.id,
-            self.state,
-            self.current_term,
-            self.last_log_index,
-            self.last_applied,
-            self.current_leader,
-            self.membership_config.summary(),
-            self.snapshot,
-            self.leader_metrics.as_ref().map(|x| x.summary()).unwrap_or_default(),
+                self.id,
+                self.state,
+                self.current_term,
+                self.last_log_index,
+                self.last_applied,
+                self.current_leader,
+                self.membership_config.summary(),
+                self.snapshot,
+                self.replication.as_ref().map(|x| x.summary()).unwrap_or_default(),
         )
     }
 }
@@ -80,7 +80,7 @@ impl<C: RaftTypeConfig> RaftMetrics<C> {
             current_leader: None,
             membership_config: Arc::new(EffectiveMembership::default()),
             snapshot: None,
-            leader_metrics: None,
+            replication: None,
         }
     }
 }

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -209,7 +209,7 @@ fn init_wait_test<C: RaftTypeConfig>() -> (RaftMetrics<C>, Wait<C>, watch::Sende
         )),
 
         snapshot: None,
-        leader_metrics: None,
+        replication: None,
     };
     let (tx, rx) = watch::channel(init.clone());
     let w = Wait {

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -65,7 +65,7 @@ async fn leader_metrics() -> Result<()> {
         .wait_for_metrics(
             &0,
             |x| {
-                if let Some(ref q) = x.leader_metrics {
+                if let Some(ref q) = x.replication {
                     q.data().replication.is_empty()
                 } else {
                     false
@@ -113,7 +113,7 @@ async fn leader_metrics() -> Result<()> {
         .wait_for_metrics(
             &0,
             |x| {
-                if let Some(ref q) = x.leader_metrics {
+                if let Some(ref q) = x.replication {
                     q.data().replication == want_repl
                 } else {
                     false
@@ -162,7 +162,7 @@ async fn leader_metrics() -> Result<()> {
             .wait_for_metrics(
                 &0,
                 |x| {
-                    if let Some(ref q) = x.leader_metrics {
+                    if let Some(ref q) = x.replication {
                         q.data().replication == want_repl
                     } else {
                         false
@@ -190,7 +190,7 @@ async fn leader_metrics() -> Result<()> {
         router
             .wait_for_metrics(
                 &leader,
-                |x| x.leader_metrics.is_none(),
+                |x| x.replication.is_none(),
                 timeout(),
                 "node 0 should close all replication",
             )
@@ -220,7 +220,7 @@ async fn leader_metrics() -> Result<()> {
     router
         .wait_for_metrics(
             &leader,
-            |x| x.leader_metrics.is_some(),
+            |x| x.replication.is_some(),
             timeout(),
             "new leader spawns replication",
         )


### PR DESCRIPTION

## Changelog

##### Refactor: replicate_client_request() does not need an entry, only log_id

##### rename RaftMetrics.leader_metrics to replication
- part of #229

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/279)
<!-- Reviewable:end -->
