### PR TITLE
Refactor: move installation of client resp callback out of `replicate_client_request()`

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -285,7 +285,12 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
         self.core.metrics_flags.set_data_changed();
 
-        self.replicate_client_request(entry.log_id, resp_tx).await?;
+        // Install callback in which the entry will be applied to state machine.
+        if let Some(tx) = resp_tx {
+            self.client_resp_channels.insert(entry.log_id.index, tx);
+        }
+
+        self.replicate_client_request(entry.log_id).await?;
 
         Ok(())
     }


### PR DESCRIPTION

## Changelog

##### Refactor: move installation of client resp callback out of `replicate_client_request()`
Installing callback is not a job of `replicate_client_request()`.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/280)
<!-- Reviewable:end -->
