### PR TITLE
Refactor: reduce election conflict

### DIFF
--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -43,7 +43,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             });
         }
 
-        self.set_next_election_time();
+        self.set_next_election_time(false);
         self.reject_election_for_a_while();
 
         if req.vote > self.engine.state.vote {

--- a/openraft/src/core/internal_msg.rs
+++ b/openraft/src/core/internal_msg.rs
@@ -1,5 +1,4 @@
 use crate::core::snapshot_state::SnapshotUpdate;
-use crate::raft::VoteResponse;
 use crate::NodeId;
 
 /// Message for communication between internal tasks.
@@ -8,5 +7,4 @@ use crate::NodeId;
 #[derive(Debug, Clone)]
 pub(crate) enum InternalMessage<NID: NodeId> {
     SnapshotUpdate(SnapshotUpdate<NID>),
-    VoteResponse { target: NID, vote_resp: VoteResponse<NID> },
 }

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -12,6 +12,7 @@ mod replication_expectation;
 mod replication_state;
 mod server_state;
 mod snapshot_state;
+mod tick;
 
 pub(crate) use internal_msg::InternalMessage;
 pub use raft_core::RaftCore;
@@ -20,3 +21,5 @@ pub(crate) use replication_state::replication_lag;
 pub use server_state::ServerState;
 use snapshot_state::SnapshotState;
 use snapshot_state::SnapshotUpdate;
+pub(crate) use tick::Tick;
+pub(crate) use tick::VoteWiseTime;

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -1,0 +1,87 @@
+//! tick emitter emits a `RaftMsg::Tick` event at a certain interval.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::sleep_until;
+use tokio::time::Instant;
+use tracing::Level;
+use tracing::Span;
+use tracing_futures::Instrument;
+
+use crate::raft::RaftMsg;
+use crate::NodeId;
+use crate::RaftNetworkFactory;
+use crate::RaftStorage;
+use crate::RaftTypeConfig;
+use crate::Vote;
+
+/// An instant time point bound to a vote.
+///
+/// If the vote on a node changes, the timeout belonging to a previous vote becomes invalid.
+/// See: https://datafuselabs.github.io/openraft/vote.html
+#[derive(Debug)]
+pub(crate) struct VoteWiseTime<NID: NodeId> {
+    pub(crate) vote: Vote<NID>,
+    pub(crate) time: Instant,
+}
+
+impl<NID: NodeId> VoteWiseTime<NID> {
+    pub(crate) fn new(vote: Vote<NID>, time: Instant) -> Self {
+        Self { vote, time }
+    }
+
+    /// Return the time if vote does not change since it is set.
+    pub(crate) fn get_time(&self, current_vote: &Vote<NID>) -> Option<Instant> {
+        debug_assert!(&self.vote <= current_vote);
+
+        if &self.vote == current_vote {
+            Some(self.time)
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) struct Tick<C, N, S>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkFactory<C>,
+    S: RaftStorage<C>,
+{
+    interval: Duration,
+
+    tx: mpsc::UnboundedSender<(RaftMsg<C, N, S>, Span)>,
+}
+
+impl<C, N, S> Tick<C, N, S>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkFactory<C>,
+    S: RaftStorage<C>,
+{
+    pub(crate) fn spawn(interval: Duration, tx: mpsc::UnboundedSender<(RaftMsg<C, N, S>, Span)>) -> JoinHandle<()> {
+        let t = Tick { interval, tx };
+
+        tokio::spawn(
+            async move {
+                let mut i = 0;
+                loop {
+                    i += 1;
+
+                    let at = Instant::now() + t.interval;
+                    sleep_until(at).await;
+
+                    let send_res = t.tx.send((RaftMsg::Tick { i }, tracing::span!(Level::DEBUG, "tick")));
+                    if let Err(_e) = send_res {
+                        tracing::info!("Tick fails to send, receiving end quit.");
+                    } else {
+                        tracing::debug!("Tick sent: {}", i)
+                    }
+                }
+            }
+            .instrument(tracing::span!(parent: &Span::current(), Level::DEBUG, "tick")),
+        )
+    }
+}

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -64,7 +64,12 @@ pub(crate) enum Command<NID: NodeId> {
 
     /// Install a timer to trigger an election, e.g., calling `Engine::elect()` after some `timeout` which is decided
     /// by the runtime. An already installed timer should be cleared.
-    InstallElectionTimer {},
+    InstallElectionTimer {
+        /// When a candidate fails to elect, it falls back to follower.
+        /// If many enough greater last-log-ids are seen, then this node can never become a leader.
+        /// Thus give it a longer sleep time before next election.
+        can_be_leader: bool,
+    },
 
     /// Reject election by other candidate for a while.
     /// The interval is decided by the runtime.

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -141,7 +141,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: false },
             Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
@@ -204,7 +204,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: false },
             Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
@@ -273,7 +273,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: false },
             Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
@@ -337,7 +337,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: false },
             Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -141,7 +141,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     assert_eq!(
         vec![
             //
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: true },
             Command::UpdateServerState {
                 server_state: ServerState::Follower
             }
@@ -187,7 +187,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: true },
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::UpdateServerState {
                 server_state: ServerState::Follower
@@ -215,7 +215,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         assert_eq!(
             vec![
                 //
-                Command::InstallElectionTimer {},
+                Command::InstallElectionTimer { can_be_leader: true },
                 Command::SaveVote { vote: Vote::new(3, 1) },
             ],
             eng.commands

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -108,7 +108,7 @@ fn test_internal_handle_vote_req_committed_vote() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: false },
             Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(3, 2)
@@ -149,7 +149,7 @@ fn test_internal_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow:
     assert_eq!(
         vec![
             //
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: true },
             Command::UpdateServerState {
                 server_state: ServerState::Follower
             }
@@ -184,7 +184,7 @@ fn test_internal_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer {},
+            Command::InstallElectionTimer { can_be_leader: true },
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::UpdateServerState {
                 server_state: ServerState::Follower
@@ -212,7 +212,7 @@ fn test_internal_handle_vote_req_granted_follower_learner_does_not_emit_update_s
         assert_eq!(
             vec![
                 //
-                Command::InstallElectionTimer {},
+                Command::InstallElectionTimer { can_be_leader: true },
                 Command::SaveVote { vote: Vote::new(3, 1) },
             ],
             eng.commands

--- a/openraft/tests/elect/t10_elect_compare_last_log.rs
+++ b/openraft/tests/elect/t10_elect_compare_last_log.rs
@@ -76,18 +76,11 @@ async fn elect_compare_last_log() -> Result<()> {
     router.new_raft_node_with_sto(0, sto0.clone());
     router.new_raft_node_with_sto(1, sto1.clone());
 
-    router
-        .wait_for_state(
-            &btreeset! {0},
-            ServerState::Leader,
-            timeout(),
-            "only node 0 becomes leader",
-        )
-        .await?;
+    router.wait(&0, timeout()).state(ServerState::Leader, "only node 0 becomes leader").await?;
 
     Ok(())
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(5000))
+    Some(Duration::from_millis(2000))
 }


### PR DESCRIPTION

## Changelog

##### Refactor: reduce election conflict

- Refactor: use Tick instead of setting up timer everywhere.
  When RaftCore is spawned, another task is spawn for emitting a `tick`
  event at a fixed interval, to wake up the RaftCore regularly to check
  timeout events, such as election timeout for follower.

- Refactor: use api-channel(`tx_api`) for election task to send vote-response to RaftCore.

- Refactor: when switch to follower state, the election timeout is set
  differently: If the follower can become a leader, i.e, it does not
  see a greater last-log-id when electing, give it a short sleep time.
  Otherwise, there are greater last-log-id in the cluster, give it a
  longer sleep time. This way to reduce election conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/458)
<!-- Reviewable:end -->
