### PR TITLE
Refactor: simplify TypedRaftRouter

### DIFF
--- a/openraft/src/engine.rs
+++ b/openraft/src/engine.rs
@@ -152,10 +152,9 @@ impl<NID: NodeId> Engine<NID> {
         let l = entries.len();
         assert_eq!(1, l);
 
-        let entry = &mut entries[0];
-
         self.check_initialize()?;
 
+        let entry = &mut entries[0];
         let log_id = self.next_log_id();
         entry.set_log_id(&log_id);
 

--- a/openraft/tests/append_entries/t60_large_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_large_heartbeat.rs
@@ -30,7 +30,7 @@ async fn large_heartbeat() -> Result<()> {
     router.client_request_many(0, "foo", 100).await;
     log_index += 100;
 
-    router.wait(&1, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
+    router.wait(&1, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
 
     Ok(())
 }

--- a/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
+++ b/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
@@ -55,10 +55,10 @@ async fn stale_last_log_id() -> Result<()> {
         log_index += n_ops as u64;
     }
 
-    router.wait(&1, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
-    router.wait(&2, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
-    router.wait(&3, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
-    router.wait(&4, Some(Duration::from_millis(1000))).await?.log(Some(log_index), "").await?;
+    router.wait(&1, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
+    router.wait(&2, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
+    router.wait(&3, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
+    router.wait(&4, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
 
     Ok(())
 }

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -24,7 +24,7 @@ async fn client_reads() -> Result<()> {
     router.new_raft_node(1).await;
     router.new_raft_node(2).await;
 
-    let mut n_logs = 0;
+    let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1, 2], None, None, "empty node").await?;
@@ -34,9 +34,9 @@ async fn client_reads() -> Result<()> {
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    n_logs += 1;
+    log_index += 1;
 
-    router.wait_for_log(&btreeset![0, 1, 2], Some(n_logs), None, "init leader").await?;
+    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "init leader").await?;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Get the ID of the leader, and assert that is_leader succeeds.

--- a/openraft/tests/membership/t15_add_remove_follower.rs
+++ b/openraft/tests/membership/t15_add_remove_follower.rs
@@ -41,7 +41,7 @@ async fn add_remove_voter() -> Result<()> {
         log_index += 2; // two member-change logs
 
         router.wait_for_log(&cluster_of_4, Some(log_index), timeout(), "removed node-4").await?;
-        router.wait(&4, timeout()).await?.state(State::Learner, "").await?;
+        router.wait(&4, timeout())?.state(State::Learner, "").await?;
     }
 
     tracing::info!("--- write another 100 logs");

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -90,8 +90,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
         {
             for id in new.iter() {
                 router
-                    .wait(id, Some(Duration::from_millis(5_000)))
-                    .await?
+                    .wait(id, Some(Duration::from_millis(5_000)))?
                     .metrics(
                         |x| x.current_leader.is_some() && new.contains(&x.current_leader.unwrap()),
                         format!("node {} in new cluster has leader in new cluster, {}", id, mes),
@@ -103,16 +102,11 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
         let new_leader = router.leader().expect("expected the cluster to have a leader");
         for id in new.iter() {
             // new leader may already elected and committed a blank log.
-            router
-                .wait(id, timeout())
-                .await?
-                .log_at_least(Some(log_index), format!("new cluster, {}", mes))
-                .await?;
+            router.wait(id, timeout())?.log_at_least(Some(log_index), format!("new cluster, {}", mes)).await?;
 
             if new_leader != orig_leader {
                 router
-                    .wait(id, timeout())
-                    .await?
+                    .wait(id, timeout())?
                     .metrics(
                         |x| x.current_term >= 2,
                         "new cluster has term >= 2 because of new election",
@@ -133,8 +127,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
             //           snapshot:None, replication:
 
             router
-                .wait(id, timeout())
-                .await?
+                .wait(id, timeout())?
                 .metrics(
                     |x| x.state == State::Learner || x.state == State::Candidate,
                     format!("node {} only in old, {}", id, mes),
@@ -148,8 +141,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
         // get new leader
 
         let m = router
-            .wait(new.iter().next().unwrap(), timeout())
-            .await?
+            .wait(new.iter().next().unwrap(), timeout())?
             .metrics(|x| x.current_leader.is_some(), format!("wait for new leader, {}", mes))
             .await?;
 
@@ -161,8 +153,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
 
     for id in new.iter() {
         router
-            .wait(id, timeout())
-            .await?
+            .wait(id, timeout())?
             // new leader may commit a blonk log
             .log_at_least(Some(log_index), format!("new cluster recv logs 100~200, {}", mes))
             .await?;
@@ -172,8 +163,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
     {
         for id in only_in_old {
             let res = router
-                .wait(id, timeout())
-                .await?
+                .wait(id, timeout())?
                 .log(
                     Some(log_index),
                     format!("node {} in old cluster wont recv new logs, {}", id, mes),

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -48,8 +48,7 @@ async fn step_down() -> Result<()> {
     tracing::info!("--- old leader commits 2 membership log");
     {
         router
-            .wait(&orig_leader, timeout())
-            .await?
+            .wait(&orig_leader, timeout())?
             .log(Some(log_index), "old leader commits 2 membership log")
             .await?;
     }
@@ -58,8 +57,7 @@ async fn step_down() -> Result<()> {
     // Because to commit the 2nd log it only need a quorum of the new cluster.
 
     router
-        .wait(&1, timeout())
-        .await?
+        .wait(&1, timeout())?
         .log_at_least(Some(log_index), "node in old cluster commits at least 1 membership log")
         .await?;
 
@@ -70,8 +68,7 @@ async fn step_down() -> Result<()> {
 
         for id in [2, 3] {
             router
-                .wait(&id, timeout())
-                .await?
+                .wait(&id, timeout())?
                 .log_at_least(
                     Some(log_index),
                     "node in new cluster finally commit at least one blank leader-initialize log",
@@ -84,8 +81,7 @@ async fn step_down() -> Result<()> {
     {
         for id in [1, 2, 3] {
             router
-                .wait(&id, timeout())
-                .await?
+                .wait(&id, timeout())?
                 .metrics(
                     |x| x.current_term >= 2,
                     "new cluster has term >= 2 because of new election",

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
@@ -22,19 +23,23 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 
+    let mut log_index = 0;
+
     router.new_raft_node(0).await;
     router.new_raft_node(1).await;
 
     tracing::info!("--- initializing single node cluster");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.initialize(btreeset! {0}).await?;
+        log_index += 1;
 
-    // Wait for node 0 to become leader.
-    router.initialize_with(0, btreeset![0]).await?;
-    router.wait_for_state(&btreeset![0], State::Leader, None, "init").await?;
+        router.wait(&0, timeout())?.state(State::Leader, "n0 -> leader").await?;
+    }
 
-    let mut n_logs = 0;
     tracing::info!("--- add one learner");
     router.add_learner(0, 1).await?;
-    n_logs += 1;
+    log_index += 1;
 
     tracing::info!("--- write one log");
     router.client_request(0, "foo", 1).await;
@@ -42,12 +47,16 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     // Wait for metrics to be up to date.
     // Once last_applied updated, the key should be visible in state machine.
     tracing::info!("--- wait for log to sync");
-    n_logs += 2u64;
+    log_index += 1;
     for node_id in 0..2 {
-        router.wait_for_log(&btreeset![node_id], Some(n_logs), None, "write one log").await?;
+        router.wait_for_log(&btreeset![node_id], Some(log_index), None, "write one log").await?;
         let mut sto = router.get_storage_handle(&node_id)?;
         assert!(sto.get_state_machine().await.client_status.get("foo").is_some());
     }
 
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
 }

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -206,11 +206,7 @@ async fn leader_metrics() -> Result<()> {
             )
             .await?;
 
-        router
-            .wait(&leader, timeout())
-            .await?
-            .metrics(|x| x.current_leader.is_some(), "elect new leader")
-            .await?;
+        router.wait(&leader, timeout())?.metrics(|x| x.current_leader.is_some(), "elect new leader").await?;
     }
 
     tracing::info!("--- check leader metrics after leadership transferred.");

--- a/openraft/tests/state_machine/t10_total_order_apply.rs
+++ b/openraft/tests/state_machine/t10_total_order_apply.rs
@@ -23,11 +23,12 @@ async fn total_order_apply() -> Result<()> {
     router.new_raft_node(1).await;
 
     tracing::info!("--- initializing single node cluster");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.initialize(btreeset! {0}).await?;
 
-    router.initialize_with(0, btreeset![0]).await?;
-    router
-        .wait_for_metrics(&0u64, |x| x.state == State::Leader, timeout(), "n0.state -> Leader")
-        .await?;
+        router.wait(&0, timeout())?.state(State::Leader, "n0 -> leader").await?;
+    }
 
     tracing::info!("--- add one learner");
     router.add_learner(0, 1).await?;

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -84,8 +84,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     tracing::info!("--- every node receives joint log");
     for i in 0..5 {
         router
-            .wait(&i, None)
-            .await?
+            .wait(&i, None)?
             .metrics(|x| x.last_applied.index() >= Some(log_index - 1), "joint log applied")
             .await?;
     }
@@ -93,8 +92,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     tracing::info!("--- only 3 node applied membership config");
     for i in 0..3 {
         router
-            .wait(&i, None)
-            .await?
+            .wait(&i, None)?
             .metrics(|x| x.last_applied.index() == Some(log_index), "uniform log applied")
             .await?;
 


### PR DESCRIPTION

## Changelog

##### Refactor: simplify TypedRaftRouter
- Refactor: `TypedRaftRouter::wait()` does not need to be async

- Refactor: remove `TypedRaftRouter::initialize_with()`: without this
  wrapper it is much simpler.

- Fix: Test: `metrics_state_machine_consistency()` used wrong `log_index`.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/289)
<!-- Reviewable:end -->
