### PR TITLE
Refactor: add coherent QuorumSet support

### DIFF
--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -312,40 +312,6 @@ fn test_membership_greatest_majority_value() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_membership_is_safe_to() -> anyhow::Result<()> {
-    let set123 = || btreeset! {1,2,3};
-    let set345 = || btreeset! {3,4,5};
-    let set789 = || btreeset! {7,8,9};
-
-    let m123 = Membership::<u64>::new(vec![set123()], None);
-    let m345 = Membership::<u64>::new(vec![set345()], None);
-    let m123_345 = Membership::<u64>::new(vec![set123(), set345()], None);
-    let m345_789 = Membership::<u64>::new(vec![set345(), set789()], None);
-
-    assert!(m123.is_safe_to(&m123));
-    assert!(!m123.is_safe_to(&m345));
-    assert!(m123.is_safe_to(&m123_345));
-    assert!(!m123.is_safe_to(&m345_789));
-
-    assert!(!m345.is_safe_to(&m123));
-    assert!(m345.is_safe_to(&m345));
-    assert!(m345.is_safe_to(&m123_345));
-    assert!(m345.is_safe_to(&m345_789));
-
-    assert!(m123_345.is_safe_to(&m123));
-    assert!(m123_345.is_safe_to(&m345));
-    assert!(m123_345.is_safe_to(&m123_345));
-    assert!(m123_345.is_safe_to(&m345_789));
-
-    assert!(!m345_789.is_safe_to(&m123));
-    assert!(m345_789.is_safe_to(&m345));
-    assert!(m345_789.is_safe_to(&m123_345));
-    assert!(m345_789.is_safe_to(&m345_789));
-
-    Ok(())
-}
-
-#[test]
 fn test_membership_next_safe() -> anyhow::Result<()> {
     let c1 = || btreeset! {1,2,3};
     let c2 = || btreeset! {3,4,5};

--- a/openraft/src/quorum/coherent.rs
+++ b/openraft/src/quorum/coherent.rs
@@ -1,0 +1,34 @@
+use crate::quorum::QuorumSet;
+
+/// **Coherent** quorum set A and B is defined as: `∀ qᵢ ∈ A, ∀ qⱼ ∈ B: qᵢ ∩ qⱼ != ø`, i.e., `A ~ B`.
+/// A distributed consensus protocol such as openraft is only allowed to switch membership between two **coherent**
+/// quorum sets. Being coherent is one of the two restrictions. The other restriction is to disable other
+/// smaller candidate to elect.
+pub(crate) trait Coherent<ID, Other>
+where
+    ID: PartialOrd + Ord + 'static,
+    Self: QuorumSet<ID>,
+    Other: QuorumSet<ID>,
+{
+    /// Returns if two QuorumSet are coherent.
+    fn is_coherent(&self, other: &Other) -> bool;
+}
+
+pub(crate) trait FindCoherent<ID, Other>
+where
+    ID: PartialOrd + Ord + 'static,
+    Self: QuorumSet<ID>,
+    Other: QuorumSet<ID>,
+{
+    /// Build a QuorumSet `X` so that `self` is coherent with `X` and `X` is coherent with `other`,
+    /// i.e., `self ~ X ~ other`.
+    /// Then `X` is the intermediate QuorumSet when changing membership from `self` to `other`.
+    ///
+    /// E.g.(`cᵢcⱼ` is a joint of `cᵢ` and `cⱼ`):
+    /// - `c₁.find_coherent(c₁)`   returns `c₁`
+    /// - `c₁.find_coherent(c₂)`   returns `c₁c₂`
+    /// - `c₁c₂.find_coherent(c₂)` returns `c₂`
+    /// - `c₁c₂.find_coherent(c₁)` returns `c₁`
+    /// - `c₁c2.find_coherent(c₃)` returns `c₂c₃`
+    fn find_coherent(&self, other: Other) -> Self;
+}

--- a/openraft/src/quorum/coherent_impl.rs
+++ b/openraft/src/quorum/coherent_impl.rs
@@ -1,0 +1,75 @@
+use crate::quorum::coherent::FindCoherent;
+use crate::quorum::Coherent;
+use crate::quorum::Joint;
+use crate::quorum::QuorumSet;
+
+impl<ID, QS> Coherent<ID, Joint<ID, QS, Vec<QS>>> for Joint<ID, QS, Vec<QS>>
+where
+    ID: PartialOrd + Ord + 'static,
+    QS: QuorumSet<ID> + PartialEq,
+{
+    /// Check if two `joint` are coherent.
+    ///
+    /// Read more about:
+    /// [safe-membership-change](https://datafuselabs.github.io/openraft/dynamic-membership.html#the-safe-to-relation)
+    fn is_coherent(&self, other: &Joint<ID, QS, Vec<QS>>) -> bool {
+        for a in self.children() {
+            for b in other.children() {
+                if a == b {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+impl<ID, QS> Coherent<ID, Joint<ID, QS, &[QS]>> for Joint<ID, QS, &[QS]>
+where
+    ID: PartialOrd + Ord + 'static,
+    QS: QuorumSet<ID> + PartialEq,
+{
+    fn is_coherent(&self, other: &Joint<ID, QS, &[QS]>) -> bool {
+        for a in self.children().iter() {
+            for b in other.children().iter() {
+                if a == b {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+impl<ID, QS> Coherent<ID, QS> for Joint<ID, QS, Vec<QS>>
+where
+    ID: PartialOrd + Ord + 'static,
+    QS: QuorumSet<ID> + PartialEq,
+{
+    fn is_coherent(&self, other: &QS) -> bool {
+        for a in self.children().iter() {
+            if a == other {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+/// Impl to build a intermediate quorum set that is coherent with a joint and a uniform quorum set.
+impl<ID, QS> FindCoherent<ID, QS> for Joint<ID, QS, Vec<QS>>
+where
+    ID: PartialOrd + Ord + 'static,
+    QS: QuorumSet<ID> + PartialEq + Clone,
+{
+    fn find_coherent(&self, other: QS) -> Self {
+        if self.is_coherent(&other) {
+            Joint::from(vec![other])
+        } else {
+            Joint::from(vec![self.children().last().unwrap().clone(), other])
+        }
+    }
+}

--- a/openraft/src/quorum/coherent_test.rs
+++ b/openraft/src/quorum/coherent_test.rs
@@ -1,0 +1,99 @@
+use maplit::btreeset;
+
+use crate::quorum::coherent::Coherent;
+use crate::quorum::coherent::FindCoherent;
+use crate::quorum::joint::AsJoint;
+use crate::quorum::Joint;
+
+#[test]
+fn test_is_coherent_vec() -> anyhow::Result<()> {
+    let s123 = || btreeset! {1,2,3};
+    let s345 = || btreeset! {3,4,5};
+    let s789 = || btreeset! {7,8,9};
+
+    let j123 = Joint::from(vec![s123()]);
+    let j345 = Joint::from(vec![s345()]);
+    let j123_345 = Joint::from(vec![s123(), s345()]);
+    let j345_789 = Joint::from(vec![s345(), s789()]);
+
+    assert!(j123.is_coherent(&j123));
+    assert!(!j123.is_coherent(&j345));
+    assert!(j123.is_coherent(&j123_345));
+    assert!(!j123.is_coherent(&j345_789));
+
+    assert!(!j345.is_coherent(&j123));
+    assert!(j345.is_coherent(&j345));
+    assert!(j345.is_coherent(&j123_345));
+    assert!(j345.is_coherent(&j345_789));
+
+    assert!(j123_345.is_coherent(&j123));
+    assert!(j123_345.is_coherent(&j345));
+    assert!(j123_345.is_coherent(&j123_345));
+    assert!(j123_345.is_coherent(&j345_789));
+
+    assert!(!j345_789.is_coherent(&j123));
+    assert!(j345_789.is_coherent(&j345));
+    assert!(j345_789.is_coherent(&j123_345));
+    assert!(j345_789.is_coherent(&j345_789));
+
+    Ok(())
+}
+
+#[test]
+fn test_is_coherent_slice() -> anyhow::Result<()> {
+    let s123 = || btreeset! {1,2,3};
+    let s345 = || btreeset! {3,4,5};
+    let s789 = || btreeset! {7,8,9};
+
+    let v123 = vec![s123()];
+    let v345 = vec![s345()];
+    let v123_345 = vec![s123(), s345()];
+    let v345_789 = vec![s345(), s789()];
+
+    let j123 = v123.as_joint();
+    let j345 = v345.as_joint();
+    let j123_345 = v123_345.as_joint();
+    let j345_789 = v345_789.as_joint();
+
+    assert!(j123.is_coherent(&j123));
+    assert!(!j123.is_coherent(&j345));
+    assert!(j123.is_coherent(&j123_345));
+    assert!(!j123.is_coherent(&j345_789));
+
+    assert!(!j345.is_coherent(&j123));
+    assert!(j345.is_coherent(&j345));
+    assert!(j345.is_coherent(&j123_345));
+    assert!(j345.is_coherent(&j345_789));
+
+    assert!(j123_345.is_coherent(&j123));
+    assert!(j123_345.is_coherent(&j345));
+    assert!(j123_345.is_coherent(&j123_345));
+    assert!(j123_345.is_coherent(&j345_789));
+
+    assert!(!j345_789.is_coherent(&j123));
+    assert!(j345_789.is_coherent(&j345));
+    assert!(j345_789.is_coherent(&j123_345));
+    assert!(j345_789.is_coherent(&j345_789));
+
+    Ok(())
+}
+
+#[test]
+fn test_find_coherent_joint() -> anyhow::Result<()> {
+    let s1 = || btreeset! {1,2,3};
+    let s2 = || btreeset! {3,4,5};
+    let s3 = || btreeset! {7,8,9};
+
+    let j1 = Joint::from(vec![s1()]);
+    let j2 = Joint::from(vec![s2()]);
+    let j12 = Joint::from(vec![s1(), s2()]);
+    let j23 = Joint::from(vec![s2(), s3()]);
+
+    assert_eq!(j1, j1.find_coherent(s1()));
+    assert_eq!(j12, j1.find_coherent(s2()));
+    assert_eq!(j1, j12.find_coherent(s1()));
+    assert_eq!(j2, j12.find_coherent(s2()));
+    assert_eq!(j23, j12.find_coherent(s3()));
+
+    Ok(())
+}

--- a/openraft/src/quorum/joint.rs
+++ b/openraft/src/quorum/joint.rs
@@ -19,6 +19,8 @@ where
 /// A wrapper that uses other data to define a joint quorum set.
 ///
 /// The input ids has to be a quorum in every sub-config to constitute a joint-quorum.
+#[derive(Debug)]
+#[derive(PartialEq)]
 pub(crate) struct Joint<ID, QS, D>
 where
     ID: 'static,
@@ -35,6 +37,10 @@ where
 {
     pub(crate) fn new(data: D) -> Self {
         Self { data, _p: PhantomData }
+    }
+
+    pub(crate) fn children(&self) -> &D {
+        &self.data
     }
 }
 

--- a/openraft/src/quorum/mod.rs
+++ b/openraft/src/quorum/mod.rs
@@ -2,6 +2,8 @@
 //! The most common quorum is **majority**.
 //! A quorum set is a collection of quorums, e.g. the quorum set of majority of `{a,b,c}` is `{a,b}, {b,c}, {a,c}`.
 
+mod coherent;
+mod coherent_impl;
 mod joint;
 mod joint_impl;
 mod quorum_set;
@@ -12,9 +14,12 @@ mod util;
 #[cfg(test)]
 mod bench;
 
+#[cfg(test)] mod coherent_test;
 #[cfg(test)] mod quorum_set_test;
 #[cfg(test)] mod util_test;
 
+pub(crate) use coherent::Coherent;
+pub(crate) use coherent::FindCoherent;
 pub(crate) use joint::AsJoint;
 pub(crate) use joint::Joint;
 pub(crate) use quorum_set::QuorumSet;


### PR DESCRIPTION

## Changelog

##### Refactor: add coherent QuorumSet support

**Coherent** quorum set A and B is defined as: `∀ qᵢ ∈ A, ∀ qⱼ ∈ B: qᵢ ∩ qⱼ != ø`, i.e., `A ~ B`.

- `is_coherent()` checks if two `QuorumSet`s are coherent, i.e, it is
  safe to change from one to another.

- `find_coherent()` builds an `QuorumSet` as an intermediate one to help
  changing membership between two incoherent ones.

Other changes:
- Remove unused `Membership::is_safe_to()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/411)
<!-- Reviewable:end -->
