### PR TITLE
Fix: continuous index in test suit last_membership_in_log

### DIFF
--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -164,11 +164,11 @@ where
             store
                 .append_to_log(&[
                     &Entry {
-                        log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 3),
+                        log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 2),
                         payload: EntryPayload::Membership(Membership::new(vec![btreeset! {7,8,9}], None)),
                     },
                     &Entry {
-                        log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 4),
+                        log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 3),
                         payload: EntryPayload::Blank,
                     },
                 ])

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -165,10 +165,14 @@ where
                 .append_to_log(&[
                     &Entry {
                         log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 2),
-                        payload: EntryPayload::Membership(Membership::new(vec![btreeset! {7,8,9}], None)),
+                        payload: EntryPayload::Blank,
                     },
                     &Entry {
                         log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 3),
+                        payload: EntryPayload::Membership(Membership::new(vec![btreeset! {7,8,9}], None)),
+                    },
+                    &Entry {
+                        log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 4),
                         payload: EntryPayload::Blank,
                     },
                 ])
@@ -239,10 +243,16 @@ where
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
         {
             store
-                .append_to_log(&[&Entry {
-                    log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 3),
-                    payload: EntryPayload::Membership(Membership::new(vec![btreeset! {7,8,9}], None)),
-                }])
+                .append_to_log(&[
+                    &Entry {
+                        log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 2),
+                        payload: EntryPayload::Blank,
+                    },
+                    &Entry {
+                        log_id: LogId::new(LeaderId::new(1, NODE_ID.into()), 3),
+                        payload: EntryPayload::Membership(Membership::new(vec![btreeset! {7,8,9}], None)),
+                    },
+                ])
                 .await?;
 
             let mem = store.get_membership().await?;


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->

Signed-off-by: MrCroxx <mrcroxx@outlook.com>

A small fix for #282 . Make test log indices continuous to prevent from causing log gaps.

**Checklist**
- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will `:)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/283)
<!-- Reviewable:end -->
