### PR TITLE
Fix: span.enter() in async block will leak memory

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -21,18 +21,19 @@ jobs:
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^(Change:|Feature:|Dep:|Doc:|Test:|CI:|Refactor:|Fix:|Fixdoc:|Fixup:|Merge) .+$'
+          pattern: '^(Change:|Feature:|Dep:|Doc:|Test:|CI:|Refactor:|Fix:|Fixdoc:|Fixup:|Merge|BumpVer:) .+$'
           flags: 'gm'
           error: |
             Subject line has to contain a commit type, e.g.: "Change: blabla" or a merge commit e.g.: "Merge xxx".
             Valid types are:
-              Change   - breaking change
-              Feature  - API compatible new feature 
-              Dep      - dependency update
-              Doc      - doc update
-              Test     - test udpate
-              CI       - CI workflow update
-              Refactor - refactor without function change.
-              Fix      - fix bug
-              Fixdoc   - fix doc
-              Fixup    - minor change: e.g., fix sth mentioned in a review.
+              Change    - breaking change
+              Feature   - API compatible new feature 
+              Dep       - dependency update
+              Doc       - doc update
+              Test      - test udpate
+              CI        - CI workflow update
+              Refactor  - refactor without function change.
+              Fix       - fix bug
+              Fixdoc    - fix doc
+              Fixup     - minor change: e.g., fix sth mentioned in a review.
+              BumpVer   - Bump to a new version.

--- a/.github/workflows/release-raft.yaml
+++ b/.github/workflows/release-raft.yaml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-alpha*"
+      - "!v*-beta*"
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -24,10 +24,23 @@ Currently openraft is the consensus engine of meta-service cluster in [databend]
 
 - **Get started**: [The guide](https://datafuselabs.github.io/openraft) is the best place to get started,
   followed by [the docs](https://docs.rs/openraft/latest/) for more in-depth details.
-- **Openraft API is not stable yet.** Before `1.0.0`, an upgrade may contain incompatible changes.
-  Check our [change-log](https://github.com/datafuselabs/openraft/blob/main/change-log.md)
 - Openraft is derived from [async-raft](https://docs.rs/crate/async-raft/latest) with several bugs fixed: [Fixed bugs](https://github.com/datafuselabs/openraft/blob/main/derived-from-async-raft.md).
 
+# Versions
+
+- **Openraft API is not stable yet**. Before `1.0.0`, an upgrade may contain incompatible changes.
+  Check our [change-log](https://github.com/datafuselabs/openraft/blob/main/change-log.md). A commit message starts with a keyword to indicate the modification type of the commit:
+
+  - `Change:` if it introduces incompatible changes.
+  - `Feature:` if it introduces compatible non-breaking new features.
+  - `Fix:` if it just fixes a bug.
+
+- **Branch [release-0.6](https://github.com/datafuselabs/openraft/tree/release-0.6)**: In this release branch, [v0.6.5](https://github.com/datafuselabs/openraft/tree/v0.6.5) is the latest
+    published version. `release-0.6` won't accept new features but only bug fixes.
+
+- **Branch [release-0.7](https://github.com/datafuselabs/openraft/tree/release-0.7)**: In this release branch, [v0.7.0-alpha.1](https://github.com/datafuselabs/openraft/tree/v0.7.0-alpha.1) is the latest version. `release-0.7` won't be published until the backward compatibility with `release-0.6` is ready.
+
+- **Branch main** has been under active development.
 
 # Roadmap
 
@@ -47,7 +60,7 @@ Currently openraft is the consensus engine of meta-service cluster in [databend]
    - - [ ] Consider to separate log storage and log order storage.
    -   Leader only determines and replicates the index of log entries, not log
    -   payload.
-   -->
+      -->
 
 
 # Features

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-# Openraft
+<div align="center">
+    <h1>Openraft</h1>
+    <h4>
+        Advanced <a href="https://raft.github.io/">Raft</a> in 🦀 Rust using <a href="https://tokio.rs/">Tokio</a>. Please ⭐ on <a href="https://github.com/datafuselabs/openraft">github</a>!
+    </h4>
 
-<strong>
-    Advanced <a href="https://raft.github.io/">Raft</a> using <a href="https://tokio.rs/">the Tokio framework</a>. Please ⭐ on <a href="https://github.com/datafuselabs/openraft">github</a>!
-</strong>
 
----
-
-[![CI](https://github.com/datafuselabs/openraft/actions/workflows/ci.yaml/badge.svg)](https://github.com/datafuselabs/openraft/actions/workflows/ci.yaml)
 [![Crates.io](https://img.shields.io/crates/v/openraft.svg)](https://crates.io/crates/openraft)
 [![docs.rs](https://docs.rs/openraft/badge.svg)](https://docs.rs/openraft)
+[![guides](https://img.shields.io/badge/guide-%E2%86%97-brightgreen)](https://datafuselabs.github.io/openraft)
+<br/>
+[![CI](https://github.com/datafuselabs/openraft/actions/workflows/ci.yaml/badge.svg)](https://github.com/datafuselabs/openraft/actions/workflows/ci.yaml)
 ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)
 ![Crates.io](https://img.shields.io/crates/d/openraft.svg)
 ![Crates.io](https://img.shields.io/crates/dv/openraft.svg)
 
-Raft is not yet good enough.
+</div>
+
+🪵🪵🪵 Raft is not yet good enough.
 This project intends to improve raft as the next generation consensus protocol for distributed data storage systems (SQL, NoSQL, KV, Streaming, Graph ... or maybe something more exotic).
 
 Currently openraft is the consensus engine of meta-service cluster in [databend](https://github.com/datafuselabs/databend).
@@ -21,44 +24,10 @@ Currently openraft is the consensus engine of meta-service cluster in [databend]
 
 - **Get started**: [The guide](https://datafuselabs.github.io/openraft) is the best place to get started,
   followed by [the docs](https://docs.rs/openraft/latest/) for more in-depth details.
-
 - **Openraft API is not stable yet.** Before `1.0.0`, an upgrade may contain incompatible changes.
   Check our [change-log](https://github.com/datafuselabs/openraft/blob/main/change-log.md)
+- Openraft is derived from [async-raft](https://docs.rs/crate/async-raft/latest) with several bugs fixed: [Fixed bugs](https://github.com/datafuselabs/openraft/blob/main/derived-from-async-raft.md).
 
-- Openraft is derived from [async-raft](https://docs.rs/crate/async-raft/latest) with several bugs fixed:
-
-<details>
-  <summary>List of fixed bugs:</summary>
-
-
--   Fixed: [6c0ccaf3](https://github.com/datafuselabs/openraft/commit/6c0ccaf3ab3f262437d8fc021d4b13437fa4c9ac) consider joint config when starting up and committing.; by drdr xp; 2021-12-24
--   Fixed: [228077a6](https://github.com/datafuselabs/openraft/commit/228077a66d5099fd404ae9c68f0977e5f978f102) a restarted follower should not wait too long to elect. Otherwise, the entire cluster hangs; by drdr xp; 2021-11-19
--   Fixed: [a48a3282](https://github.com/datafuselabs/openraft/commit/a48a3282c58bdcae3309545a06431aecf3e65db8) handle-vote should compare last_log_id in dictionary order, not in vector order; by drdr xp; 2021-09-09
--   Fixed: [eed681d5](https://github.com/datafuselabs/openraft/commit/eed681d57950fc58b6ca71a45814b8f6d2bb1223) race condition of concurrent snapshot-install and apply.; by drdr xp; 2021-09-01
--   Fixed: [9540c904](https://github.com/datafuselabs/openraft/commit/9540c904da4ae005baec01868e01016f3bc76810) when append-entries, deleting entries after prev-log-id causes committed entry to be lost; by drdr xp; 2021-08-31
--   Fixed: [6d53aa12](https://github.com/datafuselabs/openraft/commit/6d53aa12f66ecd08e81bcb055eb17387b835e2eb) too many(50) inconsistent log should not live lock append-entries; by drdr xp; 2021-08-31
--   Fixed: [4d58a51e](https://github.com/datafuselabs/openraft/commit/4d58a51e41189acba06c1d2a0e8466759d9eb785) a non-voter not in joint config should not block replication; by drdr xp; 2021-08-31
--   Fixed: [8cd24ba0](https://github.com/datafuselabs/openraft/commit/8cd24ba0f0212e94e61f21a7be0ce0806fcc66d5) RaftCore.entries_cache is inconsistent with storage. removed it.; by drdr xp; 2021-08-23
--   Fixed: [2eccb9e1](https://github.com/datafuselabs/openraft/commit/2eccb9e1f82f1bf71f6a2cf9ef6da7bf6232fa84) install snapshot req with offset GE 0 should not start a new session.; by drdr xp; 2021-08-22
--   Fixed: [eee8e534](https://github.com/datafuselabs/openraft/commit/eee8e534e0b0b9abdb37dd94aeb64dc1affd3ef7) snapshot replication does not need to send a last 0 size chunk; by drdr xp; 2021-08-22
--   Fixed: [beb0302b](https://github.com/datafuselabs/openraft/commit/beb0302b4fec0758062141e727bf1bbcfd4d4b98) leader should not commit when there is no replication to voters.; by drdr xp; 2021-08-18
--   Fixed: [dba24036](https://github.com/datafuselabs/openraft/commit/dba24036cda834e8c970d2561b1ff435afd93165) after 2 log compaction, membership should be able to be extract from prev compaction log; by drdr xp; 2021-07-14
--   Fixed: [447dc11c](https://github.com/datafuselabs/openraft/commit/447dc11cab51fb3b1925177d13e4dd89f998837b) when finalize_snapshot_installation, memstore should not load membership from its old log that are going to be overridden by snapshot.; by drdr xp; 2021-07-13
--   Fixed: [cf4badd0](https://github.com/datafuselabs/openraft/commit/cf4badd0d762757519e2db5ed2f2fc65c2f49d02) leader should re-create and send snapshot when `threshold/2 < last_log_index - snapshot < threshold`; by drdr xp; 2021-07-08
--   Fixed: [d60f1e85](https://github.com/datafuselabs/openraft/commit/d60f1e852d3e5b9455589593067599d261f695b2) client_read has using wrong quorum=majority-1; by drdr xp; 2021-07-02
--   Fixed: [11cb5453](https://github.com/datafuselabs/openraft/commit/11cb5453e2200eda06d26396620eefe66b169975) doc-include can only be used in nightly build; by drdr xp; 2021-06-16
--   Fixed: [a10d9906](https://github.com/datafuselabs/openraft/commit/a10d99066b8c447d7335c7f34e08bd78c4b49f61) when handle_update_match_index(), non-voter should also be considered, because when member change a non-voter is also count as a quorum member; by drdr xp; 2021-06-16
--   Fixed: [d882e743](https://github.com/datafuselabs/openraft/commit/d882e743db4734b2188b137ebf20c0443cf9fb49) when calc quorum, the non-voter should be count; by drdr xp; 2021-06-02
--   Fixed: [6202138f](https://github.com/datafuselabs/openraft/commit/6202138f0766dcfd07a1a825af165f132de6b920) a conflict is expected even when appending empty entries; by drdr xp; 2021-05-24
--   Fixed: [f449b64a](https://github.com/datafuselabs/openraft/commit/f449b64aa9254d9a18bc2abb5f602913af079ca9) discarded log in replication_buffer should be finally sent.; by drdr xp; 2021-05-22
--   Fixed: [6d680484](https://github.com/datafuselabs/openraft/commit/6d680484ee3e352d4caf37f5cd6f57630f46d9e2) #112 : when a follower is removed, leader should stop sending log to it.; by drdr xp; 2021-05-21
--   Fixed: [89bb48f8](https://github.com/datafuselabs/openraft/commit/89bb48f8702762d33b59a7c9b9710bde4a97478c) last_applied should be updated only when logs actually applied.; by drdr xp; 2021-05-20
--   Fixed: [39690593](https://github.com/datafuselabs/openraft/commit/39690593a07c6b9ded4b7b8f1aca3191fa7641e4) a NonVoter should stay as NonVoter instead of Follower after restart; by drdr xp; 2021-05-14
-
-
-A full list of changes/fixes can be found in [change-log](https://github.com/datafuselabs/openraft/blob/main/change-log.md)
-
-</details>
 
 # Roadmap
 

--- a/derived-from-async-raft.md
+++ b/derived-from-async-raft.md
@@ -1,0 +1,29 @@
+## Openraft is derived from [async-raft](https://docs.rs/crate/async-raft/latest).
+Bugs that are found in async-raft are fixed by openraft:
+
+-   Fixed: [6c0ccaf3](https://github.com/datafuselabs/openraft/commit/6c0ccaf3ab3f262437d8fc021d4b13437fa4c9ac) consider joint config when starting up and committing.; by drdr xp; 2021-12-24
+-   Fixed: [228077a6](https://github.com/datafuselabs/openraft/commit/228077a66d5099fd404ae9c68f0977e5f978f102) a restarted follower should not wait too long to elect. Otherwise, the entire cluster hangs; by drdr xp; 2021-11-19
+-   Fixed: [a48a3282](https://github.com/datafuselabs/openraft/commit/a48a3282c58bdcae3309545a06431aecf3e65db8) handle-vote should compare last_log_id in dictionary order, not in vector order; by drdr xp; 2021-09-09
+-   Fixed: [eed681d5](https://github.com/datafuselabs/openraft/commit/eed681d57950fc58b6ca71a45814b8f6d2bb1223) race condition of concurrent snapshot-install and apply.; by drdr xp; 2021-09-01
+-   Fixed: [9540c904](https://github.com/datafuselabs/openraft/commit/9540c904da4ae005baec01868e01016f3bc76810) when append-entries, deleting entries after prev-log-id causes committed entry to be lost; by drdr xp; 2021-08-31
+-   Fixed: [6d53aa12](https://github.com/datafuselabs/openraft/commit/6d53aa12f66ecd08e81bcb055eb17387b835e2eb) too many(50) inconsistent log should not live lock append-entries; by drdr xp; 2021-08-31
+-   Fixed: [4d58a51e](https://github.com/datafuselabs/openraft/commit/4d58a51e41189acba06c1d2a0e8466759d9eb785) a non-voter not in joint config should not block replication; by drdr xp; 2021-08-31
+-   Fixed: [8cd24ba0](https://github.com/datafuselabs/openraft/commit/8cd24ba0f0212e94e61f21a7be0ce0806fcc66d5) RaftCore.entries_cache is inconsistent with storage. removed it.; by drdr xp; 2021-08-23
+-   Fixed: [2eccb9e1](https://github.com/datafuselabs/openraft/commit/2eccb9e1f82f1bf71f6a2cf9ef6da7bf6232fa84) install snapshot req with offset GE 0 should not start a new session.; by drdr xp; 2021-08-22
+-   Fixed: [eee8e534](https://github.com/datafuselabs/openraft/commit/eee8e534e0b0b9abdb37dd94aeb64dc1affd3ef7) snapshot replication does not need to send a last 0 size chunk; by drdr xp; 2021-08-22
+-   Fixed: [beb0302b](https://github.com/datafuselabs/openraft/commit/beb0302b4fec0758062141e727bf1bbcfd4d4b98) leader should not commit when there is no replication to voters.; by drdr xp; 2021-08-18
+-   Fixed: [dba24036](https://github.com/datafuselabs/openraft/commit/dba24036cda834e8c970d2561b1ff435afd93165) after 2 log compaction, membership should be able to be extract from prev compaction log; by drdr xp; 2021-07-14
+-   Fixed: [447dc11c](https://github.com/datafuselabs/openraft/commit/447dc11cab51fb3b1925177d13e4dd89f998837b) when finalize_snapshot_installation, memstore should not load membership from its old log that are going to be overridden by snapshot.; by drdr xp; 2021-07-13
+-   Fixed: [cf4badd0](https://github.com/datafuselabs/openraft/commit/cf4badd0d762757519e2db5ed2f2fc65c2f49d02) leader should re-create and send snapshot when `threshold/2 < last_log_index - snapshot < threshold`; by drdr xp; 2021-07-08
+-   Fixed: [d60f1e85](https://github.com/datafuselabs/openraft/commit/d60f1e852d3e5b9455589593067599d261f695b2) client_read has using wrong quorum=majority-1; by drdr xp; 2021-07-02
+-   Fixed: [11cb5453](https://github.com/datafuselabs/openraft/commit/11cb5453e2200eda06d26396620eefe66b169975) doc-include can only be used in nightly build; by drdr xp; 2021-06-16
+-   Fixed: [a10d9906](https://github.com/datafuselabs/openraft/commit/a10d99066b8c447d7335c7f34e08bd78c4b49f61) when handle_update_match_index(), non-voter should also be considered, because when member change a non-voter is also count as a quorum member; by drdr xp; 2021-06-16
+-   Fixed: [d882e743](https://github.com/datafuselabs/openraft/commit/d882e743db4734b2188b137ebf20c0443cf9fb49) when calc quorum, the non-voter should be count; by drdr xp; 2021-06-02
+-   Fixed: [6202138f](https://github.com/datafuselabs/openraft/commit/6202138f0766dcfd07a1a825af165f132de6b920) a conflict is expected even when appending empty entries; by drdr xp; 2021-05-24
+-   Fixed: [f449b64a](https://github.com/datafuselabs/openraft/commit/f449b64aa9254d9a18bc2abb5f602913af079ca9) discarded log in replication_buffer should be finally sent.; by drdr xp; 2021-05-22
+-   Fixed: [6d680484](https://github.com/datafuselabs/openraft/commit/6d680484ee3e352d4caf37f5cd6f57630f46d9e2) #112 : when a follower is removed, leader should stop sending log to it.; by drdr xp; 2021-05-21
+-   Fixed: [89bb48f8](https://github.com/datafuselabs/openraft/commit/89bb48f8702762d33b59a7c9b9710bde4a97478c) last_applied should be updated only when logs actually applied.; by drdr xp; 2021-05-20
+-   Fixed: [39690593](https://github.com/datafuselabs/openraft/commit/39690593a07c6b9ded4b7b8f1aca3191fa7641e4) a NonVoter should stay as NonVoter instead of Follower after restart; by drdr xp; 2021-05-14
+
+
+A full list of changes/fixes can be found in the [change-log](https://github.com/datafuselabs/openraft/blob/main/change-log.md).

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -722,9 +722,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                 }));
             }
 
-            let span = tracing::debug_span!("CHrx:LineRate");
-            let _en = span.enter();
-
             // Check raft channel to ensure we are staying up-to-date
             self.try_drain_raft_rx().await?;
             if self.need_to_replicate {

--- a/openraft/tests/membership/t25_elect_with_new_config.rs
+++ b/openraft/tests/membership/t25_elect_with_new_config.rs
@@ -23,9 +23,6 @@ use crate::fixtures::RaftRouter;
 /// - restore the isolated node and assert that it becomes a follower.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn leader_election_after_changing_0_to_01234() -> Result<()> {
-    let span = tracing::debug_span!("ut-dynamic_membership");
-    let _ent = span.enter();
-
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -32,9 +32,6 @@ use crate::fixtures::RaftRouter;
 /// - asserts node-4 becomes learner and the leader stops sending logs to it.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn leader_metrics() -> Result<()> {
-    let span = tracing::debug_span!("leader_metrics");
-    let _ent = span.enter();
-
     let all_members = btreeset![0, 1, 2, 3, 4];
     let left_members = btreeset![0, 1, 2, 3];
 

--- a/scripts/build_change_log.py
+++ b/scripts/build_change_log.py
@@ -4,6 +4,7 @@
 import sys
 import subprocess
 import semantic_version
+import toml
 import yaml
 import re
 import os
@@ -271,14 +272,22 @@ def build_changelog():
 
             f.write(cont + '\n\n')
 
+def load_cargo_version():
+    with open('./openraft/Cargo.toml',  'r') as f:
+        cargo = f.read()
+
+    t = toml.loads(cargo)
+    ver = t['package']['version']
+    print("--- openraft/Cargo.toml version is",  ver)
+    return ver
+
+
 if __name__ == "__main__":
-    # Usage: to build change log from git log
-    # ./scripts/build_change_log.py 0.5.10
-    new_ver = sys.argv[1]
-    if len(sys.argv) > 2:
-        commit = sys.argv[2]
-    else:
-        commit = 'HEAD'
-    build_ver_changelog(new_ver, commit=commit)
+    # Usage: to build change log from git log for the current version.
+    # ./scripts/build_change_log.py
+
+    new_ver = load_cargo_version()
+
+    build_ver_changelog(new_ver)
     build_changelog()
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 semantic_version
+toml
 jinja2
 PyYAML


### PR DESCRIPTION
## Changelog

##### Doc: describe versions and branches status


##### Doc: add badge "guide", adjust README format.

- Move derived-from-async-raft out of README


##### CI: allows commit message starting with BumpVer:


##### CI: build_change_log.py load version from Cargo.toml


##### CI: do not fire release action for alpha and beta tags


##### CI: fix changelog builder: add commit message types

And skip version change log when exists


##### Fixup: span.enter() in async block causes memory leak

- fix: #381 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/382)
<!-- Reviewable:end -->
