### PR TITLE
Refactor: Engine::initialize() sets server state to Candidate

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -44,17 +44,12 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
         &mut self,
         member_nodes: BTreeMap<C::NodeId, Option<Node>>,
     ) -> Result<(), InitializeError<C::NodeId>> {
-        let member_ids = member_nodes.keys().cloned().collect::<BTreeSet<C::NodeId>>();
-
-        let membership = Membership::with_nodes(vec![member_ids], member_nodes)?;
+        let membership = Membership::try_from(member_nodes)?;
         let payload = EntryPayload::<C>::Membership(membership);
 
         let mut entry_refs = [EntryRef::new(&payload)];
         self.core.engine.initialize(&mut entry_refs)?;
         self.run_engine_commands(&entry_refs).await?;
-
-        // TODO: This should be done by Engine.
-        self.core.set_target_state(State::Candidate);
 
         Ok(())
     }

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -12,6 +12,7 @@ use crate::LeaderId;
 use crate::LogId;
 use crate::Membership;
 use crate::MetricsChangeFlags;
+use crate::State;
 use crate::Vote;
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -45,6 +46,7 @@ fn test_initialize() -> anyhow::Result<()> {
 
         eng.initialize(&mut entries)?;
         assert_eq!(Some(log_id0), eng.state.last_log_id);
+        assert_eq!(State::Candidate, eng.state.target_state);
         assert_eq!(
             MetricsChangeFlags {
                 leader: false,

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -61,6 +61,17 @@ pub struct Membership<NID: NodeId> {
     nodes: BTreeMap<NID, Option<Node>>,
 }
 
+impl<NID: NodeId> TryFrom<BTreeMap<NID, Option<Node>>> for Membership<NID> {
+    type Error = MissingNodeInfo<NID>;
+
+    fn try_from(b: BTreeMap<NID, Option<Node>>) -> Result<Self, Self::Error> {
+        let member_ids = b.keys().cloned().collect::<BTreeSet<NID>>();
+
+        let membership = Membership::with_nodes(vec![member_ids], b)?;
+        Ok(membership)
+    }
+}
+
 impl<NID: NodeId> MessageSummary for Membership<NID> {
     fn summary(&self) -> String {
         let mut res = vec!["members:[".to_string()];

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -81,7 +81,6 @@ pub struct InitialState<NID: NodeId> {
     /// The latest cluster membership configuration found, in log or in state machine.
     pub effective_membership: Arc<EffectiveMembership<NID>>,
 
-    /// The target state of the system.
     pub target_state: State,
 }
 


### PR DESCRIPTION

## Changelog

##### Refactor: Engine::initialize() sets server state to Candidate
- Feature: impl TryFrom<BTreeMap> for Membership.

- part of #292

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/296)
<!-- Reviewable:end -->
