### PR TITLE
Change: RaftState tracks last 2 membership configs

### DIFF
--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -239,10 +239,10 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         // TODO(xp): just compare the membership config in the snapshot and the current effective membership config and
         //           decide whether to replace the effective confg.
         //           No need to bother the storage.
-        let membership = self.storage.get_membership().await?;
-        tracing::debug!("storage membership: {:?}", membership);
+        let memberships = self.storage.get_membership().await?;
+        tracing::debug!("storage membership: {:?}", memberships);
 
-        self.update_membership(membership);
+        self.update_membership(memberships);
 
         self.snapshot_last_log_id = self.engine.state.last_applied;
         self.engine.metrics_flags.set_data_changed();

--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -83,7 +83,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             .core
             .engine
             .state
-            .effective_membership
+            .membership_state
+            .effective
             .node_ids()
             .filter(|elem| *elem != &self.core.id)
             .cloned()

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -35,7 +35,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         target: C::NodeId,
         caller_tx: Option<RaftRespTx<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>>>,
     ) -> ReplicationState<C> {
-        let target_node = self.core.engine.state.effective_membership.get_node(&target);
+        let target_node = self.core.engine.state.membership_state.effective.get_node(&target);
         let repl_stream = ReplicationStream::new::<N, S>(
             target,
             target_node.cloned(),
@@ -180,7 +180,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     fn calc_commit_log_id(&self) -> Option<LogId<C::NodeId>> {
         let repl_indexes = self.get_match_log_ids();
 
-        let committed = self.core.engine.state.effective_membership.membership.greatest_majority_value(&repl_indexes);
+        let committed =
+            self.core.engine.state.membership_state.effective.membership.greatest_majority_value(&repl_indexes);
 
         // TODO(xp): remove this line
         std::cmp::max(committed.cloned(), self.core.engine.state.committed)
@@ -190,7 +191,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
     /// Collect indexes of the greatest matching log on every replica(include the leader itself)
     fn get_match_log_ids(&self) -> BTreeMap<C::NodeId, LogId<C::NodeId>> {
-        let node_ids = self.core.engine.state.effective_membership.all_members();
+        let node_ids = self.core.engine.state.membership_state.effective.all_members();
 
         let mut res = BTreeMap::new();
 

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -39,7 +39,7 @@ fn test_elect() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.id = 1;
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m1()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m1()));
 
         eng.elect();
 
@@ -77,7 +77,7 @@ fn test_elect() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.id = 1;
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m1()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m1()));
 
         // Build in-progress election state
         eng.state.vote = Vote::new_committed(1, 2);
@@ -121,7 +121,7 @@ fn test_elect() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.id = 1;
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m12()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m12()));
         eng.state.last_log_id = Some(log_id(1, 1));
 
         eng.elect();

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -30,7 +30,7 @@ fn eng() -> Engine<u64> {
     let mut eng = Engine::<u64>::default();
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
-    eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
+    eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.leader = Some(Leader {
         vote_granted_by: Default::default(),
     });

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -39,7 +39,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.state.vote = Vote::new(2, 1);
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
 
         eng.handle_vote_resp(2, VoteResponse {
             vote: Vote::new(2, 2),
@@ -70,7 +70,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.leader = Some(Leader {
             vote_granted_by: btreeset! {1},
         });
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -107,7 +107,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.leader = Some(Leader {
             vote_granted_by: btreeset! {1},
         });
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -147,7 +147,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.leader = Some(Leader {
             vote_granted_by: btreeset! {1},
         });
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -184,7 +184,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.leader = Some(Leader {
             vote_granted_by: btreeset! {1},
         });
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234()));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -221,7 +221,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.leader = Some(Leader {
             vote_granted_by: btreeset! {1},
         });
-        eng.state.effective_membership = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
+        eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -50,7 +50,7 @@ fn test_initialize() -> anyhow::Result<()> {
             },
             eng.metrics_flags
         );
-        assert_eq!(m12(), eng.state.effective_membership.membership);
+        assert_eq!(m12(), eng.state.membership_state.effective.membership);
 
         assert_eq!(
             vec![

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -51,6 +51,7 @@ pub use crate::entry::EntryPayload;
 pub use crate::entry::RaftPayload;
 pub use crate::membership::EffectiveMembership;
 pub use crate::membership::Membership;
+pub use crate::membership::MembershipState;
 pub use crate::metrics::RaftMetrics;
 pub use crate::network::RPCTypes;
 pub use crate::network::RaftNetwork;

--- a/openraft/src/membership/membership_state.rs
+++ b/openraft/src/membership/membership_state.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use crate::EffectiveMembership;
+use crate::NodeId;
+
+/// The state of membership configs a raft node needs to know.
+///
+/// A raft node needs to store at most 2 membership config log:
+// - The first(committed) one must have been committed, because (1): raft allows to propose new membership only when the
+//   previous one is committed.
+// - The second(effective) may be committed or not.
+//
+// By (1) we have:
+// (2) there is at most one outstanding, uncommitted membership log. On
+// either leader or follower, the second last one must have been committed.
+// A committed log must be consistent with the leader.
+//
+// (3) By raft design, the last membership takes effect.
+//
+// When handling append-entries RPC:
+// (4) a raft follower will delete logs that are inconsistent with the leader.
+//
+// By (3) and (4), a follower needs to revert the effective membership to the previous one.
+//
+// By (2), a follower only need to revert at most one membership log.
+//
+// Thus a raft node will only need to store at most two recent membership logs.
+#[derive(Debug, Clone, Default)]
+#[derive(PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(bound = "")]
+pub struct MembershipState<NID: NodeId> {
+    pub committed: Arc<EffectiveMembership<NID>>,
+
+    // Using `Arc` because the effective membership will be copied to RaftMetrics frequently.
+    pub effective: Arc<EffectiveMembership<NID>>,
+}
+
+impl<NID: NodeId> MembershipState<NID> {}

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -1,5 +1,6 @@
 mod effective_membership;
 #[allow(clippy::module_inception)] mod membership;
+mod membership_state;
 
 #[cfg(test)] mod membership_test;
 
@@ -8,3 +9,4 @@ pub mod quorum;
 pub use effective_membership::EffectiveMembership;
 pub use membership::IntoOptionNodes;
 pub use membership::Membership;
+pub use membership_state::MembershipState;

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-
 use crate::engine::LogIdList;
 use crate::leader::Leader;
-use crate::membership::EffectiveMembership;
 use crate::raft_types::RaftLogId;
 use crate::LogId;
+use crate::MembershipState;
 use crate::NodeId;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
@@ -35,7 +33,7 @@ pub struct RaftState<NID: NodeId> {
     pub log_ids: LogIdList<NID>,
 
     /// The latest cluster membership configuration found, in log or in state machine.
-    pub effective_membership: Arc<EffectiveMembership<NID>>,
+    pub membership_state: MembershipState<NID>,
 
     // --
     // -- volatile fields: they are not persisted.

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -20,6 +20,7 @@ use crate::Entry;
 use crate::EntryPayload;
 use crate::LogId;
 use crate::LogIdOptionExt;
+use crate::MembershipState;
 use crate::NodeId;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -175,52 +176,93 @@ where C: RaftTypeConfig
     /// Snapshot builder type.
     type SnapshotBuilder: RaftSnapshotBuilder<C, Self::SnapshotData>;
 
-    /// Returns the last membership config found in log or state machine.
-    /// TODO(xp): if there is no membership log, return `{log_id:None, membership: vec![]}`.
-    ///           The raft core should always have an effective_membership.
-    ///           Initially, it is empty.
-    async fn get_membership(&mut self) -> Result<EffectiveMembership<C::NodeId>, StorageError<C::NodeId>> {
+    /// Returns the last 2 membership config found in log or state machine.
+    ///
+    /// A raft node needs to store at most 2 membership config log:
+    /// - The first one must be committed, because raft allows to propose new membership only when the previous one is
+    ///   committed.
+    /// - The second may be committed or not.
+    ///
+    /// Because when handling append-entries RPC, (1) a raft follower will delete logs that are inconsistent with the
+    /// leader,
+    /// and (2) a membership will take effect at once it is written,
+    /// a follower needs to revert the effective membership to a previous one.
+    ///
+    /// And because (3) there is at most one outstanding, uncommitted membership log,
+    /// a follower only need to revert at most one membership log.
+    ///
+    /// Thus a raft node will only need to store at most two recent membership logs.
+    ///
+    /// It returns a vec of one or two memberships:
+    /// - the `first()` is committed.
+    /// - the `last()` is the effective one but may not be committed.
+    ///
+    /// If there is no membership log, return `[{log_id:None, membership: vec![]}]`.
+    /// The raft core always have an `effective_membership`.
+    async fn get_membership(&mut self) -> Result<MembershipState<C::NodeId>, StorageError<C::NodeId>> {
         let (_, sm_mem) = self.last_applied_state().await?;
 
         let sm_mem_next_index = sm_mem.log_id.next_index();
 
         let log_mem = self.last_membership_in_log(sm_mem_next_index).await?;
+        tracing::debug!(membership_in_sm=?sm_mem, membership_in_log=?log_mem, "RaftStorage::get_membership");
 
-        if let Some(x) = log_mem {
-            return Ok(x);
+        // There 2 membership configs in logs.
+        if log_mem.len() == 2 {
+            return Ok(MembershipState {
+                committed: Arc::new(log_mem[0].clone()),
+                effective: Arc::new(log_mem[1].clone()),
+            });
         }
 
-        return Ok(sm_mem);
+        let effective = if log_mem.is_empty() {
+            sm_mem.clone()
+        } else {
+            log_mem[0].clone()
+        };
+
+        let res = MembershipState {
+            committed: Arc::new(sm_mem),
+            effective: Arc::new(effective),
+        };
+
+        return Ok(res);
     }
 
-    /// Get the latest membership config found in the log.
+    /// Get the last 2 membership configs found in the log.
     ///
-    /// This method should returns membership with the greatest log index which is `>=since_index`.
+    /// This method returns at most membership logs with greatest log index which is `>=since_index`.
     /// If no such membership log is found, it returns `None`, e.g., when logs are cleaned after being applied.
     #[tracing::instrument(level = "trace", skip(self))]
     async fn last_membership_in_log(
         &mut self,
         since_index: u64,
-    ) -> Result<Option<EffectiveMembership<C::NodeId>>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<EffectiveMembership<C::NodeId>>, StorageError<C::NodeId>> {
         let st = self.get_log_state().await?;
 
         let mut end = st.last_log_id.next_index();
         let start = std::cmp::max(st.last_purged_log_id.next_index(), since_index);
         let step = 64;
 
+        let mut res = vec![];
+
         while start < end {
             let entries = self.try_get_log_entries(start..end).await?;
 
             for ent in entries.iter().rev() {
                 if let EntryPayload::Membership(ref mem) = ent.payload {
-                    return Ok(Some(EffectiveMembership::new(Some(ent.log_id), mem.clone())));
+                    let em = EffectiveMembership::new(Some(ent.log_id), mem.clone());
+                    res.insert(0, em);
+                    if res.len() == 2 {
+                        return Ok(res);
+                    }
                 }
             }
 
             end = end.saturating_sub(step);
         }
 
-        Ok(None)
+        Ok(res)
     }
 
     /// Get Raft's state information from storage.
@@ -233,7 +275,7 @@ where C: RaftTypeConfig
         let mut last_purged_log_id = st.last_purged_log_id;
         let mut last_log_id = st.last_log_id;
         let (last_applied, _) = self.last_applied_state().await?;
-        let membership = self.get_membership().await?;
+        let mem_state = self.get_membership().await?;
 
         // Clean up dirty state: snapshot is installed but logs are not cleaned.
         if last_log_id < last_applied {
@@ -252,7 +294,7 @@ where C: RaftTypeConfig
             // See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
             vote: vote.unwrap_or_default(),
             log_ids,
-            effective_membership: Arc::new(membership),
+            membership_state: mem_state,
 
             // -- volatile fields: they are not persisted.
             leader: None,

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -218,9 +218,16 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
         let mut sto = router.get_storage_handle(&1)?;
         let m = sto.get_membership().await?;
 
+        // new membership is applied, thus get_membership() only returns one entry.
+
         assert_eq!(
             Membership::new(vec![btreeset! {1,3,4}], Some(btreeset! {2})),
-            m.membership,
+            m.committed.membership,
+            "membership should be overridden by the snapshot"
+        );
+        assert_eq!(
+            Membership::new(vec![btreeset! {1,3,4}], Some(btreeset! {2})),
+            m.effective.membership,
             "membership should be overridden by the snapshot"
         );
     }

--- a/openraft/tests/snapshot/snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/snapshot_overrides_membership.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::Config;
+use openraft::EffectiveMembership;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LeaderId;
@@ -101,7 +102,9 @@ async fn snapshot_overrides_membership() -> Result<()> {
             {
                 let m = sto.get_membership().await?;
 
-                assert_eq!(Membership::new(vec![btreeset! {2,3}], None), m.membership);
+                println!("{:?}", m);
+                assert_eq!(&EffectiveMembership::default(), m.committed.as_ref());
+                assert_eq!(Membership::new(vec![btreeset! {2,3}], None), m.effective.membership);
             }
         }
 
@@ -133,7 +136,12 @@ async fn snapshot_overrides_membership() -> Result<()> {
 
             assert_eq!(
                 Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),
-                m.membership,
+                m.committed.membership,
+                "membership should be overridden by the snapshot"
+            );
+            assert_eq!(
+                Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),
+                m.effective.membership,
                 "membership should be overridden by the snapshot"
             );
         }

--- a/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/snapshot_uses_prev_snap_membership.rs
@@ -77,7 +77,12 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
 
         assert_eq!(
             Membership::new(vec![btreeset! {0,1}], None),
-            m.membership,
+            m.committed.membership,
+            "membership "
+        );
+        assert_eq!(
+            Membership::new(vec![btreeset! {0,1}], None),
+            m.effective.membership,
             "membership "
         );
 
@@ -125,7 +130,12 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
 
         assert_eq!(
             Membership::new(vec![btreeset! {0,1}], None),
-            m.membership,
+            m.committed.membership,
+            "membership "
+        );
+        assert_eq!(
+            Membership::new(vec![btreeset! {0,1}], None),
+            m.effective.membership,
             "membership "
         );
     }


### PR DESCRIPTION

## Changelog

##### Change: RaftState tracks last 2 membership configs
A raft node needs to store at most 2 membership config log:
- The first one must be committed, because
  (1): raft allows to propose new membership only when the previous one is committed.
- The second may be committed or not.

By (1) we have:
(2) there is at most one outstanding, uncommitted membership log. On
either leader or follower, the second last one must be committed.
A committed log must be consistent with the leader.

(3) By raft design, the last membership takes effect.

When handling append-entries RPC:
(4) a raft follower will delete logs that are inconsistent with the leader.

By (3) and (4), a follower needs to revert the effective membership to the previous one.

By (2), a follower only need to revert at most one membership log.

Thus a raft node will only need to store at most two recent membership logs.

For the vec of one or two memberships:
- the `first()` is committed.
- the `last()` is the effective one but may not be committed.

Changes:

- Add `committed_membership` to RaftState, to store the previous
  committed membership config.

- Change: `RaftStorage::get_membership()` returns a vec of at most 2 memberships.

- Change: `RaftStorage::last_membership_in_log()` returns a vec of at most 2 memberships.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/332)
<!-- Reviewable:end -->
