### PR TITLE
Refactor: simplify config arg attributes for keep_unsnapshoted_log

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -129,7 +129,12 @@ pub struct Config {
     /// please set this to true.
     ///
     /// By default, `OpenRaft` purges `applied_log`s from time to time regardless of snapshots, because it assumes once
-    /// logs are `applied` to the state machine, logs are persisted on disk. If not so, set this to true.
+    /// logs are `applied` to the state machine, logs are persisted on disk.
+    ///
+    /// If an implementation does not persist data when `RaftStorage::apply_to_state_machine()` returns, and just
+    /// relies on `snapshot` to rebuild the state machine when the next time it restarts, the application must always
+    /// set `keep_unsnapshoted_log` to `true`, so that only logs that are already included in a snapshot will be
+    /// purged.
     //
     // This is another way to implement:
     // #[clap(long, env = "RAFT_KEEP_UNSNAPSHOTED_LOG",

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -130,7 +130,12 @@ pub struct Config {
     ///
     /// By default, `OpenRaft` purges `applied_log`s from time to time regardless of snapshots, because it assumes once
     /// logs are `applied` to the state machine, logs are persisted on disk. If not so, set this to true.
-    #[clap(long, env = "RAFT_KEEP_UNSNAPSHOTED_LOG", default_value_t = false, value_parser=clap::value_parser!(bool))]
+    //
+    // This is another way to implement:
+    // #[clap(long, env = "RAFT_KEEP_UNSNAPSHOTED_LOG",
+    //        default_value_t = false,
+    //        value_parser=clap::value_parser!(bool))]
+    #[clap(long, env = "RAFT_KEEP_UNSNAPSHOTED_LOG")]
     pub keep_unsnapshoted_log: bool,
 
     /// The maximum snapshot chunk size allowed when transmitting snapshots (in bytes)

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -56,6 +56,7 @@ fn test_build() -> anyhow::Result<()> {
         "--max-payload-entries=201",
         "--replication-lag-threshold=202",
         "--snapshot-policy=since_last:203",
+        "--keep-unsnapshoted-log",
         "--snapshot-max-chunk-size=204",
         "--max-applied-log-to-keep=205",
         "--purge-batch-size=207",
@@ -69,9 +70,21 @@ fn test_build() -> anyhow::Result<()> {
     assert_eq!(201, config.max_payload_entries);
     assert_eq!(202, config.replication_lag_threshold);
     assert_eq!(SnapshotPolicy::LogsSinceLast(203), config.snapshot_policy);
+    assert_eq!(true, config.keep_unsnapshoted_log);
     assert_eq!(204, config.snapshot_max_chunk_size);
     assert_eq!(205, config.max_applied_log_to_keep);
     assert_eq!(207, config.purge_batch_size);
+
+    Ok(())
+}
+
+#[test]
+fn test_config_build_() -> anyhow::Result<()> {
+    let config = Config::build(&["foo", "--keep-unsnapshoted-log"])?;
+    assert_eq!(true, config.keep_unsnapshoted_log);
+
+    let config = Config::build(&["foo"])?;
+    assert_eq!(false, config.keep_unsnapshoted_log);
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### Refactor: simplify config arg attributes for keep_unsnapshoted_log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/465)
<!-- Reviewable:end -->
