### PR TITLE
Change: VoteRequest does not need type param RaftTypeConfig. Only NodeId

### DIFF
--- a/example-raft-kv/src/network/raft.rs
+++ b/example-raft-kv/src/network/raft.rs
@@ -8,15 +8,13 @@ use openraft::raft::VoteRequest;
 use web::Json;
 
 use crate::app::ExampleApp;
+use crate::ExampleNodeId;
 use crate::ExampleTypeConfig;
 
 // --- Raft communication
 
 #[post("/raft-vote")]
-pub async fn vote(
-    app: Data<ExampleApp>,
-    req: Json<VoteRequest<ExampleTypeConfig>>,
-) -> actix_web::Result<impl Responder> {
+pub async fn vote(app: Data<ExampleApp>, req: Json<VoteRequest<ExampleNodeId>>) -> actix_web::Result<impl Responder> {
     let res = app.raft.vote(req.0).await;
     Ok(Json(res))
 }

--- a/example-raft-kv/src/network/raft_network_impl.rs
+++ b/example-raft-kv/src/network/raft_network_impl.rs
@@ -88,7 +88,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
 
     async fn send_vote(
         &mut self,
-        req: VoteRequest<ExampleTypeConfig>,
+        req: VoteRequest<ExampleNodeId>,
     ) -> Result<VoteResponse<ExampleNodeId>, RPCError<ExampleTypeConfig, VoteError<ExampleNodeId>>> {
         self.owner.send_rpc(self.target, self.target_node.as_ref(), "raft-vote", req).await
     }

--- a/openraft/src/core/vote.rs
+++ b/openraft/src/core/vote.rs
@@ -22,7 +22,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     #[tracing::instrument(level = "debug", skip(self, req), fields(req=%req.summary()))]
     pub(super) async fn handle_vote_request(
         &mut self,
-        req: VoteRequest<C>,
+        req: VoteRequest<C::NodeId>,
     ) -> Result<VoteResponse<C::NodeId>, VoteError<C::NodeId>> {
         tracing::debug!(
             %req.vote,

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -61,7 +61,7 @@ where C: RaftTypeConfig
     /// Send a RequestVote RPC to the target Raft node (§5).
     async fn send_vote(
         &mut self,
-        rpc: VoteRequest<C>,
+        rpc: VoteRequest<C::NodeId>,
     ) -> Result<VoteResponse<C::NodeId>, RPCError<C, VoteError<C::NodeId>>>;
 }
 

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -926,7 +926,7 @@ where
     /// Send a RequestVote RPC to the target Raft node (§5).
     async fn send_vote(
         &mut self,
-        rpc: VoteRequest<C>,
+        rpc: VoteRequest<C::NodeId>,
     ) -> std::result::Result<VoteResponse<C::NodeId>, RPCError<C, VoteError<C::NodeId>>> {
         self.owner.rand_send_delay().await;
 


### PR DESCRIPTION

## Changelog

##### Change: VoteRequest does not need type param RaftTypeConfig. Only NodeId

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/308)
<!-- Reviewable:end -->
