### PR TITLE
Change: add `last_membership` to `SnapshotMeta`

### DIFF
--- a/example-raft-kv/src/store/mod.rs
+++ b/example-raft-kv/src/store/mod.rs
@@ -132,7 +132,9 @@ impl RaftSnapshotBuilder<ExampleTypeConfig, Cursor<Vec<u8>>> for Arc<ExampleStor
     async fn build_snapshot(
         &mut self,
     ) -> Result<Snapshot<ExampleTypeConfig, Cursor<Vec<u8>>>, StorageError<ExampleNodeId>> {
-        let (data, last_applied_log);
+        let data;
+        let last_applied_log;
+        let last_membership;
 
         {
             // Serialize the data of the state machine.
@@ -141,6 +143,7 @@ impl RaftSnapshotBuilder<ExampleTypeConfig, Cursor<Vec<u8>>> for Arc<ExampleStor
                 .map_err(|e| StorageIOError::new(ErrorSubject::StateMachine, ErrorVerb::Read, AnyError::new(&e)))?;
 
             last_applied_log = state_machine.last_applied_log;
+            last_membership = state_machine.last_membership.clone();
         }
 
         let last_applied_log = match last_applied_log {
@@ -163,6 +166,7 @@ impl RaftSnapshotBuilder<ExampleTypeConfig, Cursor<Vec<u8>>> for Arc<ExampleStor
 
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,
+            last_membership,
             snapshot_id,
         };
 

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -32,6 +32,9 @@ pub struct SnapshotMeta<NID: NodeId> {
     // Log entries upto which this snapshot includes, inclusive.
     pub last_log_id: LogId<NID>,
 
+    // The last applied membership config.
+    pub last_membership: EffectiveMembership<NID>,
+
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be different in bytes.
     pub snapshot_id: SnapshotId,

--- a/openraft/tests/api_install_snapshot.rs
+++ b/openraft/tests/api_install_snapshot.rs
@@ -53,6 +53,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
                 leader_id: LeaderId::new(1, 0),
                 index: 0,
             },
+            last_membership: Default::default(),
         },
         offset: 0,
         data: vec![1, 2, 3],


### PR DESCRIPTION

## Changelog

##### Change: add `last_membership` to `SnapshotMeta`
Raft actually has two slots of logs: the membership log and the application log.

In order to simplify the design and implementation, raft stores these two slots of logs in one slot.

A log snapshot, should contain the information about these two slots:
- last applied business log: `last_applied`,
- and last applied membership log: `last_applied_membership`, which is not included in `SnapshotMeta` and should be added.

With `last_applied_membership`, the `Engine` will be able to handle the install-snapshot event without accessing the `RaftStorage`.

- Fix: #334

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/335)
<!-- Reviewable:end -->
