### PR TITLE
BumpVer: 0.6.4-patch.1

### DIFF
--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.32"
-openraft = { version="0.6", path= "../openraft" }
+openraft = { version="0.6.4-patch.1", path= "../openraft" }
 async-trait = "0.1.36"
 serde = { version="1.0.114", features=["derive"] }
 serde_json = "1.0.57"

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft"
-version = "0.6.4"
+version = "0.6.4-patch.1"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -657,9 +657,6 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
                 });
             }
 
-            let span = tracing::debug_span!("CHrx:LineRate");
-            let _en = span.enter();
-
             tokio::select! {
                 _ = self.heartbeat.tick() => {
                     tracing::debug!("heartbeat triggered");


### PR DESCRIPTION
## Changelog

##### BumpVer: 0.6.4-patch.1


##### Fix: span.enter() in async loop causes memory leak

It is explained in:
https://onesignal.com/blog/solving-memory-leaks-in-rust/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/378)
<!-- Reviewable:end -->
