### PR TITLE
Fix: #424 wrong range when searching for membership entries: `[end-step, end)`

### DIFF
--- a/openraft/src/storage.rs
+++ b/openraft/src/storage.rs
@@ -136,7 +136,8 @@ where
         let step = 64;
 
         while start < end {
-            let entries = self.try_get_log_entries(start..end).await?;
+            let step_start = std::cmp::max(start, end.saturating_sub(step));
+            let entries = self.try_get_log_entries(step_start..end).await?;
 
             for ent in entries.iter().rev() {
                 if let EntryPayload::Membership(ref mem) = ent.payload {


### PR DESCRIPTION
## Changelog

##### Fix: bug in searching for membership entries: `[end-step, end)`.

The iterating range searching for membership log entries should be
`[end-step, end)`, not `[start, end)`.
With this bug it will return duplicated membership entries.

- Bug: #424

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/426)
<!-- Reviewable:end -->
