### PR TITLE
Fixup: client_request() should return a result instead of panic

### DIFF
--- a/openraft/tests/benchmark/bench_cluster.rs
+++ b/openraft/tests/benchmark/bench_cluster.rs
@@ -94,7 +94,7 @@ async fn do_bench(bench_config: &BenchConfig) -> anyhow::Result<()> {
     let now = Instant::now();
 
     for i in 0..n {
-        router.client_request(0, "foo", i as u64).await
+        router.client_request(0, "foo", i as u64).await?;
     }
 
     let elapsed = now.elapsed();

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -53,7 +53,7 @@ async fn learner_restart() -> Result<()> {
     }
 
     router.add_learner(0, 1).await?;
-    router.client_request(0, "foo", 1).await;
+    router.client_request(0, "foo", 1).await?;
     log_index += 2;
 
     router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "write one log").await?;

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -42,7 +42,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     log_index += 1;
 
     tracing::info!("--- write one log");
-    router.client_request(0, "foo", 1).await;
+    router.client_request(0, "foo", 1).await?;
 
     // Wait for metrics to be up to date.
     // Once last_applied updated, the key should be visible in state machine.

--- a/openraft/tests/state_machine/t40_clean_applied_logs.rs
+++ b/openraft/tests/state_machine/t40_clean_applied_logs.rs
@@ -30,7 +30,7 @@ async fn clean_applied_logs() -> Result<()> {
 
     let count = (10 - log_index) as usize;
     for idx in 0..count {
-        router.client_request(0, "0", idx as u64).await;
+        router.client_request(0, "0", idx as u64).await?;
         // raft commit at once with a single leader cluster.
         // If we send too fast, logs are removed before forwarding to learner.
         // Then it triggers snapshot replication, which is not expected.


### PR DESCRIPTION

## Changelog

##### Fixup: client_request() should return a result instead of panic

- Part of #373