### PR TITLE
Change: remove `tx` from `spawn_replication_stream()`

### DIFF
--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -81,7 +81,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         };
 
         for target in targets {
-            let state = self.spawn_replication_stream(target, None).await;
+            let state = self.spawn_replication_stream(target).await;
             self.nodes.insert(target, state);
         }
 
@@ -148,8 +148,8 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             RaftMsg::ClientWriteRequest { rpc, tx } => {
                 self.write_entry(rpc.payload, Some(tx)).await?;
             }
-            RaftMsg::AddLearner { id, node, tx, blocking } => {
-                self.add_learner(id, node, tx, blocking).await;
+            RaftMsg::AddLearner { id, node, tx } => {
+                self.add_learner(id, node, tx).await?;
             }
             RaftMsg::ChangeMembership {
                 changes,

--- a/openraft/src/core/replication_state.rs
+++ b/openraft/src/core/replication_state.rs
@@ -2,9 +2,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 
 use crate::config::Config;
-use crate::error::AddLearnerError;
-use crate::raft::AddLearnerResponse;
-use crate::raft::RaftRespTx;
 use crate::raft_types::LogIdOptionExt;
 use crate::replication::ReplicationStream;
 use crate::LogId;
@@ -23,10 +20,6 @@ pub(crate) struct ReplicationState<NID: NodeId> {
     ///
     /// It will be reset once a successful replication is done.
     pub failures: u64,
-
-    /// The response channel to use for when this node has successfully synced with the cluster.
-    #[allow(clippy::type_complexity)]
-    pub tx: Option<RaftRespTx<AddLearnerResponse<NID>, AddLearnerError<NID>>>,
 }
 
 impl<NID: NodeId> MessageSummary<ReplicationState<NID>> for ReplicationState<NID> {

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::raft::AddLearnerResponse;
 use openraft::Config;
 use openraft::LeaderId;
 use openraft::LogId;
@@ -37,12 +36,7 @@ async fn add_learner_basic() -> Result<()> {
     tracing::info!("--- re-adding leader does nothing");
     {
         let res = router.add_learner(0, 0).await?;
-        assert_eq!(
-            AddLearnerResponse {
-                matched: Some(LogId::new(LeaderId::new(1, 0), log_index))
-            },
-            res
-        );
+        assert_eq!(Some(LogId::new(LeaderId::new(1, 0), log_index)), res.matched);
     }
 
     tracing::info!("--- add new node node-1");
@@ -78,12 +72,7 @@ async fn add_learner_basic() -> Result<()> {
     tracing::info!("--- re-add node-1, nothing changes");
     {
         let res = router.add_learner(0, 1).await?;
-        assert_eq!(
-            AddLearnerResponse {
-                matched: Some(LogId::new(LeaderId::new(1, 0), log_index))
-            },
-            res
-        );
+        assert_eq!(Some(LogId::new(LeaderId::new(1, 0), log_index)), res.matched);
     }
 
     Ok(())
@@ -120,7 +109,7 @@ async fn add_learner_non_blocking() -> Result<()> {
         let raft = router.get_raft_handle(&0)?;
         let res = raft.add_learner(1, None, false).await?;
 
-        assert_eq!(AddLearnerResponse { matched: None }, res);
+        assert_eq!(None, res.matched);
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Change: remove `tx` from `spawn_replication_stream()`

Replication should not be responsible invoke the callback when
replication become upto date. It makes the logic dirty.
Such a job can be done by watching the metrics change.

- Change: API: AddLearnerResponse has a new field `membership_log_id`
  which is the log id of the membership log that contains the newly
  added learner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/419)
<!-- Reviewable:end -->
