### PR TITLE
Dep: memstore 0.7.0 depends on openraft 0.7.0

### DIFF
--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 categories = ["algorithms", "asynchronous", "data-structures"]
 description = "An in-memory implementation of the `openraft::RaftStorage` trait."
-documentation = "https://docs.rs/memstore"
+documentation = "https://docs.rs/openraft-memstore"
 homepage = "https://github.com/datafuselabs/openraft"
 keywords = ["raft", "consensus"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
### Dep: memstore 0.7.0 depends on openraft 0.7.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/434)
<!-- Reviewable:end -->
