### PR TITLE
Refactor:  move engine test supporting types to engine::testing

### DIFF
--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -1,6 +1,7 @@
 use maplit::btreeset;
 
 use crate::core::ServerState;
+use crate::engine::testing::Config;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::EntryRef;
@@ -14,15 +15,6 @@ use crate::LogId;
 use crate::Membership;
 use crate::MetricsChangeFlags;
 use crate::Vote;
-
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
-pub(crate) struct Req {}
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
-pub(crate) struct Resp {}
-
-crate::declare_raft_types!(
-   pub(crate) Config: D = Req, R = Resp, NodeId = u64
-);
 
 #[test]
 fn test_initialize() -> anyhow::Result<()> {

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -6,6 +6,8 @@ mod initialize_test;
 mod log_id_list;
 #[cfg(test)]
 mod log_id_list_test;
+#[cfg(test)]
+mod testing;
 
 pub(crate) use engine::Command;
 pub(crate) use engine::Engine;

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -1,0 +1,14 @@
+/// Req for test
+#[derive(Clone)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct Req {}
+
+/// Resp for test
+#[derive(Clone)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct Resp {}
+
+// Config for test
+crate::declare_raft_types!(
+   pub(crate) Config: D = Req, R = Resp, NodeId = u64
+);


### PR DESCRIPTION

## Changelog

##### Refactor:  move engine test supporting types to engine::testing

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/310)
<!-- Reviewable:end -->
