### PR TITLE
Refactor: simplify communication from RaftCore to ReplicationStream

### DIFF
--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -69,7 +69,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         // Setup state as leader.
         self.core.last_heartbeat = None;
         self.core.next_election_timeout = None;
-        self.core.engine.state.vote.commit();
+        debug_assert!(self.core.engine.state.vote.committed);
 
         // Spawn replication streams for followers and learners.
         let targets = self

--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -199,8 +199,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRun
                 }
             }
             Command::ReplicateInputEntries { range } => {
-                for i in range.clone() {
-                    self.replicate_entry(*input_entries[i].get_log_id());
+                if let Some(last) = range.clone().last() {
+                    self.replicate_entry(*input_entries[last].get_log_id());
                 }
             }
             Command::UpdateMembership { .. } => {

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -219,8 +219,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             (NO_LOG, MULTI, IS_LEARNER) => ServerState::Learner,  // impossible: no logs but there are other members.
 
             // If this is the only configured member and there is live state, then this is
-            // a single-node cluster. Become leader.
-            (HAS_LOG, SINGLE, IS_VOTER) => ServerState::Leader,
+            // a single-node cluster. It should become the leader at once.
+            (HAS_LOG, SINGLE, IS_VOTER) => ServerState::Candidate,
 
             // The initial state when a raft is created from empty store.
             (NO_LOG, SINGLE, IS_VOTER) => ServerState::Learner,

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -12,9 +12,9 @@ use crate::error::AddLearnerError;
 use crate::metrics::UpdateMatchedLogId;
 use crate::raft::AddLearnerResponse;
 use crate::raft::RaftRespTx;
-use crate::replication::RaftEvent;
 use crate::replication::ReplicaEvent;
 use crate::replication::ReplicationStream;
+use crate::replication::UpdateReplication;
 use crate::storage::Snapshot;
 use crate::summary::MessageSummary;
 use crate::versioned::Updatable;
@@ -174,12 +174,10 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
             // Update all replication streams based on new commit index.
             for node in self.nodes.values() {
-                let _ = node.repl_stream.repl_tx.send((
-                    RaftEvent::UpdateCommittedLogId {
-                        committed: self.core.engine.state.committed,
-                    },
-                    tracing::debug_span!("CH"),
-                ));
+                let _ = node.repl_stream.repl_tx.send(UpdateReplication {
+                    last_log_id: None,
+                    committed: self.core.engine.state.committed,
+                });
             }
 
             // Apply committed entries, and send applying result to client if there is a channel awaiting it

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -51,7 +51,8 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
     {
         let mut sto0 = router.new_store();
 
-        sto0.save_vote(&Vote::new(5, 0)).await?;
+        // When the node starts, it will become candidate and increment its vote to (5,0)
+        sto0.save_vote(&Vote::new(4, 0)).await?;
         sto0.append_to_log(&[
             // manually insert the initializing log
             &Entry {


### PR DESCRIPTION

## Changelog

##### Refactor: simplify communication from RaftCore to ReplicationStream

Replace the event type enum with a struct:
One struct to notify the replication to update either new last_log_id or
new committed.

Remove the unused span from the channel.


##### Refactor: when a single-node cluster starts, enter candidate state

By entering candidate state, run a round of election, in order to
intialize the every state, such as the `vote` should be committed before
entering leader state.

Avoid a specialized running path, e.g. let the single node in the
cluster to enter leader state at once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/393)
<!-- Reviewable:end -->
