### PR TITLE
Refactor: add QuorumSet to impl a set of quorum

### DIFF
--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -14,6 +14,7 @@ use crate::error::ClientWriteError;
 use crate::error::QuorumNotEnough;
 use crate::error::RPCError;
 use crate::error::Timeout;
+use crate::quorum::QuorumSet;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::ClientWriteResponse;
@@ -50,7 +51,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         let mem = &self.core.engine.state.membership_state.effective.membership;
         let mut granted = btreeset! {self.core.id};
 
-        if mem.is_majority(&granted) {
+        if mem.is_quorum(granted.iter()) {
             let _ = tx.send(Ok(()));
             return;
         }
@@ -133,7 +134,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             granted.insert(target);
 
             let mem = &self.core.engine.state.membership_state.effective.membership;
-            if mem.is_majority(&granted) {
+            if mem.is_quorum(granted.iter()) {
                 let _ = tx.send(Ok(()));
                 return;
             }

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -56,7 +56,7 @@ fn m34() -> Membership<u64> {
 fn eng() -> Engine<u64> {
     let mut eng = Engine::<u64> {
         id: 2, // make it a member
-        single_node_cluster: btreeset! {2},
+        single_node_cluster: [2],
         ..Default::default()
     };
     eng.state.vote = Vote::new(3, 2);

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use crate::quorum::QuorumSet;
 use crate::Membership;
 use crate::NodeId;
 
@@ -37,6 +38,6 @@ impl<NID: NodeId> Leader<NID> {
 
     /// Return if a quorum of `membership` has granted it.
     pub(crate) fn is_granted_by(&self, membership: &Membership<NID>) -> bool {
-        membership.is_majority(&self.vote_granted_by)
+        membership.is_quorum(self.vote_granted_by.iter())
     }
 }

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -13,6 +13,7 @@ mod defensive;
 mod entry;
 mod membership;
 mod node;
+mod quorum;
 mod raft_types;
 mod replication;
 mod storage_error;

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
-use std::option::Option::None;
 
 use maplit::btreemap;
 use maplit::btreeset;
 
 use crate::error::MissingNodeInfo;
+use crate::quorum::QuorumSet;
 use crate::testing::DummyConfig as Config;
 use crate::Membership;
 use crate::MessageSummary;
@@ -248,23 +248,25 @@ fn test_membership_with_nodes() -> anyhow::Result<()> {
 #[test]
 fn test_membership_majority() -> anyhow::Result<()> {
     {
-        let m12345 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5}], None);
-        assert!(!m12345.is_majority(&btreeset! {0}));
-        assert!(!m12345.is_majority(&btreeset! {0,1,2}));
-        assert!(!m12345.is_majority(&btreeset! {6,7,8}));
-        assert!(m12345.is_majority(&btreeset! {1,2,3}));
-        assert!(m12345.is_majority(&btreeset! {3,4,5}));
-        assert!(m12345.is_majority(&btreeset! {1,3,4,5}));
+        let m12345 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }], None);
+
+        assert!(!m12345.is_quorum([0].iter()));
+        assert!(!m12345.is_quorum([0, 1, 2].iter()));
+        assert!(!m12345.is_quorum([6, 7, 8].iter()));
+        assert!(m12345.is_quorum([1, 2, 3].iter()));
+        assert!(m12345.is_quorum([3, 4, 5].iter()));
+        assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
     }
 
     {
-        let m12345_678 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}], None);
-        assert!(!m12345_678.is_majority(&btreeset! {0}));
-        assert!(!m12345_678.is_majority(&btreeset! {0,1,2}));
-        assert!(!m12345_678.is_majority(&btreeset! {6,7,8}));
-        assert!(!m12345_678.is_majority(&btreeset! {1,2,3}));
-        assert!(m12345_678.is_majority(&btreeset! {1,2,3,6,7}));
-        assert!(m12345_678.is_majority(&btreeset! {1,2,3,4,7,8}));
+        let m12345_678 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
+
+        assert!(!m12345_678.is_quorum([0].iter()));
+        assert!(!m12345_678.is_quorum([0, 1, 2].iter()));
+        assert!(!m12345_678.is_quorum([6, 7, 8].iter()));
+        assert!(!m12345_678.is_quorum([1, 2, 3].iter()));
+        assert!(m12345_678.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(m12345_678.is_quorum([1, 2, 3, 4, 7, 8].iter()));
     }
 
     Ok(())

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -5,8 +5,6 @@ mod membership_state;
 #[cfg(test)] mod membership_state_test;
 #[cfg(test)] mod membership_test;
 
-pub mod quorum;
-
 pub use effective_membership::EffectiveMembership;
 pub use membership::IntoOptionNodes;
 pub use membership::Membership;

--- a/openraft/src/membership/quorum.rs
+++ b/openraft/src/membership/quorum.rs
@@ -1,3 +1,0 @@
-pub fn majority_of(n: usize) -> usize {
-    n / 2 + 1
-}

--- a/openraft/src/quorum/mod.rs
+++ b/openraft/src/quorum/mod.rs
@@ -1,0 +1,9 @@
+mod quorum_set;
+mod quorum_set_impl;
+mod util;
+
+#[cfg(test)] mod quorum_set_test;
+#[cfg(test)] mod util_test;
+
+pub(crate) use quorum_set::QuorumSet;
+pub(crate) use util::majority_of;

--- a/openraft/src/quorum/quorum_set.rs
+++ b/openraft/src/quorum/quorum_set.rs
@@ -1,0 +1,5 @@
+/// A set of quorums
+pub(crate) trait QuorumSet<ID: 'static> {
+    /// Check if a series of ID constitute a quorum that is defined by this quorum set.
+    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool;
+}

--- a/openraft/src/quorum/quorum_set_impl.rs
+++ b/openraft/src/quorum/quorum_set_impl.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeSet;
+
+use crate::quorum::quorum_set::QuorumSet;
+use crate::quorum::util::majority_of;
+
+/// Impl a simple majority quorum set
+impl<ID> QuorumSet<ID> for BTreeSet<ID>
+where ID: PartialOrd + Ord + 'static
+{
+    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
+        let mut count = 0;
+        let majority = majority_of(self.len());
+        for id in ids {
+            if self.contains(id) {
+                count += 1;
+                if count >= majority {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+/// Impl a simple majority quorum set
+impl<ID> QuorumSet<ID> for &[ID]
+where ID: PartialEq + 'static
+{
+    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
+        let majority = majority_of(self.len());
+
+        // TODO(xp): benchmark these two implementations
+        // let mut count = 0;
+        // for id in ids {
+        //     if self.contains(id) {
+        //         count += 1;
+        //         if count >= majority {
+        //             return true;
+        //         }
+        //     }
+        // }
+        // false
+
+        let count = ids.fold(0, |v, id| if self.contains(id) { v + 1 } else { v });
+        count >= majority
+    }
+}
+
+/// Impl joint quorum set.
+/// The input ids has to be a quorum in every sub-config to constitute a joint-quorum.
+impl<ID, QS> QuorumSet<ID> for Vec<QS>
+where
+    ID: 'static,
+    QS: QuorumSet<ID>,
+{
+    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
+        for child in self.iter() {
+            if !child.is_quorum(ids.clone()) {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/openraft/src/quorum/quorum_set_impl.rs
+++ b/openraft/src/quorum/quorum_set_impl.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 
 use crate::quorum::quorum_set::QuorumSet;
-use crate::quorum::util::majority_of;
 
 /// Impl a simple majority quorum set
 impl<ID> QuorumSet<ID> for BTreeSet<ID>
@@ -9,11 +8,11 @@ where ID: PartialOrd + Ord + 'static
 {
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
         let mut count = 0;
-        let majority = majority_of(self.len());
+        let limit = self.len();
         for id in ids {
             if self.contains(id) {
-                count += 1;
-                if count >= majority {
+                count += 2;
+                if count > limit {
                     return true;
                 }
             }
@@ -28,22 +27,18 @@ impl<ID> QuorumSet<ID> for &[ID]
 where ID: PartialEq + 'static
 {
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
-        let majority = majority_of(self.len());
+        let mut count = 0;
+        let limit = self.len();
+        for id in ids {
+            if self.contains(id) {
+                count += 2;
+                if count > limit {
+                    return true;
+                }
+            }
+        }
 
-        // TODO(xp): benchmark these two implementations
-        // let mut count = 0;
-        // for id in ids {
-        //     if self.contains(id) {
-        //         count += 1;
-        //         if count >= majority {
-        //             return true;
-        //         }
-        //     }
-        // }
-        // false
-
-        let count = ids.fold(0, |v, id| if self.contains(id) { v + 1 } else { v });
-        count >= majority
+        false
     }
 }
 

--- a/openraft/src/quorum/quorum_set_test.rs
+++ b/openraft/src/quorum/quorum_set_test.rs
@@ -1,0 +1,55 @@
+use maplit::btreeset;
+
+use crate::quorum::quorum_set::QuorumSet;
+
+#[test]
+fn test_quorum_set_impl() -> anyhow::Result<()> {
+    // BTreeSet as majority quorum set
+    {
+        let m12345 = btreeset! {1,2,3,4,5};
+
+        assert!(!m12345.is_quorum([0].iter()));
+        assert!(!m12345.is_quorum([0, 1, 2].iter()));
+        assert!(!m12345.is_quorum([6, 7, 8].iter()));
+        assert!(m12345.is_quorum([1, 2, 3].iter()));
+        assert!(m12345.is_quorum([3, 4, 5].iter()));
+        assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
+    }
+
+    // Vec<BTreeSet> as majority quorum set
+    {
+        let m12345 = vec![btreeset! {1,2,3,4,5}];
+
+        assert!(!m12345.is_quorum([0].iter()));
+        assert!(!m12345.is_quorum([0, 1, 2].iter()));
+        assert!(!m12345.is_quorum([6, 7, 8].iter()));
+        assert!(m12345.is_quorum([1, 2, 3].iter()));
+        assert!(m12345.is_quorum([3, 4, 5].iter()));
+        assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
+    }
+
+    // Vec<BTreeSet, BTreeSet> as joint-of-majority quorum set
+    {
+        let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
+
+        assert!(!m12345_678.is_quorum([0].iter()));
+        assert!(!m12345_678.is_quorum([0, 1, 2].iter()));
+        assert!(!m12345_678.is_quorum([6, 7, 8].iter()));
+        assert!(!m12345_678.is_quorum([1, 2, 3].iter()));
+        assert!(m12345_678.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(m12345_678.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+    }
+
+    // Vec<&[], &[]> as joint-of-majority quorum set
+    {
+        let m12345_678: Vec<&[usize]> = vec![&[1, 2, 3, 4, 5], &[6, 7, 8]];
+
+        assert!(!m12345_678.is_quorum([0].iter()));
+        assert!(!m12345_678.is_quorum([0, 1, 2].iter()));
+        assert!(!m12345_678.is_quorum([6, 7, 8].iter()));
+        assert!(!m12345_678.is_quorum([1, 2, 3].iter()));
+        assert!(m12345_678.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(m12345_678.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+    }
+    Ok(())
+}

--- a/openraft/src/quorum/util.rs
+++ b/openraft/src/quorum/util.rs
@@ -1,0 +1,3 @@
+pub(crate) fn majority_of(n: usize) -> usize {
+    n / 2 + 1
+}

--- a/openraft/src/quorum/util_test.rs
+++ b/openraft/src/quorum/util_test.rs
@@ -1,0 +1,15 @@
+use crate::quorum::util::majority_of;
+
+#[test]
+fn test_majority_of() -> anyhow::Result<()> {
+    assert_eq!(1, majority_of(0));
+    assert_eq!(1, majority_of(1));
+    assert_eq!(2, majority_of(2));
+    assert_eq!(2, majority_of(3));
+    assert_eq!(3, majority_of(4));
+    assert_eq!(3, majority_of(5));
+    assert_eq!(4, majority_of(6));
+    assert_eq!(4, majority_of(7));
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### Refactor: add QuorumSet to impl a set of quorum

Move the quorum related functions from `Membership` to standalone mod
`QuorumSet`.

- Auto implement a simple majority quorum set for `BTreeSet` and `slice`.

- Auto implement a joint quorum set for `Vec` of some `QuorumSet`
  implementation.

- Fix: #395

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/397)
<!-- Reviewable:end -->
