### PR TITLE
Fix: membership_state.committed should be updated when a membership-config log is committed on leader or follower

### DIFF
--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -224,6 +224,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         // commit index must not > last_log_id.index
         // This is guaranteed by caller.
         self.engine.state.committed = committed;
+        {
+            let st = &mut self.engine.state;
+            if st.committed >= st.membership_state.effective.log_id {
+                st.membership_state.committed = st.membership_state.effective.clone();
+            }
+        }
 
         self.replicate_to_state_machine_if_needed().await?;
 

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -164,7 +164,13 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         // If a new commit index has been established, then update a few needed elements.
 
         if commit_log_id > self.core.engine.state.committed {
-            self.core.engine.state.committed = commit_log_id;
+            {
+                let st = &mut self.core.engine.state;
+                st.committed = commit_log_id;
+                if st.committed >= st.membership_state.effective.log_id {
+                    st.membership_state.committed = st.membership_state.effective.clone();
+                }
+            }
 
             // Update all replication streams based on new commit index.
             for node in self.nodes.values() {


### PR DESCRIPTION
## Changelog

##### Fix: membership_state.committed should be updated when a membership-config log is committed on leader or follower


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/362)
<!-- Reviewable:end -->
