### PR TITLE
Refactor: simplify `apply_to_state_machine()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Currently openraft is the consensus engine of meta-service cluster in [databend]
 - [ ] Goal performance is 1,000,000 put/sec.
 
     Bench history:
-    - 2022 Jul 01: 41,000 put/sec; ns/op: 23,255;
-    - 2022 Jul 07: 43,000 put/sec; ns/op: 23,218; [hash](url) Use `Progress` to track replication.
+    - 2022 Jul 01: 41,000 put/sec; 23,255 ns/op;
+    - 2022 Jul 07: 43,000 put/sec; 23,218 ns/op; Use `Progress` to track replication.
+    - 2022 Jul 09: 45,000 put/sec; 21,784 ns/op; Batch purge applied log
 
     Run the benchmark: `make bench_cluster_of_3`
 

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -175,6 +175,10 @@ pub struct Config {
     #[clap(long, env = "RAFT_MAX_APPLIED_LOG_TO_KEEP", default_value = "1000")]
     pub max_applied_log_to_keep: u64,
 
+    /// The minimal number of applied logs to purge in a batch.
+    #[clap(long, default_value = "1")]
+    pub purge_batch_size: u64,
+
     /// Policy to remove a replication stream for an unreachable removed node.
     #[clap(
         long,

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -60,6 +60,7 @@ fn test_build() -> anyhow::Result<()> {
         "--snapshot-max-chunk-size=204",
         "--max-applied-log-to-keep=205",
         "--remove-replication=max_network_failures:206",
+        "--purge-batch-size=207",
     ])?;
 
     assert_eq!("bar", config.cluster_name);
@@ -76,6 +77,7 @@ fn test_build() -> anyhow::Result<()> {
         RemoveReplicationPolicy::MaxNetworkFailures(206),
         config.remove_replication
     );
+    assert_eq!(207, config.purge_batch_size);
 
     Ok(())
 }

--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -273,7 +273,9 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
         // Install callback channels.
         if let Some(tx) = resp_tx {
-            self.client_resp_channels.insert(entry_refs[0].log_id.index, tx);
+            if let Some(l) = &mut self.core.leader_data {
+                l.client_resp_channels.insert(entry_refs[0].log_id.index, tx);
+            }
         }
 
         self.run_engine_commands(&entry_refs).await?;

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -7,18 +7,15 @@ use tokio::time::Duration;
 use tracing::Instrument;
 use tracing::Level;
 
-use crate::core::apply_to_state_machine;
 use crate::core::LeaderState;
 use crate::core::ServerState;
 use crate::error::CheckIsLeaderError;
-use crate::error::ClientWriteError;
 use crate::error::QuorumNotEnough;
 use crate::error::RPCError;
 use crate::error::Timeout;
 use crate::quorum::QuorumSet;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
-use crate::raft::ClientWriteResponse;
 use crate::raft::RaftRespTx;
 use crate::replication::UpdateReplication;
 use crate::Entry;
@@ -177,46 +174,11 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         let entries = self.core.storage.get_log_entries(log_index..=log_index).await?;
         let entry = &entries[0];
 
-        let tx = self.client_resp_channels.remove(&log_index);
+        self.handle_special_log(entry).await;
 
-        let apply_res = self.apply_entry_to_state_machine(entry).await?;
+        self.core.apply_to_state_machine(log_index).await?;
 
-        self.send_response(entry, apply_res, tx).await;
-
-        // Trigger log compaction if needed.
-        self.core.trigger_log_compaction_if_needed(false).await;
         Ok(())
-    }
-
-    #[tracing::instrument(level = "debug", skip(self, entry, resp, tx), fields(entry=%entry.summary()))]
-    pub(super) async fn send_response(
-        &mut self,
-        entry: &Entry<C>,
-        resp: C::R,
-        tx: Option<RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>>,
-    ) {
-        let tx = match tx {
-            None => return,
-            Some(x) => x,
-        };
-
-        let membership = if let EntryPayload::Membership(ref c) = entry.payload {
-            Some(c.clone())
-        } else {
-            None
-        };
-
-        let res = Ok(ClientWriteResponse {
-            log_id: entry.log_id,
-            data: resp,
-            membership,
-        });
-
-        let send_res = tx.send(res);
-        tracing::debug!(
-            "send client response through tx, send_res is error: {}",
-            send_res.is_err()
-        );
     }
 
     pub async fn handle_special_log(&mut self, entry: &Entry<C>) {
@@ -231,48 +193,5 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             EntryPayload::Blank => {}
             EntryPayload::Normal(_) => {}
         }
-    }
-
-    /// Apply the given log entry to the state machine.
-    #[tracing::instrument(level = "debug", skip(self, entry))]
-    pub(super) async fn apply_entry_to_state_machine(
-        &mut self,
-        entry: &Entry<C>,
-    ) -> Result<C::R, StorageError<C::NodeId>> {
-        self.handle_special_log(entry).await;
-
-        // First, we just ensure that we apply any outstanding up to, but not including, the index
-        // of the given entry. We need to be able to return the data response from applying this
-        // entry to the state machine.
-        //
-        // Note that this would only ever happen if a node had unapplied logs from before becoming leader.
-
-        let log_id = &entry.log_id;
-        let index = log_id.index;
-        let max_keep = self.core.config.max_applied_log_to_keep;
-
-        let expected_next_index = match self.core.engine.state.last_applied {
-            None => 0,
-            Some(log_id) => log_id.index + 1,
-        };
-
-        if index != expected_next_index {
-            let entries = self.core.storage.get_log_entries(expected_next_index..index).await?;
-
-            let data_entries: Vec<_> = entries.iter().collect();
-            if !data_entries.is_empty() {
-                apply_to_state_machine(self.core, &data_entries, max_keep).await?;
-            }
-        }
-
-        // Apply this entry to the state machine and return its data response.
-        let apply_res = apply_to_state_machine(self.core, &[entry], max_keep).await?;
-
-        // TODO(xp): deal with partial apply.
-        self.core.engine.metrics_flags.set_data_changed();
-
-        // TODO(xp) merge this function to replication_to_state_machine?
-
-        Ok(apply_res.into_iter().next().unwrap())
     }
 }

--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -8,12 +8,9 @@ use crate::core::RaftCore;
 use crate::core::ReplicationState;
 use crate::core::ServerState;
 use crate::engine::Command;
-use crate::error::ClientWriteError;
 use crate::error::Fatal;
 use crate::metrics::ReplicationMetrics;
-use crate::raft::ClientWriteResponse;
 use crate::raft::RaftMsg;
-use crate::raft::RaftRespTx;
 use crate::raft_types::RaftLogId;
 use crate::replication::ReplicaEvent;
 use crate::replication::UpdateReplication;
@@ -46,9 +43,6 @@ pub(crate) struct LeaderState<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S
     /// The cloneable sender channel for replication stream events.
     #[allow(clippy::type_complexity)]
     pub(super) replication_tx: mpsc::UnboundedSender<(ReplicaEvent<C::NodeId, S::SnapshotData>, Span)>,
-
-    /// Channels to send result back to client when logs are committed.
-    pub(super) client_resp_channels: BTreeMap<u64, RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>>,
 }
 
 impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderState<'a, C, N, S> {
@@ -61,7 +55,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             replication_metrics: Versioned::new(ReplicationMetrics::default()),
             replication_tx,
             replication_rx,
-            client_resp_channels: Default::default(),
         }
     }
 

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -17,7 +17,6 @@ mod snapshot_state;
 
 pub(crate) use internal_msg::InternalMessage;
 use leader_state::LeaderState;
-use raft_core::apply_to_state_machine;
 pub use raft_core::RaftCore;
 pub(crate) use replication_expectation::Expectation;
 pub use replication_state::is_matched_upto_date;

--- a/openraft/src/engine/calc_purge_upto_test.rs
+++ b/openraft/src/engine/calc_purge_upto_test.rs
@@ -53,18 +53,21 @@ fn test_calc_purge_upto() -> anyhow::Result<()> {
         (Some(log_id(1, 2)), Some(log_id(3, 4)), 5, None),
     ];
 
-    for (last_purged, last_applied, max_keep, want) in cases {
+    for (last_purged, committed, max_keep, want) in cases {
         let mut eng = eng();
+        eng.config.max_applied_log_to_keep = max_keep;
+        eng.config.purge_batch_size = 1;
+
         if let Some(last_purged) = last_purged {
             eng.state.log_ids.purge(&last_purged);
         }
-        eng.state.last_applied = last_applied;
-        let got = eng.calc_purge_upto(max_keep);
+        eng.state.committed = committed;
+        let got = eng.calc_purge_upto();
 
         assert_eq!(
             want, got,
             "case: last_purged: {:?}, last_applied: {:?}, max_keep: {}",
-            last_purged, last_applied, max_keep
+            last_purged, committed, max_keep
         );
     }
 

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -626,8 +626,12 @@ impl<NID: NodeId> Engine<NID> {
                 Some(x) => x,
             };
 
+            tracing::debug!(progress = debug(&leader.progress), "leader progress");
+
             *leader.progress.update(&node_id, log_id)
         };
+
+        tracing::debug!(committed = debug(&committed), "committed after updating progress");
 
         // Only when the log id is proposed by current leader, it is committed.
         if let Some(c) = committed {

--- a/openraft/src/engine/follower_commit_entries_test.rs
+++ b/openraft/src/engine/follower_commit_entries_test.rs
@@ -4,6 +4,7 @@ use maplit::btreeset;
 
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::LogIdList;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -165,6 +166,58 @@ fn test_follower_commit_entries_gt_last_entry() -> anyhow::Result<()> {
             since: Some(log_id(1, 1)),
             upto: log_id(2, 3)
         }],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_follower_commit_entries_purge_to_committed() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.log_ids = LogIdList::new([log_id(2, 2), log_id(2, 3)]);
+    eng.config.max_applied_log_to_keep = 0;
+    eng.config.purge_batch_size = 1;
+
+    eng.follower_commit_entries(Some(log_id(3, 1)), None, &[blank(2, 3)]);
+
+    assert_eq!(Some(log_id(2, 3)), eng.state.committed);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_purged_log_id());
+
+    assert_eq!(
+        vec![
+            Command::FollowerCommit {
+                since: Some(log_id(1, 1)),
+                upto: log_id(2, 3)
+            },
+            Command::PurgeLog { upto: log_id(2, 3) },
+        ],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_follower_commit_entries_purge_to_committed_minus_1() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.log_ids = LogIdList::new([log_id(1, 1), log_id(2, 3)]);
+    eng.config.max_applied_log_to_keep = 1;
+    eng.config.purge_batch_size = 1;
+
+    eng.follower_commit_entries(Some(log_id(3, 1)), None, &[blank(2, 3)]);
+
+    assert_eq!(Some(log_id(2, 3)), eng.state.committed);
+    assert_eq!(Some(log_id(1, 2)), eng.state.last_purged_log_id());
+
+    assert_eq!(
+        vec![
+            Command::FollowerCommit {
+                since: Some(log_id(1, 1)),
+                upto: log_id(2, 3)
+            },
+            Command::PurgeLog { upto: log_id(1, 2) },
+        ],
         eng.commands
     );
 

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -22,4 +22,5 @@ mod log_id_list;
 
 pub(crate) use command::Command;
 pub(crate) use engine_impl::Engine;
+pub(crate) use engine_impl::EngineConfig;
 pub use log_id_list::LogIdList;

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -4,6 +4,7 @@ use maplit::btreeset;
 
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::LogIdList;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -95,6 +96,68 @@ fn test_update_progress_update_leader_progress() -> anyhow::Result<()> {
                 since: Some(log_id(2, 1)),
                 upto: log_id(2, 3)
             }
+        ],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_update_progress_purge_upto_committed() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.log_ids = LogIdList::new([log_id(2, 0), log_id(2, 5)]);
+    eng.config.max_applied_log_to_keep = 0;
+    eng.config.purge_batch_size = 1;
+
+    eng.state.new_leader();
+
+    // progress: None, (2,1), (2,3); committed: (2,1)
+    eng.update_progress(3, Some(log_id(1, 2)));
+    eng.update_progress(2, Some(log_id(2, 1)));
+    eng.update_progress(3, Some(log_id(2, 3)));
+    assert_eq!(Some(log_id(2, 1)), eng.state.committed);
+    assert_eq!(
+        vec![
+            Command::ReplicateCommitted {
+                committed: Some(log_id(2, 1))
+            },
+            Command::LeaderCommit {
+                since: None,
+                upto: log_id(2, 1)
+            },
+            Command::PurgeLog { upto: log_id(2, 1) },
+        ],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_update_progress_purge_upto_committed_minus_1() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.log_ids = LogIdList::new([log_id(2, 0), log_id(2, 5)]);
+    eng.config.max_applied_log_to_keep = 1;
+    eng.config.purge_batch_size = 1;
+
+    eng.state.new_leader();
+
+    // progress: None, (2,1), (2,3); committed: (2,1)
+    eng.update_progress(3, Some(log_id(1, 2)));
+    eng.update_progress(2, Some(log_id(2, 2)));
+    eng.update_progress(3, Some(log_id(2, 4)));
+    assert_eq!(Some(log_id(2, 2)), eng.state.committed);
+    assert_eq!(
+        vec![
+            Command::ReplicateCommitted {
+                committed: Some(log_id(2, 2))
+            },
+            Command::LeaderCommit {
+                since: None,
+                upto: log_id(2, 2)
+            },
+            Command::PurgeLog { upto: log_id(2, 1) },
         ],
         eng.commands
     );

--- a/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
+++ b/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
@@ -25,6 +25,7 @@ async fn stale_last_log_id() -> Result<()> {
             election_timeout_max: 1000,
             max_payload_entries: 1,
             max_applied_log_to_keep: 0,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/benchmark/bench_cluster.rs
+++ b/openraft/tests/benchmark/bench_cluster.rs
@@ -82,6 +82,7 @@ async fn do_bench(bench_config: &BenchConfig) -> anyhow::Result<()> {
         Config {
             election_timeout_min: 200,
             election_timeout_max: 2000,
+            purge_batch_size: 1024,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -39,6 +39,7 @@ async fn compaction() -> Result<()> {
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 2,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -25,6 +25,7 @@ async fn add_learner_basic() -> Result<()> {
         Config {
             replication_lag_threshold: 0,
             max_applied_log_to_keep: 2000, // prevent snapshot
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t24_snapshot_ge_half_threshold.rs
+++ b/openraft/tests/snapshot/t24_snapshot_ge_half_threshold.rs
@@ -29,6 +29,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 6,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
+++ b/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
@@ -26,6 +26,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 0,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -37,6 +37,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 0,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
@@ -37,6 +37,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             // Use 3, with 1 it triggers a compaction when replicating ent-1,
             // because ent-0 is removed.
             max_applied_log_to_keep: 3,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -40,6 +40,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 0,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/state_machine/t40_clean_applied_logs.rs
+++ b/openraft/tests/state_machine/t40_clean_applied_logs.rs
@@ -20,6 +20,7 @@ async fn clean_applied_logs() -> Result<()> {
     let config = Arc::new(
         Config {
             max_applied_log_to_keep: 2,
+            purge_batch_size: 1,
             ..Default::default()
         }
         .validate()?,


### PR DESCRIPTION

## Changelog

##### Refactor: simplify `apply_to_state_machine()`.

- Feature: add config `purge_batch_size`: purge applied log in a batch of the specified size.
  This will reduce unnecessary storage access.

- Refactor: move `client_resp_channels` from `LeaderState` to
  `RaftCore`. So that Engine `Command` execution in future can be moved
  to `RaftCore`.

- Refactor: simplify `apply_to_state_machine()`. Remove duplicated
  implementation for leader and follower.

- Refactor: add `EngineConfig` that contains configurations used by
  Engine.

- Refactor: Engine emits `Command::PurgeLog`. `RaftCore` does not need
  to trigger purging manually.


##### Refactor: adjust debug logging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/442)
<!-- Reviewable:end -->
