### PR TITLE
Feature: add feature-flag: `bt` enables backtrace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,3 +52,53 @@ jobs:
         with:
           path: |
             openraft/_log/
+
+  ut-on-stable-rust:
+    name: unittest on stable rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup | Toolchain
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: "stable"
+          override: true
+          components: rustfmt, clippy
+
+      - name: Unit Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          # Parallel tests block each other and result in timeout.
+          RUST_TEST_THREADS: 2
+          RUST_LOG: debug
+          RUST_BACKTRACE: full
+
+
+      - name: Build | Release Mode | No features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+
+      - name: Build | Release Mode | No features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+        env:
+          # Enable unstable feature on stalbe rust.
+          RUSTC_BOOTSTRAP: 1
+
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          path: |
+            openraft/_log/

--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.32"
 anyerror = "0.1.6"
-openraft = { version="0.6.6", path= "../openraft" }
+openraft = { version="0.6", path= "../openraft" }
 async-trait = "0.1.36"
 serde = { version="1.0.114", features=["derive"] }
 serde_json = "1.0.57"

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(backtrace)]
-
 #[cfg(test)]
 mod test;
 
@@ -12,7 +10,6 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use anyerror::AnyError;
 use openraft::async_trait::async_trait;
 use openraft::raft::Entry;
 use openraft::raft::EntryPayload;
@@ -20,6 +17,7 @@ use openraft::raft::Membership;
 use openraft::storage::HardState;
 use openraft::storage::InitialState;
 use openraft::storage::Snapshot;
+use openraft::AnyError;
 use openraft::AppData;
 use openraft::AppDataResponse;
 use openraft::EffectiveMembership;

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -17,8 +17,8 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1.0.32"
+anyerror = { version = "0.1.6", features = ["anyhow"]}
 async-trait = "0.1.36"
-anyerror = "0.1.6"
 byte-unit = "4.0.12"
 bytes = "1.0"
 derive_more = { version="0.99.9" }
@@ -43,6 +43,10 @@ tracing-subscriber = { version = "0.3.3",  features=["env-filter"] }
 
 [features]
 docinclude = [] # Used only for activating `doc(include="...")` on nightly.
+
+# Enable backtrace when generating an error.
+# Stable rust does not support backtrace.
+bt  = ["anyerror/backtrace", "anyhow/backtrace"]
 
 [package.metadata.docs.rs]
 features = ["docinclude"] # Activate `docinclude` during docs.rs build.

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -471,7 +471,8 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
                     Ok(res) => match res {
                         Ok(snapshot) => {
                             let _ = tx_compaction.try_send(SnapshotUpdate::SnapshotComplete(snapshot.meta.last_log_id));
-                            let _ = chan_tx.send(snapshot.meta.last_log_id.index); // This will always succeed.
+                            // This will always succeed.
+                            let _ = chan_tx.send(snapshot.meta.last_log_id.index);
                         }
                         Err(err) => {
                             tracing::error!({error=%err}, "error while generating snapshot");

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -61,7 +61,7 @@ pub enum ReplicationError {
 
     #[error(transparent)]
     IO {
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         #[from]
         source: std::io::Error,
     },
@@ -75,7 +75,7 @@ pub enum ReplicationError {
 
     #[error(transparent)]
     Network {
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         source: anyhow::Error,
     },
 }

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -1,5 +1,11 @@
 #![doc = include_str!("../README.md")]
-#![feature(backtrace)]
+#![cfg_attr(feature = "bt", feature(backtrace))]
+
+//! # Feature flags
+//!
+//! - `bt`: Enable backtrace: generate backtrace for errors. This requires a unstable feature `backtrace` thus it can
+//!   not be used with stable rust, unless explicity allowing using unstable features in stable rust with
+//!   `RUSTC_BOOTSTRAP=1`.
 
 pub mod config;
 mod core;
@@ -24,6 +30,8 @@ mod store_wrapper;
 
 pub mod types;
 
+pub use anyerror;
+pub use anyerror::AnyError;
 pub use async_trait;
 pub use store_ext::StoreExt;
 pub use store_wrapper::Wrapper;

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -1,4 +1,3 @@
-use std::backtrace::Backtrace;
 use std::fmt::Formatter;
 
 use anyerror::AnyError;
@@ -15,7 +14,7 @@ impl DefensiveError {
         DefensiveError {
             subject,
             violation,
-            backtrace: format!("{:?}", Backtrace::capture()),
+            backtrace: anyerror::backtrace_str(),
         }
     }
 }
@@ -54,7 +53,7 @@ impl StorageIOError {
             subject,
             verb,
             source,
-            backtrace: format!("{:?}", Backtrace::capture()),
+            backtrace: anyerror::backtrace_str(),
         }
     }
 }

--- a/openraft/src/types/v065/storage_error.rs
+++ b/openraft/src/types/v065/storage_error.rs
@@ -18,7 +18,7 @@ pub struct DefensiveError {
     /// The description of the violation.
     pub violation: Violation,
 
-    pub backtrace: String,
+    pub backtrace: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -103,7 +103,7 @@ pub enum StorageError {
     #[error(transparent)]
     Defensive {
         #[from]
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         source: DefensiveError,
     },
 
@@ -111,7 +111,7 @@ pub enum StorageError {
     #[error(transparent)]
     IO {
         #[from]
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         source: StorageIOError,
     },
 }
@@ -122,5 +122,5 @@ pub struct StorageIOError {
     pub(crate) subject: ErrorSubject,
     pub(crate) verb: ErrorVerb,
     pub(crate) source: AnyError,
-    pub(crate) backtrace: String,
+    pub(crate) backtrace: Option<String>,
 }


### PR DESCRIPTION
`--features bt` enables backtrace when generating errors.
By default errors does not contain backtrace info.

Thus openraft can be built on stable rust by default.

To use on stable rust with backtrace, set `RUSTC_BOOTSTRAP=1`, e.g.:
```
RUSTUP_TOOLCHAIN=stable RUSTC_BOOTSTRAP=1 make test
```

- Fix: #469

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/470)
<!-- Reviewable:end -->
