### PR TITLE
Change: remove error `AddLearnerError::Exists`

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -136,9 +136,6 @@ pub enum AddLearnerError<NID: NodeId> {
     #[error(transparent)]
     ForwardToLeader(#[from] ForwardToLeader<NID>),
 
-    #[error("node {0} is already a learner")]
-    Exists(NID),
-
     #[error(transparent)]
     MissingNodeInfo(#[from] MissingNodeInfo<NID>),
 


### PR DESCRIPTION

## Changelog

##### Change: remove error `AddLearnerError::Exists`

Even when the learner to add already exists, the caller may still want
to block until the replication catches up. Thus it does not expect an
error.

And `Exists` is not an issue the caller has to deal with, it does not
have to be an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/420)
<!-- Reviewable:end -->
