### PR TITLE
Change: `external_request()` replace the 1st arg ServerState with RaftState

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -858,7 +858,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 }
             }
             RaftMsg::ExternalRequest { req } => {
-                req(self.engine.state.server_state, &mut self.storage, &mut self.network);
+                req(&self.engine.state, &mut self.storage, &mut self.network);
             }
             RaftMsg::Elect { server_state_count } => {
                 if server_state_count != Some(self.server_state_count) {

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -57,6 +57,7 @@ use openraft::Raft;
 use openraft::RaftMetrics;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
+use openraft::RaftState;
 use openraft::RaftTypeConfig;
 use openraft::ServerState;
 use openraft::StoreExt;
@@ -568,7 +569,7 @@ where
 
     /// Send external request to the particular node.
     pub fn external_request<
-        F: FnOnce(ServerState, &mut StoreExt<C, S>, &mut TypedRaftRouter<C, S>) + Send + 'static,
+        F: FnOnce(&RaftState<C::NodeId>, &mut StoreExt<C, S>, &mut TypedRaftRouter<C, S>) + Send + 'static,
     >(
         &self,
         target: C::NodeId,

--- a/openraft/tests/initialize/t20_initialization.rs
+++ b/openraft/tests/initialize/t20_initialization.rs
@@ -61,7 +61,7 @@ async fn initialization() -> anyhow::Result<()> {
     // (since they are awaited).
     for node in [0, 1, 2] {
         router.external_request(node, |s, _sto, _net| {
-            assert_eq!(s, ServerState::Learner);
+            assert_eq!(s.server_state, ServerState::Learner);
         });
     }
 
@@ -110,7 +110,7 @@ async fn initialization() -> anyhow::Result<()> {
     let mut follower_count = 0;
     for node in [0, 1, 2] {
         let (tx, rx) = oneshot::channel();
-        router.external_request(node, |s, _sm, _net| tx.send(s).unwrap());
+        router.external_request(node, |s, _sm, _net| tx.send(s.server_state).unwrap());
         match rx.await.unwrap() {
             ServerState::Leader => {
                 assert!(!found_leader);
@@ -140,7 +140,7 @@ async fn initialize_err_target_not_include_target() -> anyhow::Result<()> {
 
     for node in [0, 1] {
         router.external_request(node, |s, _sto, _net| {
-            assert_eq!(s, ServerState::Learner);
+            assert_eq!(s.server_state, ServerState::Learner);
         });
     }
 
@@ -174,7 +174,7 @@ async fn initialize_err_not_allowed() -> anyhow::Result<()> {
 
     for node in [0] {
         router.external_request(node, |s, _sto, _net| {
-            assert_eq!(s, ServerState::Learner);
+            assert_eq!(s.server_state, ServerState::Learner);
         });
     }
 


### PR DESCRIPTION

## Changelog

##### Change: `external_request()` replace the 1st arg ServerState with RaftState

This change let user do more things with a external fn request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/361)
<!-- Reviewable:end -->
