### PR TITLE
Refactor: move impl of QuorumSet from Membership to EffectiveMembership

### DIFF
--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -48,10 +48,10 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     pub(super) async fn handle_check_is_leader_request(&mut self, tx: RaftRespTx<(), CheckIsLeaderError<C::NodeId>>) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
-        let mem = &self.core.engine.state.membership_state.effective.membership;
+        let em = &self.core.engine.state.membership_state.effective;
         let mut granted = btreeset! {self.core.id};
 
-        if mem.is_quorum(granted.iter()) {
+        if em.is_quorum(granted.iter()) {
             let _ = tx.send(Ok(()));
             return;
         }
@@ -133,7 +133,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
             granted.insert(target);
 
-            let mem = &self.core.engine.state.membership_state.effective.membership;
+            let mem = &self.core.engine.state.membership_state.effective;
             if mem.is_quorum(granted.iter()) {
                 let _ = tx.send(Ok(()));
                 return;

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -111,7 +111,7 @@ impl<NID: NodeId> Engine<NID> {
         // Safe unwrap()
         let leader = self.state.leader.as_mut().unwrap();
         leader.grant_vote_by(self.id);
-        let quorum_granted = leader.is_granted_by(&self.state.membership_state.effective.membership);
+        let quorum_granted = leader.is_granted_by(&self.state.membership_state.effective);
 
         // Fast-path: if there is only one node in the cluster.
 
@@ -209,7 +209,7 @@ impl<NID: NodeId> Engine<NID> {
         if resp.vote_granted {
             leader.grant_vote_by(target);
 
-            let quorum_granted = leader.is_granted_by(&self.state.membership_state.effective.membership);
+            let quorum_granted = leader.is_granted_by(&self.state.membership_state.effective);
             if quorum_granted {
                 tracing::debug!("quorum granted vote");
 
@@ -606,12 +606,12 @@ impl<NID: NodeId> Engine<NID> {
         entry: &Ent,
     ) {
         if let Some(m) = prev_membership {
-            if !m.membership.is_quorum(self.single_node_cluster.iter()) {
+            if !m.is_quorum(self.single_node_cluster.iter()) {
                 return;
             }
         }
 
-        if !self.state.membership_state.effective.membership.is_quorum(self.single_node_cluster.iter()) {
+        if !self.state.membership_state.effective.is_quorum(self.single_node_cluster.iter()) {
             return;
         }
 

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use crate::quorum::QuorumSet;
-use crate::Membership;
+use crate::EffectiveMembership;
 use crate::NodeId;
 
 /// Leader data.
@@ -37,7 +37,7 @@ impl<NID: NodeId> Leader<NID> {
     }
 
     /// Return if a quorum of `membership` has granted it.
-    pub(crate) fn is_granted_by(&self, membership: &Membership<NID>) -> bool {
-        membership.is_quorum(self.vote_granted_by.iter())
+    pub(crate) fn is_granted_by(&self, em: &EffectiveMembership<NID>) -> bool {
+        em.is_quorum(self.vote_granted_by.iter())
     }
 }

--- a/openraft/src/membership/bench/is_quorum.rs
+++ b/openraft/src/membership/bench/is_quorum.rs
@@ -5,11 +5,13 @@ use test::black_box;
 use test::Bencher;
 
 use crate::quorum::QuorumSet;
+use crate::EffectiveMembership;
 use crate::Membership;
 
 #[bench]
 fn m12345_ids_slice(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = [1, 2, 3, 6, 7];
 
     b.iter(|| m.is_quorum(black_box(x.iter())))
@@ -18,6 +20,7 @@ fn m12345_ids_slice(b: &mut Bencher) {
 #[bench]
 fn m12345_ids_btreeset(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = btreeset! {1, 2, 3, 6, 7};
 
     b.iter(|| m.is_quorum(black_box(x.iter())))
@@ -26,6 +29,7 @@ fn m12345_ids_btreeset(b: &mut Bencher) {
 #[bench]
 fn m12345_678_ids_slice(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = [1, 2, 3, 6, 7];
 
     b.iter(|| m.is_quorum(black_box(x.iter())))
@@ -34,6 +38,7 @@ fn m12345_678_ids_slice(b: &mut Bencher) {
 #[bench]
 fn m12345_678_ids_btreeset(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = btreeset! {1, 2, 3, 6, 7};
 
     b.iter(|| m.is_quorum(black_box(x.iter())))

--- a/openraft/src/membership/effective_membership_test.rs
+++ b/openraft/src/membership/effective_membership_test.rs
@@ -1,0 +1,34 @@
+use maplit::btreeset;
+
+use crate::quorum::QuorumSet;
+use crate::EffectiveMembership;
+use crate::Membership;
+
+#[test]
+fn test_effective_membership_majority() -> anyhow::Result<()> {
+    {
+        let m12345 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }], None);
+        let m = EffectiveMembership::new(None, m12345);
+
+        assert!(!m.is_quorum([0].iter()));
+        assert!(!m.is_quorum([0, 1, 2].iter()));
+        assert!(!m.is_quorum([6, 7, 8].iter()));
+        assert!(m.is_quorum([1, 2, 3].iter()));
+        assert!(m.is_quorum([3, 4, 5].iter()));
+        assert!(m.is_quorum([1, 3, 4, 5].iter()));
+    }
+
+    {
+        let m12345_678 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
+        let m = EffectiveMembership::new(None, m12345_678);
+
+        assert!(!m.is_quorum([0].iter()));
+        assert!(!m.is_quorum([0, 1, 2].iter()));
+        assert!(!m.is_quorum([6, 7, 8].iter()));
+        assert!(!m.is_quorum([1, 2, 3].iter()));
+        assert!(m.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(m.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+    }
+
+    Ok(())
+}

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -7,10 +7,8 @@ use maplit::btreemap;
 
 use crate::error::MissingNodeInfo;
 use crate::quorum::majority_of;
-use crate::quorum::AsJoint;
 use crate::quorum::FindCoherent;
 use crate::quorum::Joint;
-use crate::quorum::QuorumSet;
 use crate::MessageSummary;
 use crate::Node;
 use crate::NodeId;
@@ -248,11 +246,6 @@ impl<NID: NodeId> Membership<NID> {
         false
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn is_learner(&self, node_id: &NID) -> bool {
-        self.contains(node_id) && !self.is_member(node_id)
-    }
-
     /// Returns the greatest value that presents in `values` that constitutes a joint majority.
     ///
     /// E.g., for a given membership: [{1,2,3}, {4,5,6}], and a value set: {1:10, 2:20, 5:20, 6:20},
@@ -338,18 +331,5 @@ impl<NID: NodeId> Membership<NID> {
             members.extend(config)
         }
         members
-    }
-}
-
-/// Implement joint quorum set for `Membership`.
-impl<NID: NodeId> QuorumSet<NID> for Membership<NID> {
-    type Iter = std::collections::btree_set::IntoIter<NID>;
-
-    fn is_quorum<'a, I: Iterator<Item = &'a NID> + Clone>(&self, ids: I) -> bool {
-        self.configs.as_joint().is_quorum(ids)
-    }
-
-    fn ids(&self) -> Self::Iter {
-        self.configs.as_joint().ids()
     }
 }

--- a/openraft/src/membership/membership_state.rs
+++ b/openraft/src/membership/membership_state.rs
@@ -27,7 +27,6 @@ use crate::NodeId;
 // Thus a raft node will only need to store at most two recent membership logs.
 #[derive(Debug, Clone, Default)]
 #[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct MembershipState<NID: NodeId> {
     pub committed: Arc<EffectiveMembership<NID>>,
 

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -4,7 +4,6 @@ use maplit::btreemap;
 use maplit::btreeset;
 
 use crate::error::MissingNodeInfo;
-use crate::quorum::QuorumSet;
 use crate::testing::DummyConfig as Config;
 use crate::Membership;
 use crate::MessageSummary;
@@ -80,12 +79,9 @@ fn test_membership_with_learners() -> anyhow::Result<()> {
         // test learner and membership
         assert_eq!(btreeset! {1}, m1_2.build_member_ids());
         assert_eq!(btreeset! {2}, m1_2.learner_ids().cloned().collect());
-        assert!(m1_2.is_learner(&2));
 
         assert_eq!(btreeset! {1}, m1_23.build_member_ids());
         assert_eq!(btreeset! {2,3}, m1_23.learner_ids().cloned().collect());
-        assert!(m1_23.is_learner(&2));
-        assert!(m1_23.is_learner(&3));
 
         // Adding a member as learner has no effect:
 
@@ -241,33 +237,6 @@ fn test_membership_with_nodes() -> anyhow::Result<()> {
         }),
         res
     );
-
-    Ok(())
-}
-
-#[test]
-fn test_membership_majority() -> anyhow::Result<()> {
-    {
-        let m12345 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }], None);
-
-        assert!(!m12345.is_quorum([0].iter()));
-        assert!(!m12345.is_quorum([0, 1, 2].iter()));
-        assert!(!m12345.is_quorum([6, 7, 8].iter()));
-        assert!(m12345.is_quorum([1, 2, 3].iter()));
-        assert!(m12345.is_quorum([3, 4, 5].iter()));
-        assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
-    }
-
-    {
-        let m12345_678 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
-
-        assert!(!m12345_678.is_quorum([0].iter()));
-        assert!(!m12345_678.is_quorum([0, 1, 2].iter()));
-        assert!(!m12345_678.is_quorum([6, 7, 8].iter()));
-        assert!(!m12345_678.is_quorum([1, 2, 3].iter()));
-        assert!(m12345_678.is_quorum([1, 2, 3, 6, 7].iter()));
-        assert!(m12345_678.is_quorum([1, 2, 3, 4, 7, 8].iter()));
-    }
 
     Ok(())
 }

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -6,6 +6,7 @@ mod membership_state;
 #[cfg(test)]
 mod bench;
 
+#[cfg(test)] mod effective_membership_test;
 #[cfg(test)] mod membership_state_test;
 #[cfg(test)] mod membership_test;
 

--- a/openraft/src/quorum/joint.rs
+++ b/openraft/src/quorum/joint.rs
@@ -19,8 +19,8 @@ where
 /// A wrapper that uses other data to define a joint quorum set.
 ///
 /// The input ids has to be a quorum in every sub-config to constitute a joint-quorum.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Clone, Debug, Default)]
+#[derive(PartialEq, Eq)]
 pub(crate) struct Joint<ID, QS, D>
 where
     ID: 'static,


### PR DESCRIPTION

## Changelog

##### Refactor: move impl of QuorumSet from Membership to EffectiveMembership

Add a field `EffectiveMembership.node_id_quorum_set`, to store a
`QuorumSet` built from the `Membership` config. This quorum set can have
a different structure from the `Membership`, to optimized quorum check.

Other changes:

- Remove unused Membership::is_learner()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/412)
<!-- Reviewable:end -->
