### PR TITLE
Refactor: when installing snapshot, delete logs included in snapshot

### DIFF
--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -17,7 +17,6 @@ mod snapshot_state;
 pub(crate) use internal_msg::InternalMessage;
 use leader_state::LeaderState;
 use raft_core::apply_to_state_machine;
-use raft_core::purge_applied_logs;
 use raft_core::MetricsProvider;
 pub use raft_core::RaftCore;
 pub use replication_state::is_matched_upto_date;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -582,21 +582,12 @@ where
 
     tracing::debug!(%last_applied, max_keep, delete_lt = end, "delete_applied_logs");
 
-    if end == 0 {
-        return Ok(());
-    }
-
     let st = sto.get_log_state().await?;
-
-    if st.last_log_id < Some(*last_applied) {
-        sto.purge_logs_upto(*last_applied).await?;
-        return Ok(());
-    }
 
     // non applied logs are deleted. it is a bug.
     assert!(st.last_purged_log_id <= Some(*last_applied));
 
-    if st.last_purged_log_id.index() >= Some(end - 1) {
+    if st.last_purged_log_id.next_index() >= end {
         return Ok(());
     }
 


### PR DESCRIPTION

## Changelog

##### Refactor: when installing snapshot, delete logs included in snapshot
A local log that is included in snapshot may be inconsistent with the leader.
It has to purge all of them to prevent these log form being replicated, when this node becomes leader.

When deleting these logs, it does not need to consider the `max_applied_log_to_keep` config.
Thus `purge_applied_logs()` does not need to deal with the condition
that `last_log_id` is inconsistent with `last_applied`.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/323)
<!-- Reviewable:end -->
