### PR TITLE
Change: API: cleanup APIs in Membership and EffectiveMembership

### DIFF
--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -48,10 +48,10 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     pub(super) async fn handle_check_is_leader_request(&mut self, tx: RaftRespTx<(), CheckIsLeaderError<C::NodeId>>) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
-        let mem = &self.core.engine.state.membership_state.effective.membership;
+        let em = &self.core.engine.state.membership_state.effective;
         let mut granted = btreeset! {self.core.id};
 
-        if mem.is_quorum(granted.iter()) {
+        if em.is_quorum(granted.iter()) {
             let _ = tx.send(Ok(()));
             return;
         }
@@ -61,7 +61,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         let membership = &self.core.engine.state.membership_state.effective.membership;
 
         for (target, node) in self.nodes.iter() {
-            if !membership.is_member(target) {
+            if !membership.is_voter(target) {
                 continue;
             }
 
@@ -133,7 +133,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
             granted.insert(target);
 
-            let mem = &self.core.engine.state.membership_state.effective.membership;
+            let mem = &self.core.engine.state.membership_state.effective;
             if mem.is_quorum(granted.iter()) {
                 let _ = tx.send(Ok(()));
                 return;

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use crate::quorum::QuorumSet;
-use crate::Membership;
+use crate::EffectiveMembership;
 use crate::NodeId;
 
 /// Leader data.
@@ -37,7 +37,7 @@ impl<NID: NodeId> Leader<NID> {
     }
 
     /// Return if a quorum of `membership` has granted it.
-    pub(crate) fn is_granted_by(&self, membership: &Membership<NID>) -> bool {
-        membership.is_quorum(self.vote_granted_by.iter())
+    pub(crate) fn is_granted_by(&self, em: &EffectiveMembership<NID>) -> bool {
+        em.is_quorum(self.vote_granted_by.iter())
     }
 }

--- a/openraft/src/membership/bench/is_quorum.rs
+++ b/openraft/src/membership/bench/is_quorum.rs
@@ -5,11 +5,13 @@ use test::black_box;
 use test::Bencher;
 
 use crate::quorum::QuorumSet;
+use crate::EffectiveMembership;
 use crate::Membership;
 
 #[bench]
 fn m12345_ids_slice(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = [1, 2, 3, 6, 7];
 
     b.iter(|| m.is_quorum(black_box(x.iter())))
@@ -18,6 +20,7 @@ fn m12345_ids_slice(b: &mut Bencher) {
 #[bench]
 fn m12345_ids_btreeset(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = btreeset! {1, 2, 3, 6, 7};
 
     b.iter(|| m.is_quorum(black_box(x.iter())))
@@ -26,6 +29,7 @@ fn m12345_ids_btreeset(b: &mut Bencher) {
 #[bench]
 fn m12345_678_ids_slice(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = [1, 2, 3, 6, 7];
 
     b.iter(|| m.is_quorum(black_box(x.iter())))
@@ -34,6 +38,7 @@ fn m12345_678_ids_slice(b: &mut Bencher) {
 #[bench]
 fn m12345_678_ids_btreeset(b: &mut Bencher) {
     let m = Membership::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = EffectiveMembership::new(None, m);
     let x = btreeset! {1, 2, 3, 6, 7};
 
     b.iter(|| m.is_quorum(black_box(x.iter())))

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -1,8 +1,10 @@
-use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 
 use crate::entry::RaftEntry;
+use crate::membership::NodeRole;
+use crate::quorum::Joint;
+use crate::quorum::QuorumSet;
 use crate::raft_types::RaftLogId;
 use crate::LogId;
 use crate::Membership;
@@ -25,8 +27,13 @@ pub struct EffectiveMembership<NID: NodeId> {
 
     pub membership: Membership<NID>,
 
+    /// The quorum set built from `membership`.
+    // #[serde(skip_serialize)]
+    // #[serde(deserialize_wit="")]
+    quorum_set: Joint<NID, Vec<NID>, Vec<Vec<NID>>>,
+
     /// Cache of union of all members
-    all_members: BTreeSet<NID>,
+    voter_ids: BTreeSet<NID>,
 }
 
 impl<NID: NodeId> Debug for EffectiveMembership<NID> {
@@ -34,14 +41,14 @@ impl<NID: NodeId> Debug for EffectiveMembership<NID> {
         f.debug_struct("EffectiveMembership")
             .field("log_id", &self.log_id)
             .field("membership", &self.membership)
-            .field("all_members", &self.all_members)
+            .field("all_members", &self.voter_ids)
             .finish()
     }
 }
 
 impl<NID: NodeId> PartialEq for EffectiveMembership<NID> {
     fn eq(&self, other: &Self) -> bool {
-        self.log_id == other.log_id && self.membership == other.membership && self.all_members == other.all_members
+        self.log_id == other.log_id && self.membership == other.membership && self.voter_ids == other.voter_ids
     }
 }
 
@@ -60,50 +67,93 @@ impl<NID: NodeId, Ent: RaftEntry<NID>> From<&Ent> for EffectiveMembership<NID> {
 
 impl<NID: NodeId> EffectiveMembership<NID> {
     pub fn new(log_id: Option<LogId<NID>>, membership: Membership<NID>) -> Self {
-        let all_members = membership.build_member_ids();
+        let voter_ids = membership.voter_ids().collect();
+
+        let configs = membership.get_joint_config();
+        let mut joint = vec![];
+        for c in configs {
+            joint.push(c.iter().copied().collect::<Vec<_>>());
+        }
+
+        let quorum_set = Joint::from(joint);
+
         Self {
             log_id,
             membership,
-            all_members,
+            quorum_set,
+            voter_ids,
+        }
+    }
+}
+
+/// Membership API
+impl<NID: NodeId> EffectiveMembership<NID> {
+    /// Return if a node is a voter or learner, or not in this membership config at all.
+    pub(crate) fn get_node_role(&self, nid: &NID) -> Option<NodeRole> {
+        if self.voter_ids.contains(nid) {
+            Some(NodeRole::Voter)
+        } else if self.contains(nid) {
+            Some(NodeRole::Learner)
+        } else {
+            None
         }
     }
 
-    pub(crate) fn is_single(&self) -> bool {
-        // an empty membership contains no nodes.
-        self.all_members().len() <= 1
+    #[allow(dead_code)]
+    pub(crate) fn is_voter(&self, nid: &NID) -> bool {
+        self.membership.is_voter(nid)
     }
 
-    pub(crate) fn all_members(&self) -> &BTreeSet<NID> {
-        &self.all_members
+    /// Returns an Iterator of all voter node ids. Learners are not included.
+    pub fn voter_ids(&self) -> impl Iterator<Item = NID> + '_ {
+        self.voter_ids.iter().copied()
     }
 
-    /// Node id of all nodes(members and learners) in this config.
-    pub(crate) fn node_ids(&self) -> impl Iterator<Item = &NID> {
-        self.membership.node_ids()
+    /// Returns an Iterator of all learner node ids. Voters are not included.
+    #[allow(dead_code)]
+    pub(crate) fn learner_ids(&self) -> impl Iterator<Item = NID> + '_ {
+        self.membership.learner_ids()
     }
 
-    /// Returns reference to all configs.
-    ///
-    /// Membership is defined by a joint of multiple configs.
-    /// Each config is a set of node-id.
-    /// This method returns a immutable reference to the vec of node-id sets, without node infos.
-    pub fn get_configs(&self) -> &Vec<BTreeSet<NID>> {
-        self.membership.get_configs()
+    /// Returns if a voter or learner exists in this membership.
+    pub(crate) fn contains(&self, id: &NID) -> bool {
+        self.membership.contains(id)
     }
 
-    /// Get a the node info by node id.
+    /// Get a the node(either voter or learner) by node id.
     pub fn get_node(&self, node_id: &NID) -> Option<&Node> {
         self.membership.get_node(node_id)
     }
 
-    /// Get all node infos.
-    pub fn get_nodes(&self) -> &BTreeMap<NID, Option<Node>> {
-        self.membership.get_nodes()
+    /// Returns an Iterator of all nodes(voters and learners).
+    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &Option<Node>)> {
+        self.membership.nodes()
+    }
+
+    /// Returns reference to the joint config.
+    ///
+    /// Membership is defined by a joint of multiple configs.
+    /// Each config is a vec of node-id.
+    pub fn get_joint_config(&self) -> &Vec<Vec<NID>> {
+        self.quorum_set.children()
     }
 }
 
 impl<NID: NodeId> MessageSummary<EffectiveMembership<NID>> for EffectiveMembership<NID> {
     fn summary(&self) -> String {
         format!("{{log_id:{:?} membership:{}}}", self.log_id, self.membership.summary())
+    }
+}
+
+/// Implement node-id joint quorum set.
+impl<NID: NodeId> QuorumSet<NID> for EffectiveMembership<NID> {
+    type Iter = std::collections::btree_set::IntoIter<NID>;
+
+    fn is_quorum<'a, I: Iterator<Item = &'a NID> + Clone>(&self, ids: I) -> bool {
+        self.quorum_set.is_quorum(ids)
+    }
+
+    fn ids(&self) -> Self::Iter {
+        self.quorum_set.ids()
     }
 }

--- a/openraft/src/membership/effective_membership_test.rs
+++ b/openraft/src/membership/effective_membership_test.rs
@@ -1,0 +1,34 @@
+use maplit::btreeset;
+
+use crate::quorum::QuorumSet;
+use crate::EffectiveMembership;
+use crate::Membership;
+
+#[test]
+fn test_effective_membership_majority() -> anyhow::Result<()> {
+    {
+        let m12345 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }], None);
+        let m = EffectiveMembership::new(None, m12345);
+
+        assert!(!m.is_quorum([0].iter()));
+        assert!(!m.is_quorum([0, 1, 2].iter()));
+        assert!(!m.is_quorum([6, 7, 8].iter()));
+        assert!(m.is_quorum([1, 2, 3].iter()));
+        assert!(m.is_quorum([3, 4, 5].iter()));
+        assert!(m.is_quorum([1, 3, 4, 5].iter()));
+    }
+
+    {
+        let m12345_678 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
+        let m = EffectiveMembership::new(None, m12345_678);
+
+        assert!(!m.is_quorum([0].iter()));
+        assert!(!m.is_quorum([0, 1, 2].iter()));
+        assert!(!m.is_quorum([6, 7, 8].iter()));
+        assert!(!m.is_quorum([1, 2, 3].iter()));
+        assert!(m.is_quorum([1, 2, 3, 6, 7].iter()));
+        assert!(m.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+    }
+
+    Ok(())
+}

--- a/openraft/src/membership/membership_state.rs
+++ b/openraft/src/membership/membership_state.rs
@@ -27,7 +27,6 @@ use crate::NodeId;
 // Thus a raft node will only need to store at most two recent membership logs.
 #[derive(Debug, Clone, Default)]
 #[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct MembershipState<NID: NodeId> {
     pub committed: Arc<EffectiveMembership<NID>>,
 
@@ -37,6 +36,6 @@ pub struct MembershipState<NID: NodeId> {
 
 impl<NID: NodeId> MembershipState<NID> {
     pub(crate) fn is_member(&self, id: &NID) -> bool {
-        self.effective.membership.is_member(id)
+        self.effective.membership.is_voter(id)
     }
 }

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -1,11 +1,13 @@
 mod effective_membership;
 #[allow(clippy::module_inception)] mod membership;
 mod membership_state;
+mod node_type;
 
 #[cfg(feature = "bench")]
 #[cfg(test)]
 mod bench;
 
+#[cfg(test)] mod effective_membership_test;
 #[cfg(test)] mod membership_state_test;
 #[cfg(test)] mod membership_test;
 
@@ -13,3 +15,4 @@ pub use effective_membership::EffectiveMembership;
 pub use membership::IntoOptionNodes;
 pub use membership::Membership;
 pub use membership_state::MembershipState;
+pub(crate) use node_type::NodeRole;

--- a/openraft/src/membership/node_type.rs
+++ b/openraft/src/membership/node_type.rs
@@ -1,0 +1,6 @@
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) enum NodeRole {
+    Voter,
+    Learner,
+}

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -100,30 +100,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
         assert_eq!(
             btreeset![1, 2],
-            got.membership_config.membership.get_configs().get(0).unwrap().clone()
-        );
-    }
-
-    {
-        // wait for next_members
-        let (init, w, tx) = init_wait_test::<Config>();
-
-        let h = tokio::spawn(async move {
-            sleep(Duration::from_millis(10)).await;
-            let mut update = init.clone();
-            update.membership_config = Arc::new(EffectiveMembership::new(
-                None,
-                Membership::new(vec![btreeset! {}, btreeset! {1,2}], None),
-            ));
-            let rst = tx.send(update);
-            assert!(rst.is_ok());
-        });
-        let got = w.next_members(Some(btreeset![1, 2]), "next_members").await?;
-        h.await?;
-
-        assert_eq!(
-            Some(btreeset![1, 2]),
-            got.membership_config.membership.get_configs().get(1).cloned()
+            got.membership_config.membership.get_joint_config().get(0).unwrap().clone()
         );
     }
 

--- a/openraft/src/quorum/joint.rs
+++ b/openraft/src/quorum/joint.rs
@@ -19,8 +19,9 @@ where
 /// A wrapper that uses other data to define a joint quorum set.
 ///
 /// The input ids has to be a quorum in every sub-config to constitute a joint-quorum.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Clone, Debug, Default)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct Joint<ID, QS, D>
 where
     ID: 'static,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -15,7 +15,6 @@ use tokio::time::interval;
 use tokio::time::timeout;
 use tokio::time::Duration;
 use tokio::time::Interval;
-use tracing::Instrument;
 use tracing::Span;
 
 use crate::config::Config;
@@ -185,12 +184,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
             need_to_replicate: true,
         };
 
-        let handle = tokio::spawn(this.main().instrument(tracing::trace_span!("repl-stream").or_current()));
+        let handle = tokio::spawn(this.main());
 
         ReplicationStream { handle, repl_tx }
     }
 
-    #[tracing::instrument(level="trace", skip(self), fields(vote=%self.vote, target=display(self.target), cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="debug", skip(self), fields(vote=%self.vote, target=display(self.target), cluster=%self.config.cluster_name))]
     async fn main(mut self) {
         loop {
             // If it returns Ok(), always go back to LineRate state.

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -470,10 +470,7 @@ where
         for i in node_ids.iter() {
             let wait = self.wait(i, timeout);
             wait.metrics(
-                |x| {
-                    x.membership_config.get_configs().len() == 1
-                        && x.membership_config.get_configs()[0].clone() == members
-                },
+                |x| x.membership_config.voter_ids().collect::<BTreeSet<C::NodeId>>() == members,
                 msg,
             )
             .await?;
@@ -694,8 +691,8 @@ where
                 node.id, node.last_log_index
             );
 
-            let configs = node.membership_config.get_configs();
-            assert_eq!(0, configs.len(), "expected empty configs, got: {:?}", configs);
+            let nodes_count = node.membership_config.nodes().count();
+            assert_eq!(0, nodes_count, "expected empty configs, got: {:?}", nodes_count);
 
             assert!(
                 !node.membership_config.membership.is_in_joint_consensus(),
@@ -777,9 +774,7 @@ where
                 "node {} has last_log_index {:?}, expected {:?}",
                 node.id, node.last_log_index, expected_last_log
             );
-            let members = node.membership_config.get_configs()[0].clone();
-            let mut members = members.into_iter().collect::<Vec<_>>();
-            members.sort_unstable();
+            let members = node.membership_config.voter_ids().collect::<Vec<_>>();
             assert_eq!(
                 members, all_nodes,
                 "node {} has membership {:?}, expected {:?}",

--- a/openraft/tests/life_cycle/t20_initialization.rs
+++ b/openraft/tests/life_cycle/t20_initialization.rs
@@ -111,7 +111,7 @@ async fn initialization() -> anyhow::Result<()> {
                 panic!("expect Membership payload")
             }
         };
-        assert_eq!(btreeset![0, 1, 2], mem.get_configs()[0].clone());
+        assert_eq!(btreeset![0, 1, 2], mem.get_joint_config()[0].clone());
 
         let sm_mem = sto.last_applied_state().await?.1;
         assert_eq!(

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -73,7 +73,7 @@ async fn add_learner_basic() -> Result<()> {
         router.wait_for_log(&btreeset! {0,1}, Some(log_index), timeout(), "replication to learner").await?;
     }
 
-    tracing::info!("--- re-add node-1, expect error");
+    tracing::info!("--- re-add node-1, nothing changes");
     {
         let res = router.add_learner(0, 1).await?;
         assert_eq!(

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -99,7 +99,7 @@ async fn step_down() -> Result<()> {
         assert_eq!(metrics.current_term, 1);
         assert_eq!(metrics.last_log_index, Some(8));
         assert_eq!(metrics.last_applied, Some(LogId::new(LeaderId::new(1, 0), 8)));
-        assert_eq!(metrics.membership_config.get_configs().clone(), vec![btreeset![
+        assert_eq!(metrics.membership_config.get_joint_config().clone(), vec![vec![
             1, 2, 3
         ]]);
         assert!(!cfg.is_in_joint_consensus());


### PR DESCRIPTION

## Changelog

##### Change: API: cleanup APIs in Membership and EffectiveMembership

- Refactor: move impl of `QuorumSet` from `Membership` to `EffectiveMembership`.

  Add a field `EffectiveMembership.quorum_set`, to store a
  `QuorumSet` built from the `Membership` config. This quorum set can have
  a different structure from the `Membership`, to optimized quorum check.

- Refactor: impl methods in `Membership` or `EffectiveMembership` with
  Iterator if possible.

- Refactor: use term `voter` and `learner` for methods and fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/413)
<!-- Reviewable:end -->
