### PR TITLE
Change: Stop replication to removed node at once when new membership is seen

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Cluster Controls](./cluster-controls.md)
     - [Cluster Formation](./cluster-formation.md)
     - [Dynamic Membership](./dynamic-membership.md)
+    - [Node lifecycle](./node-lifecycle.md)
 
 - [Metrics](./metrics.md)
 

--- a/guide/src/dynamic-membership.md
+++ b/guide/src/dynamic-membership.md
@@ -16,13 +16,10 @@ and immediately begin syncing logs from the leader.
 ## `Raft::change_membership(node_list, turn_to_learner)`
 
 This method will initiate a membership change and returns when the effective
-membership becomes `node_list`.
+membership becomes `node_list` and committed.
 
-If there are nodes in the given membership that is not a `Learner`, this method will add it
-as Learner first.
-Thus it is recommended that the application always call `Raft::add_learner` first.
-Otherwise, `Raft::change_membership` may block for long before committing the
-given membership and return.
+If there are nodes in the given membership that is not a `Learner`, this method will fail.
+Thus the application should always call `Raft::add_learner` first.
 
 Once the new membership is committed, whether or not a `Voter` that is not in the new membership will
 revert to a `Learner` is base on the `turn_to_learner`.
@@ -36,12 +33,6 @@ with `node_list` {3,4,5}, then:
     - If `turn_to_learner` is true, after commit the new membership is {"members":{3,4,5}, "learners":{1,2}}.
     - Otherwise if `turn_to_learner` is false, then the new membership is {"members":{3,4,5}, "learners":{}}, 
       in which the members not exists in the new membership just be removed from the cluster.
-
-## `Raft::remove_members(members, turn_to_learner)`
-Remove members directly, `turn_to_learner` has the same meaning in `change_membership`.
-
-## `Raft::add_members(members)`
-Add members directly.
 
 ## Extended membership change algo
 

--- a/guide/src/node-lifecycle.md
+++ b/guide/src/node-lifecycle.md
@@ -1,0 +1,49 @@
+# Node life cycle
+
+- When a node is added with `Raft::add_learner()`, it starts to receive log
+    replication from the leader at once, i.e., becomes a `Learner`.
+
+- A learner becomes a `Voter`, when `Raft::change_membership()` adds it a
+    `Voter`. A `Voter` will then become `Candidate` or `Leader`.
+
+- When a node, no matter a `Learner` or `Voter`, is removed from membership, the
+    leader stops replicating to it at once, i.e., when the new membership that
+    does not contain the node is seen(no need to commit).
+
+    The removed node won't receive any log replication or heartbeat from the
+    leader. It will enter `Candidate` because it does not know it is removed.
+
+
+## Remove a node from membership config
+
+When membership changes, e.g., from a joint config `[(1,2,3),
+(3,4,5)]` to uniform config `[3,4,5]`(assuming the leader is `3`), the leader
+stops replication to `1,2` when `[3,4,5]` is seen(not committed).
+
+It is correct because:
+
+- If the leader(`3`) finally committed `[3,4,5]`, it will eventually stop replication to `1,2`.
+
+- If the leader(`3`) crashes before committing `[3,4,5]`:
+  - And a new leader sees the membership config log `[3,4,5]`, it will continue to commit it and finally stop replication to `1,2`.
+  - Or a new leader does not see membership config log `[3,4,5]`, it will re-establish replication to `1,2`.
+
+In any case, stopping replication at once is OK.
+
+One of the considerations is:
+The nodes, e.g., `1,2` do not know they have been removed from the cluster:
+
+- Removed node will enter the candidate state and keeps increasing its term and electing itself.
+  This won't affect the working cluster: 
+
+  - The nodes in the working cluster have greater logs; thus, the election will never succeed.
+
+  - The leader won't try to communicate with the removed nodes thus it won't see their higher `term`.
+
+- Removed nodes should be shut down finally. No matter whether the leader
+  replicates the membership without these removed nodes to them, there should
+  always be an external process that shuts them down. Because there is no
+  guarantee that a removed node can receive the membership log in a finite time.
+
+
+

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -53,50 +53,6 @@ fn parse_snapshot_policy(src: &str) -> Result<SnapshotPolicy, ConfigError> {
     Ok(SnapshotPolicy::LogsSinceLast(n_logs))
 }
 
-/// Policy to remove a replication.
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum RemoveReplicationPolicy {
-    /// Leader will remove a replication to a node that is removed from membership,
-    /// if the `committed` index advanced too many the index of the **uniform** membership log in which the node is
-    /// removed.
-    CommittedAdvance(u64),
-
-    /// Leader removes a replication if it encountered the specified number of network failures.
-    MaxNetworkFailures(u64),
-}
-
-fn parse_remove_replication_policy(src: &str) -> Result<RemoveReplicationPolicy, ConfigError> {
-    let elts = src.split(':').collect::<Vec<_>>();
-    if elts.len() != 2 {
-        return Err(ConfigError::InvalidRemoveReplicationPolicy {
-            syntax: "committed_advance:<num>|max_network_failures:<num>".to_string(),
-            invalid: src.to_string(),
-        });
-    }
-
-    if elts[0] == "committed_advance" {
-        let n_logs = elts[1].parse::<u64>().map_err(|e| ConfigError::InvalidNumber {
-            invalid: src.to_string(),
-            reason: e.to_string(),
-        })?;
-        return Ok(RemoveReplicationPolicy::CommittedAdvance(n_logs));
-    }
-
-    if elts[0] == "max_network_failures" {
-        let n = elts[1].parse::<u64>().map_err(|e| ConfigError::InvalidNumber {
-            invalid: src.to_string(),
-            reason: e.to_string(),
-        })?;
-        return Ok(RemoveReplicationPolicy::MaxNetworkFailures(n));
-    }
-
-    Err(ConfigError::InvalidRemoveReplicationPolicy {
-        syntax: "committed_advance:<num>|max_network_failures:<num>".to_string(),
-        invalid: src.to_string(),
-    })
-}
-
 /// The runtime configuration for a Raft node.
 ///
 /// The default values used by this type should generally work well for Raft clusters which will
@@ -178,15 +134,6 @@ pub struct Config {
     /// The minimal number of applied logs to purge in a batch.
     #[clap(long, default_value = "1")]
     pub purge_batch_size: u64,
-
-    /// Policy to remove a replication stream for an unreachable removed node.
-    #[clap(
-        long,
-        env = "RAFT_FORCE_REMOVE_REPLICATION",
-        default_value = "max_network_failures:10",
-        parse(try_from_str=parse_remove_replication_policy)
-    )]
-    pub remove_replication: RemoveReplicationPolicy,
 }
 
 impl Default for Config {

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -1,4 +1,3 @@
-use crate::config::config::RemoveReplicationPolicy;
 use crate::config::error::ConfigError;
 use crate::Config;
 use crate::SnapshotPolicy;
@@ -59,7 +58,6 @@ fn test_build() -> anyhow::Result<()> {
         "--snapshot-policy=since_last:203",
         "--snapshot-max-chunk-size=204",
         "--max-applied-log-to-keep=205",
-        "--remove-replication=max_network_failures:206",
         "--purge-batch-size=207",
     ])?;
 
@@ -73,29 +71,7 @@ fn test_build() -> anyhow::Result<()> {
     assert_eq!(SnapshotPolicy::LogsSinceLast(203), config.snapshot_policy);
     assert_eq!(204, config.snapshot_max_chunk_size);
     assert_eq!(205, config.max_applied_log_to_keep);
-    assert_eq!(
-        RemoveReplicationPolicy::MaxNetworkFailures(206),
-        config.remove_replication
-    );
     assert_eq!(207, config.purge_batch_size);
 
-    Ok(())
-}
-
-#[test]
-fn test_option_remove_replication() -> anyhow::Result<()> {
-    let config = Config::build(&["foo", "--remove-replication=max_network_failures:206"])?;
-
-    assert_eq!(
-        RemoveReplicationPolicy::MaxNetworkFailures(206),
-        config.remove_replication
-    );
-
-    let config = Config::build(&["foo", "--remove-replication=committed_advance:206"])?;
-
-    assert_eq!(
-        RemoveReplicationPolicy::CommittedAdvance(206),
-        config.remove_replication
-    );
     Ok(())
 }

--- a/openraft/src/config/error.rs
+++ b/openraft/src/config/error.rs
@@ -18,7 +18,4 @@ pub enum ConfigError {
 
     #[error("{reason} when parsing {invalid:?}")]
     InvalidNumber { invalid: String, reason: String },
-
-    #[error("remove replication policy string is invalid: '{invalid:?}' expect: '{syntax}'")]
-    InvalidRemoveReplicationPolicy { invalid: String, syntax: String },
 }

--- a/openraft/src/config/mod.rs
+++ b/openraft/src/config/mod.rs
@@ -4,6 +4,5 @@ mod error;
 #[cfg(test)] mod config_test;
 
 pub use config::Config;
-pub use config::RemoveReplicationPolicy;
 pub use config::SnapshotPolicy;
 pub use error::ConfigError;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -979,7 +979,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
             Command::ReplicateInputEntries { .. } => {
                 unreachable!("leader specific command")
             }
-            Command::UpdateMembership { .. } => {}
+            Command::UpdateReplicationStreams { .. } => {
+                unreachable!("leader specific command")
+            }
+            Command::UpdateMembership { .. } => {
+                // TODO: not used
+            }
         }
 
         Ok(())

--- a/openraft/src/core/replication_state.rs
+++ b/openraft/src/core/replication_state.rs
@@ -4,39 +4,16 @@ use std::fmt::Formatter;
 use crate::raft_types::LogIdOptionExt;
 use crate::replication::ReplicationStream;
 use crate::LogId;
-use crate::MessageSummary;
 use crate::NodeId;
 
 /// A struct tracking the state of a replication stream from the perspective of the Raft actor.
 pub(crate) struct ReplicationState<NID: NodeId> {
-    pub matched: Option<LogId<NID>>,
-
-    pub remove_since: Option<u64>,
-
     pub repl_stream: ReplicationStream<NID>,
-
-    /// Count of replication failures.
-    ///
-    /// It will be reset once a successful replication is done.
-    pub failures: u64,
-}
-
-impl<NID: NodeId> MessageSummary<ReplicationState<NID>> for ReplicationState<NID> {
-    fn summary(&self) -> String {
-        format!(
-            "matched: {:?}, remove_after_commit: {:?}, failures: {}",
-            self.matched, self.remove_since, self.failures
-        )
-    }
 }
 
 impl<NID: NodeId> Debug for ReplicationState<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReplicationState")
-            .field("matched", &self.matched)
-            .field("remove_since", &self.remove_since)
-            .field("failures", &self.failures)
-            .finish()
+        f.debug_struct("ReplicationState").finish()
     }
 }
 

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -39,8 +39,19 @@ pub(crate) enum Command<NID: NodeId> {
     /// Replicate a `range` of entries in the input buffer.
     ReplicateInputEntries { range: Range<usize> },
 
-    /// Membership config changed, need to update replication stream etc.
-    UpdateMembership { membership: Arc<EffectiveMembership<NID>> },
+    /// Membership config changed, need to update replication streams.
+    UpdateMembership {
+        // TODO: not used yet.
+        membership: Arc<EffectiveMembership<NID>>,
+    },
+
+    /// Membership config changed, need to update replication streams.
+    UpdateReplicationStreams {
+        /// Replication to remove.
+        remove: Vec<(NID, Option<LogId<NID>>)>,
+        /// Replication to add.
+        add: Vec<(NID, Option<LogId<NID>>)>,
+    },
 
     /// Move the cursor pointing to an entry in the input buffer.
     MoveInputCursorBy { n: usize },
@@ -87,6 +98,7 @@ impl<NID: NodeId> Command<NID> {
             Command::FollowerCommit { .. } => flags.set_data_changed(),
             Command::ReplicateInputEntries { .. } => {}
             Command::UpdateMembership { .. } => flags.set_cluster_changed(),
+            Command::UpdateReplicationStreams { .. } => flags.set_replication_changed(),
             Command::MoveInputCursorBy { .. } => {}
             Command::SaveVote { .. } => flags.set_data_changed(),
             Command::SendVote { .. } => {}

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -261,7 +261,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
+            leader: true,
             other_metrics: true
         },
         eng.metrics_flags
@@ -282,6 +282,10 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
                     Some(LogId::new(LeaderId::new(3, 1), 5)),
                     m34()
                 )),
+            },
+            Command::UpdateReplicationStreams {
+                remove: vec![],
+                add: vec![(3, None), (4, None)]
             },
             Command::ReplicateInputEntries { range: 0..3 },
             Command::MoveInputCursorBy { n: 3 },
@@ -336,7 +340,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
+            leader: true,
             other_metrics: true
         },
         eng.metrics_flags
@@ -358,6 +362,10 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                     Some(LogId::new(LeaderId::new(3, 1), 5)),
                     m1_2()
                 )),
+            },
+            Command::UpdateReplicationStreams {
+                remove: vec![],
+                add: vec![(2, None)]
             },
             // second commit upto the end.
             Command::ReplicateCommitted {
@@ -422,7 +430,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
+            leader: true,
             other_metrics: true
         },
         eng.metrics_flags
@@ -436,6 +444,10 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                     Some(LogId::new(LeaderId::new(3, 1), 5)),
                     m1_2()
                 )),
+            },
+            Command::UpdateReplicationStreams {
+                remove: vec![(3, None)],
+                add: vec![(2, None)]
             },
             // It is correct to commit if the membership change ot a one node cluster.
             Command::ReplicateCommitted {

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -119,16 +119,23 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
+            leader: true,
             other_metrics: true
         },
         eng.metrics_flags
     );
 
     assert_eq!(
-        vec![Command::UpdateMembership {
-            membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
-        },],
+        vec![
+            //
+            Command::UpdateMembership {
+                membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
+            },
+            Command::UpdateReplicationStreams {
+                add: vec![(4, None)],
+                remove: vec![], // node-2 is leader, won't be removed
+            }
+        ],
         eng.commands
     );
 

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -55,7 +55,6 @@ pub use metrics::ReplicationTargetMetrics;
 pub use crate::change_members::ChangeMembers;
 pub use crate::config::Config;
 pub use crate::config::ConfigError;
-pub use crate::config::RemoveReplicationPolicy;
 pub use crate::config::SnapshotPolicy;
 pub use crate::core::ServerState;
 pub use crate::defensive::DefensiveCheck;

--- a/openraft/tests/membership/t15_add_remove_follower.rs
+++ b/openraft/tests/membership/t15_add_remove_follower.rs
@@ -18,30 +18,29 @@ use crate::fixtures::RaftRouter;
 /// - asserts node-4 becomes learner and the leader stops sending logs to it.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn add_remove_voter() -> Result<()> {
-    let cluster_of_5 = btreeset![0, 1, 2, 3, 4];
-    let cluster_of_4 = btreeset![0, 1, 2, 3];
+    let c01234 = btreeset![0, 1, 2, 3, 4];
+    let c0123 = btreeset![0, 1, 2, 3];
 
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(cluster_of_5.clone(), btreeset! {}).await?;
+    let mut log_index = router.new_nodes_from_single(c01234.clone(), btreeset! {}).await?;
 
     tracing::info!("--- write 100 logs");
     {
         router.client_request_many(0, "client", 100).await?;
         log_index += 100;
 
-        router.wait_for_log(&cluster_of_5, Some(log_index), timeout(), "write 100 logs").await?;
+        router.wait_for_log(&c01234, Some(log_index), timeout(), "write 100 logs").await?;
     }
 
     tracing::info!("--- remove n{}", 4);
     {
         let node = router.get_raft_handle(&0)?;
-        node.change_membership(cluster_of_4.clone(), true, false).await?;
+        node.change_membership(c0123.clone(), true, false).await?;
         log_index += 2; // two member-change logs
 
-        router.wait_for_log(&cluster_of_4, Some(log_index), timeout(), "removed node-4").await?;
-        router.wait(&4, timeout()).state(ServerState::Learner, "").await?;
+        router.wait_for_log(&c0123, Some(log_index), timeout(), "removed node-4 from membership").await?;
     }
 
     tracing::info!("--- write another 100 logs");
@@ -50,13 +49,15 @@ async fn add_remove_voter() -> Result<()> {
         log_index += 100;
     }
 
-    router.wait_for_log(&cluster_of_4, Some(log_index), timeout(), "4 nodes recv logs 100~200").await?;
+    router.wait_for_log(&c0123, Some(log_index), timeout(), "4 nodes recv logs 100~200").await?;
 
     tracing::info!("--- log will not be sync to removed node");
     {
         let x = router.latest_metrics();
         assert!(x[4].last_log_index < Some(log_index - 50));
     }
+
+    router.wait(&4, timeout()).state(ServerState::Candidate, "node-4 tries to elect").await?;
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### Change: Stop replication to removed node at once when new membership is seen

Before this commit, when membership changes, e.g., from a joint config
`[(1,2,3), (3,4,5)]` to uniform config `[3,4,5]`(assuming the leader is
`3`), the leader stops replication to `1,2` when `[3,4,5]` is
committed.

This is an unnecessarily complicated solution.
It is OK for the leader to stop replication to `1,2` as soon as config `[3,4,5]` is seen, instead of when config `[3,4,5]` is committed.

- If the leader(`3`) finally committed `[3,4,5]`, it will eventually stop replication to `1,2`.
- If the leader(`3`) crashes before committing `[3,4,5]`:
  - And a new leader sees the membership config log `[3,4,5]`, it will continue to commit it and finally stop replication to `1,2`.
  - Or a new leader does not see membership config log `[3,4,5]`, it will re-establish replication to `1,2`.

In any case, stopping replication at once is OK.

One of the considerations about this modification is:
The nodes, e.g., `1,2` do not know they have been removed from the cluster:

- Removed node will enter the candidate state and keeps increasing its term and electing itself.
  This won't affect the working cluster:

  - The nodes in the working cluster have greater logs; thus, the election will never succeed.

  - The leader won't try to communicate with the removed nodes thus it won't see their higher `term`.

- Removed nodes should be shut down finally. No matter whether the
  leader replicates the membership without these removed nodes to them,
  there should always be an external process that shuts them down.
  Because there is no guarantee that a removed node can receive the
  membership log in a finite time.

Changes:

- Change: remove config `remove_replication`, since replication will
  be removed at once.

- Refactor: Engine outputs `Command::UpdateReplicationStream` to inform
  the Runtime to update replication, when membership changes.

- Refactor: remove `ReplicationState.failures`, replication does not
  need count failures to remove it.

- Refactor: remove `ReplicationState.matched`: the **matched** log id
  has been tracked by `Engine.state.leader.progress`.

- Fix: #446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/447)
<!-- Reviewable:end -->
