### PR TITLE
Refactor: add Engine commands, extract `internal_handle_vote_req()`

### DIFF
--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -366,7 +366,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// Very importantly, this routine must not block the main control loop main task, else it
     /// may cause the Raft leader to timeout the requests to this node.
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn replicate_to_state_machine_if_needed(&mut self) -> Result<(), StorageError<C::NodeId>> {
+    pub(crate) async fn replicate_to_state_machine_if_needed(&mut self) -> Result<(), StorageError<C::NodeId>> {
         tracing::debug!(?self.engine.state.last_applied, ?self.engine.state.committed, "replicate_to_sm_if_needed");
 
         // If we don't have any new entries to replicate, then do nothing.

--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -188,7 +188,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRun
     {
         // Run leader specific commands or pass non leader specific commands to self.core.
         match cmd {
-            Command::Commit { ref upto } => {
+            Command::LeaderCommit { ref upto } => {
                 for ent in input_entries.iter() {
                     let log_id = ent.get_log_id();
                     if log_id <= upto {

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -26,7 +26,13 @@ pub(crate) enum Command<NID: NodeId> {
 
     // Commit entries that are already in the store, upto `upto`, inclusive.
     // And send applied result to the client that proposed the entry.
-    Commit {
+    LeaderCommit {
+        upto: LogId<NID>,
+    },
+
+    /// Commit entries that are already in the store, upto `upto`, inclusive.
+    #[allow(dead_code)]
+    FollowerCommit {
         upto: LogId<NID>,
     },
 
@@ -50,14 +56,22 @@ pub(crate) enum Command<NID: NodeId> {
         vote: Vote<NID>,
     },
 
-    // Send vote to all other members
+    /// Send vote to all other members
     SendVote {
         vote_req: VoteRequest<NID>,
     },
 
-    // Install a timer to trigger an election after some `timeout` which is decided by the runtime.
-    // An already installed timer should be cleared.
+    /// Install a timer to trigger an election, e.g., calling `Engine::elect()` after some `timeout` which is decided
+    /// by the runtime. An already installed timer should be cleared.
     InstallElectionTimer {},
+
+    /// Reject election by other candidate for a while.
+    /// The interval is decided by the runtime.
+    ///
+    /// When a leader is established and has not yet timeout,
+    /// A candidate should not take the leadership.
+    #[allow(dead_code)]
+    RejectElection {},
 
     #[allow(dead_code)]
     PurgeLog {
@@ -85,13 +99,15 @@ impl<NID: NodeId> Command<NID> {
         match &self {
             Command::UpdateServerState { .. } => flags.set_cluster_changed(),
             Command::AppendInputEntries { .. } => flags.set_data_changed(),
-            Command::Commit { .. } => flags.set_data_changed(),
+            Command::LeaderCommit { .. } => flags.set_data_changed(),
+            Command::FollowerCommit { .. } => flags.set_data_changed(),
             Command::ReplicateInputEntries { .. } => {}
             Command::UpdateMembership { .. } => flags.set_cluster_changed(),
             Command::MoveInputCursorBy { .. } => {}
             Command::SaveVote { .. } => flags.set_data_changed(),
             Command::SendVote { .. } => {}
             Command::InstallElectionTimer { .. } => {}
+            Command::RejectElection { .. } => {}
             Command::PurgeLog { .. } => flags.set_data_changed(),
             Command::DeleteConflictLog { .. } => flags.set_data_changed(),
             Command::BuildSnapshot { .. } => flags.set_data_changed(),

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -194,7 +194,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::AppendInputEntries { range: 0..3 },
-            Command::Commit {
+            Command::LeaderCommit {
                 upto: LogId::new(LeaderId::new(3, 2), 6)
             },
             Command::ReplicateInputEntries { range: 0..3 },
@@ -323,7 +323,7 @@ fn test_leader_append_entries_allow_fast_commit_if_no_member_changed() -> anyhow
                     m2_1()
                 )),
             },
-            Command::Commit {
+            Command::LeaderCommit {
                 upto: LogId::new(LeaderId::new(3, 2), 6)
             },
             Command::ReplicateInputEntries { range: 0..3 },

--- a/openraft/src/entry.rs
+++ b/openraft/src/entry.rs
@@ -138,6 +138,15 @@ impl<'p, C: RaftTypeConfig> MessageSummary for EntryRef<'p, C> {
     }
 }
 
+impl<C: RaftTypeConfig> From<&Entry<C>> for Entry<C> {
+    fn from(er: &Entry<C>) -> Self {
+        Entry {
+            log_id: er.log_id,
+            payload: er.payload.clone(),
+        }
+    }
+}
+
 impl<'p, C: RaftTypeConfig> From<&EntryRef<'p, C>> for Entry<C> {
     fn from(er: &EntryRef<'p, C>) -> Self {
         Entry {
@@ -146,6 +155,7 @@ impl<'p, C: RaftTypeConfig> From<&EntryRef<'p, C>> for Entry<C> {
         }
     }
 }
+
 impl<'p, C: RaftTypeConfig> EntryRef<'p, C> {
     pub fn new(payload: &'p EntryPayload<C>) -> Self {
         Self {

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -109,5 +109,5 @@ async fn step_down() -> Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(2000))
+    Some(Duration::from_millis(3_000))
 }


### PR DESCRIPTION

## Changelog

##### Refactor: add Engine commands, extract `internal_handle_vote_req()`

- Add `Command::LeaderCommit` and `Command::FollowerCommit` since leader
  and follower do differently when committing an entry.

- Add `Command::RejectElection` to inform the runtime to reject election
  for a while, when a active leader is found, e.g., when receiving an
  append-entries RPC.

- Extract vote checking logic into standalone method
  `internal_handle_vote_req()`, which will be used by all 3 RPC handler:
  `vote`, `append-entries` and `install-snapshot`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/367)
<!-- Reviewable:end -->
