### PR TITLE
Refactor: move `LeaderState.nodes` to `RaftCore.leader_data`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -971,7 +971,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         Ok(())
     }
 
-    // TODO: make it private
     #[tracing::instrument(level = "debug", skip(self, msg), fields(state = debug(self.engine.state.server_state), id=display(self.id)))]
     pub(crate) async fn handle_api_msg(&mut self, msg: RaftMsg<C, N, S>) -> Result<(), Fatal<C::NodeId>> {
         tracing::debug!("recv from rx_api: {}", msg.summary());

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -122,10 +122,10 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
             }
         };
 
-        self.update_replication_metrics(target, matched);
-
         self.core.engine.update_progress(target, Some(matched));
         self.run_engine_commands(&[]).await?;
+
+        self.update_replication_metrics(target, matched);
 
         Ok(())
     }

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -99,9 +99,19 @@ impl<'a, C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> LeaderS
         );
 
         // TODO(xp): a leader has to refuse a message from a previous leader.
-        if !self.nodes.contains_key(&target) {
+        if let Some(l) = &self.core.leader_data {
+            if !l.nodes.contains_key(&target) {
+                return Ok(());
+            };
+        } else {
+            // no longer a leader.
+            tracing::warn!(
+                target = display(target),
+                result = debug(&result),
+                "received replication update but no longer a leader"
+            );
             return Ok(());
-        };
+        }
 
         tracing::debug!("update matched: {:?}", result);
 


### PR DESCRIPTION

## Changelog

##### Refactor: move `LeaderState.nodes` to `RaftCore.leader_data`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/451)
<!-- Reviewable:end -->
