### PR TITLE
Refactor: clearn metrics flags every time metrics is reported

### DIFF
--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -214,13 +214,13 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         );
     }
 
-    pub fn handle_special_log(&mut self, entry: &Entry<C>) {
+    pub async fn handle_special_log(&mut self, entry: &Entry<C>) {
         match &entry.payload {
             EntryPayload::Membership(ref m) => {
                 if m.is_in_joint_consensus() {
                     // nothing to do
                 } else {
-                    self.handle_uniform_consensus_committed(&entry.log_id);
+                    self.handle_uniform_consensus_committed(&entry.log_id).await;
                 }
             }
             EntryPayload::Blank => {}
@@ -234,7 +234,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         &mut self,
         entry: &Entry<C>,
     ) -> Result<C::R, StorageError<C::NodeId>> {
-        self.handle_special_log(entry);
+        self.handle_special_log(entry).await;
 
         // First, we just ensure that we apply any outstanding up to, but not including, the index
         // of the given entry. We need to be able to return the data response from applying this

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -17,7 +17,6 @@ mod snapshot_state;
 pub(crate) use internal_msg::InternalMessage;
 use leader_state::LeaderState;
 use raft_core::apply_to_state_machine;
-use raft_core::MetricsProvider;
 pub use raft_core::RaftCore;
 pub use replication_state::is_matched_upto_date;
 use replication_state::ReplicationState;

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -126,7 +126,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             Err(_err_str) => {
                 state.failures += 1;
 
-                self.try_remove_replication(target);
+                self.try_remove_replication(target).await;
                 return Ok(());
             }
         };
@@ -148,7 +148,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         }
 
         // Drop replication stream if needed.
-        if self.try_remove_replication(target) {
+        if self.try_remove_replication(target).await {
             // nothing to do
         } else {
             self.update_replication_metrics(target, matched);


### PR DESCRIPTION
## Changelog

##### Refactor: clearn metrics flags every time metrics is reported
Remove `MetricsProvider`, use an `Option` instead.

##### Fix: flaky test: update replication metrics only when the replication task stopped

Otherwise, the test script believes replication is shut down then
restore the network communication, there will be unexpected logs sent to
a follower hense the test fails: `stop_replication_to_removed_unreachable_follower_network_failure`.

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/349)
<!-- Reviewable:end -->
