### PR TITLE
Refactor: merge follower_loop and learner_loop

### DIFF
--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -31,6 +31,7 @@ mod raft_state;
 mod runtime;
 pub mod storage;
 pub mod testing;
+pub mod timer;
 pub mod versioned;
 
 pub use anyerror;

--- a/openraft/src/timer/mod.rs
+++ b/openraft/src/timer/mod.rs
@@ -1,0 +1,7 @@
+mod timeout;
+
+// Not yet ready to publish :)
+#[allow(unused_imports)] pub(crate) use timeout::RaftTimer;
+#[allow(unused_imports)] pub(crate) use timeout::Timeout;
+
+#[cfg(test)] mod timeout_test;

--- a/openraft/src/timer/timeout.rs
+++ b/openraft/src/timer/timeout.rs
@@ -1,0 +1,117 @@
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::select;
+use futures::future::Either;
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::Receiver;
+use tokio::sync::oneshot::Sender;
+use tokio::time::sleep_until;
+use tokio::time::Instant;
+use tracing::trace_span;
+use tracing::Instrument;
+
+pub(crate) trait RaftTimer {
+    /// Create a new instance that will call `callback` after `timeout`.
+    fn new<F: FnOnce() + Send + 'static>(callback: F, timeout: Duration) -> Self;
+
+    /// Update the timeout to a duration since now.
+    fn update_timeout(&self, timeout: Duration);
+}
+
+/// A oneshot timeout that supports deadline updating.
+///
+/// When timeout deadline is reached, the `callback: Fn()` is called.
+/// `callback` is guaranteed to be called at most once.
+///
+/// The deadline can be updated to a higher value then the old deadline won't trigger the `callback`.
+pub(crate) struct Timeout {
+    /// A guard to notify the inner-task to quit when it is dropped.
+    // tx is not explicitly used.
+    #[allow(dead_code)]
+    tx: Sender<()>,
+
+    /// Shared state for running the sleep-notify task.
+    inner: Arc<TimeoutInner>,
+}
+
+pub(crate) struct TimeoutInner {
+    /// The time when this Timeout is created.
+    ///
+    /// The `relative_deadline` stores timeout deadline relative to `init` in micro second.
+    /// Thus a `u64` is enough for it to run for years.
+    init: Instant,
+
+    /// The micro seconds since `init` after which the callback will be triggered.
+    relative_deadline: AtomicU64,
+}
+
+impl RaftTimer for Timeout {
+    fn new<F: FnOnce() + Send + 'static>(callback: F, timeout: Duration) -> Self {
+        let (tx, rx) = oneshot::channel();
+
+        let inner = TimeoutInner {
+            init: Instant::now(),
+            relative_deadline: AtomicU64::new(timeout.as_micros() as u64),
+        };
+
+        let inner = Arc::new(inner);
+
+        let t = Timeout {
+            tx,
+            inner: inner.clone(),
+        };
+
+        tokio::spawn(inner.sleep_loop(rx, callback).instrument(trace_span!("timeout-loop").or_current()));
+
+        t
+    }
+
+    fn update_timeout(&self, timeout: Duration) {
+        let since_init = Instant::now() + timeout - self.inner.init;
+
+        let new_at = since_init.as_micros() as u64;
+
+        self.inner.relative_deadline.fetch_max(new_at, Ordering::Relaxed);
+    }
+}
+
+impl TimeoutInner {
+    /// Sleep until the deadline and send callback if the deadline is not changed.
+    /// Otherwise, sleep again.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn sleep_loop<F: FnOnce() + Send + 'static>(self: Arc<Self>, rx: Receiver<()>, callback: F) {
+        let mut wake_up_at = None;
+
+        let mut rx = rx;
+        loop {
+            let curr_deadline = self.relative_deadline.load(Ordering::Relaxed);
+
+            if wake_up_at == Some(curr_deadline) {
+                // `relative_deadline` is not updated.
+                callback();
+                return;
+            }
+
+            // `relative_deadline` is updated, keep sleeping.
+
+            wake_up_at = Some(curr_deadline);
+
+            let deadline = self.init + Duration::from_micros(curr_deadline);
+
+            let either = select(Box::pin(sleep_until(deadline)), rx).await;
+            rx = match either {
+                Either::Left((_sleep_res, rx)) => {
+                    tracing::debug!("sleep returned, continue to check if deadline changed");
+                    rx
+                }
+                Either::Right((_sleep_fut, _rx_res)) => {
+                    tracing::debug!("Timeout is closed without notifying");
+                    return;
+                }
+            };
+        }
+    }
+}

--- a/openraft/src/timer/timeout_test.rs
+++ b/openraft/src/timer/timeout_test.rs
@@ -1,0 +1,99 @@
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use tokio::time::sleep;
+use tokio::time::Instant;
+
+use crate::timer::timeout::RaftTimer;
+use crate::timer::Timeout;
+
+#[async_entry::test(worker_threads = 3)]
+async fn test_timeout() -> anyhow::Result<()> {
+    tracing::info!("--- set timeout, recv result");
+    {
+        let (tx, rx) = oneshot::channel();
+        let now = Instant::now();
+        let _t = Timeout::new(
+            || {
+                let _ = tx.send(1u64);
+            },
+            Duration::from_millis(50),
+        );
+
+        let res = rx.await?;
+        assert_eq!(1u64, res);
+
+        let elapsed = now.elapsed();
+        assert!(elapsed < Duration::from_millis(50 + 20));
+        assert!(Duration::from_millis(50 - 20) < elapsed);
+    }
+
+    tracing::info!("--- update timeout");
+    {
+        let (tx, rx) = oneshot::channel();
+        let now = Instant::now();
+        let t = Timeout::new(
+            || {
+                let _ = tx.send(1u64);
+            },
+            Duration::from_millis(50),
+        );
+
+        // Update timeout to 100 ms after 20 ms, the expected elapsed is 120 ms.
+        sleep(Duration::from_millis(20)).await;
+        t.update_timeout(Duration::from_millis(100));
+
+        let _res = rx.await?;
+
+        let elapsed = now.elapsed();
+        assert!(elapsed < Duration::from_millis(120 + 20));
+        assert!(Duration::from_millis(120 - 20) < elapsed);
+    }
+
+    tracing::info!("--- update timeout to a lower value wont take effect");
+    {
+        let (tx, rx) = oneshot::channel();
+        let now = Instant::now();
+        let t = Timeout::new(
+            || {
+                let _ = tx.send(1u64);
+            },
+            Duration::from_millis(50),
+        );
+
+        // Update timeout to 10 ms after 20 ms, the expected elapsed is still 50 ms.
+        sleep(Duration::from_millis(20)).await;
+        t.update_timeout(Duration::from_millis(10));
+
+        let _res = rx.await?;
+
+        let elapsed = now.elapsed();
+        assert!(elapsed < Duration::from_millis(50 + 20));
+        assert!(Duration::from_millis(50 - 20) < elapsed);
+    }
+
+    tracing::info!("--- drop the `Timeout` will cancel the callback");
+    {
+        let (tx, rx) = oneshot::channel();
+        let now = Instant::now();
+        let t = Timeout::new(
+            || {
+                let _ = tx.send(1u64);
+            },
+            Duration::from_millis(50),
+        );
+
+        // Drop the Timeout after 20 ms, the expected elapsed is 20 ms.
+        sleep(Duration::from_millis(20)).await;
+        drop(t);
+
+        let res = rx.await;
+        assert!(res.is_err());
+
+        let elapsed = now.elapsed();
+        assert!(elapsed < Duration::from_millis(20 + 10));
+        assert!(Duration::from_millis(20 - 10) < elapsed);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### Refactor: merge follower_loop and learner_loop
-   Refactor: Merge `follower_loop` and `learner_loop`.
    And  use a `Timeout` instance to trigger election. Avoid building unnecessary futures.

-   Feature: add oneshot Timeout supporting update deadline.

    - The `callback` will be called at most once.
    - If the `Timeout` is dropped, the callback will be canceled.
    - The timeout deadline can only be updated to a higher value.

    Synopsis:

    ```
    let t = Timeout::new(|| {println!("hello");},  Duration::from_milli(10));
    t.update_timeout(Duration::from_millis(10));
    ```

-   Refactor: add server_state_count to count ServerState changes to
    track different round of follower-loop.

-   Refactor: RaftCore keeps a `tx_api` for Timeout to send message.

-   Fix: #351

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/352)
<!-- Reviewable:end -->
