### PR TITLE
Refactor: Engine does not set metrics_flags one by one. metrics changes can be extracted from the engine output commands

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -295,6 +295,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         &mut self,
         input_entries: &[EntryRef<'p, C>],
     ) -> Result<(), StorageError<C::NodeId>> {
+        self.core.engine.update_metrics_flags();
+
         let mut curr = 0;
         let mut commands = vec![];
         swap(&mut self.core.engine.commands, &mut commands);

--- a/openraft/src/core/learner_state.rs
+++ b/openraft/src/core/learner_state.rs
@@ -124,6 +124,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Learner
         &mut self,
         input_entries: &[EntryRef<'p, C>],
     ) -> Result<(), StorageError<C::NodeId>> {
+        self.core.engine.update_metrics_flags();
+
         let mut curr = 0;
         let it = self.core.engine.commands.drain(..).collect::<Vec<_>>();
         for cmd in it {

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -568,6 +568,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         &mut self,
         input_entries: &[EntryRef<'p, C>],
     ) -> Result<(), StorageError<C::NodeId>> {
+        self.engine.update_metrics_flags();
+
         let mut curr = 0;
         let mut commands = vec![];
         swap(&mut self.engine.commands, &mut commands);
@@ -589,6 +591,11 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
     ) -> Result<(), StorageError<C::NodeId>> {
         // Run non-role-specific command.
         match cmd {
+            Command::UpdateServerState { .. } => {
+                // This is not used. server state is already set by the engine.
+                // This only used for notifying that metrics changed and probably will be removed when Engine is
+                // finished.
+            }
             Command::AppendInputEntries { range } => {
                 let entry_refs = &input_ref_entries[range.clone()];
 

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -45,6 +45,7 @@ fn test_initialize() -> anyhow::Result<()> {
         eng.id = 1;
 
         eng.initialize(&mut entries)?;
+        eng.update_metrics_flags();
 
         assert_eq!(Some(log_id0), eng.state.get_log_id(0));
         assert_eq!(None, eng.state.get_log_id(1));
@@ -64,7 +65,10 @@ fn test_initialize() -> anyhow::Result<()> {
             vec![
                 Command::AppendInputEntries { range: 0..1 },
                 Command::UpdateMembership { membership: m12() },
-                Command::MoveInputCursorBy { n: 1 }
+                Command::MoveInputCursorBy { n: 1 },
+                Command::UpdateServerState {
+                    server_state: ServerState::Candidate
+                }
             ],
             eng.commands
         );


### PR DESCRIPTION

## Changelog

##### Refactor: Engine does not set metrics_flags one by one. metrics changes can be extracted from the engine output commands

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/309)
<!-- Reviewable:end -->
