### PR TITLE
Refactor: remove unnecessary async in fixtures/mod.rs

### DIFF
--- a/openraft/tests/api_install_snapshot.rs
+++ b/openraft/tests/api_install_snapshot.rs
@@ -32,7 +32,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
 
     tracing::info!("--- initializing cluster");
     {
-        router.new_raft_node(0).await;
+        router.new_raft_node(0);
 
         router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
         router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
@@ -41,10 +41,10 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         log_index += 1;
 
         router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init leader").await?;
-        router.assert_stable_cluster(Some(1), Some(log_index)).await;
+        router.assert_stable_cluster(Some(1), Some(log_index));
     }
 
-    let n = router.remove_node(0).await.ok_or_else(|| anyhow::anyhow!("node not found"))?;
+    let n = router.remove_node(0).ok_or_else(|| anyhow::anyhow!("node not found"))?;
     let req0 = InstallSnapshotRequest {
         vote: Vote::new_committed(1, 0),
         meta: SnapshotMeta {

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -40,7 +40,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     // Expect conflict even if the message contains no entries.
 

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -26,14 +26,14 @@ async fn append_conflicts() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     tracing::info!("--- wait for init node to ready");
 
     router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
     router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
 
-    let (r0, mut sto0) = router.remove_node(0).await.unwrap();
+    let (r0, mut sto0) = router.remove_node(0).unwrap();
     check_logs(&mut sto0, vec![]).await?;
 
     tracing::info!("--- case 0: prev_log_id == None, no logs");

--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -37,15 +37,15 @@ async fn append_inconsistent_log() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- remove all nodes and fake the logs");
 
-    let (r0, mut sto0) = router.remove_node(0).await.unwrap();
-    let (r1, sto1) = router.remove_node(1).await.unwrap();
-    let (r2, mut sto2) = router.remove_node(2).await.unwrap();
+    let (r0, mut sto0) = router.remove_node(0).unwrap();
+    let (r1, sto1) = router.remove_node(1).unwrap();
+    let (r2, mut sto2) = router.remove_node(2).unwrap();
 
     r0.shutdown().await?;
     r1.shutdown().await?;
@@ -82,14 +82,14 @@ async fn append_inconsistent_log() -> Result<()> {
 
     tracing::info!("--- restart node 1 and isolate. To let node-2 to become leader, node-1 should not vote for node-0");
     {
-        router.new_raft_node_with_sto(1, sto1.clone()).await;
-        router.isolate_node(1).await;
+        router.new_raft_node_with_sto(1, sto1.clone());
+        router.isolate_node(1);
     }
 
     tracing::info!("--- restart node 0 and 2");
     {
-        router.new_raft_node_with_sto(0, sto0.clone()).await;
-        router.new_raft_node_with_sto(2, sto2.clone()).await;
+        router.new_raft_node_with_sto(0, sto0.clone());
+        router.new_raft_node_with_sto(2, sto2.clone());
     }
 
     // leader appends a blank log.

--- a/openraft/tests/append_entries/t40_append_updates_membership.rs
+++ b/openraft/tests/append_entries/t40_append_updates_membership.rs
@@ -27,14 +27,14 @@ async fn append_updates_membership() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     tracing::info!("--- wait for init node to ready");
 
     router.wait_for_log(&btreeset![0], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0], ServerState::Learner, None, "empty").await?;
 
-    let (r0, _sto0) = router.remove_node(0).await.unwrap();
+    let (r0, _sto0) = router.remove_node(0).unwrap();
 
     tracing::info!("--- append-entries update membership");
     {

--- a/openraft/tests/client_api/t10_client_writes.rs
+++ b/openraft/tests/client_api/t10_client_writes.rs
@@ -33,16 +33,16 @@ async fn client_writes() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
+    router.new_raft_node(2);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1, 2], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0, 1, 2], ServerState::Learner, None, "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
@@ -53,7 +53,7 @@ async fn client_writes() -> Result<()> {
     router.wait_for_state(&btreeset![0], ServerState::Leader, None, "cluster leader").await?;
     router.wait_for_state(&btreeset![1, 2], ServerState::Follower, None, "cluster follower").await?;
 
-    router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    router.assert_stable_cluster(Some(1), Some(log_index));
 
     // Write a bunch of data and assert that the cluster stayes stable.
     let leader = router.leader().expect("leader not found");
@@ -69,7 +69,7 @@ async fn client_writes() -> Result<()> {
     log_index += 500 * 6;
     router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "sync logs").await?;
 
-    router.assert_stable_cluster(Some(1), Some(log_index)).await; // The extra 1 is from the leader's initial commit entry.
+    router.assert_stable_cluster(Some(1), Some(log_index)); // The extra 1 is from the leader's initial commit entry.
 
     router
         .assert_storage_state(

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -20,16 +20,16 @@ async fn client_reads() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
+    router.new_raft_node(2);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1, 2], None, None, "empty node").await?;
     router.wait_for_state(&btreeset![0, 1, 2], ServerState::Learner, None, "empty node").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
@@ -37,7 +37,7 @@ async fn client_reads() -> Result<()> {
     log_index += 1;
 
     router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "init leader").await?;
-    router.assert_stable_cluster(Some(1), Some(1)).await;
+    router.assert_stable_cluster(Some(1), Some(1));
 
     // Get the ID of the leader, and assert that is_leader succeeds.
     let leader = router.leader().expect("leader not found");
@@ -52,12 +52,12 @@ async fn client_reads() -> Result<()> {
 
     tracing::info!("--- isolate node 1 then is_leader should work");
 
-    router.isolate_node(1).await;
+    router.isolate_node(1);
     router.is_leader(leader).await?;
 
     tracing::info!("--- isolate node 2 then is_leader should fail");
 
-    router.isolate_node(2).await;
+    router.isolate_node(2);
     let rst = router.is_leader(leader).await;
     tracing::debug!(?rst, "is_leader with majority down");
 

--- a/openraft/tests/client_api/t50_lagging_network_write.rs
+++ b/openraft/tests/client_api/t50_lagging_network_write.rs
@@ -30,13 +30,13 @@ async fn lagging_network_write() -> Result<()> {
     );
     let mut router = RaftRouter::builder(config).send_delay(50).build();
 
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
     router.wait_for_state(&btreeset![0], ServerState::Learner, None, "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
@@ -45,14 +45,14 @@ async fn lagging_network_write() -> Result<()> {
 
     router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init").await?;
     router.wait_for_state(&btreeset![0], ServerState::Leader, None, "init").await?;
-    router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    router.assert_stable_cluster(Some(1), Some(log_index));
 
     // Sync some new nodes.
-    router.new_raft_node(1).await;
+    router.new_raft_node(1);
     router.add_learner(0, 1).await?;
     log_index += 1;
 
-    router.new_raft_node(2).await;
+    router.new_raft_node(2);
     router.add_learner(0, 2).await?;
     log_index += 1;
 

--- a/openraft/tests/concurrent_write_and_add_learner.rs
+++ b/openraft/tests/concurrent_write_and_add_learner.rs
@@ -46,7 +46,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     let mut log_index;
 
@@ -61,8 +61,8 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     tracing::info!("--- adding two candidate nodes");
     {
         // Sync some new nodes.
-        router.new_raft_node(1).await;
-        router.new_raft_node(2).await;
+        router.new_raft_node(1);
+        router.new_raft_node(2);
         router.add_learner(0, 1).await?;
         router.add_learner(0, 2).await?;
         log_index += 2; // two add_learner logs
@@ -74,7 +74,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
         log_index += 2; // Tow member change logs
 
         wait_log(&router, &candidates, log_index).await?;
-        router.assert_stable_cluster(Some(1), Some(log_index)).await; // Still in term 1, so leader is still node 0.
+        router.assert_stable_cluster(Some(1), Some(log_index)); // Still in term 1, so leader is still node 0.
     }
 
     let leader = router.leader().unwrap();
@@ -90,7 +90,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     // Concurrently add Learner and write another log.
     tracing::info!("--- concurrently add learner and write another log");
     {
-        router.new_raft_node(3).await;
+        router.new_raft_node(3);
         let r = router.clone();
 
         let handle = {

--- a/openraft/tests/elect_compare_last_log.rs
+++ b/openraft/tests/elect_compare_last_log.rs
@@ -31,8 +31,8 @@ async fn elect_compare_last_log() -> Result<()> {
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 
-    let mut sto0 = router.new_store().await;
-    let mut sto1 = router.new_store().await;
+    let mut sto0 = router.new_store();
+    let mut sto1 = router.new_store();
 
     tracing::info!("--- fake store: sto0: last log: 2,1");
     {
@@ -72,8 +72,8 @@ async fn elect_compare_last_log() -> Result<()> {
 
     tracing::info!("--- bring up cluster and elect");
 
-    router.new_raft_node_with_sto(0, sto0.clone()).await;
-    router.new_raft_node_with_sto(1, sto1.clone()).await;
+    router.new_raft_node_with_sto(0, sto0.clone());
+    router.new_raft_node_with_sto(1, sto1.clone());
 
     router
         .wait_for_state(

--- a/openraft/tests/initialize/t20_initialization.rs
+++ b/openraft/tests/initialize/t20_initialization.rs
@@ -35,16 +35,16 @@ async fn initialization() -> anyhow::Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
+    router.new_raft_node(2);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1, 2], None, timeout(), "empty").await?;
     router.wait_for_state(&btreeset![0, 1, 2], ServerState::Learner, timeout(), "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Sending an external requests will also find all nodes in Learner state.
     //
@@ -75,7 +75,7 @@ async fn initialization() -> anyhow::Result<()> {
         router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), timeout(), "init").await?;
     }
 
-    router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    router.assert_stable_cluster(Some(1), Some(log_index));
 
     for i in 0..3 {
         let mut sto = router.get_storage_handle(&1)?;
@@ -135,8 +135,8 @@ async fn initialize_err_target_not_include_target() -> anyhow::Result<()> {
 
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
 
     for node in [0, 1] {
         router.external_request(node, |s, _sto, _net| {
@@ -170,7 +170,7 @@ async fn initialize_err_not_allowed() -> anyhow::Result<()> {
 
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     for node in [0] {
         router.external_request(node, |s, _sto, _net| {

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -33,15 +33,15 @@ async fn learner_restart() -> Result<()> {
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0, 1], ServerState::Learner, None, "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     tracing::info!("--- initializing single node cluster");
     {
@@ -58,11 +58,11 @@ async fn learner_restart() -> Result<()> {
 
     router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "write one log").await?;
 
-    let (node0, _sto0) = router.remove_node(0).await.unwrap();
+    let (node0, _sto0) = router.remove_node(0).unwrap();
     assert_node_state(0, &node0, 1, log_index, ServerState::Leader);
     node0.shutdown().await?;
 
-    let (node1, sto1) = router.remove_node(1).await.unwrap();
+    let (node1, sto1) = router.remove_node(1).unwrap();
     assert_node_state(0, &node1, 1, log_index, ServerState::Learner);
     node1.shutdown().await?;
 

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -57,7 +57,7 @@ async fn add_learner_basic() -> Result<()> {
 
         router.wait_for_log(&btreeset! {0}, Some(log_index), timeout(), "write 1000 logs to leader").await?;
 
-        router.new_raft_node(1).await;
+        router.new_raft_node(1);
         router.add_learner(0, 1).await?;
         log_index += 1;
         router.wait_for_log(&btreeset! {0,1}, Some(log_index), timeout(), "add learner").await?;
@@ -115,7 +115,7 @@ async fn add_learner_non_blocking() -> Result<()> {
 
         router.wait(&0, timeout()).log(Some(log_index), "received 100 logs").await?;
 
-        router.new_raft_node(1).await;
+        router.new_raft_node(1);
         let raft = router.get_raft_handle(&0)?;
         let res = raft.add_learner(1, None, false).await?;
 
@@ -140,15 +140,15 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
     );
     let timeout = Some(Duration::from_millis(2000));
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1], None, timeout, "empty").await?;
     router.wait_for_state(&btreeset![0, 1], ServerState::Learner, timeout, "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
@@ -156,20 +156,20 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
     log_index += 1;
 
     router.wait_for_log(&btreeset![0, 1], Some(log_index), timeout, "init").await?;
-    router.assert_stable_cluster(Some(1), Some(1)).await;
+    router.assert_stable_cluster(Some(1), Some(1));
 
     // Submit a config change which adds two new nodes and removes the current leader.
     let orig_leader = router.leader().expect("expected the cluster to have a leader");
     assert_eq!(0, orig_leader, "expected original leader to be node 0");
 
     // add a learner
-    router.new_raft_node(2).await;
+    router.new_raft_node(2);
     router.add_learner(orig_leader, 2).await?;
     log_index += 1;
     router.wait_for_log(&btreeset![0, 1], Some(log_index), timeout, "add learner").await?;
 
-    router.new_raft_node(3).await;
-    router.new_raft_node(4).await;
+    router.new_raft_node(3);
+    router.new_raft_node(4);
     router.add_learner(orig_leader, 3).await?;
     router.add_learner(orig_leader, 4).await?;
     log_index += 2;

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -73,7 +73,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
     tracing::info!("--- change to {:?}", new);
     {
         for id in only_in_new {
-            router.new_raft_node(*id).await;
+            router.new_raft_node(*id);
             router.add_learner(0, *id).await?;
             log_index += 1;
             router.wait_for_log(&old, Some(log_index), timeout(), &format!("add learner, {}", mes)).await?;

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -39,7 +39,7 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
 
     tracing::info!("--- change membership without adding-learner");
     {
-        router.new_raft_node(1).await;
+        router.new_raft_node(1);
         router.add_learner(0, 1).await?;
         log_index += 1;
         router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "add learner").await?;
@@ -80,7 +80,7 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
 
     tracing::info!("--- stop replication by isolating node 1");
     {
-        router.isolate_node(1).await;
+        router.isolate_node(1);
     }
 
     tracing::info!("--- write up to 100 logs");
@@ -93,7 +93,7 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
 
     tracing::info!("--- restore replication and change membership at once, expect NonVoterIsLagging");
     {
-        router.restore_node(1).await;
+        router.restore_node(1);
         let node = router.get_raft_handle(&0)?;
         let res = node.change_membership(btreeset! {0,1}, false, false).await;
 

--- a/openraft/tests/membership/t30_commit_joint_config.rs
+++ b/openraft/tests/membership/t30_commit_joint_config.rs
@@ -21,7 +21,7 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     // router.assert_pristine_cluster().await;
 
@@ -34,8 +34,8 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
     router.wait_for_log(&btreeset![0], Some(log_index), None, "init node 0").await?;
 
     // Sync some new nodes.
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
+    router.new_raft_node(1);
+    router.new_raft_node(2);
 
     tracing::info!("--- adding new nodes to cluster");
     let mut new_nodes = futures::stream::FuturesUnordered::new();
@@ -50,8 +50,8 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
 
     tracing::info!("--- isolate node 1,2, so that membership [0,1,2] wont commit");
 
-    router.isolate_node(1).await;
-    router.isolate_node(2).await;
+    router.isolate_node(1);
+    router.isolate_node(2);
 
     tracing::info!("--- changing cluster config, should timeout");
 
@@ -89,14 +89,14 @@ async fn commit_joint_config_during_012_to_234() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
     tracing::info!("--- isolate 3,4");
 
-    router.isolate_node(3).await;
-    router.isolate_node(4).await;
+    router.isolate_node(3);
+    router.isolate_node(4);
 
     tracing::info!("--- changing config to 0,1,2");
     let node = router.get_raft_handle(&0)?;

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -33,8 +33,8 @@ async fn step_down() -> Result<()> {
     // Submit a config change which adds two new nodes and removes the current leader.
     let orig_leader = router.leader().expect("expected the cluster to have a leader");
     assert_eq!(0, orig_leader, "expected original leader to be node 0");
-    router.new_raft_node(2).await;
-    router.new_raft_node(3).await;
+    router.new_raft_node(2);
+    router.new_raft_node(3);
     router.add_learner(0, 2).await?;
     router.add_learner(0, 3).await?;
     log_index += 2;

--- a/openraft/tests/membership/t40_removed_follower.rs
+++ b/openraft/tests/membership/t40_removed_follower.rs
@@ -15,14 +15,14 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- add node 3,4");
 
-    router.new_raft_node(3).await;
-    router.new_raft_node(4).await;
+    router.new_raft_node(3);
+    router.new_raft_node(4);
 
     router.add_learner(0, 3).await?;
     router.add_learner(0, 4).await?;

--- a/openraft/tests/membership/t45_remove_unreachable_follower.rs
+++ b/openraft/tests/membership/t45_remove_unreachable_follower.rs
@@ -16,7 +16,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
     let config = Arc::new(Config::build(&["foo", "--remove-replication=max_network_failures:2"])?);
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
@@ -24,7 +24,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
 
     tracing::info!("--- isolate node 4");
     {
-        router.isolate_node(4).await;
+        router.isolate_node(4);
     }
 
     // logs on node 4 will stop here:
@@ -60,7 +60,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
 
     tracing::info!("--- restore network isolation, node 4 won't catch up log and will enter candidate state");
     {
-        router.restore_node(4).await;
+        router.restore_node(4);
 
         router
             .wait(&4, timeout())

--- a/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -31,7 +31,7 @@ async fn new_leader_auto_commit_uniform_config() -> Result<()> {
     let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
 
     let mut sto = router.get_storage_handle(&0)?;
-    router.remove_node(0).await;
+    router.remove_node(0);
 
     {
         sto.append_to_log(&[&Entry {
@@ -50,8 +50,8 @@ async fn new_leader_auto_commit_uniform_config() -> Result<()> {
     let _ = log_index;
 
     // To let tne router not panic
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
+    router.new_raft_node(1);
+    router.new_raft_node(2);
 
     let node = Raft::new(0, config.clone(), router.clone(), sto.clone());
 

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -25,8 +25,8 @@ async fn metrics_state_machine_consistency() -> Result<()> {
 
     let mut log_index = 0;
 
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
 
     tracing::info!("--- initializing single node cluster");
     {

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -41,7 +41,7 @@ async fn leader_metrics() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     // Assert all nodes are in learner state & have no entries.
     let mut log_index = 0;
@@ -49,7 +49,7 @@ async fn leader_metrics() -> Result<()> {
     router.wait_for_log(&btreeset![0], None, timeout(), "init").await?;
     router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "init").await?;
 
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     tracing::info!("--- initializing cluster");
 
@@ -57,7 +57,7 @@ async fn leader_metrics() -> Result<()> {
     log_index += 1;
 
     router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init cluster").await?;
-    router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    router.assert_stable_cluster(Some(1), Some(log_index));
 
     router
         .wait_for_metrics(
@@ -75,10 +75,10 @@ async fn leader_metrics() -> Result<()> {
         .await?;
 
     // Sync some new nodes.
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
-    router.new_raft_node(3).await;
-    router.new_raft_node(4).await;
+    router.new_raft_node(1);
+    router.new_raft_node(2);
+    router.new_raft_node(3);
+    router.new_raft_node(4);
 
     tracing::info!("--- adding 4 new nodes to cluster");
 
@@ -103,7 +103,7 @@ async fn leader_metrics() -> Result<()> {
 
     router.wait_for_log(&all_members, Some(log_index), timeout(), "change members to 0,1,2,3,4").await?;
 
-    router.assert_stable_cluster(Some(1), Some(log_index)).await; // Still in term 1, so leader is still node 0.
+    router.assert_stable_cluster(Some(1), Some(log_index)); // Still in term 1, so leader is still node 0.
 
     let ww = ReplicationTargetMetrics::new(LogId::new(LeaderId::new(1, 0), log_index));
     let want_repl = btreemap! { 1=>ww.clone(), 2=>ww.clone(), 3=>ww.clone(), 4=>ww.clone(), };

--- a/openraft/tests/metrics/t40_metrics_wait.rs
+++ b/openraft/tests/metrics/t40_metrics_wait.rs
@@ -24,7 +24,7 @@ async fn metrics_wait() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     let cluster = btreeset![0];
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
     {
         let n0 = router.get_raft_handle(&0)?;
         n0.initialize(cluster.clone()).await?;

--- a/openraft/tests/replication_1_voter_to_isolated_learner.rs
+++ b/openraft/tests/replication_1_voter_to_isolated_learner.rs
@@ -27,7 +27,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
 
     tracing::info!("--- stop replication to node 1");
     {
-        router.isolate_node(1).await;
+        router.isolate_node(1);
 
         router.client_request_many(0, "0", (10 - log_index) as usize).await;
         log_index = 10;
@@ -44,7 +44,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
 
     tracing::info!("--- restore replication to node 1");
     {
-        router.restore_node(1).await;
+        router.restore_node(1);
 
         router.client_request_many(0, "0", (10 - log_index) as usize).await;
         log_index = 10;

--- a/openraft/tests/shutdown.rs
+++ b/openraft/tests/shutdown.rs
@@ -25,16 +25,16 @@ async fn initialization() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
+    router.new_raft_node(2);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1, 2], None, timeout(), "empty").await?;
     router.wait_for_state(&btreeset![0, 1, 2], ServerState::Learner, timeout(), "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
@@ -42,17 +42,17 @@ async fn initialization() -> Result<()> {
     log_index += 1;
 
     router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "init").await?;
-    router.assert_stable_cluster(Some(1), Some(1)).await;
+    router.assert_stable_cluster(Some(1), Some(1));
 
     tracing::info!("--- performing node shutdowns");
     {
-        let (node0, _) = router.remove_node(0).await.ok_or_else(|| anyhow!("failed to find node 0 in router"))?;
+        let (node0, _) = router.remove_node(0).ok_or_else(|| anyhow!("failed to find node 0 in router"))?;
         node0.shutdown().await?;
 
-        let (node1, _) = router.remove_node(1).await.ok_or_else(|| anyhow!("failed to find node 1 in router"))?;
+        let (node1, _) = router.remove_node(1).ok_or_else(|| anyhow!("failed to find node 1 in router"))?;
         node1.shutdown().await?;
 
-        let (node2, _) = router.remove_node(2).await.ok_or_else(|| anyhow!("failed to find node 2 in router"))?;
+        let (node2, _) = router.remove_node(2).ok_or_else(|| anyhow!("failed to find node 2 in router"))?;
         node2.shutdown().await?;
     }
 

--- a/openraft/tests/singlenode.rs
+++ b/openraft/tests/singlenode.rs
@@ -28,14 +28,14 @@ async fn single_node() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
     router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
@@ -43,13 +43,13 @@ async fn single_node() -> Result<()> {
     log_index += 1;
 
     router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init").await?;
-    router.assert_stable_cluster(Some(1), Some(1)).await;
+    router.assert_stable_cluster(Some(1), Some(1));
 
     // Write some data to the single node cluster.
     router.client_request_many(0, "0", 1000).await;
     log_index += 1000;
     router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "client_request_many").await?;
-    router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    router.assert_stable_cluster(Some(1), Some(log_index));
     router
         .assert_storage_state(1, log_index, Some(0), LogId::new(LeaderId::new(1, 0), log_index), None)
         .await?;

--- a/openraft/tests/snapshot/after_snapshot_add_learner_and_request_a_log.rs
+++ b/openraft/tests/snapshot/after_snapshot_add_learner_and_request_a_log.rs
@@ -47,7 +47,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
                 "send log to trigger snapshot",
             )
             .await?;
-        router.assert_stable_cluster(Some(1), Some(log_index)).await;
+        router.assert_stable_cluster(Some(1), Some(log_index));
 
         router
             .wait_for_snapshot(
@@ -74,7 +74,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
 
         tracing::info!("--- add learner to the cluster to receive snapshot, which overrides the learner storage");
         {
-            router.new_raft_node(1).await;
+            router.new_raft_node(1);
             router.add_learner(0, 1).await.expect("failed to add new node as learner");
             log_index += 1;
 

--- a/openraft/tests/snapshot/snapshot_chunk_size.rs
+++ b/openraft/tests/snapshot/snapshot_chunk_size.rs
@@ -37,7 +37,7 @@ async fn snapshot_chunk_size() -> Result<()> {
 
     tracing::info!("--- initializing cluster");
     {
-        router.new_raft_node(0).await;
+        router.new_raft_node(0);
 
         router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
         router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
@@ -84,7 +84,7 @@ async fn snapshot_chunk_size() -> Result<()> {
 
     tracing::info!("--- add learner to receive snapshot and logs");
     {
-        router.new_raft_node(1).await;
+        router.new_raft_node(1);
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
         log_index += 1;
 

--- a/openraft/tests/snapshot/snapshot_ge_half_threshold.rs
+++ b/openraft/tests/snapshot/snapshot_ge_half_threshold.rs
@@ -43,7 +43,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         log_index = snapshot_threshold - 1;
 
         router.wait_for_log(&btreeset![0], Some(log_index), None, "send log to trigger snapshot").await?;
-        router.assert_stable_cluster(Some(1), Some(log_index)).await;
+        router.assert_stable_cluster(Some(1), Some(log_index));
 
         router
             .wait_for_snapshot(
@@ -72,7 +72,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
 
     tracing::info!("--- add learner to receive snapshot and logs");
     {
-        router.new_raft_node(1).await;
+        router.new_raft_node(1);
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
         log_index += 1;
 

--- a/openraft/tests/snapshot/snapshot_line_rate_to_snapshot.rs
+++ b/openraft/tests/snapshot/snapshot_line_rate_to_snapshot.rs
@@ -54,7 +54,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
     tracing::info!("--- stop replication to node 1");
     tracing::info!("--- send just enough logs to trigger snapshot");
     {
-        router.isolate_node(1).await;
+        router.isolate_node(1);
 
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await;
 
@@ -80,7 +80,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
 
     tracing::info!("--- restore node 1 and replication");
     {
-        router.restore_node(1).await;
+        router.restore_node(1);
 
         router.wait_for_log(&btreeset![1], Some(log_index), timeout(), "replicate by snapshot").await?;
         router

--- a/openraft/tests/snapshot/snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/snapshot_overrides_membership.rs
@@ -58,7 +58,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 "send log to trigger snapshot",
             )
             .await?;
-        router.assert_stable_cluster(Some(1), Some(log_index)).await;
+        router.assert_stable_cluster(Some(1), Some(log_index));
 
         router
             .wait_for_snapshot(
@@ -82,7 +82,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
     tracing::info!("--- create learner");
     {
         tracing::info!("--- create learner");
-        router.new_raft_node(1).await;
+        router.new_raft_node(1);
         let mut sto = router.get_storage_handle(&1)?;
 
         tracing::info!("--- add a membership config log to the learner");

--- a/openraft/tests/snapshot/t10_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t10_snapshot_delete_conflict_logs.rs
@@ -49,7 +49,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
 
     tracing::info!("--- manually init node-0 with a higher vote, in order to override conflict log on learner later");
     {
-        let mut sto0 = router.new_store().await;
+        let mut sto0 = router.new_store();
 
         sto0.save_vote(&Vote::new(5, 0)).await?;
         sto0.append_to_log(&[
@@ -62,7 +62,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
         .await?;
         log_index = 1;
 
-        router.new_raft_node_with_sto(0, sto0).await;
+        router.new_raft_node_with_sto(0, sto0);
 
         router.wait(&0, timeout()).state(ServerState::Leader, "init node-0 server-state").await?;
         router.wait(&0, timeout()).log(Some(log_index), "init node-0 log").await?;
@@ -82,7 +82,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
 
     tracing::info!("--- create node-1 and add conflicting logs");
     {
-        router.new_raft_node(1).await;
+        router.new_raft_node(1);
 
         let req = AppendEntriesRequest {
             vote: Vote::new(1, 0),

--- a/openraft/tests/state_machine/t10_total_order_apply.rs
+++ b/openraft/tests/state_machine/t10_total_order_apply.rs
@@ -19,8 +19,8 @@ async fn total_order_apply() -> Result<()> {
     let config = Arc::new(Config::default().validate().expect("failed to build Raft config"));
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
+    router.new_raft_node(0);
+    router.new_raft_node(1);
 
     tracing::info!("--- initializing single node cluster");
     {

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -29,14 +29,14 @@ async fn state_machine_apply_membership() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
+    router.new_raft_node(0);
 
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0], ServerState::Learner, None, "empty").await?;
-    router.assert_pristine_cluster().await;
+    router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
@@ -44,7 +44,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     log_index += 1;
 
     router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init").await?;
-    router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    router.assert_stable_cluster(Some(1), Some(log_index));
 
     for i in 0..=0 {
         let mut sto = router.get_storage_handle(&i)?;
@@ -58,10 +58,10 @@ async fn state_machine_apply_membership() -> Result<()> {
     }
 
     // Sync some new nodes.
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
-    router.new_raft_node(3).await;
-    router.new_raft_node(4).await;
+    router.new_raft_node(1);
+    router.new_raft_node(2);
+    router.new_raft_node(3);
+    router.new_raft_node(4);
 
     tracing::info!("--- adding new nodes to cluster");
     let mut new_nodes = futures::stream::FuturesUnordered::new();


### PR DESCRIPTION

## Changelog

##### Refactor: remove unnecessary async in fixtures/mod.rs
```
router.assert_pristine_cluster() does not need to be async
router.assert_stable_cluster()   does not need to be async
router.isolate_node()            does not need to be async
router.new_raft_ndoe()           does not need to be async
router.new_raft_node_with_sto()  does not need to be async
router.new_store()               does not need to be async
router.remove_node()             does not need to be async
router.restore_node()            does not need to be async
```

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/347)
<!-- Reviewable:end -->
