### PR TITLE
Refactor: QuorumSet::ids() returns `Iterator` instead of `BTreeSet`.

### DIFF
--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -359,11 +359,13 @@ impl<NID: NodeId> Membership<NID> {
 
 /// Implement joint quorum set for `Membership`.
 impl<NID: NodeId> QuorumSet<NID> for Membership<NID> {
+    type Iter = std::collections::btree_set::IntoIter<NID>;
+
     fn is_quorum<'a, I: Iterator<Item = &'a NID> + Clone>(&self, ids: I) -> bool {
         self.configs.as_joint().is_quorum(ids)
     }
 
-    fn ids(&self) -> BTreeSet<NID> {
+    fn ids(&self) -> Self::Iter {
         self.configs.as_joint().ids()
     }
 }

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -69,7 +69,7 @@ where
 {
     #[allow(dead_code)]
     pub(crate) fn new(quorum_set: QS) -> Self {
-        let vector = quorum_set.ids().iter().map(|id| (*id, V::default())).collect();
+        let vector = quorum_set.ids().map(|id| (id, V::default())).collect();
 
         Self {
             quorum_set,

--- a/openraft/src/quorum/joint.rs
+++ b/openraft/src/quorum/joint.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::marker::PhantomData;
 
 use maplit::btreeset;
@@ -45,6 +44,8 @@ where
     ID: PartialOrd + Ord + 'static,
     QS: QuorumSet<ID>,
 {
+    type Iter = std::collections::btree_set::IntoIter<ID>;
+
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
         for child in self.data.iter() {
             if !child.is_quorum(ids.clone()) {
@@ -54,12 +55,12 @@ where
         true
     }
 
-    fn ids(&self) -> BTreeSet<ID> {
+    fn ids(&self) -> Self::Iter {
         let mut ids = btreeset! {};
         for child in self.data.iter() {
-            ids.append(&mut child.ids())
+            ids.extend(child.ids())
         }
-        ids
+        ids.into_iter()
     }
 }
 
@@ -69,6 +70,8 @@ where
     ID: PartialOrd + Ord + 'static,
     QS: QuorumSet<ID>,
 {
+    type Iter = std::collections::btree_set::IntoIter<ID>;
+
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
         for child in self.data.iter() {
             if !child.is_quorum(ids.clone()) {
@@ -78,11 +81,11 @@ where
         true
     }
 
-    fn ids(&self) -> BTreeSet<ID> {
+    fn ids(&self) -> Self::Iter {
         let mut ids = btreeset! {};
         for child in self.data.iter() {
-            ids.append(&mut child.ids())
+            ids.extend(child.ids())
         }
-        ids
+        ids.into_iter()
     }
 }

--- a/openraft/src/quorum/quorum_set.rs
+++ b/openraft/src/quorum/quorum_set.rs
@@ -1,13 +1,13 @@
-use std::collections::BTreeSet;
-
 /// A set of quorums is a collection of quorum.
 ///
 /// A quorum is a collection of nodes that a read or write operation in distributed system has to contact to.
 /// See: http://web.mit.edu/6.033/2005/wwwdocs/quorum_note.html
 pub(crate) trait QuorumSet<ID: 'static> {
+    type Iter: Iterator<Item = ID>;
+
     /// Check if a series of ID constitute a quorum that is defined by this quorum set.
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool;
 
     /// Returns all ids in this QuorumSet
-    fn ids(&self) -> BTreeSet<ID>;
+    fn ids(&self) -> Self::Iter;
 }

--- a/openraft/src/quorum/quorum_set_impl.rs
+++ b/openraft/src/quorum/quorum_set_impl.rs
@@ -6,6 +6,8 @@ use crate::quorum::quorum_set::QuorumSet;
 impl<ID> QuorumSet<ID> for BTreeSet<ID>
 where ID: PartialOrd + Ord + Copy + 'static
 {
+    type Iter = std::collections::btree_set::IntoIter<ID>;
+
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
         let mut count = 0;
         let limit = self.len();
@@ -20,8 +22,8 @@ where ID: PartialOrd + Ord + Copy + 'static
         false
     }
 
-    fn ids(&self) -> BTreeSet<ID> {
-        self.iter().copied().collect::<BTreeSet<_>>()
+    fn ids(&self) -> Self::Iter {
+        self.clone().into_iter()
     }
 }
 
@@ -29,6 +31,8 @@ where ID: PartialOrd + Ord + Copy + 'static
 impl<ID> QuorumSet<ID> for Vec<ID>
 where ID: PartialOrd + Ord + Copy + 'static
 {
+    type Iter = std::collections::btree_set::IntoIter<ID>;
+
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
         let mut count = 0;
         let limit = self.len();
@@ -43,8 +47,8 @@ where ID: PartialOrd + Ord + Copy + 'static
         false
     }
 
-    fn ids(&self) -> BTreeSet<ID> {
-        self.iter().copied().collect::<BTreeSet<_>>()
+    fn ids(&self) -> Self::Iter {
+        BTreeSet::from_iter(self.iter().cloned()).into_iter()
     }
 }
 
@@ -52,6 +56,8 @@ where ID: PartialOrd + Ord + Copy + 'static
 impl<ID> QuorumSet<ID> for &[ID]
 where ID: PartialOrd + Ord + Copy + 'static
 {
+    type Iter = std::collections::btree_set::IntoIter<ID>;
+
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
         let mut count = 0;
         let limit = self.len();
@@ -66,7 +72,7 @@ where ID: PartialOrd + Ord + Copy + 'static
         false
     }
 
-    fn ids(&self) -> BTreeSet<ID> {
-        self.iter().copied().collect::<BTreeSet<_>>()
+    fn ids(&self) -> Self::Iter {
+        BTreeSet::from_iter(self.iter().copied()).into_iter()
     }
 }

--- a/openraft/src/quorum/quorum_set_test.rs
+++ b/openraft/src/quorum/quorum_set_test.rs
@@ -106,24 +106,24 @@ fn test_joint_quorum_set_impl() -> anyhow::Result<()> {
 fn test_ids() -> anyhow::Result<()> {
     {
         let m12345: &[u64] = &[1, 2, 3, 4, 5];
-        assert_eq!(btreeset! {1,2,3,4,5}, m12345.ids());
+        assert_eq!(btreeset! {1,2,3,4,5}, m12345.ids().collect());
     }
 
     {
         let m12345 = vec![1, 2, 3, 4, 5];
-        assert_eq!(btreeset! {1,2,3,4,5}, m12345.ids());
+        assert_eq!(btreeset! {1,2,3,4,5}, m12345.ids().collect());
     }
 
     {
         let m12345 = btreeset! {1,2,3,4,5};
-        assert_eq!(btreeset! {1,2,3,4,5}, m12345.ids());
+        assert_eq!(btreeset! {1,2,3,4,5}, m12345.ids().collect());
     }
 
     {
         let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {4,5,6,7,8}];
         let qs = m12345_678.as_joint();
 
-        assert_eq!(btreeset! {1,2,3,4,5,6,7,8}, qs.ids());
+        assert_eq!(btreeset! {1,2,3,4,5,6,7,8}, qs.ids().collect());
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Refactor: QuorumSet::ids() returns `Iterator` instead of `BTreeSet`.

As @schreter suggested, prefer using `Iterator` to a concrete type.

The return value of `QuorumSet::ids()` now is defined by a associated
type: `QuorumSet::Iter`. In this implementation, it always uses a
`btree_set::IntoIter`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/410)
<!-- Reviewable:end -->
