### PR TITLE
Refactor: add InternalServerState

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ bench_cluster_of_5:
 fmt:
 	cargo fmt
 
+fix:
+	cargo fix --allow-staged
+
 doc:
 	cargo doc --all --no-deps
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -359,7 +359,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         // Spawn parallel requests, all with the standard timeout for heartbeats.
         let mut pending = FuturesUnordered::new();
 
-        let voter_progresses = if let Some(l) = &self.engine.state.leader {
+        let voter_progresses = if let Some(l) = &self.engine.state.internal_server_state.leading() {
             l.progress
                 .iter()
                 .filter(|(id, _v)| l.progress.is_voter(id) == Some(true))
@@ -493,7 +493,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         let curr = &self.engine.state.membership_state.effective;
         if curr.contains(&target) {
-            let matched = if let Some(l) = &self.engine.state.leader {
+            let matched = if let Some(l) = &self.engine.state.internal_server_state.leading() {
                 *l.progress.get(&target)
             } else {
                 unreachable!("it has to be a leader!!!");
@@ -642,7 +642,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 Expectation::AtLineRate => {
                     // Expect to be at line rate but not.
 
-                    let matched = if let Some(l) = &self.engine.state.leader {
+                    let matched = if let Some(l) = &self.engine.state.internal_server_state.leading() {
                         *l.progress.get(node_id)
                     } else {
                         unreachable!("it has to be a leader!!!");
@@ -1443,7 +1443,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 let _ = tx.send(self.handle_vote_request(rpc).await.extract_fatal()?);
             }
             RaftMsg::VoteResponse { target, resp, vote } => {
-                if self.does_server_state_count_match(vote, "RevertToFollower") {
+                if self.does_server_state_count_match(vote, "VoteResponse") {
                     self.handle_vote_resp(resp, target).await?;
                 }
             }

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -44,7 +44,10 @@ fn test_elect() -> anyhow::Result<()> {
         eng.elect();
 
         assert_eq!(Vote::new_committed(1, 1), eng.state.vote);
-        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
+        assert_eq!(
+            Some(btreeset! {1},),
+            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+        );
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
@@ -57,6 +60,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         assert_eq!(
             vec![
+                Command::SaveVote { vote: Vote::new(1, 1) },
                 Command::SaveVote {
                     vote: Vote::new_committed(1, 1)
                 },
@@ -77,12 +81,15 @@ fn test_elect() -> anyhow::Result<()> {
         // Build in-progress election state
         eng.state.vote = Vote::new_committed(1, 2);
         eng.state.new_leader();
-        eng.state.leader.as_mut().map(|l| l.vote_granted_by.insert(1));
+        eng.state.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
 
         eng.elect();
 
         assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
+        assert_eq!(
+            Some(btreeset! {1},),
+            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+        );
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
@@ -95,6 +102,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         assert_eq!(
             vec![
+                Command::SaveVote { vote: Vote::new(2, 1) },
                 Command::SaveVote {
                     vote: Vote::new_committed(2, 1)
                 },
@@ -116,7 +124,10 @@ fn test_elect() -> anyhow::Result<()> {
         eng.elect();
 
         assert_eq!(Vote::new(1, 1), eng.state.vote);
-        assert_eq!(Some(btreeset! {1},), eng.state.leader.map(|x| x.vote_granted_by));
+        assert_eq!(
+            Some(btreeset! {1},),
+            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+        );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -9,6 +9,7 @@ use crate::error::NotAMembershipEntry;
 use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::error::RejectVoteRequest;
+use crate::internal_server_state::InternalServerState;
 use crate::membership::EffectiveMembership;
 use crate::membership::NodeRole;
 use crate::progress::Progress;
@@ -123,13 +124,10 @@ impl<NID: NodeId> Engine<NID> {
     /// Start to elect this node as leader
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn elect(&mut self) {
-        // init election
-        self.enter_leader();
-        // TODO: this should be part of the job of enter_leader()
-        self.state.vote = Vote::new(self.state.vote.term + 1, self.id);
+        self.handle_vote_change(&Vote::new(self.state.vote.term + 1, self.id)).unwrap();
 
         // Safe unwrap()
-        let leader = self.state.leader.as_mut().unwrap();
+        let leader = self.state.internal_server_state.leading_mut().unwrap();
         leader.grant_vote_by(self.id);
         let quorum_granted = leader.is_vote_granted();
 
@@ -146,7 +144,6 @@ impl<NID: NodeId> Engine<NID> {
 
         // Slow-path: send vote request, let a quorum grant it.
 
-        self.push_command(Command::SaveVote { vote: self.state.vote });
         self.push_command(Command::SendVote {
             vote_req: VoteRequest::new(self.state.vote, self.state.last_log_id()),
         });
@@ -165,7 +162,7 @@ impl<NID: NodeId> Engine<NID> {
         );
 
         let res = if req.last_log_id >= self.state.last_log_id() {
-            self.internal_handle_vote_change(&req.vote)
+            self.handle_vote_change(&req.vote)
         } else {
             Err(RejectVoteRequest::ByLastLogId(self.state.last_log_id()))
         };
@@ -204,9 +201,9 @@ impl<NID: NodeId> Engine<NID> {
         );
 
         // If this node is no longer a leader(i.e., electing), just ignore the delayed vote_resp.
-        let leader = match &mut self.state.leader {
-            None => return,
-            Some(l) => l,
+        let leader = match &mut self.state.internal_server_state {
+            InternalServerState::Leading(l) => l,
+            InternalServerState::Following => return,
         };
 
         if resp.vote < self.state.vote {
@@ -234,14 +231,10 @@ impl<NID: NodeId> Engine<NID> {
 
         // vote is rejected:
 
-        let node_role = self.state.membership_state.effective.get_node_role(&self.id);
-        debug_assert_eq!(Some(NodeRole::Voter), node_role);
-
-        // TODO(xp): This is a simplified impl: revert to follower as soon as seeing a higher `vote`.
-        //           When reverted to follower, it waits for heartbeat for 2 second before starting a new round of
-        //           election.
-        self.set_server_state(ServerState::Follower);
-        self.leave_leader();
+        debug_assert_eq!(
+            Some(NodeRole::Voter),
+            self.state.membership_state.effective.get_node_role(&self.id)
+        );
 
         // If peer's vote is greater than current vote, revert to follower state.
         if resp.vote > self.state.vote {
@@ -255,6 +248,20 @@ impl<NID: NodeId> Engine<NID> {
             self.push_command(Command::InstallElectionTimer { can_be_leader: false });
         } else {
             self.push_command(Command::InstallElectionTimer { can_be_leader: true });
+        }
+
+        debug_assert!(self.is_voter());
+
+        if self.state.internal_server_state.is_following() {
+            return;
+        }
+
+        // TODO:  use enter_following()
+        // self.enter_following();
+        {
+            self.state.internal_server_state = InternalServerState::Following;
+
+            self.set_server_state(ServerState::Follower);
         }
     }
 
@@ -355,7 +362,7 @@ impl<NID: NodeId> Engine<NID> {
             "local state"
         );
 
-        let res = self.internal_handle_vote_change(vote);
+        let res = self.handle_vote_change(vote);
         if let Err(rejected) = res {
             return rejected.into();
         }
@@ -650,7 +657,7 @@ impl<NID: NodeId> Engine<NID> {
         });
 
         // If membership changes, the progress should be upgraded.
-        if let Some(leader) = &mut self.state.leader {
+        if let Some(leader) = &mut self.state.internal_server_state.leading_mut() {
             let old_progress = leader.progress.clone();
 
             let old_repls = old_progress.iter().copied().collect::<BTreeMap<_, _>>();
@@ -694,7 +701,7 @@ impl<NID: NodeId> Engine<NID> {
         tracing::debug!("update_progress: node_id:{} log_id:{:?}", node_id, log_id);
 
         let committed = {
-            let leader = match &mut self.state.leader {
+            let leader = match self.state.internal_server_state.leading_mut() {
                 None => {
                     return;
                 }
@@ -765,7 +772,9 @@ impl<NID: NodeId> Engine<NID> {
     /// Enter leader state.
     ///
     /// Leader state has two phase: election phase and replication phase, similar to paxos phase-1 and phase-2
-    fn enter_leader(&mut self) {
+    pub(crate) fn enter_leading(&mut self) {
+        debug_assert_eq!(self.state.vote.node_id, self.id);
+
         self.state.new_leader();
         // TODO: install heartbeat timer
     }
@@ -773,9 +782,41 @@ impl<NID: NodeId> Engine<NID> {
     /// Leave leader state.
     ///
     /// This node then becomes raft-follower or raft-learner.
-    fn leave_leader(&mut self) {
-        self.state.leader = None;
-        // TODO: install election timer if it is a voter
+    pub(crate) fn enter_following(&mut self) {
+        // TODO: entering following needs to check last-log-id on other node to decide the election timeout.
+
+        // TODO: a candidate that can not elect successfully should not enter following state.
+        //       It should just sleep in leading state(candidate state for an application).
+        //       This way it holds that 'vote.node_id != self.id <=> following state`.
+        // debug_assert_ne!(self.state.vote.node_id, self.id);
+
+        let vote = &self.state.vote;
+
+        if vote.committed {
+            // There is an active leader.
+            // Do not elect for a longer while.
+            // TODO: Installing a timer should not be part of the Engine's job.
+            self.push_command(Command::InstallElectionTimer { can_be_leader: false });
+            // There is an active leader, reject election for a while.
+            // TODO: remove this when heartbeat log is ready.
+            self.push_command(Command::RejectElection {});
+        } else {
+            // There is an active candidate.
+            // Do not elect for a short while.
+            self.push_command(Command::InstallElectionTimer { can_be_leader: true });
+        }
+
+        if self.state.internal_server_state.is_following() {
+            return;
+        }
+
+        self.state.internal_server_state = InternalServerState::Following;
+
+        if self.is_voter() {
+            self.set_server_state(ServerState::Follower);
+        } else {
+            self.set_server_state(ServerState::Learner);
+        }
     }
 
     /// Update effective membership config if encountering a membership config log entry.
@@ -956,16 +997,12 @@ impl<NID: NodeId> Engine<NID> {
         }
     }
 
-    /// Check and grant a vote request.
+    /// Check and change vote.
     /// This is used by all 3 RPC append-entries, vote, install-snapshot to check the `vote` field.
     ///
-    /// Grant vote if [vote, last_log_id] >= mine by vector comparison.
-    /// Note: A greater `vote` won't be stored if `last_log_id` is smaller.
-    /// We do not need to upgrade `vote` for a node that can not become leader.
-    ///
-    /// If the `vote` is committed, i.e., it is granted by a quorum, then the vote holder, e.g. the leader already has
-    /// all of the committed logs, thus in such case, we do not need to check `last_log_id`.
-    pub(crate) fn internal_handle_vote_change(&mut self, vote: &Vote<NID>) -> Result<(), RejectVoteRequest<NID>> {
+    /// Grant vote if vote >= mine.
+    /// Note: This method does not check last-log-id. handle-vote-request has to deal with last-log-id itself.
+    pub(crate) fn handle_vote_change(&mut self, vote: &Vote<NID>) -> Result<(), RejectVoteRequest<NID>> {
         // Partial ord compare:
         // Vote does not has to be total ord.
         // `!(a >= b)` does not imply `a < b`.
@@ -979,35 +1016,15 @@ impl<NID: NodeId> Engine<NID> {
 
         // Grant the vote
 
-        // If the vote is granted by a quorum, this node should not try to elect.
-        let can_be_leader = !vote.committed;
-
-        // There is an active leader or an active candidate.
-        // Do not elect for a while.
-        self.push_command(Command::InstallElectionTimer { can_be_leader });
-        if vote.committed {
-            // There is an active leader, reject election for a while.
-            self.push_command(Command::RejectElection {});
-        }
-
         if vote > &self.state.vote {
             self.state.vote = *vote;
             self.push_command(Command::SaveVote { vote: *vote });
         }
 
-        // I'm no longer a leader.
-        self.leave_leader();
-
-        #[allow(clippy::collapsible_else_if)]
-        if self.state.server_state == ServerState::Follower || self.state.server_state == ServerState::Learner {
-            // nothing to do
+        if self.state.vote.node_id == self.id {
+            self.enter_leading();
         } else {
-            let node_type = self.state.membership_state.effective.get_node_role(&self.id);
-            if node_type == Some(NodeRole::Voter) {
-                self.set_server_state(ServerState::Follower);
-            } else {
-                self.set_server_state(ServerState::Learner);
-            }
+            self.enter_following();
         }
 
         Ok(())
@@ -1041,7 +1058,7 @@ impl<NID: NodeId> Engine<NID> {
     /// The node is candidate or leader
     fn is_becoming_leader(&self) -> bool {
         // self.state.vote.node_id == self.id
-        self.state.leader.is_some()
+        self.state.internal_server_state.is_leading()
     }
 
     fn is_leader(&self) -> bool {

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use maplit::btreeset;
+use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
 use crate::engine::Command;
@@ -141,14 +142,11 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            },
+            Command::InstallElectionTimer { can_be_leader: false },
+            Command::RejectElection {},
             Command::DeleteConflictLog { since: log_id(1, 2) },
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
@@ -204,14 +202,11 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            },
+            Command::InstallElectionTimer { can_be_leader: false },
+            Command::RejectElection {},
             Command::DeleteConflictLog { since: log_id(1, 2) },
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
@@ -235,6 +230,8 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
 #[test]
 fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()> {
     let mut eng = eng();
+    eng.state.vote = Vote::new(1, 2);
+    eng.enter_leading();
 
     let resp = eng.handle_append_entries_req(
         &Vote::new_committed(2, 1),
@@ -273,11 +270,11 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
+            Command::InstallElectionTimer { can_be_leader: false },
+            Command::RejectElection {},
             Command::UpdateServerState {
                 server_state: ServerState::Follower
             },
@@ -337,14 +334,11 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            },
+            Command::InstallElectionTimer { can_be_leader: false },
+            Command::RejectElection {},
             Command::DeleteConflictLog { since: log_id(2, 3) },
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -35,15 +35,15 @@ fn eng() -> Engine<u64> {
 }
 
 #[test]
-fn test_internal_handle_vote_change_reject_smaller_vote() -> anyhow::Result<()> {
+fn test_handle_vote_change_reject_smaller_vote() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    let resp = eng.internal_handle_vote_change(&Vote::new(1, 2));
+    let resp = eng.handle_vote_change(&Vote::new(1, 2));
 
     assert_eq!(Err(RejectVoteRequest::ByVote(Vote::new(2, 1))), resp);
 
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.leader.is_some());
+    assert!(eng.state.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(
@@ -60,16 +60,16 @@ fn test_internal_handle_vote_change_reject_smaller_vote() -> anyhow::Result<()> 
 }
 
 #[test]
-fn test_internal_handle_vote_change_committed_vote() -> anyhow::Result<()> {
+fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    let resp = eng.internal_handle_vote_change(&Vote::new_committed(3, 2));
+    let resp = eng.handle_vote_change(&Vote::new_committed(3, 2));
 
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new_committed(3, 2), eng.state.vote);
-    assert!(eng.state.leader.is_none());
+    assert!(eng.state.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
@@ -83,11 +83,11 @@ fn test_internal_handle_vote_change_committed_vote() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::SaveVote {
                 vote: Vote::new_committed(3, 2)
             },
+            Command::InstallElectionTimer { can_be_leader: false },
+            Command::RejectElection {},
             Command::UpdateServerState {
                 server_state: ServerState::Follower
             }
@@ -99,18 +99,18 @@ fn test_internal_handle_vote_change_committed_vote() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_internal_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
+fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
     // Equal vote should not emit a SaveVote command.
 
     let mut eng = eng();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    let resp = eng.internal_handle_vote_change(&Vote::new(2, 1));
+    let resp = eng.handle_vote_change(&Vote::new(2, 1));
 
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.leader.is_none());
+    assert!(eng.state.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
@@ -135,18 +135,18 @@ fn test_internal_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_internal_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
+fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
     let mut eng = eng();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    let resp = eng.internal_handle_vote_change(&Vote::new(3, 1));
+    let resp = eng.handle_vote_change(&Vote::new(3, 1));
 
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new(3, 1), eng.state.vote);
-    assert!(eng.state.leader.is_none());
+    assert!(eng.state.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
@@ -159,8 +159,8 @@ fn test_internal_handle_vote_change_granted_greater_vote() -> anyhow::Result<()>
 
     assert_eq!(
         vec![
-            Command::InstallElectionTimer { can_be_leader: true },
             Command::SaveVote { vote: Vote::new(3, 1) },
+            Command::InstallElectionTimer { can_be_leader: true },
             Command::UpdateServerState {
                 server_state: ServerState::Follower
             }
@@ -171,15 +171,20 @@ fn test_internal_handle_vote_change_granted_greater_vote() -> anyhow::Result<()>
 }
 
 #[test]
-fn test_internal_handle_vote_change_granted_follower_learner_does_not_emit_update_server_state_cmd(
-) -> anyhow::Result<()> {
+fn test_handle_vote_change_granted_follower_learner_does_not_emit_update_server_state_cmd() -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
-    for st in [ServerState::Learner, ServerState::Follower] {
-        let mut eng = eng();
-        eng.state.server_state = st;
+    // Learner
+    {
+        let st = ServerState::Learner;
 
-        let resp = eng.internal_handle_vote_change(&Vote::new(3, 1));
+        let mut eng = eng();
+        eng.id = 100; // make it a non-voter
+        eng.enter_following();
+        eng.state.server_state = st;
+        eng.commands = vec![];
+
+        let resp = eng.handle_vote_change(&Vote::new(3, 1));
 
         assert_eq!(Ok(()), resp);
 
@@ -187,8 +192,32 @@ fn test_internal_handle_vote_change_granted_follower_learner_does_not_emit_updat
         assert_eq!(
             vec![
                 //
-                Command::InstallElectionTimer { can_be_leader: true },
                 Command::SaveVote { vote: Vote::new(3, 1) },
+                Command::InstallElectionTimer { can_be_leader: true },
+            ],
+            eng.commands
+        );
+    }
+    // Follower
+    {
+        let st = ServerState::Follower;
+
+        let mut eng = eng();
+        eng.id = 0; // make it a voter
+        eng.enter_following();
+        eng.state.server_state = st;
+        eng.commands = vec![];
+
+        let resp = eng.handle_vote_change(&Vote::new(3, 1));
+
+        assert_eq!(Ok(()), resp);
+
+        assert_eq!(st, eng.state.server_state);
+        assert_eq!(
+            vec![
+                //
+                Command::SaveVote { vote: Vote::new(3, 1) },
+                Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.commands
         );

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -140,7 +140,7 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
     );
 
     assert!(
-        eng.state.leader.unwrap().progress.get(&4).is_none(),
+        eng.state.internal_server_state.leading().unwrap().progress.get(&4).is_none(),
         "exists, but it is a None"
     );
 
@@ -159,7 +159,7 @@ fn test_update_effective_membership_update_learner_process() -> anyhow::Result<(
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23_45()));
     eng.state.new_leader();
 
-    if let Some(l) = &mut eng.state.leader {
+    if let Some(l) = &mut eng.state.internal_server_state.leading_mut() {
         assert_eq!(&None, l.progress.get(&4));
         assert_eq!(&None, l.progress.get(&5));
 
@@ -185,7 +185,7 @@ fn test_update_effective_membership_update_learner_process() -> anyhow::Result<(
         eng.state.membership_state
     );
 
-    if let Some(l) = &mut eng.state.leader {
+    if let Some(l) = &mut eng.state.internal_server_state.leading_mut() {
         assert_eq!(
             &Some(log_id(1, 4)),
             l.progress.get(&4),

--- a/openraft/src/internal_server_state.rs
+++ b/openraft/src/internal_server_state.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+
+use crate::leader::Leader;
+use crate::EffectiveMembership;
+use crate::NodeId;
+
+/// In openraft there are only two state for a server:
+/// Leading(raft leader or raft candidate) and following(raft follower or raft learner):
+///
+/// - A leading state is able to vote(candidate in original raft) and is able to propose new log if its vote is granted
+///   by quorum(leader in original raft).
+///
+///   In this way the leadership won't be lost when it sees a higher `vote` and needs upgrade its `vote`.
+///
+/// - A following state just receives replication from a leader. A follower that is one of the member will be able to
+///   become leader. A following state that is not a member is just a learner.
+#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) enum InternalServerState<NID: NodeId> {
+    /// Leader or candidate.
+    ///
+    /// `vote.committed==true` means it is a leader.
+    Leading(Leader<NID, Arc<EffectiveMembership<NID>>>),
+
+    /// Follower or learner.
+    ///
+    /// Being a voter means it is a follower.
+    Following,
+}
+
+impl<NID: NodeId> Default for InternalServerState<NID> {
+    fn default() -> Self {
+        Self::Following
+    }
+}
+
+impl<NID: NodeId> InternalServerState<NID> {
+    pub(crate) fn leading(&self) -> Option<&Leader<NID, Arc<EffectiveMembership<NID>>>> {
+        match self {
+            InternalServerState::Leading(l) => Some(l),
+            InternalServerState::Following => None,
+        }
+    }
+
+    pub(crate) fn leading_mut(&mut self) -> Option<&mut Leader<NID, Arc<EffectiveMembership<NID>>>> {
+        match self {
+            InternalServerState::Leading(l) => Some(l),
+            InternalServerState::Following => None,
+        }
+    }
+
+    pub(crate) fn is_leading(&self) -> bool {
+        match self {
+            InternalServerState::Leading(_) => true,
+            InternalServerState::Following => false,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_following(&self) -> bool {
+        !self.is_leading()
+    }
+}

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -34,6 +34,7 @@ mod vote;
 
 mod engine;
 pub mod error;
+mod internal_server_state;
 mod leader;
 pub mod metrics;
 pub mod network;

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::engine::LogIdList;
+use crate::internal_server_state::InternalServerState;
 use crate::EffectiveMembership;
 use crate::EntryPayload;
 use crate::LogId;
@@ -64,7 +65,7 @@ where
             membership_state: mem_state,
 
             // -- volatile fields: they are not persisted.
-            leader: None,
+            internal_server_state: InternalServerState::default(),
             committed: None,
             server_state: Default::default(),
         })

--- a/openraft/src/timer/timeout_test.rs
+++ b/openraft/src/timer/timeout_test.rs
@@ -17,15 +17,15 @@ async fn test_timeout() -> anyhow::Result<()> {
             || {
                 let _ = tx.send(1u64);
             },
-            Duration::from_millis(50),
+            Duration::from_millis(500),
         );
 
         let res = rx.await?;
         assert_eq!(1u64, res);
 
         let elapsed = now.elapsed();
-        assert!(elapsed < Duration::from_millis(50 + 20));
-        assert!(Duration::from_millis(50 - 20) < elapsed);
+        assert!(elapsed < Duration::from_millis(500 + 200));
+        assert!(Duration::from_millis(500 - 200) < elapsed);
     }
 
     tracing::info!("--- update timeout");
@@ -36,18 +36,18 @@ async fn test_timeout() -> anyhow::Result<()> {
             || {
                 let _ = tx.send(1u64);
             },
-            Duration::from_millis(50),
+            Duration::from_millis(500),
         );
 
         // Update timeout to 100 ms after 20 ms, the expected elapsed is 120 ms.
-        sleep(Duration::from_millis(20)).await;
-        t.update_timeout(Duration::from_millis(100));
+        sleep(Duration::from_millis(200)).await;
+        t.update_timeout(Duration::from_millis(1000));
 
         let _res = rx.await?;
 
         let elapsed = now.elapsed();
-        assert!(elapsed < Duration::from_millis(120 + 20));
-        assert!(Duration::from_millis(120 - 20) < elapsed);
+        assert!(elapsed < Duration::from_millis(1200 + 200));
+        assert!(Duration::from_millis(1200 - 200) < elapsed);
     }
 
     tracing::info!("--- update timeout to a lower value wont take effect");
@@ -58,18 +58,18 @@ async fn test_timeout() -> anyhow::Result<()> {
             || {
                 let _ = tx.send(1u64);
             },
-            Duration::from_millis(50),
+            Duration::from_millis(500),
         );
 
         // Update timeout to 10 ms after 20 ms, the expected elapsed is still 50 ms.
-        sleep(Duration::from_millis(20)).await;
-        t.update_timeout(Duration::from_millis(10));
+        sleep(Duration::from_millis(200)).await;
+        t.update_timeout(Duration::from_millis(100));
 
         let _res = rx.await?;
 
         let elapsed = now.elapsed();
-        assert!(elapsed < Duration::from_millis(50 + 20));
-        assert!(Duration::from_millis(50 - 20) < elapsed);
+        assert!(elapsed < Duration::from_millis(500 + 200));
+        assert!(Duration::from_millis(500 - 200) < elapsed);
     }
 
     tracing::info!("--- drop the `Timeout` will cancel the callback");
@@ -80,19 +80,19 @@ async fn test_timeout() -> anyhow::Result<()> {
             || {
                 let _ = tx.send(1u64);
             },
-            Duration::from_millis(50),
+            Duration::from_millis(500),
         );
 
         // Drop the Timeout after 20 ms, the expected elapsed is 20 ms.
-        sleep(Duration::from_millis(20)).await;
+        sleep(Duration::from_millis(200)).await;
         drop(t);
 
         let res = rx.await;
         assert!(res.is_err());
 
         let elapsed = now.elapsed();
-        assert!(elapsed < Duration::from_millis(20 + 10));
-        assert!(Duration::from_millis(20 - 10) < elapsed);
+        assert!(elapsed < Duration::from_millis(200 + 100));
+        assert!(Duration::from_millis(200 - 100) < elapsed);
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Refactor: add InternalServerState

In openraft there are only two state for a server:
Leading(raft leader or raft candidate) and following(raft follower or raft learner):

- A leading state is able to vote(candidate in original raft) and is able to propose new log if its vote is granted
  by quorum(leader in original raft).

  In this way the leadership won't be lost when it sees a higher `vote` and needs upgrade its `vote`.

- A following state just receives replication from a leader. A follower that is one of the member will be able to
  become leader. A following state that is not a member is just a learner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/463)
<!-- Reviewable:end -->
