### PR TITLE
Refactor: move field `repliation_metrics` from `LeaderState` to `RaftCore.leader_data`

### DIFF
--- a/openraft/src/core/admin.rs
+++ b/openraft/src/core/admin.rs
@@ -308,7 +308,12 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             unreachable!("try to nonexistent replication to {}", target);
         }
 
-        self.replication_metrics.update(RemoveTarget { target });
+        if let Some(l) = &mut self.core.leader_data {
+            l.replication_metrics.update(RemoveTarget { target });
+        } else {
+            unreachable!("It has to be a leader!!!");
+        }
+
         // TODO(xp): set_replication_metrics_changed() can be removed.
         //           Use self.replication_metrics.version to detect changes.
         self.core.engine.metrics_flags.set_replication_changed();

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -124,7 +124,11 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
     fn update_replication_metrics(&mut self, target: C::NodeId, matched: LogId<C::NodeId>) {
         tracing::debug!(%target, ?matched, "update_leader_metrics");
 
-        self.replication_metrics.update(UpdateMatchedLogId { target, matched });
+        if let Some(l) = &mut self.core.leader_data {
+            l.replication_metrics.update(UpdateMatchedLogId { target, matched });
+        } else {
+            unreachable!("it has to be a leader!!!");
+        }
         self.core.engine.metrics_flags.set_replication_changed()
     }
 


### PR DESCRIPTION

## Changelog

##### Refactor: move field `repliation_metrics` from `LeaderState` to `RaftCore.leader_data`

So that `RaftCore` can report metrics without accessing `LeaderState`.


##### Refactor: attach sub task span to a parent: `RaftCore.span`

Let sub task such as replication enter a span that is a child of
`RaftCore.span`, to provide better tracing hierarchy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/450)
<!-- Reviewable:end -->
