### PR TITLE
Refactor: reduce test time

### DIFF
--- a/openraft/tests/client_api/t10_client_writes.rs
+++ b/openraft/tests/client_api/t10_client_writes.rs
@@ -24,7 +24,7 @@ async fn client_writes() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(
         Config {
-            snapshot_policy: SnapshotPolicy::LogsSinceLast(2000),
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(500),
             // The write load is heavy in this test, need a relatively long timeout.
             election_timeout_min: 500,
             election_timeout_max: 1000,
@@ -58,15 +58,15 @@ async fn client_writes() -> Result<()> {
     // Write a bunch of data and assert that the cluster stayes stable.
     let leader = router.leader().expect("leader not found");
     let mut clients = futures::stream::FuturesUnordered::new();
-    clients.push(router.client_request_many(leader, "0", 500));
-    clients.push(router.client_request_many(leader, "1", 500));
-    clients.push(router.client_request_many(leader, "2", 500));
-    clients.push(router.client_request_many(leader, "3", 500));
-    clients.push(router.client_request_many(leader, "4", 500));
-    clients.push(router.client_request_many(leader, "5", 500));
+    clients.push(router.client_request_many(leader, "0", 100));
+    clients.push(router.client_request_many(leader, "1", 100));
+    clients.push(router.client_request_many(leader, "2", 100));
+    clients.push(router.client_request_many(leader, "3", 100));
+    clients.push(router.client_request_many(leader, "4", 100));
+    clients.push(router.client_request_many(leader, "5", 100));
     while clients.next().await.is_some() {}
 
-    log_index += 500 * 6;
+    log_index += 100 * 6;
     router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "sync logs").await?;
 
     router.assert_stable_cluster(Some(1), Some(log_index)); // The extra 1 is from the leader's initial commit entry.
@@ -77,7 +77,7 @@ async fn client_writes() -> Result<()> {
             log_index,
             Some(0),
             LogId::new(LeaderId::new(1, 0), log_index),
-            Some(((1999..2100).into(), 1)),
+            Some(((499..600).into(), 1)),
         )
         .await?;
 

--- a/openraft/tests/state_machine/t10_total_order_apply.rs
+++ b/openraft/tests/state_machine/t10_total_order_apply.rs
@@ -14,6 +14,7 @@ use crate::fixtures::RaftRouter;
 
 /// The logs have to be applied in log index order.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+#[ignore]
 async fn total_order_apply() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(Config::default().validate().expect("failed to build Raft config"));


### PR DESCRIPTION

## Changelog

##### Refactor: reduce test time

- Ignore test `total_order_apply`.

- Reduce the number of put for `client_write`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/416)
<!-- Reviewable:end -->
