### PR TITLE
Refactor: leader step down if either a uniform or joint config is committed.

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -7,7 +7,6 @@ use tracing::Level;
 use crate::core::replication_state::replication_lag;
 use crate::core::Expectation;
 use crate::core::LeaderState;
-use crate::core::ServerState;
 use crate::entry::EntryRef;
 use crate::error::AddLearnerError;
 use crate::error::ChangeMembershipError;
@@ -286,26 +285,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         }
 
         Ok(())
-    }
-
-    /// Handle the commitment of a uniform consensus cluster configuration.
-    ///
-    /// This is ony called by leader.
-    #[tracing::instrument(level = "debug", skip(self))]
-    pub(super) async fn handle_uniform_consensus_committed(&mut self, log_id: &LogId<C::NodeId>) {
-        // Step down if needed.
-
-        let _ = log_id;
-
-        // TODO: Leader does not need to step down. It can keep working.
-        //       This requires to separate Leader(Proposer) and Acceptors.
-        if !self.core.engine.state.membership_state.effective.is_voter(&self.core.id) {
-            tracing::debug!("raft node is stepping down");
-
-            // TODO(xp): transfer leadership
-            self.core.set_target_state(ServerState::Learner);
-            self.core.engine.metrics_flags.set_cluster_changed();
-        }
     }
 
     /// Remove a replication if the membership that does not include it has committed.

--- a/openraft/src/core/leader_state.rs
+++ b/openraft/src/core/leader_state.rs
@@ -19,7 +19,6 @@ use crate::summary::MessageSummary;
 use crate::versioned::Versioned;
 use crate::Entry;
 use crate::EntryPayload;
-use crate::LogIdOptionExt;
 use crate::RaftNetworkFactory;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
@@ -187,11 +186,6 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRun
                         last_log_id: None,
                         committed: *committed,
                     });
-                }
-            }
-            Command::LeaderCommit { ref upto, .. } => {
-                for i in self.core.engine.state.last_applied.next_index()..(upto.index + 1) {
-                    self.client_request_post_commit(i).await?;
                 }
             }
             Command::ReplicateInputEntries { range } => {

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -167,20 +167,14 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
         }
 
         for id in only_in_old.clone() {
-            // TODO(xp): There is a chance the older leader quits before replicating 2 membership logs to every node.
-            //           Thus a node in old cluster may start electing while a new leader already elected in the new
-            //           cluster. Such a node keeps electing but it has less logs thus will never succeed.
-            //
-            //           Error: timeout after 1s when node 2 only in old, from {0, 1, 2} to {4, 5, 6} .state -> Learner
-            //           latest: Metrics{id:2,Candidate, term:7, last_log:Some(109), last_applied:Some(LogId
-            //           { leader_id: LeaderId { term: 1, node_id: 0 }, index: 109 }), leader:None,
-            //           membership:{log_id:1-0-109 membership:members:[{0, 1, 2},{4, 5, 6}],learners:[]},
-            //           snapshot:None, replication:
-
             router
                 .wait(id, timeout())
                 .metrics(
-                    |x| x.state == ServerState::Learner || x.state == ServerState::Candidate,
+                    |x| {
+                        x.state == ServerState::Follower
+                            || x.state == ServerState::Learner
+                            || x.state == ServerState::Candidate
+                    },
                     format!("node {} only in old, {}", id, mes),
                 )
                 .await?;

--- a/openraft/tests/membership/t45_remove_unreachable_follower.rs
+++ b/openraft/tests/membership/t45_remove_unreachable_follower.rs
@@ -74,7 +74,10 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
         router
             .wait(&4, timeout())
             .metrics(
-                |x| x.last_log_index == Some(node4_log_index) && x.state == ServerState::Candidate,
+                |x| {
+                    x.last_log_index == Some(node4_log_index)
+                        && (x.state == ServerState::Candidate || x.state == ServerState::Follower)
+                },
                 "node 4 stopped recv log and start to elect",
             )
             .await?;


### PR DESCRIPTION

## Changelog

##### Refactor: leader step down if either a uniform or joint config is committed.

If the effective membership that does not contain the current leader is
committed, no matter it is a joint config or uniform config, the leader
will step down.

Before this commit only when a **uniform** config is committed a leader
will step down, which is a unnecessary limit.

- Refactor: Move stepdown related methods to `RaftCore`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/448)
<!-- Reviewable:end -->
