### PR TITLE
Dep: Update clap requirement from ~3.1 to ~3.2

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 maplit = "1.0.2"
 rand = "0.8"
 serde = { version="1", features=["derive", "rc"], optional = true}
-clap = { version = "~3.1", features = ["derive", "env"] }
+clap = { version = "~3.2", features = ["derive", "env"] }
 thiserror = "1.0.29"
 tokio = { version="1.8", default-features=false, features=["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.29"


### PR DESCRIPTION

## Changelog

##### Dep: Update clap requirement from ~3.1 to ~3.2

Updates the requirements on [clap](https://github.com/clap-rs/clap) to permit the latest version.
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](https://github.com/clap-rs/clap/compare/clap_complete-v3.1.0...v3.2.5)

---
updated-dependencies:
- dependency-name: clap
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/376)
<!-- Reviewable:end -->
