### PR TITLE
Refactor: move `load_log_ids()` from `RaftState` to `LogIdList`

### DIFF
--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -2,6 +2,9 @@ use crate::raft_types::RaftLogId;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::NodeId;
+use crate::RaftStorage;
+use crate::RaftTypeConfig;
+use crate::StorageError;
 
 /// Efficient storage for log ids.
 ///
@@ -14,6 +17,103 @@ use crate::NodeId;
 #[derive(PartialEq, Eq)]
 pub struct LogIdList<NID: NodeId> {
     key_log_ids: Vec<LogId<NID>>,
+}
+
+impl<NID: NodeId> LogIdList<NID> {
+    /// Load all log ids that are the first one proposed by a leader.
+    ///
+    /// E.g., log ids with the same leader id will be got rid of, except the smallest.
+    /// The `last_log_id` will always present at the end, to simplify searching.
+    ///
+    /// Given an example with the logs `[(2,2),(2,3),(5,4),(5,5)]`, and the `last_purged_log_id` is (1,1).
+    /// This function returns `[(1,1),(2,2),(5,4),(5,5)]`.
+    ///
+    /// It adopts a modified binary-search algo.
+    /// ```text
+    /// input:
+    /// A---------------C
+    ///
+    /// load the mid log-id, then compare the first, the middle, and the last:
+    ///
+    /// A---------------A : push_res(A);
+    /// A-------A-------C : push_res(A); find(A,C) // both find `A`, need to de-dup
+    /// A-------B-------C : find(A,B); find(B,C)   // both find `B`, need to de-dup
+    /// A-------C-------C : find(A,C)
+    /// ```
+    pub async fn load_log_ids<C, Sto>(
+        last_purged_log_id: Option<LogId<NID>>,
+        last_log_id: Option<LogId<NID>>,
+        sto: &mut Sto,
+    ) -> Result<LogIdList<NID>, StorageError<NID>>
+    where
+        C: RaftTypeConfig<NodeId = NID>,
+        Sto: RaftStorage<C> + ?Sized,
+    {
+        let mut res = vec![];
+
+        let last = match last_log_id {
+            None => return Ok(LogIdList::new(res)),
+            Some(x) => x,
+        };
+        let first = match last_purged_log_id {
+            None => sto.get_log_id(0).await?,
+            Some(x) => x,
+        };
+
+        // Recursion stack
+        let mut stack = vec![(first, last)];
+
+        loop {
+            let (first, last) = match stack.pop() {
+                None => {
+                    break;
+                }
+                Some(x) => x,
+            };
+
+            // Case AA
+            if first.leader_id == last.leader_id {
+                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
+                    res.push(first);
+                }
+                continue;
+            }
+
+            // Two adjacent logs with different leader_id, no need to binary search
+            if first.index + 1 == last.index {
+                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
+                    res.push(first);
+                }
+                res.push(last);
+                continue;
+            }
+
+            let mid = sto.get_log_id((first.index + last.index) / 2).await?;
+
+            if first.leader_id == mid.leader_id {
+                // Case AAC
+                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
+                    res.push(first);
+                }
+                stack.push((mid, last));
+            } else if mid.leader_id == last.leader_id {
+                // Case ACC
+                stack.push((first, mid));
+            } else {
+                // Case ABC
+                // first.leader_id < mid_log_id.leader_id < last.leader_id
+                // Deal with (first, mid) then (mid, last)
+                stack.push((mid, last));
+                stack.push((first, mid));
+            }
+        }
+
+        if res.last() != Some(&last) {
+            res.push(last);
+        }
+
+        Ok(LogIdList::new(res))
+    }
 }
 
 impl<NID: NodeId> LogIdList<NID> {

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -5,10 +5,7 @@ use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::MembershipState;
 use crate::NodeId;
-use crate::RaftStorage;
-use crate::RaftTypeConfig;
 use crate::ServerState;
-use crate::StorageError;
 use crate::Vote;
 
 /// A struct used to represent the raft state which a Raft node needs.
@@ -56,101 +53,6 @@ pub struct RaftState<NID: NodeId> {
 }
 
 impl<NID: NodeId> RaftState<NID> {
-    /// Load all log ids that are the first one proposed by a leader.
-    ///
-    /// E.g., log ids with the same leader id will be got rid of, except the smallest.
-    /// The `last_log_id` will always present at the end, to simplify searching.
-    ///
-    /// Given an example with the logs `[(2,2),(2,3),(5,4),(5,5)]`, and the `last_purged_log_id` is (1,1).
-    /// This function returns `[(1,1),(2,2),(5,4),(5,5)]`.
-    ///
-    /// It adopts a modified binary-search algo.
-    /// ```text
-    /// input:
-    /// A---------------C
-    ///
-    /// load the mid log-id, then compare the first, the middle, and the last:
-    ///
-    /// A---------------A : push_res(A);
-    /// A-------A-------C : push_res(A); find(A,C) // both find `A`, need to de-dup
-    /// A-------B-------C : find(A,B); find(B,C)   // both find `B`, need to de-dup
-    /// A-------C-------C : find(A,C)
-    /// ```
-    pub async fn load_log_ids<C, Sto>(
-        last_purged_log_id: Option<LogId<NID>>,
-        last_log_id: Option<LogId<NID>>,
-        sto: &mut Sto,
-    ) -> Result<LogIdList<NID>, StorageError<NID>>
-    where
-        C: RaftTypeConfig<NodeId = NID>,
-        Sto: RaftStorage<C> + ?Sized,
-    {
-        let mut res = vec![];
-
-        let last = match last_log_id {
-            None => return Ok(LogIdList::new(res)),
-            Some(x) => x,
-        };
-        let first = match last_purged_log_id {
-            None => sto.get_log_id(0).await?,
-            Some(x) => x,
-        };
-
-        // Recursion stack
-        let mut stack = vec![(first, last)];
-
-        loop {
-            let (first, last) = match stack.pop() {
-                None => {
-                    break;
-                }
-                Some(x) => x,
-            };
-
-            // Case AA
-            if first.leader_id == last.leader_id {
-                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
-                    res.push(first);
-                }
-                continue;
-            }
-
-            // Two adjacent logs with different leader_id, no need to binary search
-            if first.index + 1 == last.index {
-                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
-                    res.push(first);
-                }
-                res.push(last);
-                continue;
-            }
-
-            let mid = sto.get_log_id((first.index + last.index) / 2).await?;
-
-            if first.leader_id == mid.leader_id {
-                // Case AAC
-                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
-                    res.push(first);
-                }
-                stack.push((mid, last));
-            } else if mid.leader_id == last.leader_id {
-                // Case ACC
-                stack.push((first, mid));
-            } else {
-                // Case ABC
-                // first.leader_id < mid_log_id.leader_id < last.leader_id
-                // Deal with (first, mid) then (mid, last)
-                stack.push((mid, last));
-                stack.push((first, mid));
-            }
-        }
-
-        if res.last() != Some(&last) {
-            res.push(last);
-        }
-
-        Ok(LogIdList::new(res))
-    }
-
     /// Append a list of `log_id`.
     ///
     /// The log ids in the input has to be continuous.

--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -10,6 +10,7 @@ use tokio::io::AsyncSeek;
 use tokio::io::AsyncWrite;
 
 use crate::defensive::check_range_matches_entries;
+use crate::engine::LogIdList;
 use crate::membership::EffectiveMembership;
 use crate::raft_state::RaftState;
 use crate::raft_types::SnapshotId;
@@ -285,7 +286,7 @@ where C: RaftTypeConfig
             last_purged_log_id = last_applied;
         }
 
-        let log_ids = RaftState::load_log_ids(last_purged_log_id, last_log_id, self).await?;
+        let log_ids = LogIdList::load_log_ids(last_purged_log_id, last_log_id, self).await?;
 
         Ok(RaftState {
             last_applied,


### PR DESCRIPTION

## Changelog

##### Refactor: move `load_log_ids()` from `RaftState` to `LogIdList`

This method does not need to be a method of `RaftState`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/421)
<!-- Reviewable:end -->
