### PR TITLE
Feature: remove replication stream for unreachable node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,4 +171,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-        args: --all --no-deps
+          args: --all --no-deps

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -1,3 +1,4 @@
+use crate::config::config::RemoveReplicationPolicy;
 use crate::config::error::ConfigError;
 use crate::Config;
 use crate::SnapshotPolicy;
@@ -58,6 +59,7 @@ fn test_build() -> anyhow::Result<()> {
         "--snapshot-policy=since_last:203",
         "--snapshot-max-chunk-size=204",
         "--max-applied-log-to-keep=205",
+        "--remove-replication=max_network_failures:206",
     ])?;
 
     assert_eq!("bar", config.cluster_name);
@@ -70,6 +72,28 @@ fn test_build() -> anyhow::Result<()> {
     assert_eq!(SnapshotPolicy::LogsSinceLast(203), config.snapshot_policy);
     assert_eq!(204, config.snapshot_max_chunk_size);
     assert_eq!(205, config.max_applied_log_to_keep);
+    assert_eq!(
+        RemoveReplicationPolicy::MaxNetworkFailures(206),
+        config.remove_replication
+    );
 
+    Ok(())
+}
+
+#[test]
+fn test_option_remove_replication() -> anyhow::Result<()> {
+    let config = Config::build(&["foo", "--remove-replication=max_network_failures:206"])?;
+
+    assert_eq!(
+        RemoveReplicationPolicy::MaxNetworkFailures(206),
+        config.remove_replication
+    );
+
+    let config = Config::build(&["foo", "--remove-replication=committed_advance:206"])?;
+
+    assert_eq!(
+        RemoveReplicationPolicy::CommittedAdvance(206),
+        config.remove_replication
+    );
     Ok(())
 }

--- a/openraft/src/config/error.rs
+++ b/openraft/src/config/error.rs
@@ -1,6 +1,5 @@
 /// Error variants related to configuration.
 #[derive(Debug, thiserror::Error, PartialEq)]
-#[non_exhaustive]
 pub enum ConfigError {
     #[error("election timeout: min({min}) must be < max({max})")]
     ElectionTimeout { min: u64, max: u64 },
@@ -19,4 +18,7 @@ pub enum ConfigError {
 
     #[error("{reason} when parsing {invalid:?}")]
     InvalidNumber { invalid: String, reason: String },
+
+    #[error("remove replication policy string is invalid: '{invalid:?}' expect: '{syntax}'")]
+    InvalidRemoveReplicationPolicy { invalid: String, syntax: String },
 }

--- a/openraft/src/config/mod.rs
+++ b/openraft/src/config/mod.rs
@@ -4,5 +4,6 @@ mod error;
 #[cfg(test)] mod config_test;
 
 pub use config::Config;
+pub use config::RemoveReplicationPolicy;
 pub use config::SnapshotPolicy;
 pub use error::ConfigError;

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -308,7 +308,7 @@ pub struct CommittedAdvanceTooMany {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
-#[error(transparent)]
+#[error("NetworkError: {source}")]
 pub struct NetworkError {
     #[from]
     source: AnyError,

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![doc = include_str!("../../README.md")]
 #![cfg_attr(feature = "bt", feature(backtrace))]
 
 //! # Feature flags
@@ -42,6 +42,7 @@ use serde::Serialize;
 
 pub use crate::config::Config;
 pub use crate::config::ConfigError;
+pub use crate::config::RemoveReplicationPolicy;
 pub use crate::config::SnapshotPolicy;
 pub use crate::core::ServerState;
 pub use crate::defensive::DefensiveCheck;

--- a/openraft/tests/membership/main.rs
+++ b/openraft/tests/membership/main.rs
@@ -17,4 +17,5 @@ mod t25_elect_with_new_config;
 mod t30_commit_joint_config;
 mod t30_step_down;
 mod t40_removed_follower;
+mod t45_remove_unreachable_follower;
 mod t99_new_leader_auto_commit_uniform_config;

--- a/openraft/tests/membership/t45_remove_unreachable_follower.rs
+++ b/openraft/tests/membership/t45_remove_unreachable_follower.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Replication should stop after a **unreachable** follower is removed from membership.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn stop_replication_to_removed_unreachable_follower_network_failure() -> Result<()> {
+    // If the uniform membership is committed and replication to a node encountered 2 network failure, just remove it.
+    let config = Arc::new(Config::build(&["foo", "--remove-replication=max_network_failures:2"])?);
+
+    let mut router = RaftRouter::new(config.clone());
+    router.new_raft_node(0).await;
+
+    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
+
+    router.wait_for_log(&btreeset![0, 1, 2, 3, 4], Some(log_index), timeout(), "cluster of 5").await?;
+
+    tracing::info!("--- isolate node 4");
+    {
+        router.isolate_node(4).await;
+    }
+
+    // logs on node 4 will stop here:
+    let node4_log_index = log_index;
+
+    tracing::info!("--- changing config to 0,1,2");
+    {
+        let node = router.get_raft_handle(&0)?;
+        node.change_membership(btreeset![0, 1, 2], true, false).await?;
+        log_index += 2;
+
+        for i in &[0, 1, 2, 3] {
+            router
+                .wait(i, timeout())
+                .metrics(
+                    |x| x.last_log_index >= Some(log_index),
+                    "0,1,2,3 recv change-membership logs",
+                )
+                .await?;
+        }
+    }
+
+    tracing::info!("--- replication to node 4 will be removed");
+    {
+        router
+            .wait(&0, timeout())
+            .metrics(
+                |x| x.replication.as_ref().map(|y| y.data().replication.contains_key(&4)) == Some(false),
+                "stopped replication to node 4",
+            )
+            .await?;
+    }
+
+    tracing::info!("--- restore network isolation, node 4 won't catch up log and will enter candidate state");
+    {
+        router.restore_node(4).await;
+
+        router
+            .wait(&4, timeout())
+            .metrics(
+                |x| x.last_log_index == Some(node4_log_index) && x.state == ServerState::Candidate,
+                "node 4 stopped recv log and start to elect",
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
+}


### PR DESCRIPTION

## Changelog

##### Feature: remove replication stream for unreachable node
The default trigger event to remove the replication to a node that is
not in membership is uniform membership log being committed and
replicated to that node.

But if the node is unreachable, the uniform membership log can never be
replicated.

This PR introduces another config: `Confg.remove_replication` to specify
when to remove a replication:

- `RemoveReplicationPolicy::CommittedAdvance(n)`: if the leader already
  committed `n` more logs than the uniform membership log index, remove
  the replication.

- `RemoveReplicationPolicy::MaxNetworkFailures(n)`: if the leader
  encountered `n` network failures, such as `ReplicationError::Timeout`
  or `ReplicationError::NetworkError`, remove the replication.

Changes:

- Add config: --remove-replication to specify when to stop replication to a unreachable removed node.

- `ReplicaEvent::UpdateMatched.matched: LogId` is replaced with `result:
  Result<LogId, String>` to represent a success RPC or an error.

- When `send_append_entries()` fails, report the failure to
  `LeaderState` to let the leader to decide when to remove the
  replication.

- Fix: #333

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/339)
<!-- Reviewable:end -->
