### PR TITLE
Refactor: candidate_loop() should not trigger election

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use maplit::btreeset;
+use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
 use crate::engine::Command;
@@ -146,7 +147,8 @@ fn test_elect() -> anyhow::Result<()> {
                 },
                 Command::UpdateServerState {
                     server_state: ServerState::Candidate
-                }
+                },
+                Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.commands
         );

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -127,7 +127,7 @@ impl<NID: NodeId> Engine<NID> {
         self.push_command(Command::MoveInputCursorBy { n: l });
 
         // With the new config, start to elect to become leader
-        self.set_server_state(ServerState::Candidate);
+        self.elect();
 
         Ok(())
     }
@@ -161,6 +161,7 @@ impl<NID: NodeId> Engine<NID> {
 
         // TODO: For compatibility. remove it. The runtime does not need to know about server state.
         self.set_server_state(ServerState::Candidate);
+        self.push_command(Command::InstallElectionTimer { can_be_leader: true });
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -1,4 +1,5 @@
 use maplit::btreeset;
+use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
 use crate::engine::testing::Config;
@@ -10,12 +11,86 @@ use crate::error::InitializeError;
 use crate::error::NotAMembershipEntry;
 use crate::error::NotAllowed;
 use crate::error::NotInMembers;
+use crate::raft::VoteRequest;
 use crate::EntryPayload;
 use crate::LeaderId;
 use crate::LogId;
 use crate::Membership;
 use crate::MetricsChangeFlags;
 use crate::Vote;
+
+#[test]
+fn test_initialize_single_node() -> anyhow::Result<()> {
+    let eng = Engine::<u64>::default;
+
+    let log_id0 = LogId {
+        leader_id: LeaderId::new(0, 0),
+        index: 0,
+    };
+
+    let m1 = || Membership::<u64>::new(vec![btreeset! {1}], None);
+    let payload = EntryPayload::<Config>::Membership(m1());
+    let mut entries = [EntryRef::new(&payload)];
+
+    tracing::info!("--- ok: init empty node 1 with membership(1,2)");
+    tracing::info!("--- expect OK result, check output commands and state changes");
+    {
+        let mut eng = eng();
+        eng.id = 1;
+
+        eng.initialize(&mut entries)?;
+
+        assert_eq!(Some(log_id0), eng.state.get_log_id(0));
+        assert_eq!(None, eng.state.get_log_id(1));
+        assert_eq!(Some(log_id0), eng.state.last_log_id());
+
+        assert_eq!(ServerState::Leader, eng.state.server_state);
+        assert_eq!(
+            MetricsChangeFlags {
+                leader: false,
+                other_metrics: true
+            },
+            eng.metrics_flags
+        );
+        assert_eq!(m1(), eng.state.membership_state.effective.membership);
+
+        assert_eq!(
+            vec![
+                Command::AppendInputEntries { range: 0..1 },
+                Command::UpdateMembership {
+                    membership: eng.state.membership_state.effective.clone()
+                },
+                // When update the effective membership, the engine set it to Follower.
+                // But when initializing, it will switch to Candidate at once, in the last output command.
+                Command::UpdateServerState {
+                    server_state: ServerState::Follower,
+                },
+                Command::MoveInputCursorBy { n: 1 },
+                Command::SaveVote {
+                    vote: Vote {
+                        term: 1,
+                        node_id: 1,
+                        committed: false,
+                    },
+                },
+                // TODO: duplicated SaveVote: one is emitted by elect(), the second is emitted when the node becomes
+                //       leader.
+                Command::SaveVote {
+                    vote: Vote {
+                        term: 1,
+                        node_id: 1,
+                        committed: true,
+                    },
+                },
+                Command::UpdateServerState {
+                    server_state: ServerState::Leader
+                },
+            ],
+            eng.commands
+        );
+    }
+    Ok(())
+}
 
 #[test]
 fn test_initialize() -> anyhow::Result<()> {
@@ -65,9 +140,30 @@ fn test_initialize() -> anyhow::Result<()> {
                     server_state: ServerState::Follower,
                 },
                 Command::MoveInputCursorBy { n: 1 },
+                Command::SaveVote {
+                    vote: Vote {
+                        term: 1,
+                        node_id: 1,
+                        committed: false,
+                    },
+                },
+                Command::SendVote {
+                    vote_req: VoteRequest {
+                        vote: Vote {
+                            term: 1,
+                            node_id: 1,
+                            committed: false,
+                        },
+                        last_log_id: Some(LogId {
+                            leader_id: LeaderId { term: 0, node_id: 0 },
+                            index: 0,
+                        },),
+                    },
+                },
                 Command::UpdateServerState {
                     server_state: ServerState::Candidate
-                }
+                },
+                Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.commands
         );


### PR DESCRIPTION

## Changelog

##### Refactor: candidate_loop() should not trigger election

Candidate loop should run in a passive mode: just handles messages.
A timer for election will trigger a candidate to elect when candidate
timed out collecting enough vote response.

This way in the candidate loop it does not need to call
`Engine::elect()` it self any more.

Other parts are updated according to this change:
such as `Engine::initialize()` can not rely on `candidate_loop()` to
trigger election. `initialize()` has to manually call `elect()` to enter
candidate state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/464)
<!-- Reviewable:end -->
