### PR TITLE
Change: Snapshot does not need RaftTypeConfig as type param:

### DIFF
--- a/example-raft-kv/src/store/mod.rs
+++ b/example-raft-kv/src/store/mod.rs
@@ -131,7 +131,7 @@ impl RaftSnapshotBuilder<ExampleTypeConfig, Cursor<Vec<u8>>> for Arc<ExampleStor
     #[tracing::instrument(level = "trace", skip(self))]
     async fn build_snapshot(
         &mut self,
-    ) -> Result<Snapshot<ExampleTypeConfig, Cursor<Vec<u8>>>, StorageError<ExampleNodeId>> {
+    ) -> Result<Snapshot<ExampleNodeId, Cursor<Vec<u8>>>, StorageError<ExampleNodeId>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -341,7 +341,7 @@ impl RaftStorage<ExampleTypeConfig> for Arc<ExampleStore> {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<Snapshot<ExampleTypeConfig, Self::SnapshotData>>, StorageError<ExampleNodeId>> {
+    ) -> Result<Option<Snapshot<ExampleNodeId, Self::SnapshotData>>, StorageError<ExampleNodeId>> {
         match &*self.current_snapshot.read().await {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -187,7 +187,7 @@ impl RaftLogReader<Config> for Arc<MemStore> {
 #[async_trait]
 impl RaftSnapshotBuilder<Config, Cursor<Vec<u8>>> for Arc<MemStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<Config, Cursor<Vec<u8>>>, StorageError<MemNodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<MemNodeId, Cursor<Vec<u8>>>, StorageError<MemNodeId>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -407,7 +407,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<Snapshot<Config, Self::SnapshotData>>, StorageError<MemNodeId>> {
+    ) -> Result<Option<Snapshot<MemNodeId, Self::SnapshotData>>, StorageError<MemNodeId>> {
         match &*self.current_snapshot.read().await {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -33,16 +33,18 @@ pub(crate) struct LeaderState<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S
     pub(super) core: &'a mut RaftCore<C, N, S>,
 
     /// A mapping of node IDs the replication state of the target node.
-    pub(super) nodes: BTreeMap<C::NodeId, ReplicationState<C>>,
+    pub(super) nodes: BTreeMap<C::NodeId, ReplicationState<C::NodeId>>,
 
     /// The metrics about a leader
     pub replication_metrics: Versioned<ReplicationMetrics<C::NodeId>>,
 
     /// The stream of events coming from replication streams.
-    pub(super) replication_rx: mpsc::UnboundedReceiver<(ReplicaEvent<C, S::SnapshotData>, Span)>,
+    #[allow(clippy::type_complexity)]
+    pub(super) replication_rx: mpsc::UnboundedReceiver<(ReplicaEvent<C::NodeId, S::SnapshotData>, Span)>,
 
     /// The cloneable sender channel for replication stream events.
-    pub(super) replication_tx: mpsc::UnboundedSender<(ReplicaEvent<C, S::SnapshotData>, Span)>,
+    #[allow(clippy::type_complexity)]
+    pub(super) replication_tx: mpsc::UnboundedSender<(ReplicaEvent<C::NodeId, S::SnapshotData>, Span)>,
 
     /// Channels to send result back to client when logs are committed.
     pub(super) client_resp_channels: BTreeMap<u64, RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>>,

--- a/openraft/src/core/replication_state.rs
+++ b/openraft/src/core/replication_state.rs
@@ -6,20 +6,22 @@ use crate::raft_types::LogIdOptionExt;
 use crate::replication::ReplicationStream;
 use crate::LogId;
 use crate::MessageSummary;
-use crate::RaftTypeConfig;
+use crate::NodeId;
 
 /// A struct tracking the state of a replication stream from the perspective of the Raft actor.
-pub(crate) struct ReplicationState<C: RaftTypeConfig> {
-    pub matched: Option<LogId<C::NodeId>>,
+pub(crate) struct ReplicationState<NID: NodeId> {
+    pub matched: Option<LogId<NID>>,
+
     pub remove_since: Option<u64>,
-    pub repl_stream: ReplicationStream<C>,
+
+    pub repl_stream: ReplicationStream<NID>,
 
     /// The response channel to use for when this node has successfully synced with the cluster.
     #[allow(clippy::type_complexity)]
-    pub tx: Option<RaftRespTx<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>>>,
+    pub tx: Option<RaftRespTx<AddLearnerResponse<NID>, AddLearnerError<NID>>>,
 }
 
-impl<C: RaftTypeConfig> MessageSummary for ReplicationState<C> {
+impl<NID: NodeId> MessageSummary for ReplicationState<NID> {
     fn summary(&self) -> String {
         format!(
             "matched: {:?}, remove_after_commit: {:?}",
@@ -28,18 +30,18 @@ impl<C: RaftTypeConfig> MessageSummary for ReplicationState<C> {
     }
 }
 
-impl<C: RaftTypeConfig> ReplicationState<C> {
+impl<NID: NodeId> ReplicationState<NID> {
     // TODO(xp): make this a method of Config?
 
     /// Return true if the distance behind last_log_id is smaller than the threshold to join.
-    pub fn is_line_rate(&self, last_log_id: &Option<LogId<C::NodeId>>, config: &Config) -> bool {
-        is_matched_upto_date::<C>(&self.matched, last_log_id, config)
+    pub fn is_line_rate(&self, last_log_id: &Option<LogId<NID>>, config: &Config) -> bool {
+        is_matched_upto_date::<NID>(&self.matched, last_log_id, config)
     }
 }
 
-pub fn is_matched_upto_date<C: RaftTypeConfig>(
-    matched: &Option<LogId<C::NodeId>>,
-    last_log_id: &Option<LogId<C::NodeId>>,
+pub fn is_matched_upto_date<NID: NodeId>(
+    matched: &Option<LogId<NID>>,
+    last_log_id: &Option<LogId<NID>>,
     config: &Config,
 ) -> bool {
     let my_index = matched.next_index();

--- a/openraft/src/core/replication_state_test.rs
+++ b/openraft/src/core/replication_state_test.rs
@@ -1,5 +1,4 @@
 use crate::core::is_matched_upto_date;
-use crate::testing::DummyConfig;
 use crate::Config;
 use crate::LeaderId;
 use crate::LogId;
@@ -14,11 +13,11 @@ fn test_is_line_rate() -> anyhow::Result<()> {
     };
 
     assert!(
-        is_matched_upto_date::<DummyConfig>(&None, &None, &cfg(0)),
+        is_matched_upto_date::<u64>(&None, &None, &cfg(0)),
         "matched, threshold=0"
     );
     assert!(
-        is_matched_upto_date::<DummyConfig>(
+        is_matched_upto_date::<u64>(
             &None,
             &Some(LogId {
                 leader_id: LeaderId::new(2, 0),
@@ -29,7 +28,7 @@ fn test_is_line_rate() -> anyhow::Result<()> {
         "matched, threshold=1"
     );
     assert!(
-        !is_matched_upto_date::<DummyConfig>(
+        !is_matched_upto_date::<u64>(
             &None,
             &Some(LogId {
                 leader_id: LeaderId::new(2, 0),
@@ -41,24 +40,24 @@ fn test_is_line_rate() -> anyhow::Result<()> {
     );
 
     assert!(
-        is_matched_upto_date::<DummyConfig>(&Some(LogId::new(LeaderId::new(0, 0), 0)), &None, &cfg(0)),
+        is_matched_upto_date::<u64>(&Some(LogId::new(LeaderId::new(0, 0), 0)), &None, &cfg(0)),
         "matched, threshold=0"
     );
 
     assert!(
-        is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 10)), &cfg(0)),
+        is_matched_upto_date::<u64>(&m, &Some(LogId::new(LeaderId::new(2, 0), 10)), &cfg(0)),
         "matched, threshold=0"
     );
     assert!(
-        is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 9)), &cfg(0)),
+        is_matched_upto_date::<u64>(&m, &Some(LogId::new(LeaderId::new(2, 0), 9)), &cfg(0)),
         "overflow, threshold=0"
     );
     assert!(
-        !is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(0)),
+        !is_matched_upto_date::<u64>(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(0)),
         "not caught up, threshold=0"
     );
     assert!(
-        is_matched_upto_date::<DummyConfig>(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(1)),
+        is_matched_upto_date::<u64>(&m, &Some(LogId::new(LeaderId::new(2, 0), 11)), &cfg(1)),
         "caught up, threshold=1"
     );
     Ok(())

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -42,13 +42,13 @@ pub struct SnapshotMeta<NID: NodeId> {
 
 /// The data associated with the current snapshot.
 #[derive(Debug)]
-pub struct Snapshot<C, S>
+pub struct Snapshot<NID, S>
 where
-    C: RaftTypeConfig,
+    NID: NodeId,
     S: AsyncRead + AsyncSeek + Send + Unpin + 'static,
 {
     /// metadata of a snapshot
-    pub meta: SnapshotMeta<C::NodeId>,
+    pub meta: SnapshotMeta<NID>,
 
     /// A read handle to the associated snapshot.
     pub snapshot: Box<S>,
@@ -141,7 +141,7 @@ where
     /// Building snapshot can be done by:
     /// - Performing log compaction, e.g. merge log entries that operates on the same key, like a LSM-tree does,
     /// - or by fetching a snapshot from the state machine.
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C, SD>, StorageError<C::NodeId>>;
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C::NodeId, SD>, StorageError<C::NodeId>>;
 
     // NOTES:
     // This interface is geared toward small file-based snapshots. However, not all snapshots can
@@ -417,7 +417,7 @@ where C: RaftTypeConfig
     /// of the snapshot, which should be decoded for creating this method's response data.
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<Snapshot<C, Self::SnapshotData>>, StorageError<C::NodeId>>;
+    ) -> Result<Option<Snapshot<C::NodeId, Self::SnapshotData>>, StorageError<C::NodeId>>;
 }
 
 /// APIs for debugging a store.

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -176,7 +176,7 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<Snapshot<C, Self::SnapshotData>>, StorageError<C::NodeId>> {
+    ) -> Result<Option<Snapshot<C::NodeId, Self::SnapshotData>>, StorageError<C::NodeId>> {
         self.inner().get_current_snapshot().await
     }
 
@@ -221,7 +221,7 @@ pub struct SnapshotBuilderExt<C: RaftTypeConfig, T: RaftStorage<C>> {
 #[async_trait]
 impl<C: RaftTypeConfig, T: RaftStorage<C>> RaftSnapshotBuilder<C, T::SnapshotData> for SnapshotBuilderExt<C, T> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C, T::SnapshotData>, StorageError<C::NodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C::NodeId, T::SnapshotData>, StorageError<C::NodeId>> {
         self.inner.build_snapshot().await
     }
 }


### PR DESCRIPTION

## Changelog

##### Change: Snapshot does not need RaftTypeConfig as type param:
- `Snapshot<C:RaftTypeConfig, _>` change to `Snapshot<NID: NodeId, _>`.

- And other refactored non-pub types:
  `ReplicaEvent, ReplicationStream, RaftEvent, TargetReplState, ReplicationState`

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/338)
<!-- Reviewable:end -->
