### PR TITLE
Refactor: Progress also tracks replication progress to learners

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -6,8 +6,6 @@ use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
-use crate::leader::Leader;
-use crate::progress::VecProgress;
 use crate::raft::VoteRequest;
 use crate::EffectiveMembership;
 use crate::LeaderId;
@@ -46,13 +44,7 @@ fn test_elect() -> anyhow::Result<()> {
         eng.elect();
 
         assert_eq!(Vote::new_committed(1, 1), eng.state.vote);
-        assert_eq!(
-            Some(Leader {
-                vote_granted_by: btreeset! {1},
-                progress: VecProgress::new(eng.state.membership_state.effective)
-            }),
-            eng.state.leader
-        );
+        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
@@ -90,13 +82,7 @@ fn test_elect() -> anyhow::Result<()> {
         eng.elect();
 
         assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-        assert_eq!(
-            Some(Leader {
-                vote_granted_by: btreeset! {1},
-                progress: VecProgress::new(eng.state.membership_state.effective)
-            }),
-            eng.state.leader
-        );
+        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
@@ -130,13 +116,7 @@ fn test_elect() -> anyhow::Result<()> {
         eng.elect();
 
         assert_eq!(Vote::new(1, 1), eng.state.vote);
-        assert_eq!(
-            Some(Leader {
-                vote_granted_by: btreeset! {1},
-                progress: VecProgress::new(eng.state.membership_state.effective)
-            }),
-            eng.state.leader
-        );
+        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -5,8 +5,6 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
-use crate::leader::Leader;
-use crate::progress::VecProgress;
 use crate::raft::VoteResponse;
 use crate::EffectiveMembership;
 use crate::LeaderId;
@@ -80,13 +78,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new(2, 1), eng.state.vote);
-        assert_eq!(
-            Some(Leader {
-                vote_granted_by: btreeset! {1},
-                progress: VecProgress::new(eng.state.membership_state.effective)
-            }),
-            eng.state.leader
-        );
+        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
@@ -156,13 +148,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new(2, 1), eng.state.vote);
-        assert_eq!(
-            Some(Leader {
-                vote_granted_by: btreeset! {1},
-                progress: VecProgress::new(eng.state.membership_state.effective)
-            }),
-            eng.state.leader
-        );
+        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
@@ -193,13 +179,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new(2, 1), eng.state.vote);
-        assert_eq!(
-            Some(Leader {
-                vote_granted_by: btreeset! {1,2},
-                progress: VecProgress::new(eng.state.membership_state.effective)
-            }),
-            eng.state.leader
-        );
+        assert_eq!(Some(btreeset! {1,2},), eng.state.leader.map(|x| x.vote_granted_by));
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
@@ -230,13 +210,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-        assert_eq!(
-            Some(Leader {
-                vote_granted_by: btreeset! {1,2},
-                progress: VecProgress::new(eng.state.membership_state.effective)
-            }),
-            eng.state.leader
-        );
+        assert_eq!(Some(btreeset! {1,2},), eng.state.leader.map(|x| x.vote_granted_by));
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -33,8 +33,16 @@ fn m23() -> Membership<u64> {
     Membership::<u64>::new(vec![btreeset! {2,3}], None)
 }
 
+fn m23_45() -> Membership<u64> {
+    Membership::<u64>::new(vec![btreeset! {2,3}], Some(btreeset! {4,5}))
+}
+
 fn m34() -> Membership<u64> {
     Membership::<u64>::new(vec![btreeset! {3,4}], None)
+}
+
+fn m4_356() -> Membership<u64> {
+    Membership::<u64>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
 }
 
 fn eng() -> Engine<u64> {
@@ -128,6 +136,65 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
         eng.state.leader.unwrap().progress.get(&4).is_none(),
         "exists, but it is a None"
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_update_effective_membership_update_learner_process() -> anyhow::Result<()> {
+    // When updating membership, voter progreess should inherit from learner progress, and learner process should
+    // inherit from voter process. If voter changes to learner or vice versa.
+
+    let mut eng = eng();
+    eng.state.server_state = ServerState::Leader;
+    // Make it a real leader: voted for itself and vote is committed.
+    eng.state.vote = Vote::new_committed(2, 2);
+    eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23_45()));
+    eng.state.new_leader();
+
+    if let Some(l) = &mut eng.state.leader {
+        assert_eq!(&None, l.progress.get(&4));
+        assert_eq!(&None, l.progress.get(&5));
+
+        let _ = l.progress.update(&4, Some(log_id(1, 4)));
+        assert_eq!(&Some(log_id(1, 4)), l.progress.get(&4));
+
+        let _ = l.progress.update(&5, Some(log_id(1, 5)));
+        assert_eq!(&Some(log_id(1, 5)), l.progress.get(&5));
+
+        let _ = l.progress.update(&3, Some(log_id(1, 3)));
+        assert_eq!(&Some(log_id(1, 3)), l.progress.get(&3));
+    } else {
+        unreachable!("leader should not be None");
+    }
+
+    eng.update_effective_membership(&log_id(3, 4), &m4_356());
+
+    assert_eq!(
+        MembershipState {
+            committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
+            effective: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m4_356()))
+        },
+        eng.state.membership_state
+    );
+
+    if let Some(l) = &mut eng.state.leader {
+        assert_eq!(
+            &Some(log_id(1, 4)),
+            l.progress.get(&4),
+            "learner-4 progress should be transferred to voter progress"
+        );
+        assert_eq!(
+            &Some(log_id(1, 3)),
+            l.progress.get(&3),
+            "voter-3 progress should be transferred to learner progress"
+        );
+
+        assert_eq!(&Some(log_id(1, 5)), l.progress.get(&5), "learner-5 has previous value");
+        assert_eq!(&None, l.progress.get(&6));
+    } else {
+        unreachable!("leader should not be None");
+    }
 
     Ok(())
 }

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -34,10 +34,10 @@ where
     NID: NodeId,
     QS: QuorumSet<NID> + 'static,
 {
-    pub(crate) fn new(quorum_set: QS) -> Self {
+    pub(crate) fn new(quorum_set: QS, learner_ids: impl Iterator<Item = NID>) -> Self {
         Self {
             vote_granted_by: BTreeSet::new(),
-            progress: VecProgress::new(quorum_set),
+            progress: VecProgress::new(quorum_set, learner_ids),
         }
     }
 

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -114,7 +114,8 @@ where NID: NodeId
     /// Create a new Leader, when raft enters candidate state.
     /// In openraft, Leader and Candidate shares the same state.
     pub(crate) fn new_leader(&mut self) {
-        self.leader = Some(Leader::new(self.membership_state.effective.clone()));
+        let em = &self.membership_state.effective;
+        self.leader = Some(Leader::new(em.clone(), em.learner_ids()));
     }
 
     /// Update field `committed` if the input is greater.


### PR DESCRIPTION

## Changelog

##### Refactor: Progress also tracks replication progress to learners

learner progresses are tracked by `Progress` but these progresses won't
be counted when calculate the `granted` value, i.e. the value that is
granted by a quorum.

- Refactor: rename `Progress::committed()` to `granted()`, because in
  raft granted by a quorum does not imply it is committed. A second
  requirement is that the value has to be the greatest, i.e., a log
  entry is proposed by the current leader.

- Refactor: add method `Progress::iter()` to iterate all ids and values.

- Refactor: add method `Progress::is_voter()` to check if a given id is
  a `voter`,  i.e., one defined in its quorum-set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/445)
<!-- Reviewable:end -->
