### PR TITLE
Refactor: use `vote` to identify a server state.

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Internal](./internal.md)
     - [Architecture](./architecture.md)
     - [Threads](./threading.md)
+    - [Vote](./vote.md)
     - [Replication](./replication.md)
       - [Delete-conflicting-logs](./delete_log.md)
     - [Effective Membership](./effective-membership.md)

--- a/guide/src/vote.md
+++ b/guide/src/vote.md
@@ -1,0 +1,40 @@
+# Vote
+
+```rust
+struct Vote<NID: NodeId> {
+    term: u64,
+    node_id: NID,
+    committed: bool
+}
+```
+
+`vote` in openraft defines the pseudo **time**(in other word, defines every `leader`) in a distributed consensus.
+Each `vote` can be thought as unique time point(in paxos the pseudo time is round-number or `rnd`, or `ballot-number`).
+
+In a standard raft, the corresponding concept is `term`.
+Although in standard raft a single `term` is not enough to define a **time
+point**.
+
+Every server state(leader, candidate, follower or learner) has a unique
+corresponding `vote`, thus `vote` can be used to identify different server
+states, i.e, if the `vote` changes, the server state must have changed.
+
+Note: follower and learner in openraft is almost the same. The only difference
+is a learner does not try to elect itself.
+
+Note: a follower will switch to a learner and vice versa without changing the `vote`, when a
+new membership log is replicated to a follower or learner.
+
+E.g.:
+
+- A vote `(term=1, node_id=2, committed=false)` is in a candidate state for
+    node-2.
+
+- A vote `(term=1, node_id=2, committed=true)` is in a leader state for
+    node-2.
+
+- A vote `(term=1, node_id=2, committed=false|true)` is in a follower/learner
+    state for node-3.
+
+- A vote `(term=1, node_id=1, committed=false|true)` is in another different
+    follower/learner state for node-3.


### PR DESCRIPTION

## Changelog

##### Refactor: use `vote` to identify a server state.

Every server state has a unique corresponding `vote`, thus `vote` can be
used to identify different server states, i.e, if the `vote` changes,
the server state must have been changed.

`vote` in openraft defines the pseudo **time** in the distributed
consensus. Each `vote` can be thought as unique time point.
(Although in standard raft there is no such concept.)

E.g.:

- A vote `(term=1, node_id=2, committed=false)` is in a candidate state for
  node-2.

- A vote `(term=1, node_id=2, committed=true)` is in a leader state for
  node-2.

- A vote `(term=1, node_id=2, committed=false|true)` is in a follower state for
  node-3.

- A vote `(term=1, node_id=1, committed=false|true)` is in a different follower state for
  node-3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/457)
<!-- Reviewable:end -->
