### PR TITLE
Change: after shutdown(), it should return an error when accessing Raft, instead of panicking.

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -95,6 +95,7 @@ pub enum CheckIsLeaderError<NID: NodeId> {
 
 /// An error related to a client write request.
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+#[derive(PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum ClientWriteError<NID: NodeId> {
     #[error(transparent)]


### PR DESCRIPTION

## Changelog

##### Change: after shutdown(), it should return an error when accessing Raft, instead of panicking.

- Fix: #373

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/385)
<!-- Reviewable:end -->
