### PR TITLE
Feature: add openraft::quorum::Joint

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -43,14 +43,22 @@ tracing-appender = "0.2.0"
 tracing-subscriber = { version = "0.3.3",  features=["env-filter"] }
 
 
-
 [features]
 docinclude = [] # Used only for activating `doc(include="...")` on nightly.
+
+# Enables benchmarks in unittest.
+#
+# Benchmark in openraft depends on the unstable feature `test` thus it can not be used with stable rust.
+# In order to run the benchmark with stable toolchain,
+# the unstable features have to be enabled explicitly with environment variable `RUSTC_BOOTSTRAP=1`.
+bench = []
 
 # Enable backtrace when generating an error.
 # Stable rust does not support backtrace.
 bt  = ["anyerror/backtrace", "anyhow/backtrace"]
 
+# Add serde::Serialize and serde:Deserialize bound to data types.
+# If you'd like to use `serde` to serialize messages.
 serde = ["dep:serde"]
 
 [package.metadata.docs.rs]

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -1,11 +1,19 @@
 #![doc = include_str!("../../README.md")]
 #![cfg_attr(feature = "bt", feature(backtrace))]
+#![cfg_attr(feature = "bench", feature(test))]
 
 //! # Feature flags
 //!
+//! - `bench`: Enables benchmarks in unittest. Benchmark in openraft depends on the unstable feature `test` thus it can
+//!   not be used with stable rust. In order to run the benchmark with stable toolchain, the unstable features have to
+//!   be enabled explicitly with environment variable `RUSTC_BOOTSTRAP=1`.
+//!
 //! - `bt`: Enable backtrace: generate backtrace for errors. This requires a unstable feature `backtrace` thus it can
-//!   not be used with stable rust, unless explicity allowing using unstable features in stable rust with
+//!   not be used with stable rust, unless explicitly allowing using unstable features in stable rust with
 //!   `RUSTC_BOOTSTRAP=1`.
+//!
+//! - `serde`: Add serde::Serialize and serde:Deserialize bound to data types. If you'd like to use `serde` to serialize
+//!   messages.
 
 mod config;
 mod core;

--- a/openraft/src/membership/bench/is_quorum.rs
+++ b/openraft/src/membership/bench/is_quorum.rs
@@ -1,0 +1,40 @@
+extern crate test;
+
+use maplit::btreeset;
+use test::black_box;
+use test::Bencher;
+
+use crate::quorum::QuorumSet;
+use crate::Membership;
+
+#[bench]
+fn m12345_ids_slice(b: &mut Bencher) {
+    let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let x = [1, 2, 3, 6, 7];
+
+    b.iter(|| m.is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn m12345_ids_btreeset(b: &mut Bencher) {
+    let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let x = btreeset! {1, 2, 3, 6, 7};
+
+    b.iter(|| m.is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn m12345_678_ids_slice(b: &mut Bencher) {
+    let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let x = [1, 2, 3, 6, 7];
+
+    b.iter(|| m.is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn m12345_678_ids_btreeset(b: &mut Bencher) {
+    let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let x = btreeset! {1, 2, 3, 6, 7};
+
+    b.iter(|| m.is_quorum(black_box(x.iter())))
+}

--- a/openraft/src/membership/bench/mod.rs
+++ b/openraft/src/membership/bench/mod.rs
@@ -1,0 +1,1 @@
+mod is_quorum;

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -7,6 +7,7 @@ use maplit::btreemap;
 
 use crate::error::MissingNodeInfo;
 use crate::quorum::majority_of;
+use crate::quorum::AsJoint;
 use crate::quorum::QuorumSet;
 use crate::MessageSummary;
 use crate::Node;
@@ -359,6 +360,6 @@ impl<NID: NodeId> Membership<NID> {
 /// Implement joint quorum set for `Membership`.
 impl<NID: NodeId> QuorumSet<NID> for Membership<NID> {
     fn is_quorum<'a, I: Iterator<Item = &'a NID> + Clone>(&self, ids: I) -> bool {
-        self.configs.is_quorum(ids)
+        self.configs.as_joint().is_quorum(ids)
     }
 }

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -2,6 +2,10 @@ mod effective_membership;
 #[allow(clippy::module_inception)] mod membership;
 mod membership_state;
 
+#[cfg(feature = "bench")]
+#[cfg(test)]
+mod bench;
+
 #[cfg(test)] mod membership_state_test;
 #[cfg(test)] mod membership_test;
 

--- a/openraft/src/quorum/bench/is_quorum.rs
+++ b/openraft/src/quorum/bench/is_quorum.rs
@@ -1,0 +1,50 @@
+extern crate test;
+
+use maplit::btreeset;
+use test::black_box;
+use test::Bencher;
+
+use crate::quorum::AsJoint;
+use crate::quorum::QuorumSet;
+
+#[bench]
+fn quorum_set_slice_ids_slice(b: &mut Bencher) {
+    let m12345: &[usize] = &[1, 2, 3, 4, 5];
+    let x = [1, 2, 3, 6, 7];
+    b.iter(|| m12345.is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn quorum_set_vec_ids_slice(b: &mut Bencher) {
+    let m12345 = vec![1, 2, 3, 4, 5];
+    let x = [1, 2, 3, 6, 7];
+    b.iter(|| m12345.is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn quorum_set_btreeset_ids_slice(b: &mut Bencher) {
+    let m12345678 = btreeset! {1,2,3,4,5,6,7,8};
+    let x = [1, 2, 3, 6, 7];
+    b.iter(|| m12345678.is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn quorum_set_vec_of_vec_ids_slice(b: &mut Bencher) {
+    let m12345_678 = vec![vec![1, 2, 3, 4, 5], vec![6, 7, 8]];
+    let x = [1, 2, 3, 6, 7];
+    b.iter(|| m12345_678.as_joint().is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn quorum_set_vec_of_btreeset_ids_slice(b: &mut Bencher) {
+    let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
+    let x = [1, 2, 3, 6, 7];
+    b.iter(|| m12345_678.as_joint().is_quorum(black_box(x.iter())))
+}
+
+#[bench]
+fn quorum_set_vec_of_btreeset_ids_btreeset(b: &mut Bencher) {
+    let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
+    let x = btreeset! {1,2,3,6,7};
+    b.iter(|| m12345_678.as_joint().is_quorum(black_box(x.iter())))
+}

--- a/openraft/src/quorum/bench/mod.rs
+++ b/openraft/src/quorum/bench/mod.rs
@@ -1,0 +1,1 @@
+mod is_quorum;

--- a/openraft/src/quorum/joint.rs
+++ b/openraft/src/quorum/joint.rs
@@ -1,0 +1,51 @@
+use std::marker::PhantomData;
+
+use crate::quorum::QuorumSet;
+
+/// Use another data as a joint quorum set.
+///
+/// The ids has to be a quorum in every sub-config to constitute a joint-quorum.
+pub(crate) trait AsJoint<'d, ID, QS>
+where
+    ID: 'static,
+    QS: QuorumSet<ID>,
+{
+    fn as_joint(&'d self) -> Joint<'d, ID, QS>;
+}
+
+/// A wrapper that uses other data to define a joint quorum set.
+///
+/// The input ids has to be a quorum in every sub-config to constitute a joint-quorum.
+pub(crate) struct Joint<'d, ID, QS>
+where
+    ID: 'static,
+    QS: QuorumSet<ID>,
+{
+    data: &'d [QS],
+    _p: PhantomData<ID>,
+}
+
+impl<'d, ID, QS> Joint<'d, ID, QS>
+where
+    ID: 'static,
+    QS: QuorumSet<ID>,
+{
+    pub(crate) fn new(data: &'d [QS]) -> Self {
+        Self { data, _p: PhantomData }
+    }
+}
+
+impl<'d, ID, QS> QuorumSet<ID> for Joint<'d, ID, QS>
+where
+    ID: 'static,
+    QS: QuorumSet<ID>,
+{
+    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
+        for child in self.data.iter() {
+            if !child.is_quorum(ids.clone()) {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/openraft/src/quorum/joint_impl.rs
+++ b/openraft/src/quorum/joint_impl.rs
@@ -1,0 +1,14 @@
+use crate::quorum::AsJoint;
+use crate::quorum::Joint;
+use crate::quorum::QuorumSet;
+
+/// Use a vec of some impl of `QuorumSet` as a joint quorum set.
+impl<'d, ID, QS> AsJoint<'d, ID, QS> for Vec<QS>
+where
+    ID: 'static,
+    QS: QuorumSet<ID>,
+{
+    fn as_joint(&'d self) -> Joint<'d, ID, QS> {
+        Joint::new(self)
+    }
+}

--- a/openraft/src/quorum/mod.rs
+++ b/openraft/src/quorum/mod.rs
@@ -1,9 +1,17 @@
+mod joint;
+mod joint_impl;
 mod quorum_set;
 mod quorum_set_impl;
 mod util;
 
+#[cfg(feature = "bench")]
+#[cfg(test)]
+mod bench;
+
 #[cfg(test)] mod quorum_set_test;
 #[cfg(test)] mod util_test;
 
+pub(crate) use joint::AsJoint;
+pub(crate) use joint::Joint;
 pub(crate) use quorum_set::QuorumSet;
 pub(crate) use util::majority_of;

--- a/openraft/src/quorum/quorum_set.rs
+++ b/openraft/src/quorum/quorum_set.rs
@@ -1,4 +1,7 @@
-/// A set of quorums
+/// A set of quorums is a collection of quorum.
+///
+/// A quorum is a collection of nodes that a read or write operation in distributed system has to contact to.
+/// See: http://web.mit.edu/6.033/2005/wwwdocs/quorum_note.html
 pub(crate) trait QuorumSet<ID: 'static> {
     /// Check if a series of ID constitute a quorum that is defined by this quorum set.
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool;

--- a/openraft/src/quorum/quorum_set_impl.rs
+++ b/openraft/src/quorum/quorum_set_impl.rs
@@ -17,7 +17,25 @@ where ID: PartialOrd + Ord + 'static
                 }
             }
         }
+        false
+    }
+}
 
+/// Impl a simple majority quorum set
+impl<ID> QuorumSet<ID> for Vec<ID>
+where ID: PartialEq + 'static
+{
+    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
+        let mut count = 0;
+        let limit = self.len();
+        for id in ids {
+            if self.contains(id) {
+                count += 2;
+                if count > limit {
+                    return true;
+                }
+            }
+        }
         false
     }
 }
@@ -37,24 +55,6 @@ where ID: PartialEq + 'static
                 }
             }
         }
-
         false
-    }
-}
-
-/// Impl joint quorum set.
-/// The input ids has to be a quorum in every sub-config to constitute a joint-quorum.
-impl<ID, QS> QuorumSet<ID> for Vec<QS>
-where
-    ID: 'static,
-    QS: QuorumSet<ID>,
-{
-    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
-        for child in self.iter() {
-            if !child.is_quorum(ids.clone()) {
-                return false;
-            }
-        }
-        true
     }
 }

--- a/openraft/src/quorum/quorum_set_test.rs
+++ b/openraft/src/quorum/quorum_set_test.rs
@@ -1,9 +1,22 @@
 use maplit::btreeset;
 
-use crate::quorum::quorum_set::QuorumSet;
+use crate::quorum::AsJoint;
+use crate::quorum::QuorumSet;
 
 #[test]
-fn test_quorum_set_impl() -> anyhow::Result<()> {
+fn test_simple_quorum_set_impl() -> anyhow::Result<()> {
+    // Vec as majority quorum set
+    {
+        let m12345 = vec![1, 2, 3, 4, 5];
+
+        assert!(!m12345.is_quorum([0].iter()));
+        assert!(!m12345.is_quorum([0, 1, 2].iter()));
+        assert!(!m12345.is_quorum([6, 7, 8].iter()));
+        assert!(m12345.is_quorum([1, 2, 3].iter()));
+        assert!(m12345.is_quorum([3, 4, 5].iter()));
+        assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
+    }
+
     // BTreeSet as majority quorum set
     {
         let m12345 = btreeset! {1,2,3,4,5};
@@ -16,40 +29,61 @@ fn test_quorum_set_impl() -> anyhow::Result<()> {
         assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
     }
 
+    Ok(())
+}
+
+#[test]
+fn test_joint_quorum_set_impl() -> anyhow::Result<()> {
     // Vec<BTreeSet> as majority quorum set
     {
         let m12345 = vec![btreeset! {1,2,3,4,5}];
+        let qs = m12345.as_joint();
 
-        assert!(!m12345.is_quorum([0].iter()));
-        assert!(!m12345.is_quorum([0, 1, 2].iter()));
-        assert!(!m12345.is_quorum([6, 7, 8].iter()));
-        assert!(m12345.is_quorum([1, 2, 3].iter()));
-        assert!(m12345.is_quorum([3, 4, 5].iter()));
-        assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
+        assert!(!qs.is_quorum([0].iter()));
+        assert!(!qs.is_quorum([0, 1, 2].iter()));
+        assert!(!qs.is_quorum([6, 7, 8].iter()));
+        assert!(qs.is_quorum([1, 2, 3].iter()));
+        assert!(qs.is_quorum([3, 4, 5].iter()));
+        assert!(qs.is_quorum([1, 3, 4, 5].iter()));
     }
 
     // Vec<BTreeSet, BTreeSet> as joint-of-majority quorum set
     {
         let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
+        let qs = m12345_678.as_joint();
 
-        assert!(!m12345_678.is_quorum([0].iter()));
-        assert!(!m12345_678.is_quorum([0, 1, 2].iter()));
-        assert!(!m12345_678.is_quorum([6, 7, 8].iter()));
-        assert!(!m12345_678.is_quorum([1, 2, 3].iter()));
-        assert!(m12345_678.is_quorum([1, 2, 3, 6, 7].iter()));
-        assert!(m12345_678.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+        assert!(!qs.is_quorum([0].iter()));
+        assert!(!qs.is_quorum([0, 1, 2].iter()));
+        assert!(!qs.is_quorum([6, 7, 8].iter()));
+        assert!(!qs.is_quorum([1, 2, 3].iter()));
+        assert!(qs.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(qs.is_quorum([1, 2, 3, 4, 7, 8].iter()));
     }
 
     // Vec<&[], &[]> as joint-of-majority quorum set
     {
         let m12345_678: Vec<&[usize]> = vec![&[1, 2, 3, 4, 5], &[6, 7, 8]];
+        let qs = m12345_678.as_joint();
 
-        assert!(!m12345_678.is_quorum([0].iter()));
-        assert!(!m12345_678.is_quorum([0, 1, 2].iter()));
-        assert!(!m12345_678.is_quorum([6, 7, 8].iter()));
-        assert!(!m12345_678.is_quorum([1, 2, 3].iter()));
-        assert!(m12345_678.is_quorum([1, 2, 3, 6, 7].iter()));
-        assert!(m12345_678.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+        assert!(!qs.is_quorum([0].iter()));
+        assert!(!qs.is_quorum([0, 1, 2].iter()));
+        assert!(!qs.is_quorum([6, 7, 8].iter()));
+        assert!(!qs.is_quorum([1, 2, 3].iter()));
+        assert!(qs.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(qs.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+    }
+
+    // Vec<Vec, Vec> as joint-of-majority quorum set
+    {
+        let m12345_678 = vec![vec![1, 2, 3, 4, 5], vec![6, 7, 8]];
+        let qs = m12345_678.as_joint();
+
+        assert!(!qs.is_quorum([0].iter()));
+        assert!(!qs.is_quorum([0, 1, 2].iter()));
+        assert!(!qs.is_quorum([6, 7, 8].iter()));
+        assert!(!qs.is_quorum([1, 2, 3].iter()));
+        assert!(qs.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(qs.is_quorum([1, 2, 3, 4, 7, 8].iter()));
     }
     Ok(())
 }


### PR DESCRIPTION
## Changelog

It let a user use a vector of `QuorumSet` as a joint quorum set with:
```
vec![vec![1, 2, 3], vec![4, 5, 6]].as_joint().is_quorum([1, 2, 4, 5].iter())
```

Add benchmark for various `QuorumSet` and `Membership.is_quorum()`


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/400)
<!-- Reviewable:end -->
