### PR TITLE
CI: workaround pin clap version to 3.1 or there are inappropriate lint errors: https://github.com/clap-rs/clap/issues/3822

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 maplit = "1.0.2"
 rand = "0.8"
 serde = { version="1", features=["derive", "rc"], optional = true}
-clap = { version = "3.0.7", features = ["derive", "env"] }
+clap = { version = "~3.1", features = ["derive", "env"] }
 thiserror = "1.0.29"
 tokio = { version="1.8", default-features=false, features=["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.29"


### PR DESCRIPTION

## Changelog

##### CI: workaround pin clap version to 3.1 or there are inappropriate lint errors: https://github.com/clap-rs/clap/issues/3822

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/374)
<!-- Reviewable:end -->
