### PR TITLE
Change: remove `RaftState.last_log_id` and `RaftState.last_purged_log_id`

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -72,7 +72,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         if target == self.core.id {
             tracing::debug!("target node is this node");
             let _ = tx.send(Ok(AddLearnerResponse {
-                matched: self.core.engine.state.last_log_id,
+                matched: self.core.engine.state.last_log_id(),
             }));
             return;
         }
@@ -118,7 +118,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         tracing::debug!(
             "after add target node {} as learner {:?}",
             target,
-            self.core.engine.state.last_log_id
+            self.core.engine.state.last_log_id()
         );
     }
 
@@ -204,7 +204,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         for node_id in nodes.iter() {
             match self.nodes.get(node_id) {
                 Some(node) => {
-                    if node.is_line_rate(&self.core.engine.state.last_log_id, &self.core.config) {
+                    if node.is_line_rate(&self.core.engine.state.last_log_id(), &self.core.config) {
                         // Node is ready to join.
                         continue;
                     }
@@ -219,7 +219,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
                                     .core
                                     .engine
                                     .state
-                                    .last_log_id
+                                    .last_log_id()
                                     .next_index()
                                     .saturating_sub(node.matched.next_index()),
                             }),

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -249,9 +249,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         let last_applied = changes.last_applied;
 
-        if st.last_log_id < Some(last_applied) {
-            st.last_log_id = Some(last_applied);
-        }
         if st.committed < Some(last_applied) {
             st.committed = Some(last_applied);
         }
@@ -259,7 +256,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             st.last_applied = Some(last_applied);
         }
 
-        assert!(st.last_purged_log_id <= Some(last_applied));
+        debug_assert!(st.last_purged_log_id() <= Some(last_applied));
 
         // A local log that is <= last_applied may be inconsistent with the leader.
         // It has to purge all of them to prevent these log form being replicated, when this node becomes leader.

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -42,7 +42,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             target_node.cloned(),
             self.core.engine.state.vote,
             self.core.config.clone(),
-            self.core.engine.state.last_log_id,
+            self.core.engine.state.last_log_id(),
             self.core.engine.state.committed,
             self.core.network.connect(target, target_node).await,
             self.core.storage.get_log_reader().await,
@@ -136,7 +136,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         state.matched = Some(matched);
 
         // Issue a response on the learners response channel if needed.
-        if state.is_line_rate(&self.core.engine.state.last_log_id, &self.core.config) {
+        if state.is_line_rate(&self.core.engine.state.last_log_id(), &self.core.config) {
             // This replication became line rate.
 
             // When adding a learner, it blocks until the replication becomes line-rate.
@@ -222,7 +222,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
         for id in node_ids.iter() {
             let matched = if *id == self.core.id {
-                self.core.engine.state.last_log_id
+                self.core.engine.state.last_log_id()
             } else {
                 let repl_state = self.nodes.get(id);
                 repl_state.map(|x| x.matched).unwrap_or_default()
@@ -269,7 +269,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
                 // of the configured snapshot threshold, else create a new snapshot.
                 if snapshot_is_within_half_of_threshold(
                     &snapshot.meta.last_log_id.index,
-                    &self.core.engine.state.last_log_id.unwrap_or_default().index,
+                    &self.core.engine.state.last_log_id().unwrap_or_default().index,
                     &threshold,
                 ) {
                     let _ = tx.send(snapshot);

--- a/openraft/src/engine/calc_purge_upto_test.rs
+++ b/openraft/src/engine/calc_purge_upto_test.rs
@@ -31,7 +31,7 @@ fn test_calc_purge_upto() -> anyhow::Result<()> {
         (None, None, 1, None),
         //
         (None, Some(log_id(1, 1)), 0, Some(log_id(1, 1))),
-        (None, Some(log_id(1, 1)), 1, Some(log_id(0, 0))),
+        (None, Some(log_id(1, 1)), 1, None),
         (None, Some(log_id(1, 1)), 2, None),
         //
         (Some(log_id(0, 0)), Some(log_id(1, 1)), 0, Some(log_id(1, 1))),
@@ -42,7 +42,7 @@ fn test_calc_purge_upto() -> anyhow::Result<()> {
         (None, Some(log_id(3, 4)), 1, Some(log_id(3, 3))),
         (None, Some(log_id(3, 4)), 2, Some(log_id(1, 2))),
         (None, Some(log_id(3, 4)), 3, Some(log_id(1, 1))),
-        (None, Some(log_id(3, 4)), 4, Some(log_id(0, 0))),
+        (None, Some(log_id(3, 4)), 4, None),
         (None, Some(log_id(3, 4)), 5, None),
         //
         (Some(log_id(1, 2)), Some(log_id(3, 4)), 0, Some(log_id(3, 4))),
@@ -55,7 +55,9 @@ fn test_calc_purge_upto() -> anyhow::Result<()> {
 
     for (last_purged, last_applied, max_keep, want) in cases {
         let mut eng = eng();
-        eng.state.last_purged_log_id = last_purged;
+        if let Some(last_purged) = last_purged {
+            eng.state.log_ids.purge(&last_purged);
+        }
         eng.state.last_applied = last_applied;
         let got = eng.calc_purge_upto(max_keep);
 

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::LogIdList;
 use crate::leader::Leader;
 use crate::raft::VoteRequest;
 use crate::EffectiveMembership;
@@ -122,7 +123,7 @@ fn test_elect() -> anyhow::Result<()> {
         let mut eng = eng();
         eng.id = 1;
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m12()));
-        eng.state.last_log_id = Some(log_id(1, 1));
+        eng.state.log_ids = LogIdList::new(vec![log_id(1, 1)]);
 
         eng.elect();
 

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -56,7 +56,6 @@ fn eng() -> Engine<u64> {
     eng.state.server_state = ServerState::Candidate;
     eng.state.log_ids.append(log_id(1, 1));
     eng.state.log_ids.append(log_id(2, 3));
-    eng.state.last_log_id = Some(log_id(2, 3));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
     eng
@@ -77,7 +76,7 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -120,7 +119,7 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(3, 4)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(3, 4)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -179,7 +178,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(3, 5)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(3, 5)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
@@ -260,7 +259,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(4, 6)), m34())),

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -56,7 +56,6 @@ fn eng() -> Engine<u64> {
     eng.state.log_ids.append(log_id(1, 1));
     eng.state.log_ids.append(log_id(2, 3));
     eng.state.committed = Some(log_id(0, 0));
-    eng.state.last_log_id = Some(log_id(2, 3));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
     eng
@@ -77,7 +76,7 @@ fn test_handle_append_entries_req_vote_is_rejected() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(log_id(0, 0)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -120,7 +119,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(1, 1)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(1, 1)), eng.state.last_log_id());
     assert_eq!(Some(log_id(0, 0)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -183,7 +182,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id());
     assert_eq!(Some(log_id(1, 1)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -249,7 +248,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(log_id(0, 0)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -313,7 +312,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(3, 3)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(3, 3)), eng.state.last_log_id());
     assert_eq!(Some(log_id(3, 3)), eng.state.committed);
     assert_eq!(
         MembershipState {

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::LogIdList;
 use crate::leader::Leader;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
@@ -75,7 +76,7 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
 #[test]
 fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.last_log_id = Some(log_id(2, 3));
+    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 2),
@@ -112,7 +113,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     // Equal vote should not emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.last_log_id = Some(log_id(2, 3));
+    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(2, 1),
@@ -158,7 +159,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.last_log_id = Some(log_id(2, 3));
+    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 1),

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -4,6 +4,7 @@ use crate::core::ServerState;
 use crate::engine::testing::Config;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::LogIdList;
 use crate::entry::EntryRef;
 use crate::error::InitializeError;
 use crate::error::NotAMembershipEntry;
@@ -40,7 +41,7 @@ fn test_initialize() -> anyhow::Result<()> {
 
         assert_eq!(Some(log_id0), eng.state.get_log_id(0));
         assert_eq!(None, eng.state.get_log_id(1));
-        assert_eq!(Some(log_id0), eng.state.last_log_id);
+        assert_eq!(Some(log_id0), eng.state.last_log_id());
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
@@ -70,7 +71,7 @@ fn test_initialize() -> anyhow::Result<()> {
     tracing::info!("--- not allowed because of last_log_id");
     {
         let mut eng = eng();
-        eng.state.last_log_id = Some(log_id0);
+        eng.state.log_ids = LogIdList::new(vec![log_id0]);
 
         assert_eq!(
             Err(InitializeError::NotAllowed(NotAllowed {

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::LogIdList;
 use crate::error::RejectVoteRequest;
 use crate::leader::Leader;
 use crate::EffectiveMembership;
@@ -64,7 +65,7 @@ fn test_internal_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
 #[test]
 fn test_internal_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.last_log_id = Some(log_id(2, 3));
+    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
     let resp = eng.internal_handle_vote_req(&Vote::new(3, 2), &Some(log_id(1, 3)));
 
@@ -89,7 +90,7 @@ fn test_internal_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<
 #[test]
 fn test_internal_handle_vote_req_committed_vote() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.last_log_id = Some(log_id(2, 3));
+    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
     let resp = eng.internal_handle_vote_req(&Vote::new_committed(3, 2), &None);
 
@@ -130,7 +131,7 @@ fn test_internal_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow:
     // Equal vote should not emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.last_log_id = Some(log_id(2, 3));
+    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
     let resp = eng.internal_handle_vote_req(&Vote::new(2, 1), &Some(log_id(2, 3)));
 
@@ -166,7 +167,7 @@ fn test_internal_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.last_log_id = Some(log_id(2, 3));
+    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
     let resp = eng.internal_handle_vote_req(&Vote::new(3, 1), &Some(log_id(2, 3)));
 

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -62,7 +62,6 @@ fn eng() -> Engine<u64> {
     eng.state.vote = Vote::new(3, 2);
     eng.state.log_ids.append(log_id(1, 1));
     eng.state.log_ids.append(log_id(2, 3));
-    eng.state.last_log_id = Some(log_id(2, 3));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
     eng
@@ -81,7 +80,7 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -123,7 +122,7 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id);
+    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -173,7 +172,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id);
+    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -231,7 +230,7 @@ fn test_leader_append_entries_with_membership() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id);
+    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -294,7 +293,7 @@ fn test_leader_append_entries_allow_fast_commit_if_no_member_changed() -> anyhow
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id);
+    assert_eq!(Some(LogId::new(LeaderId::new(3, 2), 6)), eng.state.last_log_id());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),

--- a/openraft/src/engine/purge_log_test.rs
+++ b/openraft/src/engine/purge_log_test.rs
@@ -14,8 +14,6 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
 fn eng() -> Engine<u64> {
     let mut eng = Engine::<u64>::default();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 2), log_id(4, 4), log_id(4, 6)]);
-    eng.state.last_purged_log_id = Some(log_id(2, 2));
-    eng.state.last_log_id = Some(log_id(4, 6));
     eng
 }
 
@@ -25,9 +23,9 @@ fn test_purge_log_already_purged() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(1, 1));
 
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(2, 2), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
 
     assert_eq!(0, eng.commands.len());
 
@@ -40,9 +38,9 @@ fn test_purge_log_equal_prev_last_purged() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(2, 2));
 
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(2, 2), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
 
     assert_eq!(0, eng.commands.len());
 
@@ -54,9 +52,9 @@ fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(2, 3));
 
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(2, 3), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(2, 3) }], eng.commands);
 
@@ -69,9 +67,9 @@ fn test_purge_log_to_last_key_log() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 4));
 
-    assert_eq!(Some(log_id(4, 4)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(4, 4)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(4, 4), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 4) }], eng.commands);
 
@@ -84,9 +82,9 @@ fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 5));
 
-    assert_eq!(Some(log_id(4, 5)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(4, 5)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(4, 5), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 5) }], eng.commands);
 
@@ -99,9 +97,9 @@ fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 6));
 
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(4, 6), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 6) }], eng.commands);
 
@@ -114,9 +112,9 @@ fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 7));
 
-    assert_eq!(Some(log_id(4, 7)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(4, 7)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(4, 7), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id(),);
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 7) }], eng.commands);
 
@@ -129,9 +127,9 @@ fn test_purge_log_to_higher_leader_lgo() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(5, 7));
 
-    assert_eq!(Some(log_id(5, 7)), eng.state.last_purged_log_id,);
+    assert_eq!(Some(log_id(5, 7)), eng.state.last_purged_log_id(),);
     assert_eq!(log_id(5, 7), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(5, 7)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(5, 7)), eng.state.last_log_id(),);
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(5, 7) }], eng.commands);
 

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -43,8 +43,6 @@ fn eng() -> Engine<u64> {
         log_id(4, 4),
         log_id(4, 6),
     ]);
-    eng.state.last_purged_log_id = Some(log_id(2, 2));
-    eng.state.last_log_id = Some(log_id(4, 6));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
     eng
@@ -56,7 +54,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
 
     eng.truncate_logs(3);
 
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id(),);
     assert_eq!(&[log_id(2, 2)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
@@ -97,7 +95,7 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
 
     eng.truncate_logs(4);
 
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id(),);
     assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
@@ -126,7 +124,7 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
 
     eng.truncate_logs(5);
 
-    assert_eq!(Some(log_id(4, 4)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 4)), eng.state.last_log_id(),);
     assert_eq!(&[log_id(2, 2), log_id(4, 4)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
@@ -147,7 +145,7 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
 
     eng.truncate_logs(6);
 
-    assert_eq!(Some(log_id(4, 5)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 5)), eng.state.last_log_id(),);
     assert_eq!(
         &[log_id(2, 2), log_id(4, 4), log_id(4, 5)],
         eng.state.log_ids.key_log_ids()
@@ -171,7 +169,7 @@ fn test_truncate_logs_since_7() -> anyhow::Result<()> {
 
     eng.truncate_logs(7);
 
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
     assert_eq!(
         &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
         eng.state.log_ids.key_log_ids()
@@ -195,7 +193,7 @@ fn test_truncate_logs_since_8() -> anyhow::Result<()> {
 
     eng.truncate_logs(8);
 
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
     assert_eq!(
         &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
         eng.state.log_ids.key_log_ids()
@@ -223,7 +221,7 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
 
     eng.truncate_logs(4);
 
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id,);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id(),);
     assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -17,16 +17,6 @@ pub struct RaftState<NID: NodeId> {
     /// The vote state of this node.
     pub vote: Vote<NID>,
 
-    /// The greatest log id that has been purged after being applied to state machine.
-    /// The range of log entries that exist in storage is `(last_purged_log_id, last_log_id]`,
-    /// left open and right close.
-    ///
-    /// `last_purged_log_id == last_log_id` means there is no log entry in the storage.
-    pub last_purged_log_id: Option<LogId<NID>>,
-
-    /// The id of the last log entry.
-    pub last_log_id: Option<LogId<NID>>,
-
     /// The LogId of the last log applied to the state machine.
     pub last_applied: Option<LogId<NID>>,
 
@@ -164,8 +154,8 @@ impl<NID: NodeId> RaftState<NID> {
     /// Append a list of `log_id`.
     ///
     /// The log ids in the input has to be continuous.
-    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: RaftLogId<NID> + 'a>(&mut self, new_log_id: &[LID]) {
-        self.log_ids.extend_from_same_leader(new_log_id)
+    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: RaftLogId<NID> + 'a>(&mut self, new_log_ids: &[LID]) {
+        self.log_ids.extend_from_same_leader(new_log_ids)
     }
 
     #[allow(dead_code)]
@@ -197,5 +187,20 @@ impl<NID: NodeId> RaftState<NID> {
         } else {
             false
         }
+    }
+
+    /// The last known log id in the store.
+    pub(crate) fn last_log_id(&self) -> Option<LogId<NID>> {
+        self.log_ids.last().cloned()
+    }
+
+    /// The greatest log id that has been purged after being applied to state machine, i.e., the oldest known log id.
+    ///
+    /// The range of log entries that exist in storage is `(last_purged_log_id, last_log_id]`,
+    /// left open and right close.
+    ///
+    /// `last_purged_log_id == last_log_id` means there is no log entry in the storage.
+    pub(crate) fn last_purged_log_id(&self) -> Option<LogId<NID>> {
+        self.log_ids.first().cloned()
     }
 }

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -52,3 +52,51 @@ fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_raft_state_last_log_id() -> anyhow::Result<()> {
+    let rs = RaftState::<u64> {
+        log_ids: LogIdList::new(vec![]),
+        ..Default::default()
+    };
+
+    assert_eq!(None, rs.last_log_id());
+
+    let rs = RaftState {
+        log_ids: LogIdList::new(vec![log_id(1, 2)]),
+        ..Default::default()
+    };
+    assert_eq!(Some(log_id(1, 2)), rs.last_log_id());
+
+    let rs = RaftState {
+        log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
+        ..Default::default()
+    };
+    assert_eq!(Some(log_id(3, 4)), rs.last_log_id());
+
+    Ok(())
+}
+
+#[test]
+fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
+    let rs = RaftState::<u64> {
+        log_ids: LogIdList::new(vec![]),
+        ..Default::default()
+    };
+
+    assert_eq!(None, rs.last_purged_log_id());
+
+    let rs = RaftState {
+        log_ids: LogIdList::new(vec![log_id(1, 2)]),
+        ..Default::default()
+    };
+    assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id());
+
+    let rs = RaftState {
+        log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
+        ..Default::default()
+    };
+    assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id());
+
+    Ok(())
+}

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -288,8 +288,6 @@ where C: RaftTypeConfig
         let log_ids = RaftState::load_log_ids(last_purged_log_id, last_log_id, self).await?;
 
         Ok(RaftState {
-            last_log_id,
-            last_purged_log_id,
             last_applied,
             // The initial value for `vote` is the minimal possible value.
             // See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -397,7 +397,7 @@ where
         let initial = store.get_initial_state().await?;
 
         assert_eq!(
-            initial.last_log_id,
+            initial.last_log_id(),
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 2)),
             "state machine has higher log"
         );
@@ -513,7 +513,7 @@ where
         let initial = store.get_initial_state().await?;
 
         assert_eq!(
-            initial.last_log_id,
+            initial.last_log_id(),
             Some(LogId::new(LeaderId::new(2, NODE_ID.into()), 1)),
             "state machine has higher log"
         );
@@ -531,12 +531,12 @@ where
         let initial = store.get_initial_state().await?;
 
         assert_eq!(
-            initial.last_log_id,
+            initial.last_log_id(),
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 1)),
             "state machine has higher log"
         );
         assert_eq!(
-            initial.last_purged_log_id,
+            initial.last_purged_log_id(),
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 1)),
             "state machine has higher log"
         );


### PR DESCRIPTION

## Changelog

##### Change: remove `RaftState.last_log_id` and `RaftState.last_purged_log_id`

Remove these two fields, which are already included in
`RaftState.log_ids`; use `last_log_id()` and `last_purged_log_id()`
instead.

- Fix: #389

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/391)
<!-- Reviewable:end -->
