### PR TITLE
Refactor: fixtures::TypedRaftRouter::wait() do not need to return a Result

### DIFF
--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -117,7 +117,7 @@ async fn append_inconsistent_log() -> Result<()> {
     }
 
     router
-        .wait(&0, Some(Duration::from_millis(2000)))?
+        .wait(&0, Some(Duration::from_millis(2000)))
         .metrics(|x| x.last_log_index == Some(log_index), "sync log to node 0")
         .await?;
 

--- a/openraft/tests/append_entries/t60_large_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_large_heartbeat.rs
@@ -30,7 +30,7 @@ async fn large_heartbeat() -> Result<()> {
     router.client_request_many(0, "foo", 100).await;
     log_index += 100;
 
-    router.wait(&1, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
+    router.wait(&1, Some(Duration::from_millis(1000))).log(Some(log_index), "").await?;
 
     Ok(())
 }

--- a/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
+++ b/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
@@ -55,10 +55,10 @@ async fn stale_last_log_id() -> Result<()> {
         log_index += n_ops as u64;
     }
 
-    router.wait(&1, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
-    router.wait(&2, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
-    router.wait(&3, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
-    router.wait(&4, Some(Duration::from_millis(1000)))?.log(Some(log_index), "").await?;
+    router.wait(&1, Some(Duration::from_millis(1000))).log(Some(log_index), "").await?;
+    router.wait(&2, Some(Duration::from_millis(1000))).log(Some(log_index), "").await?;
+    router.wait(&3, Some(Duration::from_millis(1000))).log(Some(log_index), "").await?;
+    router.wait(&4, Some(Duration::from_millis(1000))).log(Some(log_index), "").await?;
 
     Ok(())
 }

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -398,18 +398,18 @@ where
     where
         T: Fn(&RaftMetrics<C>) -> bool + Send,
     {
-        let wait = self.wait(node_id, timeout)?;
+        let wait = self.wait(node_id, timeout);
         let rst = wait.metrics(func, format!("node-{} {}", node_id, msg)).await?;
         Ok(rst)
     }
 
-    pub fn wait(&self, node_id: &C::NodeId, timeout: Option<Duration>) -> Result<Wait<C>> {
+    pub fn wait(&self, node_id: &C::NodeId, timeout: Option<Duration>) -> Wait<C> {
         let node = {
             let rt = self.routing_table.lock().unwrap();
             rt.get(node_id).expect("target node not found in routing table").clone().0
         };
 
-        Ok(node.wait(timeout))
+        node.wait(timeout)
     }
 
     /// Wait for specified nodes until they applied upto `want_log`(inclusive) logs.
@@ -422,7 +422,7 @@ where
         msg: &str,
     ) -> Result<()> {
         for i in node_ids.iter() {
-            self.wait(i, timeout)?.log(want_log, msg).await?;
+            self.wait(i, timeout).log(want_log, msg).await?;
         }
         Ok(())
     }
@@ -436,7 +436,7 @@ where
         msg: &str,
     ) -> Result<()> {
         for i in node_ids.iter() {
-            let wait = self.wait(i, timeout)?;
+            let wait = self.wait(i, timeout);
             wait.metrics(
                 |x| {
                     x.membership_config.get_configs().len() == 1
@@ -459,7 +459,7 @@ where
         msg: &str,
     ) -> Result<()> {
         for i in node_ids.iter() {
-            self.wait(i, timeout)?.state(want_state, msg).await?;
+            self.wait(i, timeout).state(want_state, msg).await?;
         }
         Ok(())
     }
@@ -474,7 +474,7 @@ where
         msg: &str,
     ) -> Result<()> {
         for i in node_ids.iter() {
-            self.wait(i, timeout)?.snapshot(want, msg).await?;
+            self.wait(i, timeout).snapshot(want, msg).await?;
         }
         Ok(())
     }

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -49,7 +49,7 @@ async fn learner_restart() -> Result<()> {
         n0.initialize(btreeset! {0}).await?;
         log_index += 1;
 
-        router.wait(&0, timeout())?.state(ServerState::Leader, "n0 -> leader").await?;
+        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
     }
 
     router.add_learner(0, 1).await?;

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -113,7 +113,7 @@ async fn add_learner_non_blocking() -> Result<()> {
         router.client_request_many(0, "learner_add", 100 - log_index as usize).await;
         log_index = 100;
 
-        router.wait(&0, timeout())?.log(Some(log_index), "received 100 logs").await?;
+        router.wait(&0, timeout()).log(Some(log_index), "received 100 logs").await?;
 
         router.new_raft_node(1).await;
         let raft = router.get_raft_handle(&0)?;
@@ -184,7 +184,7 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
     tracing::info!("--- old leader commits 2 membership log");
     {
         router
-            .wait(&orig_leader, timeout)?
+            .wait(&orig_leader, timeout)
             .log(Some(log_index), "old leader commits 2 membership log")
             .await?;
     }
@@ -193,7 +193,7 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
     // Because to commit the 2nd log it only need a quorum of the new cluster.
 
     router
-        .wait(&1, timeout)?
+        .wait(&1, timeout)
         .log_at_least(Some(log_index), "node in old cluster commits at least 1 membership log")
         .await?;
 
@@ -204,7 +204,7 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
 
         for id in [3, 4] {
             router
-                .wait(&id, timeout)?
+                .wait(&id, timeout)
                 .log_at_least(
                     Some(log_index),
                     "node in new cluster finally commit at least one blank leader-initialize log",
@@ -239,7 +239,7 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
         log_index += 1;
 
         for i in [1, 2, 3, 4] {
-            router.wait(&i, timeout)?.log_at_least(Some(log_index), "learner recv new log").await?;
+            router.wait(&i, timeout).log_at_least(Some(log_index), "learner recv new log").await?;
         }
     }
 

--- a/openraft/tests/membership/t15_add_remove_follower.rs
+++ b/openraft/tests/membership/t15_add_remove_follower.rs
@@ -41,7 +41,7 @@ async fn add_remove_voter() -> Result<()> {
         log_index += 2; // two member-change logs
 
         router.wait_for_log(&cluster_of_4, Some(log_index), timeout(), "removed node-4").await?;
-        router.wait(&4, timeout())?.state(ServerState::Learner, "").await?;
+        router.wait(&4, timeout()).state(ServerState::Learner, "").await?;
     }
 
     tracing::info!("--- write another 100 logs");

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -90,7 +90,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
         {
             for id in new.iter() {
                 router
-                    .wait(id, Some(Duration::from_millis(5_000)))?
+                    .wait(id, Some(Duration::from_millis(5_000)))
                     .metrics(
                         |x| x.current_leader.is_some() && new.contains(&x.current_leader.unwrap()),
                         format!("node {} in new cluster has leader in new cluster, {}", id, mes),
@@ -102,11 +102,11 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
         let new_leader = router.leader().expect("expected the cluster to have a leader");
         for id in new.iter() {
             // new leader may already elected and committed a blank log.
-            router.wait(id, timeout())?.log_at_least(Some(log_index), format!("new cluster, {}", mes)).await?;
+            router.wait(id, timeout()).log_at_least(Some(log_index), format!("new cluster, {}", mes)).await?;
 
             if new_leader != orig_leader {
                 router
-                    .wait(id, timeout())?
+                    .wait(id, timeout())
                     .metrics(
                         |x| x.current_term >= 2,
                         "new cluster has term >= 2 because of new election",
@@ -127,7 +127,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
             //           snapshot:None, replication:
 
             router
-                .wait(id, timeout())?
+                .wait(id, timeout())
                 .metrics(
                     |x| x.state == ServerState::Learner || x.state == ServerState::Candidate,
                     format!("node {} only in old, {}", id, mes),
@@ -141,7 +141,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
         // get new leader
 
         let m = router
-            .wait(new.iter().next().unwrap(), timeout())?
+            .wait(new.iter().next().unwrap(), timeout())
             .metrics(|x| x.current_leader.is_some(), format!("wait for new leader, {}", mes))
             .await?;
 
@@ -153,7 +153,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
 
     for id in new.iter() {
         router
-            .wait(id, timeout())?
+            .wait(id, timeout())
             // new leader may commit a blonk log
             .log_at_least(Some(log_index), format!("new cluster recv logs 100~200, {}", mes))
             .await?;
@@ -163,7 +163,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
     {
         for id in only_in_old {
             let res = router
-                .wait(id, timeout())?
+                .wait(id, timeout())
                 .log(
                     Some(log_index),
                     format!("node {} in old cluster wont recv new logs, {}", id, mes),

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -34,7 +34,7 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
         router.client_request_many(0, "non_voter_add", 100 - log_index as usize).await;
         log_index = 100;
 
-        router.wait(&0, timeout())?.log(Some(log_index), "received 100 logs").await?;
+        router.wait(&0, timeout()).log(Some(log_index), "received 100 logs").await?;
     }
 
     tracing::info!("--- change membership without adding-learner");
@@ -88,7 +88,7 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
         router.client_request_many(0, "non_voter_add", 500 - log_index as usize).await;
         log_index = 500;
 
-        router.wait(&0, timeout())?.log(Some(log_index), "received 500 logs").await?;
+        router.wait(&0, timeout()).log(Some(log_index), "received 500 logs").await?;
     }
 
     tracing::info!("--- restore replication and change membership at once, expect NonVoterIsLagging");

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -48,7 +48,7 @@ async fn step_down() -> Result<()> {
     tracing::info!("--- old leader commits 2 membership log");
     {
         router
-            .wait(&orig_leader, timeout())?
+            .wait(&orig_leader, timeout())
             .log(Some(log_index), "old leader commits 2 membership log")
             .await?;
     }
@@ -57,7 +57,7 @@ async fn step_down() -> Result<()> {
     // Because to commit the 2nd log it only need a quorum of the new cluster.
 
     router
-        .wait(&1, timeout())?
+        .wait(&1, timeout())
         .log_at_least(Some(log_index), "node in old cluster commits at least 1 membership log")
         .await?;
 
@@ -68,7 +68,7 @@ async fn step_down() -> Result<()> {
 
         for id in [2, 3] {
             router
-                .wait(&id, timeout())?
+                .wait(&id, timeout())
                 .log_at_least(
                     Some(log_index),
                     "node in new cluster finally commit at least one blank leader-initialize log",
@@ -81,7 +81,7 @@ async fn step_down() -> Result<()> {
     {
         for id in [1, 2, 3] {
             router
-                .wait(&id, timeout())?
+                .wait(&id, timeout())
                 .metrics(
                     |x| x.current_term >= 2,
                     "new cluster has term >= 2 because of new election",

--- a/openraft/tests/membership/t40_removed_follower.rs
+++ b/openraft/tests/membership/t40_removed_follower.rs
@@ -37,7 +37,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
 
         for i in 0..5 {
             router
-                .wait(&i, timeout())?
+                .wait(&i, timeout())
                 .metrics(
                     |x| x.last_log_index >= Some(log_index),
                     "all nodes recv change-membership logs",
@@ -54,7 +54,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
 
         for i in &[0, 3, 4] {
             router
-                .wait(i, timeout())?
+                .wait(i, timeout())
                 .metrics(
                     |x| x.last_applied.index() >= Some(log_index),
                     "new cluster recv new logs",
@@ -65,7 +65,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
 
     for i in &[1, 2] {
         router
-            .wait(i, timeout())?
+            .wait(i, timeout())
             .metrics(
                 |x| x.last_applied.index() < Some(log_index),
                 "old cluster does not recv new logs",

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -34,7 +34,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
         n0.initialize(btreeset! {0}).await?;
         log_index += 1;
 
-        router.wait(&0, timeout())?.state(ServerState::Leader, "n0 -> leader").await?;
+        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
     }
 
     tracing::info!("--- add one learner");

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -204,7 +204,7 @@ async fn leader_metrics() -> Result<()> {
             )
             .await?;
 
-        router.wait(&leader, timeout())?.metrics(|x| x.current_leader.is_some(), "elect new leader").await?;
+        router.wait(&leader, timeout()).metrics(|x| x.current_leader.is_some(), "elect new leader").await?;
     }
 
     tracing::info!("--- check leader metrics after leadership transferred.");

--- a/openraft/tests/metrics/t40_metrics_wait.rs
+++ b/openraft/tests/metrics/t40_metrics_wait.rs
@@ -29,15 +29,15 @@ async fn metrics_wait() -> Result<()> {
         let n0 = router.get_raft_handle(&0)?;
         n0.initialize(cluster.clone()).await?;
 
-        router.wait(&0, timeout())?.state(ServerState::Leader, "n0 -> leader").await?;
+        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
     }
 
-    router.wait(&0, None)?.current_leader(0, "become leader").await?;
+    router.wait(&0, None).current_leader(0, "become leader").await?;
     router.wait_for_log(&cluster, Some(1), None, "initial log").await?;
 
     tracing::info!("--- wait and timeout");
 
-    let rst = router.wait(&0, timeout())?.log(Some(2), "timeout waiting for log 2").await;
+    let rst = router.wait(&0, timeout()).log(Some(2), "timeout waiting for log 2").await;
 
     match rst {
         Ok(_) => {

--- a/openraft/tests/state_machine/t10_total_order_apply.rs
+++ b/openraft/tests/state_machine/t10_total_order_apply.rs
@@ -27,7 +27,7 @@ async fn total_order_apply() -> Result<()> {
         let n0 = router.get_raft_handle(&0)?;
         n0.initialize(btreeset! {0}).await?;
 
-        router.wait(&0, timeout())?.state(ServerState::Leader, "n0 -> leader").await?;
+        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
     }
 
     tracing::info!("--- add one learner");

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -84,7 +84,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     tracing::info!("--- every node receives joint log");
     for i in 0..5 {
         router
-            .wait(&i, None)?
+            .wait(&i, None)
             .metrics(|x| x.last_applied.index() >= Some(log_index - 1), "joint log applied")
             .await?;
     }
@@ -92,7 +92,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     tracing::info!("--- only 3 node applied membership config");
     for i in 0..3 {
         router
-            .wait(&i, None)?
+            .wait(&i, None)
             .metrics(|x| x.last_applied.index() == Some(log_index), "uniform log applied")
             .await?;
 


### PR DESCRIPTION

## Changelog

##### Refactor: fixtures::TypedRaftRouter::wait() do not need to return a Result

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/337)
<!-- Reviewable:end -->
