### PR TITLE
Doc: explain why to delete conflicting logs when handle append-entries RPC

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -14,4 +14,5 @@
     - [Architecture](./architecture.md)
     - [Threads](./threading.md)
     - [Replication](./replication.md)
+      - [Delete-conflicting-logs](./delete_log.md)
     - [Effective Membership](./effective-membership.md)

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -755,11 +755,13 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, req), fields(req=%req.summary()))]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(super) async fn handle_vote_request(
         &mut self,
         req: VoteRequest<C::NodeId>,
     ) -> Result<VoteResponse<C::NodeId>, VoteError<C::NodeId>> {
+        tracing::debug!(req = display(req.summary()), "handle_vote_request");
+
         // TODO(xp): Checking last_heartbeat can be removed,
         //           if we have finished using blank log for heartbeat:
         //           https://github.com/datafuselabs/openraft/issues/151

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -134,8 +134,15 @@ impl<NID: NodeId> Engine<NID> {
         self.set_server_state(ServerState::Candidate);
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn handle_vote_req(&mut self, req: VoteRequest<NID>) -> VoteResponse<NID> {
+        tracing::debug!(req = display(req.summary()), "Engine::handle_vote_res");
+        tracing::debug!(
+            my_vote = display(self.state.vote.summary()),
+            my_last_log_id = display(self.state.last_purged_log_id.summary()),
+            "Engine::handle_vote_res"
+        );
+
         let last_log_id = self.state.last_log_id;
         let vote = self.state.vote;
 
@@ -176,8 +183,19 @@ impl<NID: NodeId> Engine<NID> {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, resp))]
     pub(crate) fn handle_vote_resp(&mut self, target: NID, resp: VoteResponse<NID>) {
+        tracing::debug!(
+            resp = display(resp.summary()),
+            target = display(target),
+            "handle_vote_resp"
+        );
+        tracing::debug!(
+            my_vote = display(self.state.vote),
+            my_last_log_id = display(self.state.last_log_id.summary()),
+            "handle_vote_resp"
+        );
+
         // If this node is no longer a leader, just ignore the delayed vote_resp.
         let leader = match &mut self.state.leader {
             None => return,

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -1,6 +1,7 @@
 use std::fmt::Formatter;
 
 use crate::LeaderId;
+use crate::MessageSummary;
 use crate::NodeId;
 
 /// `Vote` represent the privilege of a node.
@@ -15,6 +16,17 @@ pub struct Vote<NID: NodeId> {
 impl<NID: NodeId> std::fmt::Display for Vote<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "vote:{}-{}", self.term, self.node_id)
+    }
+}
+
+impl<NID: NodeId> MessageSummary for Vote<NID> {
+    fn summary(&self) -> String {
+        format!(
+            "{}-{}:{}",
+            self.term,
+            self.node_id,
+            if self.committed { "committed" } else { "uncommitted" }
+        )
     }
 }
 

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -157,7 +157,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
     for id in new.iter() {
         router
             .wait(id, timeout())
-            // new leader may commit a blonk log
+            // new leader may commit a blank log
             .log_at_least(Some(log_index), format!("new cluster recv logs 100~200, {}", mes))
             .await?;
     }


### PR DESCRIPTION

## Changelog

##### Doc: explain why to delete conflicting logs when handle append-entries RPC


##### Refactor: make tracing debug message shorter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/360)
<!-- Reviewable:end -->
