### PR TITLE
Refactor: truncate_log should update server-state if membership config log is truncated

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -338,6 +338,8 @@ impl<NID: NodeId> Engine<NID> {
 
         let effective = self.state.membership_state.effective.clone();
         if Some(since) <= effective.log_id.index() {
+            let was_member = self.is_member();
+
             let committed = self.state.membership_state.committed.clone();
 
             tracing::debug!(
@@ -362,6 +364,16 @@ impl<NID: NodeId> Engine<NID> {
             });
 
             tracing::debug!(effective = debug(&effective), "Done reverting membership");
+
+            let is_member = self.is_member();
+
+            if was_member != is_member {
+                if is_member {
+                    self.set_server_state(ServerState::Follower);
+                } else {
+                    self.set_server_state(ServerState::Learner);
+                }
+            }
         }
     }
 


### PR DESCRIPTION

## Changelog

##### Refactor: truncate_log should update server-state if membership config log is truncated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/370)
<!-- Reviewable:end -->
