### PR TITLE
publish memstore as openraft-memstore

### DIFF
--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "memstore"
-version = "0.2.0"
+name = "openraft-memstore"
+version = "0.6.5"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -34,7 +34,7 @@ tracing-futures = "0.2.4"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-memstore = { version="0.2.0", path="../memstore" }
+openraft-memstore = { version="0.6.5", path="../memstore" }
 pretty_assertions = "1.0.0"
 tracing-appender = "0.2.0"
 tracing-subscriber = { version = "0.3.3",  features=["env-filter"] }

--- a/openraft/tests/append_conflicts.rs
+++ b/openraft/tests/append_conflicts.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use fixtures::RaftRouter;
 use maplit::btreeset;
-use memstore::ClientRequest;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::Entry;
 use openraft::AppData;
@@ -13,6 +12,7 @@ use openraft::LogId;
 use openraft::MessageSummary;
 use openraft::RaftStorage;
 use openraft::State;
+use openraft_memstore::ClientRequest;
 
 use crate::fixtures::ent;
 

--- a/openraft/tests/conflict_with_empty_entries.rs
+++ b/openraft/tests/conflict_with_empty_entries.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use fixtures::RaftRouter;
-use memstore::ClientRequest;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::Entry;
 use openraft::raft::EntryPayload;
 use openraft::Config;
 use openraft::LogId;
 use openraft::RaftNetwork;
+use openraft_memstore::ClientRequest;
 
 #[macro_use]
 mod fixtures;
@@ -44,7 +44,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
 
     // Expect conflict even if the message contains no entries.
 
-    let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
+    let rpc = AppendEntriesRequest::<ClientRequest> {
         term: 1,
         leader_id: 1,
         prev_log_id: LogId::new(1, 5),
@@ -60,7 +60,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
 
     // Feed 2 logs
 
-    let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
+    let rpc = AppendEntriesRequest::<ClientRequest> {
         term: 1,
         leader_id: 1,
         prev_log_id: LogId::new(0, 0),
@@ -87,7 +87,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
 
     // Expect a conflict with prev_log_index == 3
 
-    let rpc = AppendEntriesRequest::<memstore::ClientRequest> {
+    let rpc = AppendEntriesRequest::<ClientRequest> {
         term: 1,
         leader_id: 1,
         prev_log_id: LogId::new(1, 3),

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -16,11 +16,6 @@ use anyhow::Context;
 use anyhow::Result;
 use lazy_static::lazy_static;
 use maplit::btreeset;
-use memstore::ClientRequest as MemClientRequest;
-use memstore::ClientRequest;
-use memstore::ClientResponse;
-use memstore::ClientResponse as MemClientResponse;
-use memstore::MemStore;
 use openraft::async_trait::async_trait;
 use openraft::error::AddLearnerError;
 use openraft::error::ClientReadError;
@@ -48,6 +43,11 @@ use openraft::RaftMetrics;
 use openraft::RaftNetwork;
 use openraft::State;
 use openraft::StoreExt;
+use openraft_memstore::ClientRequest as MemClientRequest;
+use openraft_memstore::ClientRequest;
+use openraft_memstore::ClientResponse;
+use openraft_memstore::ClientResponse as MemClientResponse;
+use openraft_memstore::MemStore;
 #[allow(unused_imports)]
 use pretty_assertions::assert_eq;
 #[allow(unused_imports)]


### PR DESCRIPTION
### CI: publish memstore as openraft-memstore.

Future versions of openraft will be able to import this store
implementation for compatibility test.


### Refactor: refine RaftStorage doc comment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/429)
<!-- Reviewable:end -->
