### PR TITLE
Refactor: move last-log-id check out of Engine::internal_handle_vote_change()

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -431,6 +431,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
             // If we receive a response with a greater term, then revert to follower and abort this request.
             if let AppendEntriesResponse::HigherVote(vote) = data {
+                // TODO: there is no guarantee the response vote is greater than local. Because local vote may already
+                //       changed.
                 assert!(vote > self.engine.state.vote);
                 self.engine.state.vote = vote;
                 // TODO(xp): deal with storage error
@@ -759,7 +761,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         }
     }
 
-    /// Handle the admin `init_with_config` command.
+    /// Handle the admin command `initialize`.
     ///
     /// It is allowed to initialize only when `last_log_id.is_none()` and `vote==(0,0)`.
     /// See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
@@ -1542,12 +1544,13 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     #[tracing::instrument(level = "trace", skip(self))]
     async fn handle_revert_to_follower(
         &mut self,
-        _: C::NodeId,
+        _target: C::NodeId,
         vote: Vote<C::NodeId>,
     ) -> Result<(), StorageError<C::NodeId>> {
         if vote > self.engine.state.vote {
             self.engine.state.vote = vote;
             self.save_vote().await?;
+            // TODO: when switching to Follower, the next election time has to be set.
             self.set_target_state(ServerState::Follower);
         }
         Ok(())

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -125,6 +125,7 @@ impl<NID: NodeId> Engine<NID> {
     pub(crate) fn elect(&mut self) {
         // init election
         self.enter_leader();
+        // TODO: this should be part of the job of enter_leader()
         self.state.vote = Vote::new(self.state.vote.term + 1, self.id);
 
         // Safe unwrap()
@@ -163,7 +164,12 @@ impl<NID: NodeId> Engine<NID> {
             "Engine::handle_vote_req"
         );
 
-        let res = self.internal_handle_vote_req(&req.vote, &req.last_log_id);
+        let res = if req.last_log_id >= self.state.last_log_id() {
+            self.internal_handle_vote_change(&req.vote)
+        } else {
+            Err(RejectVoteRequest::ByLastLogId(self.state.last_log_id()))
+        };
+
         let vote_granted = if let Err(reject) = res {
             tracing::debug!(
                 req = display(req.summary()),
@@ -349,7 +355,7 @@ impl<NID: NodeId> Engine<NID> {
             "local state"
         );
 
-        let res = self.internal_handle_vote_req(vote, &None);
+        let res = self.internal_handle_vote_change(vote);
         if let Err(rejected) = res {
             return rejected.into();
         }
@@ -959,11 +965,7 @@ impl<NID: NodeId> Engine<NID> {
     ///
     /// If the `vote` is committed, i.e., it is granted by a quorum, then the vote holder, e.g. the leader already has
     /// all of the committed logs, thus in such case, we do not need to check `last_log_id`.
-    pub(crate) fn internal_handle_vote_req(
-        &mut self,
-        vote: &Vote<NID>,
-        last_log_id: &Option<LogId<NID>>,
-    ) -> Result<(), RejectVoteRequest<NID>> {
+    pub(crate) fn internal_handle_vote_change(&mut self, vote: &Vote<NID>) -> Result<(), RejectVoteRequest<NID>> {
         // Partial ord compare:
         // Vote does not has to be total ord.
         // `!(a >= b)` does not imply `a < b`.
@@ -973,23 +975,12 @@ impl<NID: NodeId> Engine<NID> {
             return Err(RejectVoteRequest::ByVote(self.state.vote));
         }
 
-        let mut can_be_leader = true;
-
-        if vote.committed {
-            // OK: a quorum has already granted this vote, then I'll grant it too.
-            can_be_leader = false;
-        } else {
-            // Grant non-committed vote
-            if last_log_id >= &self.state.last_log_id() {
-                // OK
-            } else {
-                return Err(RejectVoteRequest::ByLastLogId(self.state.last_log_id()));
-            }
-        };
-
-        tracing::debug!(%vote, ?last_log_id, "grant vote request" );
+        tracing::debug!(%vote, "grant vote" );
 
         // Grant the vote
+
+        // If the vote is granted by a quorum, this node should not try to elect.
+        let can_be_leader = !vote.committed;
 
         // There is an active leader or an active candidate.
         // Do not elect for a while.
@@ -1025,12 +1016,12 @@ impl<NID: NodeId> Engine<NID> {
     #[tracing::instrument(level = "debug", skip_all)]
     fn calc_server_state(&self) -> ServerState {
         tracing::debug!(
-            is_member = display(self.is_member()),
+            is_member = display(self.is_voter()),
             is_leader = display(self.is_leader()),
             is_becoming_leader = display(self.is_becoming_leader()),
             "states"
         );
-        if self.is_member() {
+        if self.is_voter() {
             if self.is_leader() {
                 ServerState::Leader
             } else if self.is_becoming_leader() {
@@ -1043,12 +1034,13 @@ impl<NID: NodeId> Engine<NID> {
         }
     }
 
-    fn is_member(&self) -> bool {
-        self.state.membership_state.is_member(&self.id)
+    fn is_voter(&self) -> bool {
+        self.state.membership_state.is_voter(&self.id)
     }
 
     /// The node is candidate or leader
     fn is_becoming_leader(&self) -> bool {
+        // self.state.vote.node_id == self.id
         self.state.leader.is_some()
     }
 

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -35,10 +35,10 @@ fn eng() -> Engine<u64> {
 }
 
 #[test]
-fn test_internal_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
+fn test_internal_handle_vote_change_reject_smaller_vote() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    let resp = eng.internal_handle_vote_req(&Vote::new(1, 2), &None);
+    let resp = eng.internal_handle_vote_change(&Vote::new(1, 2));
 
     assert_eq!(Err(RejectVoteRequest::ByVote(Vote::new(2, 1))), resp);
 
@@ -60,36 +60,11 @@ fn test_internal_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_internal_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
+fn test_internal_handle_vote_change_committed_vote() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    let resp = eng.internal_handle_vote_req(&Vote::new(3, 2), &Some(log_id(1, 3)));
-
-    assert_eq!(Err(RejectVoteRequest::ByLastLogId(Some(log_id(2, 3)))), resp);
-
-    assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.leader.is_some());
-
-    assert_eq!(ServerState::Candidate, eng.state.server_state);
-    assert_eq!(
-        MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
-        },
-        eng.metrics_flags
-    );
-
-    assert_eq!(0, eng.commands.len());
-    Ok(())
-}
-
-#[test]
-fn test_internal_handle_vote_req_committed_vote() -> anyhow::Result<()> {
-    let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
-
-    let resp = eng.internal_handle_vote_req(&Vote::new_committed(3, 2), &None);
+    let resp = eng.internal_handle_vote_change(&Vote::new_committed(3, 2));
 
     assert_eq!(Ok(()), resp);
 
@@ -124,13 +99,13 @@ fn test_internal_handle_vote_req_committed_vote() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_internal_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<()> {
+fn test_internal_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
     // Equal vote should not emit a SaveVote command.
 
     let mut eng = eng();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    let resp = eng.internal_handle_vote_req(&Vote::new(2, 1), &Some(log_id(2, 3)));
+    let resp = eng.internal_handle_vote_change(&Vote::new(2, 1));
 
     assert_eq!(Ok(()), resp);
 
@@ -160,13 +135,13 @@ fn test_internal_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow:
 }
 
 #[test]
-fn test_internal_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
+fn test_internal_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
     let mut eng = eng();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    let resp = eng.internal_handle_vote_req(&Vote::new(3, 1), &Some(log_id(2, 3)));
+    let resp = eng.internal_handle_vote_change(&Vote::new(3, 1));
 
     assert_eq!(Ok(()), resp);
 
@@ -196,15 +171,15 @@ fn test_internal_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_internal_handle_vote_req_granted_follower_learner_does_not_emit_update_server_state_cmd() -> anyhow::Result<()>
-{
+fn test_internal_handle_vote_change_granted_follower_learner_does_not_emit_update_server_state_cmd(
+) -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
     for st in [ServerState::Learner, ServerState::Follower] {
         let mut eng = eng();
         eng.state.server_state = st;
 
-        let resp = eng.internal_handle_vote_req(&Vote::new(3, 1), &Some(log_id(2, 3)));
+        let resp = eng.internal_handle_vote_change(&Vote::new(3, 1));
 
         assert_eq!(Ok(()), resp);
 

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -55,7 +55,7 @@ where E: TryInto<Fatal<NID>> + Clone
     }
 }
 
-// TODO: not used
+// TODO: not used, remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum AppendEntriesError<NID: NodeId> {
@@ -63,6 +63,7 @@ pub enum AppendEntriesError<NID: NodeId> {
     Fatal(#[from] Fatal<NID>),
 }
 
+// TODO: not used, remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum VoteError<NID: NodeId> {
@@ -70,6 +71,7 @@ pub enum VoteError<NID: NodeId> {
     Fatal(#[from] Fatal<NID>),
 }
 
+// TODO: remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum InstallSnapshotError<NID: NodeId> {

--- a/openraft/src/membership/membership_state.rs
+++ b/openraft/src/membership/membership_state.rs
@@ -35,7 +35,7 @@ pub struct MembershipState<NID: NodeId> {
 }
 
 impl<NID: NodeId> MembershipState<NID> {
-    pub(crate) fn is_member(&self, id: &NID) -> bool {
+    pub(crate) fn is_voter(&self, id: &NID) -> bool {
         self.effective.membership.is_voter(id)
     }
 }

--- a/openraft/src/membership/membership_state_test.rs
+++ b/openraft/src/membership/membership_state_test.rs
@@ -30,13 +30,13 @@ fn test_membership_state_is_member() -> anyhow::Result<()> {
         effective: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m123_345())),
     };
 
-    assert!(!x.is_member(&0));
-    assert!(x.is_member(&1));
-    assert!(x.is_member(&2));
-    assert!(x.is_member(&3));
-    assert!(x.is_member(&4));
-    assert!(x.is_member(&5));
-    assert!(!x.is_member(&6));
+    assert!(!x.is_voter(&0));
+    assert!(x.is_voter(&1));
+    assert!(x.is_voter(&2));
+    assert!(x.is_voter(&3));
+    assert!(x.is_voter(&4));
+    assert!(x.is_voter(&5));
+    assert!(!x.is_voter(&6));
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### Refactor: move last-log-id check out of Engine::internal_handle_vote_change()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/461)
<!-- Reviewable:end -->
