### PR TITLE
Refactor: using a universal receiver for internal messaging

### DIFF
--- a/openraft/src/core/follower_state.rs
+++ b/openraft/src/core/follower_state.rs
@@ -62,7 +62,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Followe
                     self.handle_msg(msg).instrument(span).await?;
                 },
 
-                Some(update) = self.core.rx_compaction.recv() => self.core.update_snapshot_state(update),
+                Some(internal_msg) = self.core.rx_internal.recv() => self.core.handle_internal_msg(internal_msg).await?,
 
                 Ok(_) = &mut self.core.rx_shutdown => self.core.set_target_state(ServerState::Shutdown),
             }

--- a/openraft/src/core/internal_msg.rs
+++ b/openraft/src/core/internal_msg.rs
@@ -1,0 +1,12 @@
+use crate::core::snapshot_state::SnapshotUpdate;
+use crate::raft::VoteResponse;
+use crate::NodeId;
+
+/// Message for communication between internal tasks.
+///
+/// Such as log compaction task, RaftCore task, replication tasks etc.
+#[derive(Debug, Clone)]
+pub(crate) enum InternalMessage<NID: NodeId> {
+    SnapshotUpdate(SnapshotUpdate<NID>),
+    VoteResponse { target: NID, vote_resp: VoteResponse<NID> },
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -5,6 +5,7 @@ mod append_entries;
 mod client;
 mod follower_state;
 mod install_snapshot;
+mod internal_msg;
 mod leader_state;
 mod learner_state;
 mod raft_core;
@@ -17,6 +18,7 @@ mod snapshot_state;
 mod vote;
 
 use follower_state::FollowerState;
+pub(crate) use internal_msg::InternalMessage;
 use leader_state::LeaderState;
 use learner_state::LearnerState;
 use raft_core::apply_to_state_machine;

--- a/openraft/src/core/snapshot_state.rs
+++ b/openraft/src/core/snapshot_state.rs
@@ -2,7 +2,7 @@ use futures::future::AbortHandle;
 use tokio::sync::broadcast;
 
 use crate::LogId;
-use crate::RaftTypeConfig;
+use crate::NodeId;
 
 /// The current snapshot state of the Raft node.
 pub(crate) enum SnapshotState<S> {
@@ -25,10 +25,11 @@ pub(crate) enum SnapshotState<S> {
 }
 
 /// An update on a snapshot creation process.
-#[derive(Debug)]
-pub(crate) enum SnapshotUpdate<C: RaftTypeConfig> {
+#[derive(Debug, Clone)]
+pub(crate) enum SnapshotUpdate<NID: NodeId> {
     /// Snapshot creation has finished successfully and covers the given index.
-    SnapshotComplete(LogId<C::NodeId>),
+    SnapshotComplete(LogId<NID>),
+
     /// Snapshot creation failed.
     SnapshotFailed,
 }

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -1,7 +1,7 @@
 use crate::engine::Command;
 use crate::entry::EntryRef;
-use crate::error::Fatal;
 use crate::RaftTypeConfig;
+use crate::StorageError;
 
 /// Defines behaviors of a runtime to support the protocol engine.
 ///
@@ -76,5 +76,5 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
         input_entries: &[EntryRef<'p, C>],
         curr: &mut usize,
         cmd: &Command<C::NodeId>,
-    ) -> Result<(), Fatal<C::NodeId>>;
+    ) -> Result<(), StorageError<C::NodeId>>;
 }


### PR DESCRIPTION

## Changelog

##### Refactor: using a universal receiver for internal messaging
Election does not need to create a channel to collect vote responses.
We create an internal channel `rx_internal` for all kinds of internal
communication.

- Refactor: avoid potential recursive call of `run_engine_commands()`.
  E.g., do not wait for external event inside `run_engine_commands()`.
  Because most external event handler(e.g., a timer for a new round
  election) will call an Engine event handler(such as `Engine::elect()`)
  with a following `run_engine_commands()`.

  Recursive call to `run_engine_commands()` may cause a unexpected order
  of cammand execution.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/312)
<!-- Reviewable:end -->
