### PR TITLE
Refactor: Engine::truncate() to delete logs that conflict with the leader and update membership.

### DIFF
--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -10,6 +10,7 @@ mod log_id_list;
 #[cfg(test)] mod log_id_list_test;
 #[cfg(test)] mod purge_log_test;
 #[cfg(test)] mod testing;
+#[cfg(test)] mod truncate_logs_test;
 
 pub(crate) use command::Command;
 pub(crate) use engine_impl::Engine;

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+
+use maplit::btreeset;
+
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::EffectiveMembership;
+use crate::LeaderId;
+use crate::LogId;
+use crate::Membership;
+use crate::MembershipState;
+use crate::MetricsChangeFlags;
+
+fn log_id(term: u64, index: u64) -> LogId<u64> {
+    LogId::<u64> {
+        leader_id: LeaderId { term, node_id: 1 },
+        index,
+    }
+}
+
+fn m01() -> Membership<u64> {
+    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+}
+
+fn m12() -> Membership<u64> {
+    Membership::<u64>::new(vec![btreeset! {1,2}], None)
+}
+
+fn eng() -> Engine<u64> {
+    let mut eng = Engine::<u64>::default();
+    eng.state.log_ids = LogIdList::new(vec![
+        log_id(2, 2), //
+        log_id(4, 4),
+        log_id(4, 6),
+    ]);
+    eng.state.last_purged_log_id = Some(log_id(2, 2));
+    eng.state.last_log_id = Some(log_id(4, 6));
+    eng
+}
+
+#[test]
+fn test_truncate_logs_since_3() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.truncate_logs(3);
+
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id,);
+    assert_eq!(&[log_id(2, 2)], eng.state.log_ids.key_log_ids());
+    assert_eq!(
+        MetricsChangeFlags {
+            leader: false,
+            other_metrics: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(vec![Command::DeleteConflictLog { since: log_id(2, 3) }], eng.commands);
+
+    Ok(())
+}
+
+#[test]
+fn test_truncate_logs_since_4() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.truncate_logs(4);
+
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id,);
+    assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
+    assert_eq!(
+        MetricsChangeFlags {
+            leader: false,
+            other_metrics: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(vec![Command::DeleteConflictLog { since: log_id(4, 4) }], eng.commands);
+
+    Ok(())
+}
+
+#[test]
+fn test_truncate_logs_since_5() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.truncate_logs(5);
+
+    assert_eq!(Some(log_id(4, 4)), eng.state.last_log_id,);
+    assert_eq!(&[log_id(2, 2), log_id(4, 4)], eng.state.log_ids.key_log_ids());
+    assert_eq!(
+        MetricsChangeFlags {
+            leader: false,
+            other_metrics: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(vec![Command::DeleteConflictLog { since: log_id(4, 5) }], eng.commands);
+
+    Ok(())
+}
+
+#[test]
+fn test_truncate_logs_since_6() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.truncate_logs(6);
+
+    assert_eq!(Some(log_id(4, 5)), eng.state.last_log_id,);
+    assert_eq!(
+        &[log_id(2, 2), log_id(4, 4), log_id(4, 5)],
+        eng.state.log_ids.key_log_ids()
+    );
+    assert_eq!(
+        MetricsChangeFlags {
+            leader: false,
+            other_metrics: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(vec![Command::DeleteConflictLog { since: log_id(4, 6) }], eng.commands);
+
+    Ok(())
+}
+
+#[test]
+fn test_truncate_logs_since_7() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.truncate_logs(7);
+
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(
+        &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
+        eng.state.log_ids.key_log_ids()
+    );
+    assert_eq!(
+        MetricsChangeFlags {
+            leader: false,
+            other_metrics: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert!(eng.commands.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_truncate_logs_since_8() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.truncate_logs(8);
+
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(
+        &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
+        eng.state.log_ids.key_log_ids()
+    );
+    assert_eq!(
+        MetricsChangeFlags {
+            leader: false,
+            other_metrics: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert!(eng.commands.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.membership_state = MembershipState {
+        committed: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m01())),
+        effective: Arc::new(EffectiveMembership::new(Some(log_id(4, 4)), m12())),
+    };
+
+    eng.truncate_logs(4);
+
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id,);
+    assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
+    assert_eq!(
+        MetricsChangeFlags {
+            leader: false,
+            other_metrics: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(
+        vec![
+            //
+            Command::DeleteConflictLog { since: log_id(4, 4) },
+            Command::UpdateMembership {
+                membership: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m01()))
+            }
+        ],
+        eng.commands
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Changelog

##### Refactor: Engine::truncate() to delete logs that conflict with the leader and update membership.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/356)
<!-- Reviewable:end -->
