### PR TITLE
Refactor: remove `ReplicationState`

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -296,10 +296,10 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
 
         let repl_state = self.nodes.remove(&target);
         if let Some(s) = repl_state {
-            let handle = s.repl_stream.handle;
+            let handle = s.handle;
 
             // Drop sender to notify the task to shutdown
-            drop(s.repl_stream.repl_tx);
+            drop(s.repl_tx);
 
             tracing::debug!("joining removed replication: {}", target);
             let _x = handle.await;

--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -167,7 +167,7 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         }
 
         for node in self.nodes.values() {
-            let _ = node.repl_stream.repl_tx.send(UpdateReplication {
+            let _ = node.repl_tx.send(UpdateReplication {
                 last_log_id: Some(log_id),
                 committed: self.core.engine.state.committed,
             });

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -18,7 +18,6 @@ use leader_state::LeaderState;
 pub use raft_core::RaftCore;
 pub(crate) use replication_expectation::Expectation;
 pub(crate) use replication_state::replication_lag;
-use replication_state::ReplicationState;
 pub use server_state::ServerState;
 use snapshot_state::SnapshotState;
 use snapshot_state::SnapshotUpdate;

--- a/openraft/src/core/replication_state.rs
+++ b/openraft/src/core/replication_state.rs
@@ -1,21 +1,6 @@
-use std::fmt::Debug;
-use std::fmt::Formatter;
-
 use crate::raft_types::LogIdOptionExt;
-use crate::replication::ReplicationStream;
 use crate::LogId;
 use crate::NodeId;
-
-/// A struct tracking the state of a replication stream from the perspective of the Raft actor.
-pub(crate) struct ReplicationState<NID: NodeId> {
-    pub repl_stream: ReplicationStream<NID>,
-}
-
-impl<NID: NodeId> Debug for ReplicationState<NID> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReplicationState").finish()
-    }
-}
 
 /// Calculate the distance between the matched log id on a replication target and local last log id
 pub(crate) fn replication_lag<NID: NodeId>(matched: &Option<LogId<NID>>, last_log_id: &Option<LogId<NID>>) -> u64 {

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -47,7 +47,7 @@ use crate::RaftTypeConfig;
 use crate::ToStorageResult;
 use crate::Vote;
 
-/// The public handle to a spawned replication stream.
+/// The handle to a spawned replication stream.
 pub(crate) struct ReplicationStream<NID: NodeId> {
     /// The spawn handle the `ReplicationCore` task.
     pub handle: JoinHandle<()>,

--- a/openraft/tests/membership/t15_add_remove_follower.rs
+++ b/openraft/tests/membership/t15_add_remove_follower.rs
@@ -63,5 +63,5 @@ async fn add_remove_voter() -> Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(1000))
+    Some(Duration::from_millis(2000))
 }


### PR DESCRIPTION

## Changelog

##### Refactor: remove `ReplicationState`

`ReplicationState` now is simply a wrapper of `ReplicationStream`.
Use `ReplicationStream` instead.


##### Test: add_remove_voter: extend timeout to wait for node-4 to entery candiate state after being removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/449)
<!-- Reviewable:end -->
