### PR TITLE
Refactor: reverting membership state does not need to bother the store.

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -14,3 +14,4 @@
     - [Architecture](./architecture.md)
     - [Threads](./threading.md)
     - [Replication](./replication.md)
+    - [Effective Membership](./effective-membership.md)

--- a/guide/src/effective-membership.md
+++ b/guide/src/effective-membership.md
@@ -1,0 +1,28 @@
+# Effective membership
+
+In openraft a membership config log takes effect as soon as it is seen.
+
+Thus the **effective** membership is always the last present one found in log.
+
+The effective membership is volatile before being committed:
+because non-committed logs has chance being overridden by a new leader.
+Thus the effective membership needs to be reverted to a previous one along with
+the conflicting logs being deleted.
+
+Because Raft does not allow to propose new membership config if the
+effective one has not yet committed,
+The Raft Engine only need to keep track of at most two membership configs: the last
+committed one and the effective one.
+
+The second last membership log has to be committed.
+
+```rust
+pub struct MembershipState<NID: NodeId> {
+    pub committed: Arc<EffectiveMembership<NID>>,
+    pub effective: Arc<EffectiveMembership<NID>>,
+}
+```
+
+When deleting conflicting logs that contains a membership config log on a
+Follower/Learner, it needs to revert at most one membership config to previous
+one, i.e., discard the effective one and make the last committed one effective.

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -311,6 +311,7 @@ where
         sto
     }
 
+    // TODO: do not need async
     #[tracing::instrument(level = "debug", skip(self, sto))]
     pub async fn new_raft_node_with_sto(&mut self, id: C::NodeId, sto: StoreWithDefensive<C, S>) {
         let node = Raft::new(id, self.config.clone(), self.clone(), sto.clone());

--- a/openraft/tests/snapshot/main.rs
+++ b/openraft/tests/snapshot/main.rs
@@ -8,3 +8,4 @@ mod snapshot_ge_half_threshold;
 mod snapshot_line_rate_to_snapshot;
 mod snapshot_overrides_membership;
 mod snapshot_uses_prev_snap_membership;
+mod t10_snapshot_delete_conflict_logs;

--- a/openraft/tests/snapshot/t10_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t10_snapshot_delete_conflict_logs.rs
@@ -1,0 +1,186 @@
+use std::option::Option::None;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::Config;
+use openraft::Entry;
+use openraft::EntryPayload;
+use openraft::LeaderId;
+use openraft::LogId;
+use openraft::Membership;
+use openraft::RaftLogReader;
+use openraft::RaftNetwork;
+use openraft::RaftNetworkFactory;
+use openraft::RaftSnapshotBuilder;
+use openraft::RaftStorage;
+use openraft::ServerState;
+use openraft::SnapshotPolicy;
+use openraft::Vote;
+
+use crate::fixtures::blank;
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Installing snapshot on a node that has logs conflict with snapshot.meta.last_log_id will delete all conflict logs.
+///
+/// - Feed logs to node-0 to build a snapshot.
+/// - Init node-1 with conflicting log.
+/// - Send snapshot to node-1 to override its conflicting logs.
+/// - ensure that snapshot overrides the existent membership and conflicting logs are deleted.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn snapshot_delete_conflicting_logs() -> Result<()> {
+    let snapshot_threshold: u64 = 10;
+
+    let config = Arc::new(
+        Config {
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
+            max_applied_log_to_keep: 0,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    let mut log_index;
+
+    tracing::info!("--- manually init node-0 with a higher vote, in order to override conflict log on learner later");
+    {
+        let mut sto0 = router.new_store().await;
+
+        sto0.save_vote(&Vote::new(5, 0)).await?;
+        sto0.append_to_log(&[
+            // manually insert the initializing log
+            &Entry {
+                log_id: LogId::new(LeaderId::new(0, 0), 0),
+                payload: EntryPayload::Membership(Membership::new(vec![btreeset! {0}], None)),
+            },
+        ])
+        .await?;
+        log_index = 1;
+
+        router.new_raft_node_with_sto(0, sto0).await;
+
+        router.wait(&0, timeout()).state(ServerState::Leader, "init node-0 server-state").await?;
+        router.wait(&0, timeout()).log(Some(log_index), "init node-0 log").await?;
+    }
+
+    tracing::info!("--- send just enough logs to trigger snapshot");
+    {
+        router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await;
+        log_index = snapshot_threshold - 1;
+
+        router.wait(&0, timeout()).log(Some(log_index), "trigger snapshot").await?;
+        router
+            .wait(&0, timeout())
+            .snapshot(LogId::new(LeaderId::new(5, 0), log_index), "build snapshot")
+            .await?;
+    }
+
+    tracing::info!("--- create node-1 and add conflicting logs");
+    {
+        router.new_raft_node(1).await;
+
+        let req = AppendEntriesRequest {
+            vote: Vote::new(1, 0),
+            prev_log_id: None,
+            entries: vec![
+                blank(0, 0),
+                blank(1, 1),
+                // conflict membership will be replaced with membership in snapshot
+                Entry {
+                    log_id: LogId::new(LeaderId::new(1, 0), 2),
+                    payload: EntryPayload::Membership(Membership::new(vec![btreeset! {2,3}], None)),
+                },
+                blank(1, 3),
+                blank(1, 4),
+                blank(1, 5),
+                blank(1, 6),
+                blank(1, 7),
+                blank(1, 8),
+                blank(1, 9),
+                blank(1, 10),
+                // another conflict membership, will be removed
+                Entry {
+                    log_id: LogId::new(LeaderId::new(1, 0), 11),
+                    payload: EntryPayload::Membership(Membership::new(vec![btreeset! {4,5}], None)),
+                },
+            ],
+            leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
+        };
+        router.connect(1, None).await.send_append_entries(req).await?;
+
+        tracing::info!("--- check that learner membership is affected");
+        {
+            let mut sto1 = router.get_storage_handle(&1)?;
+            let m = sto1.get_membership().await?;
+
+            tracing::info!("got membership of node-1: {:?}", m);
+            assert_eq!(Membership::new(vec![btreeset! {2,3}], None), m.committed.membership);
+            assert_eq!(Membership::new(vec![btreeset! {4,5}], None), m.effective.membership);
+        }
+    }
+
+    tracing::info!("--- manually build and install snapshot to node-1");
+    {
+        let mut sto0 = router.get_storage_handle(&0)?;
+
+        let snap = {
+            let mut b = sto0.get_snapshot_builder().await;
+            let snap = b.build_snapshot().await?;
+            snap
+        };
+
+        let req = InstallSnapshotRequest {
+            vote: sto0.read_vote().await?.unwrap(),
+            meta: snap.meta.clone(),
+            offset: 0,
+            data: snap.snapshot.into_inner(),
+            done: true,
+        };
+
+        router.connect(1, None).await.send_install_snapshot(req).await?;
+
+        tracing::info!("--- DONE installing snapshot");
+
+        router
+            .wait(&1, timeout())
+            .snapshot(LogId::new(LeaderId::new(5, 0), log_index), "node-1 snapshot")
+            .await?;
+    }
+
+    tracing::info!("--- check that learner membership is affected, conflict log are deleted");
+    {
+        let mut sto1 = router.get_storage_handle(&1)?;
+
+        let m = sto1.get_membership().await?;
+
+        tracing::info!("got membership of node-1: {:?}", m);
+        assert_eq!(
+            Membership::new(vec![btreeset! {0}], None),
+            m.committed.membership,
+            "membership should be overridden by the snapshot"
+        );
+        assert_eq!(
+            Membership::new(vec![btreeset! {0}], None),
+            m.effective.membership,
+            "membership should be overridden by the snapshot"
+        );
+
+        let log_st = sto1.get_log_state().await?;
+        assert_eq!(
+            Some(LogId::new(LeaderId::new(5, 0), snapshot_threshold - 1)),
+            log_st.last_log_id,
+            "reverted to last log id in snapshot"
+        );
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(5000))
+}


### PR DESCRIPTION

## Changelog

##### Refactor: reverting membership state does not need to bother the store.
Raft Engine only need to keep track of at most two membership: the last
committed one and the effective one.
Because Raft does not allow to propose new membership config if the
effective one has not yet committed.

When deleting conflicting logs on a Follower/Learner, it needs to revert
at most one membership config to previous one, i.e., discard the
effective one and make the last committed one effective.

This way we do not need to load membership from the storage, which is
expensive.

Update doc: explain snapshot replication and effective membership.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/346)
<!-- Reviewable:end -->
