### PR TITLE
Refactor: VecProgress::new() do not need arg ids

### DIFF
--- a/openraft/src/progress/bench/vec_progress_update.rs
+++ b/openraft/src/progress/bench/vec_progress_update.rs
@@ -11,7 +11,7 @@ use crate::quorum::Joint;
 fn progress_update_01234_567(b: &mut Bencher) {
     let membership: Vec<Vec<u64>> = vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7]];
     let quorum_set = Joint::from(membership);
-    let mut progress = VecProgress::<u64, u64, _>::new([0, 1, 2, 3, 4, 5, 6, 7].iter(), quorum_set);
+    let mut progress = VecProgress::<u64, u64, _>::new(quorum_set);
 
     let mut id = 0u64;
     let mut values = vec![0, 1, 2, 3, 4, 5, 6, 7];

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -68,10 +68,11 @@ where
     QS: QuorumSet<ID>,
 {
     #[allow(dead_code)]
-    pub(crate) fn new<'i>(ids: impl Iterator<Item = &'i ID>, quorum_set: QS) -> Self {
+    pub(crate) fn new(quorum_set: QS) -> Self {
+        let ids = quorum_set.ids();
         let mut vector = Vec::new();
         for id in ids {
-            vector.push((*id, V::default()));
+            vector.push((id, V::default()));
         }
 
         Self {
@@ -210,8 +211,8 @@ mod t {
 
     #[test]
     fn vec_progress_move_up() -> anyhow::Result<()> {
-        let quorum_set: Vec<u64> = vec![0, 1, 2];
-        let mut progress = VecProgress::<u64, u64, _>::new([0, 1, 2, 3, 4].iter(), quorum_set);
+        let quorum_set: Vec<u64> = vec![0, 1, 2, 3, 4];
+        let mut progress = VecProgress::<u64, u64, _>::new(quorum_set);
 
         // initial: 0-0, 1-0, 2-0, 3-0, 4-0
         let cases = vec![
@@ -243,7 +244,7 @@ mod t {
     #[test]
     fn vec_progress_update() -> anyhow::Result<()> {
         let quorum_set: Vec<u64> = vec![0, 1, 2, 3, 4];
-        let mut progress = VecProgress::<u64, u64, _>::new([0, 1, 2, 3, 4].iter(), quorum_set);
+        let mut progress = VecProgress::<u64, u64, _>::new(quorum_set);
 
         // initial: 0,0,0,0,0
         let cases = vec![


### PR DESCRIPTION

## Changelog

##### Refactor: VecProgress::new() do not need arg ids

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/406)
<!-- Reviewable:end -->
