### PR TITLE
Fix: bug in searching for membership entries: `[end-step, end)`.

### DIFF
--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -147,7 +147,8 @@ where
         let mut res = vec![];
 
         while start < end {
-            let entries = self.sto.try_get_log_entries(start..end).await?;
+            let step_start = std::cmp::max(start, end.saturating_sub(step));
+            let entries = self.sto.try_get_log_entries(step_start..end).await?;
 
             for ent in entries.iter().rev() {
                 if let EntryPayload::Membership(ref mem) = ent.payload {


### PR DESCRIPTION

## Changelog

##### Fix: bug in searching for membership entries: `[end-step, end)`.

The iterating range searching for membership log entries should be
`[end-step, end)`, not `[start, end)`.
With this bug it will return duplicated membership entries.

- Related: #424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/425)
<!-- Reviewable:end -->
