### PR TITLE
Refactor: Engine impl raft, Runtime execute commands

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -7,6 +7,7 @@ use tracing::warn;
 use crate::core::LeaderState;
 use crate::core::LearnerState;
 use crate::core::State;
+use crate::entry::EntryRef;
 use crate::error::AddLearnerError;
 use crate::error::ChangeMembershipError;
 use crate::error::ClientWriteError;
@@ -16,13 +17,13 @@ use crate::error::InitializeError;
 use crate::error::LearnerIsLagging;
 use crate::error::LearnerNotFound;
 use crate::error::MissingNodeInfo;
-use crate::error::NotAllowed;
 use crate::metrics::RemoveTarget;
 use crate::raft::AddLearnerResponse;
 use crate::raft::ChangeMembers;
 use crate::raft::ClientWriteResponse;
 use crate::raft::RaftRespTx;
 use crate::raft_types::LogIdOptionExt;
+use crate::runtime::RaftRuntime;
 use crate::versioned::Updatable;
 use crate::EntryPayload;
 use crate::LogId;
@@ -32,7 +33,6 @@ use crate::RaftNetworkFactory;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::Vote;
 
 impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LearnerState<'a, C, N, S> {
     /// Handle the admin `init_with_config` command.
@@ -44,16 +44,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
         &mut self,
         members: BTreeMap<C::NodeId, Option<Node>>,
     ) -> Result<(), InitializeError<C::NodeId>> {
-        if self.core.last_log_id.is_some() || self.core.vote != Vote::default() {
-            tracing::error!(
-                last_log_id=?self.core.last_log_id, ?self.core.vote,
-                "rejecting init_with_config request as last_log_index is not None or current_term is not 0");
-            return Err(InitializeError::NotAllowed(NotAllowed {
-                last_log_id: self.core.last_log_id,
-                vote: self.core.vote,
-            }));
-        }
-
         let node_ids = members.keys().cloned().collect::<BTreeSet<C::NodeId>>();
 
         if !node_ids.contains(&self.core.id) {
@@ -65,10 +55,13 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
         }
 
         let membership = Membership::with_nodes(vec![node_ids], members)?;
+        let payload = EntryPayload::<C>::Membership(membership);
 
-        let payload = EntryPayload::Membership(membership.clone());
-        let _ent = self.core.append_payload_to_log(payload).await?;
+        let mut entry_refs = vec![EntryRef::new(&payload)];
+        self.core.engine.initialize(&mut entry_refs)?;
+        self.run_engine_commands(&entry_refs).await?;
 
+        // TODO: This should be done by Engine.
         self.core.set_target_state(State::Candidate);
 
         Ok(())
@@ -78,35 +71,30 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
 impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderState<'a, C, N, S> {
     // add node into learner,return true if the node is already a member or learner
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn add_learner_into_membership(
+    async fn write_add_learner_entry(
         &mut self,
         target: C::NodeId,
         node: Option<Node>,
-    ) -> Result<bool, MissingNodeInfo<C::NodeId>> {
-        tracing::debug!(
-            "add_learner_into_membership target node {:?} into learner {:?}",
-            target,
-            self.nodes.keys()
-        );
-
-        let curr = &self.core.effective_membership.membership;
-
-        if curr.contains(&target) {
-            tracing::debug!("target {:?} already member or learner, can't add", target);
-            return Ok(true);
-        }
-
+    ) -> Result<(), AddLearnerError<C::NodeId>> {
+        let curr = &self.core.engine.state.effective_membership.membership;
         let new_membership = curr.add_learner(target, node)?;
 
         tracing::debug!(?new_membership, "new_config");
 
-        let _ = self.append_membership_log(new_membership, None).await;
+        self.write_entry(EntryPayload::Membership(new_membership), None).await?;
 
-        Ok(false)
+        Ok(())
     }
 
     /// Add a new node to the cluster as a learner, bringing it up-to-speed, and then responding
     /// on the given channel.
+    ///
+    /// Adding a learner does not affect election, thus it does not need to enter joint consensus.
+    ///
+    /// And it does not need to wait for the previous membership log to commit to propose the new membership log.
+    ///
+    /// If `blocking` is `true`, the result is sent to `tx` as the target node log has caught up. Otherwise, result is
+    /// sent at once, no matter whether the target node log is lagging or not.
     #[tracing::instrument(level = "debug", skip(self, tx))]
     pub(super) async fn add_learner(
         &mut self,
@@ -122,32 +110,40 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         if target == self.core.id {
             tracing::debug!("target node is this node");
             let _ = tx.send(Ok(AddLearnerResponse {
-                matched: self.core.last_log_id,
+                matched: self.core.engine.state.last_log_id,
             }));
             return;
         }
 
-        if let Some(t) = self.nodes.get(&target) {
-            tracing::debug!("target node is already a cluster member or is being synced");
-            let _ = tx.send(Ok(AddLearnerResponse { matched: t.matched }));
-            return;
+        let curr = &self.core.engine.state.effective_membership;
+        let exists = curr.get_nodes().contains_key(&target);
+        if exists {
+            tracing::debug!("target {:?} already member or learner, can't add", target);
+
+            if let Some(t) = self.nodes.get(&target) {
+                tracing::debug!("target node is already a cluster member or is being synced");
+                let _ = tx.send(Ok(AddLearnerResponse { matched: t.matched }));
+                return;
+            } else {
+                unreachable!(
+                    "node {} in membership but there is no replication stream for it",
+                    target
+                )
+            }
         }
 
-        let exist = self.add_learner_into_membership(target, node).await;
-        let exist = match exist {
-            Ok(x) => x,
-            Err(e) => {
-                let _ = tx.send(Err(AddLearnerError::<C::NodeId>::from(e)));
-                return;
-            }
-        };
-
-        if exist {
+        // TODO(xp): when new membership log is appended, write_entry() should be responsible to setup new replication
+        //           stream.
+        let res = self.write_add_learner_entry(target, node).await;
+        if let Err(e) = res {
+            let _ = tx.send(Err(e));
             return;
         }
 
         if blocking {
             let state = self.spawn_replication_stream(target, Some(tx)).await;
+            // TODO(xp): nodes, i.e., replication streams, should also be a property of follower or candidate, for
+            //           sending vote requests etc?
             self.nodes.insert(target, state);
         } else {
             let state = self.spawn_replication_stream(target, None).await;
@@ -160,7 +156,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         tracing::debug!(
             "after add target node {} as learner {:?}",
             target,
-            self.core.last_log_id
+            self.core.engine.state.last_log_id
         );
     }
 
@@ -168,7 +164,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     fn has_pending_config(&self) -> bool {
         // The last membership config is not committed yet.
         // Can not process the next one.
-        self.core.committed < self.core.effective_membership.log_id
+        self.core.engine.state.committed < self.core.engine.state.effective_membership.log_id
     }
 
     #[tracing::instrument(level = "debug", skip(self, tx))]
@@ -179,7 +175,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         turn_to_learner: bool,
         tx: RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>,
     ) -> Result<(), StorageError<C::NodeId>> {
-        let members = change_members.apply_to(self.core.effective_membership.membership.get_configs().last().unwrap());
+        let members = change_members
+            .apply_to(self.core.engine.state.effective_membership.membership.get_configs().last().unwrap());
         // Ensure cluster will have at least one node.
         if members.is_empty() {
             let _ = tx.send(Err(ClientWriteError::ChangeMembershipError(
@@ -192,14 +189,14 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             let _ = tx.send(Err(ClientWriteError::ChangeMembershipError(
                 ChangeMembershipError::InProgress(InProgress {
                     // has_pending_config() implies an existing membership log.
-                    membership_log_id: self.core.effective_membership.log_id.unwrap(),
+                    membership_log_id: self.core.engine.state.effective_membership.log_id.unwrap(),
                 }),
             )));
             return Ok(());
         }
 
-        let curr = self.core.effective_membership.membership.clone();
-        let all_members = self.core.effective_membership.all_members();
+        let curr = self.core.engine.state.effective_membership.membership.clone();
+        let all_members = self.core.engine.state.effective_membership.all_members();
         let new_members = members.difference(all_members);
 
         let new_config = {
@@ -221,7 +218,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             return Ok(());
         }
 
-        self.append_membership_log(new_config, Some(tx)).await?;
+        self.write_entry(EntryPayload::Membership(new_config), Some(tx)).await?;
         Ok(())
     }
 
@@ -245,7 +242,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         for node_id in nodes.iter() {
             match self.nodes.get(node_id) {
                 Some(node) => {
-                    if node.is_line_rate(&self.core.last_log_id, &self.core.config) {
+                    if node.is_line_rate(&self.core.engine.state.last_log_id, &self.core.config) {
                         // Node is ready to join.
                         continue;
                     }
@@ -256,7 +253,13 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
                             ChangeMembershipError::LearnerIsLagging(LearnerIsLagging {
                                 node_id: *node_id,
                                 matched: node.matched,
-                                distance: self.core.last_log_id.next_index().saturating_sub(node.matched.next_index()),
+                                distance: self
+                                    .core
+                                    .engine
+                                    .state
+                                    .last_log_id
+                                    .next_index()
+                                    .saturating_sub(node.matched.next_index()),
                             }),
                         ));
                     }
@@ -274,23 +277,42 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self, resp_tx), fields(id=display(self.core.id)))]
-    pub async fn append_membership_log(
+    /// Write a log entry to the cluster through raft protocol.
+    ///
+    /// I.e.: append the log entry to local store, forward it to a quorum(including the leader), waiting for it to be
+    /// committed and applied.
+    ///
+    /// The result of applying it to state machine is sent to `resp_tx`, if it is not `None`.
+    /// The calling side may not receive a result from `resp_tx`, if raft is shut down.
+    #[tracing::instrument(level = "debug", skip(self, payload, resp_tx), fields(id=display(self.core.id)))]
+    pub async fn write_entry(
         &mut self,
-        mem: Membership<C::NodeId>,
+        payload: EntryPayload<C>,
         resp_tx: Option<RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>>,
     ) -> Result<(), StorageError<C::NodeId>> {
-        let payload = EntryPayload::Membership(mem.clone());
-        let entry = self.core.append_payload_to_log(payload).await?;
+        let mut entry_refs = vec![EntryRef::new(&payload)];
+        // TODO: it should returns membership config error etc. currently this is done by the caller.
+        self.core.engine.leader_append_entries(&mut entry_refs);
 
-        self.core.metrics_flags.set_data_changed();
-
-        // Install callback in which the entry will be applied to state machine.
+        // Install callback channels.
         if let Some(tx) = resp_tx {
-            self.client_resp_channels.insert(entry.log_id.index, tx);
+            self.client_resp_channels.insert(entry_refs[0].log_id.index, tx);
         }
 
-        self.replicate_client_request(entry.log_id).await?;
+        self.run_engine_commands(&entry_refs).await?;
+
+        Ok(())
+    }
+
+    async fn run_engine_commands<'p>(
+        &mut self,
+        input_entries: &[EntryRef<'p, C>],
+    ) -> Result<(), StorageError<C::NodeId>> {
+        let mut curr = 0;
+        let cmds = self.core.engine.commands.drain(..).collect::<Vec<_>>();
+        for cmd in cmds {
+            self.run_command(input_entries, &mut curr, &cmd).await?;
+        }
 
         Ok(())
     }
@@ -303,7 +325,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         let index = log_id.index;
 
         // Step down if needed.
-        if !self.core.effective_membership.membership.is_member(&self.core.id) {
+        if !self.core.engine.state.effective_membership.membership.is_member(&self.core.id) {
             tracing::debug!("raft node is stepping down");
 
             // TODO(xp): transfer leadership
@@ -311,7 +333,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             return;
         }
 
-        let membership = &self.core.effective_membership.membership;
+        let membership = &self.core.engine.state.effective_membership.membership;
 
         // remove nodes which not included in nodes and learners
         for (id, state) in self.nodes.iter_mut() {
@@ -323,7 +345,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
                 "set remove_after_commit for {} = {}, membership: {:?}",
                 id,
                 index,
-                self.core.effective_membership
+                self.core.engine.state.effective_membership
             );
 
             state.remove_since = Some(index)
@@ -334,7 +356,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             self.try_remove_replication(target);
         }
 
-        self.core.metrics_flags.set_replication_changed();
+        self.core.engine.metrics_flags.set_replication_changed();
     }
 
     /// Remove a replication if the membership that does not include it has committed.
@@ -367,7 +389,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         self.replication_metrics.update(RemoveTarget { target });
         // TODO(xp): set_replication_metrics_changed() can be removed.
         //           Use self.replication_metrics.version to detect changes.
-        self.core.metrics_flags.set_replication_changed();
+        self.core.engine.metrics_flags.set_replication_changed();
 
         true
     }

--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -1,0 +1,45 @@
+use crate::core::LeaderState;
+use crate::engine::Command;
+use crate::entry::EntryRef;
+use crate::entry::RaftEntry;
+use crate::runtime::RaftRuntime;
+use crate::RaftNetworkFactory;
+use crate::RaftStorage;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+
+#[async_trait::async_trait]
+impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime<C> for LeaderState<'a, C, N, S> {
+    async fn run_command<'p>(
+        &mut self,
+        input_entries: &[EntryRef<'p, C>],
+        curr: &mut usize,
+        cmd: &Command<C::NodeId>,
+    ) -> Result<(), StorageError<C::NodeId>> {
+        // Run leader specific commands or pass non leader specific commands to self.core.
+        match cmd {
+            Command::Commit { ref upto } => {
+                for ent in input_entries.iter() {
+                    let log_id = &ent.log_id;
+                    if log_id <= upto {
+                        self.client_request_post_commit(log_id.index).await?;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            Command::ReplicateInputEntries { range } => {
+                for i in range.clone() {
+                    self.replicate_entry(*input_entries[i].get_log_id());
+                }
+            }
+            Command::UpdateMembership { .. } => {
+                // TODO: rebuild replication streams. not used yet. Currently replication stream management is done
+                // before this step.
+            }
+            _ => self.core.run_command(input_entries, curr, cmd).await?,
+        }
+
+        Ok(())
+    }
+}

--- a/openraft/src/core/learner_state.rs
+++ b/openraft/src/core/learner_state.rs
@@ -1,0 +1,36 @@
+use crate::core::LearnerState;
+use crate::engine::Command;
+use crate::entry::EntryRef;
+use crate::runtime::RaftRuntime;
+use crate::RaftNetworkFactory;
+use crate::RaftStorage;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+
+#[async_trait::async_trait]
+impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime<C> for LearnerState<'a, C, N, S> {
+    async fn run_command<'p>(
+        &mut self,
+        input_entries: &[EntryRef<'p, C>],
+        curr: &mut usize,
+        cmd: &Command<C::NodeId>,
+    ) -> Result<(), StorageError<C::NodeId>> {
+        // A learner has no special cmd impl, pass all to core.
+        self.core.run_command(input_entries, curr, cmd).await
+    }
+}
+
+impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LearnerState<'a, C, N, S> {
+    pub(crate) async fn run_engine_commands<'p>(
+        &mut self,
+        input_entries: &[EntryRef<'p, C>],
+    ) -> Result<(), StorageError<C::NodeId>> {
+        let mut curr = 0;
+        let it = self.core.engine.commands.drain(..).collect::<Vec<_>>();
+        for cmd in it {
+            self.run_command(input_entries, &mut curr, &cmd).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1,0 +1,65 @@
+use crate::core::RaftCore;
+use crate::engine::Command;
+use crate::entry::EntryRef;
+use crate::runtime::RaftRuntime;
+use crate::RaftNetworkFactory;
+use crate::RaftStorage;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+
+impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C, N, S> {
+    // TODO:
+    #[allow(dead_code)]
+    async fn run_engine_commands<'p>(
+        &mut self,
+        input_entries: &[EntryRef<'p, C>],
+    ) -> Result<(), StorageError<C::NodeId>> {
+        let mut curr = 0;
+        let it = self.engine.commands.drain(..).collect::<Vec<_>>();
+        for cmd in it {
+            self.run_command(input_entries, &mut curr, &cmd).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime<C> for RaftCore<C, N, S> {
+    async fn run_command<'p>(
+        &mut self,
+        input_ref_entries: &[EntryRef<'p, C>],
+        cur: &mut usize,
+        cmd: &Command<C::NodeId>,
+    ) -> Result<(), StorageError<C::NodeId>> {
+        // Run non-role-specific command.
+        match cmd {
+            Command::AppendInputEntries { range } => {
+                let entry_refs = &input_ref_entries[range.clone()];
+
+                let mut entries = Vec::with_capacity(entry_refs.len());
+                for ent in entry_refs.iter() {
+                    entries.push(ent.into())
+                }
+
+                // Build a slice of references.
+                let entry_refs = entries.iter().collect::<Vec<_>>();
+
+                self.storage.append_to_log(&entry_refs).await?
+            }
+            Command::MoveInputCursorBy { n } => *cur += n,
+            Command::SaveVote { .. } => {}
+            Command::PurgeAppliedLog { .. } => {}
+            Command::DeleteConflictLog { .. } => {}
+            Command::BuildSnapshot { .. } => {}
+            Command::SendVote { .. } => {}
+            Command::Commit { .. } => {}
+            Command::ReplicateInputEntries { .. } => {
+                unreachable!("leader specific command")
+            }
+            Command::UpdateMembership { .. } => {}
+        }
+
+        Ok(())
+    }
+}

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1,3 +1,5 @@
+use std::mem::swap;
+
 use crate::core::RaftCore;
 use crate::engine::Command;
 use crate::entry::EntryRef;
@@ -15,8 +17,9 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         input_entries: &[EntryRef<'p, C>],
     ) -> Result<(), StorageError<C::NodeId>> {
         let mut curr = 0;
-        let it = self.engine.commands.drain(..).collect::<Vec<_>>();
-        for cmd in it {
+        let mut commands = vec![];
+        swap(&mut self.engine.commands, &mut commands);
+        for cmd in commands {
             self.run_command(input_entries, &mut curr, &cmd).await?;
         }
 

--- a/openraft/src/engine.rs
+++ b/openraft/src/engine.rs
@@ -1,0 +1,259 @@
+use std::collections::BTreeSet;
+use std::ops::Range;
+use std::sync::Arc;
+
+use maplit::btreeset;
+
+use crate::entry::RaftEntry;
+use crate::error::InitializeError;
+use crate::error::NotAllowed;
+use crate::storage::InitialState;
+use crate::EffectiveMembership;
+use crate::LogId;
+use crate::LogIdOptionExt;
+use crate::Membership;
+use crate::MetricsChangeFlags;
+use crate::NodeId;
+use crate::Vote;
+
+/// Raft protocol algorithm.
+///
+/// It implement the complete raft algorithm except does not actually update any states.
+/// But instead, it output commands to let a `RaftRuntime` implementation execute them to actually update the states
+/// such as append-log or save-vote by execute .
+///
+/// This structure only contains necessary information to run raft algorithm,
+/// but none of the application specific data.
+/// TODO: make the fields private
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Engine<NID: NodeId> {
+    /// TODO:
+    #[allow(dead_code)]
+    pub(crate) id: NID,
+
+    /// Cache of a cluster of only this node.
+    ///
+    /// It is used to check an early commit if there is only one node in a cluster.
+    pub(crate) single_node_cluster: BTreeSet<NID>,
+
+    /// The state of this raft node.
+    pub(crate) state: InitialState<NID>,
+
+    /// Tracks what kind of metrics changed
+    pub(crate) metrics_flags: MetricsChangeFlags,
+
+    /// Command queue that need to be executed by `RaftRuntime`.
+    pub(crate) commands: Vec<Command<NID>>,
+}
+
+/// Commands to send to `RaftRuntime` to execute, to update the application state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Command<NID: NodeId> {
+    // Append a `range` of entries in the input buffer.
+    AppendInputEntries {
+        range: Range<usize>,
+    },
+
+    // Commit entries that are already in the store, upto `upto`, inclusive.
+    // And send applied result to the client that proposed the entry.
+    Commit {
+        upto: LogId<NID>,
+    },
+
+    // Replicate a `range` of entries in the input buffer.
+    ReplicateInputEntries {
+        range: Range<usize>,
+    },
+
+    // Membership config changed, need to update replication stream etc.
+    UpdateMembership {
+        membership: Membership<NID>,
+    },
+
+    // Move the cursor pointing to an entry in the input buffer.
+    MoveInputCursorBy {
+        n: usize,
+    },
+
+    //
+    // --- Draft unimplemented commands:
+    //
+    // TODO:
+    #[allow(dead_code)]
+    SaveVote {
+        vote: Vote<NID>,
+    },
+    // TODO:
+    #[allow(dead_code)]
+    SendVote {
+        vote: Vote<NID>,
+    },
+
+    // TODO:
+    #[allow(dead_code)]
+    PurgeAppliedLog {
+        upto: LogId<NID>,
+    },
+    // TODO:
+    #[allow(dead_code)]
+    DeleteConflictLog {
+        since: LogId<NID>,
+    },
+
+    // TODO:
+    #[allow(dead_code)]
+    BuildSnapshot {},
+}
+
+impl<NID: NodeId> Engine<NID> {
+    pub(crate) fn new(id: NID, init_state: &InitialState<NID>) -> Self {
+        Self {
+            id,
+            single_node_cluster: btreeset! {id},
+            state: init_state.clone(),
+            metrics_flags: MetricsChangeFlags::default(),
+            commands: vec![],
+        }
+    }
+
+    /// Check if a raft node is in a state that allows to initialize.
+    ///
+    /// It is allowed to initialize only when `last_log_id.is_none()` and `vote==(term=0, node_id=0)`.
+    /// See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
+    pub(crate) fn check_initialize(&self) -> Result<(), InitializeError<NID>> {
+        if self.state.last_log_id.is_none() && self.state.vote == Vote::default() {
+            return Ok(());
+        }
+
+        tracing::error!(?self.state.last_log_id, ?self.state.vote, "Can not initialize");
+
+        Err(InitializeError::NotAllowed(NotAllowed {
+            last_log_id: self.state.last_log_id,
+            vote: self.state.vote,
+        }))
+    }
+
+    fn next_log_id(&mut self) -> LogId<NID> {
+        let log_id = LogId::new(self.state.vote.leader_id(), self.state.last_log_id.next_index());
+        self.state.last_log_id = Some(log_id);
+
+        log_id
+    }
+
+    /// Initialize a node by appending the first log.
+    ///
+    /// - The first log has to be membership config log.
+    /// - The node has to contain no logs at all and the vote is the minimal value. See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
+    ///
+    /// Appending the very first log is slightly different from appending log by a leader or follower.
+    /// This step is not confined by the consensus protocol and has to be dealt with differently.
+    #[tracing::instrument(level = "debug", skip(self, entries))]
+    pub(crate) fn initialize<Ent: RaftEntry<NID>>(&mut self, entries: &mut [Ent]) -> Result<(), InitializeError<NID>> {
+        let l = entries.len();
+        assert_eq!(1, l);
+
+        let entry = &mut entries[0];
+
+        self.check_initialize()?;
+
+        let log_id = self.next_log_id();
+        entry.set_log_id(&log_id);
+
+        tracing::debug!("append initialization log id: {}", log_id);
+
+        self.commands.push(Command::AppendInputEntries { range: 0..l });
+        self.metrics_flags.set_data_changed();
+
+        if let Some(m) = entry.get_membership() {
+            let em = EffectiveMembership::new(Some(*entry.get_log_id()), m.clone());
+            self.state.effective_membership = Arc::new(em);
+
+            self.commands.push(Command::UpdateMembership { membership: m.clone() });
+            self.metrics_flags.set_cluster_changed();
+        } else {
+            panic!("Initialization log has to be a membership config entry",);
+        }
+
+        // TODO: set target state. This should be done by Engine but currently it is not.
+
+        self.commands.push(Command::MoveInputCursorBy { n: l });
+
+        Ok(())
+    }
+
+    /// Update the state for a new log entry to append. Update effective membership if the payload contains
+    /// membership config.
+    ///
+    /// TODO(xp): There is no check and this method must be called by a leader.
+    /// TODO(xp): metrics flag needs to be dealt with.
+    /// TODO(xp): if vote indicates this node is not the leader, refuse append
+    #[tracing::instrument(level = "debug", skip(self, entries))]
+    pub(crate) fn leader_append_entries<Ent: RaftEntry<NID>>(&mut self, entries: &mut [Ent]) {
+        let l = entries.len();
+        if l == 0 {
+            return;
+        }
+
+        for entry in entries.iter_mut() {
+            let log_id = self.next_log_id();
+            entry.set_log_id(&log_id);
+
+            tracing::debug!("append log id: {}", log_id);
+        }
+
+        self.commands.push(Command::AppendInputEntries { range: 0..l });
+        self.metrics_flags.set_data_changed();
+
+        for entry in entries.iter_mut() {
+            // TODO: if previous membership is not committed, reject a new change-membership propose.
+            //       unless the new config does not change any members but only learners.
+            if let Some(m) = entry.get_membership() {
+                let em = EffectiveMembership::new(Some(*entry.get_log_id()), m.clone());
+                self.state.effective_membership = Arc::new(em);
+
+                self.commands.push(Command::UpdateMembership { membership: m.clone() });
+                self.metrics_flags.set_cluster_changed();
+            }
+        }
+
+        if self.state.effective_membership.membership.is_majority(&self.single_node_cluster) {
+            // already committed
+            let last = entries.last().unwrap();
+            let last_log_id = last.get_log_id();
+            self.state.committed = Some(*last_log_id);
+            // TODO: only leader need to do this. currently only leader call this method.
+            self.commands.push(Command::Commit { upto: *last_log_id });
+        }
+
+        // TODO: only leader need to do this. currently only leader call this method.
+        // still need to replicate to learners
+        self.commands.push(Command::ReplicateInputEntries { range: 0..l });
+
+        self.commands.push(Command::MoveInputCursorBy { n: l });
+    }
+
+    // --- Draft API ---
+
+    // // --- app API ---
+    //
+    // /// Write a new log entry.
+    // pub(crate) fn write(&mut self) -> Result<Vec<AlgoCmd<NID>>, ForwardToLeader<NID>> {
+    //     todo!()
+    // }
+    //
+    // /// Trigger elect
+    // pub(crate) fn elect(&mut self) -> Result<Vec<AlgoCmd<NID>>, Infallible> {
+    //     todo!()
+    // }
+    //
+    // // --- raft protocol API ---
+    //
+    // //
+    // pub(crate) fn handle_vote() {}
+    // pub(crate) fn handle_append_entries() {}
+    // pub(crate) fn handle_install_snapshot() {}
+    //
+    // pub(crate) fn handle_vote_resp() {}
+    // pub(crate) fn handle_append_entries_resp() {}
+    // pub(crate) fn handle_install_snapshot_resp() {}
+}

--- a/openraft/src/entry.rs
+++ b/openraft/src/entry.rs
@@ -140,6 +140,23 @@ impl<'p, C: RaftTypeConfig> MessageSummary for EntryRef<'p, C> {
     }
 }
 
+impl<'p, C: RaftTypeConfig> From<&EntryRef<'p, C>> for Entry<C> {
+    fn from(er: &EntryRef<'p, C>) -> Self {
+        Entry {
+            log_id: er.log_id,
+            payload: er.payload.clone(),
+        }
+    }
+}
+impl<'p, C: RaftTypeConfig> EntryRef<'p, C> {
+    pub fn new(payload: &'p EntryPayload<C>) -> Self {
+        Self {
+            log_id: Default::default(),
+            payload,
+        }
+    }
+}
+
 // impl traits for EntryPayload
 
 impl<C: RaftTypeConfig> RaftPayload<C::NodeId> for EntryPayload<C> {

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -21,10 +21,12 @@ mod store_wrapper;
 mod summary;
 mod vote;
 
+mod engine;
 pub mod error;
 pub mod metrics;
 pub mod network;
 pub mod raft;
+mod runtime;
 pub mod storage;
 pub mod testing;
 pub mod versioned;

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -1,0 +1,71 @@
+use crate::engine::Command;
+use crate::entry::EntryRef;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+
+/// Defines behaviors of a runtime to support the protocol engine.
+///
+/// An Engine defines the consensus algorithm, i.e., what to do(`command`) when some `event` happens:
+///
+/// It receives events such as `write-log-entry` from a client,
+/// or `elect` from a timer, and outputs `command`, such as
+/// `append-entry-to-storage`, or `commit-entry-at-index-5` to a runtime to execute.
+///
+/// A `RaftRuntime` talks to `RaftStorage` and `RaftNetwork` to get things done.
+///
+/// The workflow of writing something through raft protocol with engine and runtime would be like
+/// this:
+///
+/// ```text
+/// Client                    Engine                         Runtime      Storage      Netwoork
+///   |                         |      write x=1                |            |            |
+///   |-------------------------------------------------------->|            |            |
+///   |        event:write      |                               |            |            |
+///   |        .------------------------------------------------|            |            |
+///   |        '--------------->|                               |            |            |
+///   |                         |      cmd:append-log-1         |            |            |
+///   |                         |--+--------------------------->|   append   |            |
+///   |                         |  |                            |----------->|            |
+///   |                         |  |                            |<-----------|            |
+///   |                         |  |   cmd:replicate-log-1      |   ok       |            |
+///   |                         |  '--------------------------->|            |            |
+///   |                         |                               |            |   send     |
+///   |                         |                               |------------------------>|
+///   |                         |                               |            |   send     |
+///   |                         |                               |------------------------>|
+///   |                         |                               |            |            |
+///   |                         |                               |<------------------------|
+///   |         event:ok        |                               |   ok       |            |
+///   |        .------------------------------------------------|            |            |
+///   |        '--------------->|                               |            |            |
+///   |                         |                               |<------------------------|
+///   |         event:ok        |                               |   ok       |            |
+///   |        .------------------------------------------------|            |            |
+///   |        '--------------->|                               |            |            |
+///   |                         |     cmd:commit-log-1          |            |            |
+///   |                         |------------------------------>|            |            |
+///   |                         |     cmd:apply-log-1           |            |            |
+///   |                         |------------------------------>|            |            |
+///   |                         |                               |   apply    |            |
+///   |                         |                               |----------->|            |
+///   |                         |                               |<-----------|            |
+///   |                         |                               |   ok       |            |
+///   |<--------------------------------------------------------|            |            |
+///   |        response         |                               |            |            |
+/// ```
+///
+/// TODO: add this diagram to guides/
+#[async_trait::async_trait]
+pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
+    /// Run a command produced by the engine.
+    ///
+    /// A command consumes zero or more input entries.
+    /// `curr` points to next non consumed entry in the `input_entries`.
+    /// It's the command's duty to decide move `curr` forward.
+    async fn run_command<'p>(
+        &mut self,
+        input_entries: &[EntryRef<'p, C>],
+        curr: &mut usize,
+        cmd: &Command<C::NodeId>,
+    ) -> Result<(), StorageError<C::NodeId>>;
+}

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -62,6 +62,15 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// A command consumes zero or more input entries.
     /// `curr` points to next non consumed entry in the `input_entries`.
     /// It's the command's duty to decide move `curr` forward.
+    ///
+    /// TODO(xp): remove this method. The API should run all commands in one shot.
+    ///           E.g. `run_engine_commands(input_entries, commands)`.
+    ///           But it relates to the different behaviors of server states.
+    ///           LeaderState is a wrapper of RaftCore thus it can not just reuse `RaftCore::run_engine_commands()`.
+    ///           Thus LeaderState may have to re-implememnt every command.
+    ///           This can be done after moving all raft-algorithm logic into Engine.
+    ///           Then a Runtime do not need to differentiate states such as LeaderState or FollowerState and all
+    ///           command execution can be implemented in one method.
     async fn run_command<'p>(
         &mut self,
         input_entries: &[EntryRef<'p, C>],


### PR DESCRIPTION

## Changelog

##### Refactor: Engine impl raft, Runtime execute commands
`Engine` implement raft algorithm and stores a `state` in it which
contains just enough information to run raft.
It does not contain any application related data, such as `AppData` or
`AppDataResponse`.

`Engine` receives events, deals with them, then output several
`Command` that a `Runtime` executes them to update the application
state, such as push log entries into `RaftStorage`.

`RaftCore` is a `RaftRuntime` impl.
`LeaderState`, `FollowerState` and so on are **wrapper** Runtime.

A `RaftRuntime` talks to `RaftStorage` and `RaftNetwork` to get things done.

The workflow of writing something through raft protocol with engine and runtime would be like
this:

```text
Client                    Engine                         Runtime      Storage      Netwoork
  |                         |      write x=1                |            |            |
  |-------------------------------------------------------->|            |            |
  |        event:write      |                               |            |            |
  |        .------------------------------------------------|            |            |
  |        '--------------->|                               |            |            |
  |                         |      cmd:append-log-1         |            |            |
  |                         |--+--------------------------->|   append   |            |
  |                         |  |                            |----------->|            |
  |                         |  |                            |<-----------|            |
  |                         |  |   cmd:replicate-log-1      |   ok       |            |
  |                         |  '--------------------------->|            |            |
  |                         |                               |            |   send     |
  |                         |                               |------------------------>|
  |                         |                               |            |   send     |
  |                         |                               |------------------------>|
  |                         |                               |            |            |
  |                         |                               |<------------------------|
  |         event:ok        |                               |   ok       |            |
  |        .------------------------------------------------|            |            |
  |        '--------------->|                               |            |            |
  |                         |                               |<------------------------|
  |         event:ok        |                               |   ok       |            |
  |        .------------------------------------------------|            |            |
  |        '--------------->|                               |            |            |
  |                         |     cmd:commit-log-1          |            |            |
  |                         |------------------------------>|            |            |
  |                         |     cmd:apply-log-1           |            |            |
  |                         |------------------------------>|            |            |
  |                         |                               |   apply    |            |
  |                         |                               |----------->|            |
  |                         |                               |<-----------|            |
  |                         |                               |   ok       |            |
  |<--------------------------------------------------------|            |            |
  |        response         |                               |            |            |
```

A common workflow with Runtime-Engine is like the following:
```rust
let mut entry_refs = vec![EntryRef::new(&payload)];
self.core.engine.initialize(&mut entry_refs)?;
self.run_engine_commands(&entry_refs).await?;
```

- Implement `client-write` and `initialize` with the new Engine.
  These two refactoring are considered as a demo using the new
  architecture.

  Most other logic that should be implemented by `Engine` is still left
  in the `RaftCore`. They should be rewritten in the next several PR.

- Refactor: Merge several leader-append-log methods into one:
  `LeaderState::write_entry()`.

- Refactor: raft state fields such as `last_log_id`, `last_applied` are
  moved from `RaftCore` to its internal engine: `RaftCore.engine`.
  Because in future `RaftCore` should not be interested in these fields.

- Change: `InitialState`: add new fieds: `committed`, `target_state`.
  Now `InitialState` is not used only when initializing.
  In future it is the state container in the engine.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/287)
<!-- Reviewable:end -->
