### PR TITLE
Refactor: Turn Node into a trait

### DIFF
--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -5,6 +5,7 @@ use actix_web::middleware::Logger;
 use actix_web::web::Data;
 use actix_web::App;
 use actix_web::HttpServer;
+use openraft::BasicNode;
 use openraft::Config;
 use openraft::Raft;
 
@@ -26,7 +27,7 @@ pub type ExampleNodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
-    pub ExampleTypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId
+    pub ExampleTypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId, Node = BasicNode
 );
 
 pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, Arc<ExampleStore>>;

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -4,6 +4,7 @@ use actix_web::web::Data;
 use actix_web::Responder;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
+use openraft::BasicNode;
 use web::Json;
 
 use crate::app::ExampleApp;
@@ -45,7 +46,7 @@ pub async fn consistent_read(app: Data<ExampleApp>, req: Json<String>) -> actix_
             let key = req.0;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, CheckIsLeaderError<ExampleNodeId>> = Ok(value.unwrap_or_default());
+            let res: Result<String, CheckIsLeaderError<ExampleNodeId, BasicNode>> = Ok(value.unwrap_or_default());
             Ok(Json(res))
         }
         Err(e) => Ok(Json(Err(e))),

--- a/examples/raft-kv-memstore/src/network/management.rs
+++ b/examples/raft-kv-memstore/src/network/management.rs
@@ -7,7 +7,7 @@ use actix_web::web;
 use actix_web::web::Data;
 use actix_web::Responder;
 use openraft::error::Infallible;
-use openraft::Node;
+use openraft::BasicNode;
 use openraft::RaftMetrics;
 use web::Json;
 
@@ -27,10 +27,7 @@ pub async fn add_learner(
     req: Json<(ExampleNodeId, String)>,
 ) -> actix_web::Result<impl Responder> {
     let node_id = req.0 .0;
-    let node = Node {
-        addr: req.0 .1.clone(),
-        ..Default::default()
-    };
+    let node = BasicNode { addr: req.0 .1.clone() };
     let res = app.raft.add_learner(node_id, Some(node), true).await;
     Ok(Json(res))
 }
@@ -49,10 +46,7 @@ pub async fn change_membership(
 #[post("/init")]
 pub async fn init(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
     let mut nodes = BTreeMap::new();
-    nodes.insert(app.id, Node {
-        addr: app.addr.clone(),
-        data: Default::default(),
-    });
+    nodes.insert(app.id, BasicNode { addr: app.addr.clone() });
     let res = app.raft.initialize(nodes).await;
     Ok(Json(res))
 }
@@ -62,6 +56,6 @@ pub async fn init(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
 pub async fn metrics(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
     let metrics = app.raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<ExampleNodeId>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<ExampleNodeId, BasicNode>, Infallible> = Ok(metrics);
     Ok(Json(res))
 }

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -10,7 +10,7 @@ use maplit::btreemap;
 use maplit::btreeset;
 use openraft::error::NodeNotFound;
 use openraft::AnyError;
-use openraft::Node;
+use openraft::BasicNode;
 use tokio::runtime::Runtime;
 
 /// Setup a cluster of 3 nodes.
@@ -90,9 +90,9 @@ async fn test_cluster() -> anyhow::Result<()> {
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
     assert_eq!(
         btreemap! {
-            1 => Some(Node::new("127.0.0.1:21001")),
-            2 => Some(Node::new("127.0.0.1:21002")),
-            3 => Some(Node::new("127.0.0.1:21003")),
+            1 => Some(BasicNode::new("127.0.0.1:21001")),
+            2 => Some(BasicNode::new("127.0.0.1:21002")),
+            3 => Some(BasicNode::new("127.0.0.1:21003")),
         },
         nodes_in_cluster
     );
@@ -188,7 +188,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     match x {
         Err(e) => {
             let s = e.to_string();
-            let expect_err:String = "error occur on remote peer 2: has to forward request to: Some(1), Some(Node { addr: \"127.0.0.1:21001\", data: {} })".to_string();
+            let expect_err:String = "error occur on remote peer 2: has to forward request to: Some(1), Some(BasicNode { addr: \"127.0.0.1:21001\" })".to_string();
 
             assert_eq!(s, expect_err);
         }

--- a/examples/raft-kv-rocksdb/src/client.rs
+++ b/examples/raft-kv-rocksdb/src/client.rs
@@ -19,6 +19,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::ExampleNode;
 use crate::ExampleNodeId;
 use crate::ExampleRequest;
 use crate::ExampleTypeConfig;
@@ -55,14 +56,17 @@ impl ExampleClient {
     pub async fn write(
         &self,
         req: &ExampleRequest,
-    ) -> Result<ClientWriteResponse<ExampleTypeConfig>, RPCError<ExampleNodeId, ClientWriteError<ExampleNodeId>>> {
+    ) -> Result<
+        ClientWriteResponse<ExampleTypeConfig>,
+        RPCError<ExampleNodeId, ExampleNode, ClientWriteError<ExampleNodeId, ExampleNode>>,
+    > {
         self.send_rpc_to_leader("api/write", Some(req)).await
     }
 
     /// Read value by key, in an inconsistent mode.
     ///
     /// This method may return stale value because it does not force to read on a legal leader.
-    pub async fn read(&self, req: &String) -> Result<String, RPCError<ExampleNodeId, Infallible>> {
+    pub async fn read(&self, req: &String) -> Result<String, RPCError<ExampleNodeId, ExampleNode, Infallible>> {
         self.do_send_rpc_to_leader("api/read", Some(req)).await
     }
 
@@ -72,7 +76,7 @@ impl ExampleClient {
     pub async fn consistent_read(
         &self,
         req: &String,
-    ) -> Result<String, RPCError<ExampleNodeId, CheckIsLeaderError<ExampleNodeId>>> {
+    ) -> Result<String, RPCError<ExampleNodeId, ExampleNode, CheckIsLeaderError<ExampleNodeId, ExampleNode>>> {
         self.do_send_rpc_to_leader("api/consistent_read", Some(req)).await
     }
 
@@ -84,7 +88,9 @@ impl ExampleClient {
     /// With a initialized cluster, new node can be added with [`write`].
     /// Then setup replication with [`add_learner`].
     /// Then make the new node a member with [`change_membership`].
-    pub async fn init(&self) -> Result<(), RPCError<ExampleNodeId, InitializeError<ExampleNodeId>>> {
+    pub async fn init(
+        &self,
+    ) -> Result<(), RPCError<ExampleNodeId, ExampleNode, InitializeError<ExampleNodeId, ExampleNode>>> {
         self.do_send_rpc_to_leader("cluster/init", Some(&Empty {})).await
     }
 
@@ -94,7 +100,10 @@ impl ExampleClient {
     pub async fn add_learner(
         &self,
         req: (ExampleNodeId, String, String),
-    ) -> Result<AddLearnerResponse<ExampleNodeId>, RPCError<ExampleNodeId, AddLearnerError<ExampleNodeId>>> {
+    ) -> Result<
+        AddLearnerResponse<ExampleNodeId>,
+        RPCError<ExampleNodeId, ExampleNode, AddLearnerError<ExampleNodeId, ExampleNode>>,
+    > {
         self.send_rpc_to_leader("cluster/add-learner", Some(&req)).await
     }
 
@@ -105,7 +114,10 @@ impl ExampleClient {
     pub async fn change_membership(
         &self,
         req: &BTreeSet<ExampleNodeId>,
-    ) -> Result<ClientWriteResponse<ExampleTypeConfig>, RPCError<ExampleNodeId, ClientWriteError<ExampleNodeId>>> {
+    ) -> Result<
+        ClientWriteResponse<ExampleTypeConfig>,
+        RPCError<ExampleNodeId, ExampleNode, ClientWriteError<ExampleNodeId, ExampleNode>>,
+    > {
         self.send_rpc_to_leader("cluster/change-membership", Some(req)).await
     }
 
@@ -114,7 +126,9 @@ impl ExampleClient {
     /// Metrics contains various information about the cluster, such as current leader,
     /// membership config, replication status etc.
     /// See [`RaftMetrics`].
-    pub async fn metrics(&self) -> Result<RaftMetrics<ExampleNodeId>, RPCError<ExampleNodeId, Infallible>> {
+    pub async fn metrics(
+        &self,
+    ) -> Result<RaftMetrics<ExampleNodeId, ExampleNode>, RPCError<ExampleNodeId, ExampleNode, Infallible>> {
         self.do_send_rpc_to_leader("cluster/metrics", None::<&()>).await
     }
 
@@ -129,7 +143,7 @@ impl ExampleClient {
         &self,
         uri: &str,
         req: Option<&Req>,
-    ) -> Result<Resp, RPCError<ExampleNodeId, Err>>
+    ) -> Result<Resp, RPCError<ExampleNodeId, ExampleNode, Err>>
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,
@@ -174,17 +188,22 @@ impl ExampleClient {
         &self,
         uri: &str,
         req: Option<&Req>,
-    ) -> Result<Resp, RPCError<ExampleNodeId, Err>>
+    ) -> Result<Resp, RPCError<ExampleNodeId, ExampleNode, Err>>
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,
-        Err: std::error::Error + Serialize + DeserializeOwned + TryInto<ForwardToLeader<ExampleNodeId>> + Clone,
+        Err: std::error::Error
+            + Serialize
+            + DeserializeOwned
+            + TryInto<ForwardToLeader<ExampleNodeId, ExampleNode>>
+            + Clone,
     {
         // Retry at most 3 times to find a valid leader.
         let mut n_retry = 3;
 
         loop {
-            let res: Result<Resp, RPCError<ExampleNodeId, Err>> = self.do_send_rpc_to_leader(uri, req).await;
+            let res: Result<Resp, RPCError<ExampleNodeId, ExampleNode, Err>> =
+                self.do_send_rpc_to_leader(uri, req).await;
 
             let rpc_err = match res {
                 Ok(x) => return Ok(x),
@@ -193,7 +212,7 @@ impl ExampleClient {
 
             if let RPCError::RemoteError(remote_err) = &rpc_err {
                 let forward_err_res =
-                    <Err as TryInto<ForwardToLeader<ExampleNodeId>>>::try_into(remote_err.source.clone());
+                    <Err as TryInto<ForwardToLeader<ExampleNodeId, ExampleNode>>>::try_into(remote_err.source.clone());
 
                 if let Ok(ForwardToLeader {
                     leader_id: Some(leader_id),
@@ -204,7 +223,7 @@ impl ExampleClient {
                     // Update target to the new leader.
                     {
                         let mut t = self.leader.lock().unwrap();
-                        let api_addr = leader_node.data.get("api_addr").unwrap().clone();
+                        let api_addr = leader_node.api_addr.clone();
                         *t = (leader_id, api_addr);
                     }
 

--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -21,9 +22,25 @@ pub mod store;
 
 pub type ExampleNodeId = u64;
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
+pub struct ExampleNode {
+    pub rpc_addr: String,
+    pub api_addr: String,
+}
+
+impl Display for ExampleNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ExampleNode {{ rpc_addr: {}, api_addr: {} }}",
+            self.rpc_addr, self.api_addr
+        )
+    }
+}
+
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
-    pub ExampleTypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId
+    pub ExampleTypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId, Node = ExampleNode
 );
 
 pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, Arc<ExampleStore>>;

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -8,6 +8,7 @@ use tide::Response;
 use tide::StatusCode;
 
 use crate::app::ExampleApp;
+use crate::ExampleNode;
 use crate::ExampleNodeId;
 use crate::Server;
 
@@ -51,7 +52,7 @@ async fn consistent_read(mut req: Request<Arc<ExampleApp>>) -> tide::Result {
 
             let value = state_machine.get(&key)?;
 
-            let res: Result<String, CheckIsLeaderError<ExampleNodeId>> = Ok(value.unwrap_or_default());
+            let res: Result<String, CheckIsLeaderError<ExampleNodeId, ExampleNode>> = Ok(value.unwrap_or_default());
             Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
         }
         e => Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&e)?).build()),

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 use async_std::task::block_on;
 use maplit::btreemap;
 use maplit::btreeset;
-use openraft::Node;
 use raft_key_value_rocks::client::ExampleClient;
 use raft_key_value_rocks::start_example_raft_node;
 use raft_key_value_rocks::store::ExampleRequest;
+use raft_key_value_rocks::ExampleNode;
 
 /// Setup a cluster of 3 nodes.
 /// Write to it and read from it.
@@ -91,9 +91,9 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
     assert_eq!(
         btreemap! {
-            1 => Some(Node{addr: get_rpc_addr(1), data: btreemap!{"api_addr".into() => get_addr(1)}}),
-            2 => Some(Node{addr: get_rpc_addr(2), data: btreemap!{"api_addr".into() => get_addr(2)}}),
-            3 => Some(Node{addr: get_rpc_addr(3), data: btreemap!{"api_addr".into() => get_addr(3)}}),
+            1 => Some(ExampleNode{rpc_addr: get_rpc_addr(1), api_addr: get_addr(1)}),
+            2 => Some(ExampleNode{rpc_addr: get_rpc_addr(2), api_addr: get_addr(2)}),
+            3 => Some(ExampleNode{rpc_addr: get_rpc_addr(3), api_addr: get_addr(3)}),
         },
         nodes_in_cluster
     );
@@ -189,7 +189,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     match x {
         Err(e) => {
             let s = e.to_string();
-            let expect_err:String = "error occur on remote peer 2: has to forward request to: Some(1), Some(Node { addr: \"127.0.0.1:22001\", data: {\"api_addr\": \"127.0.0.1:21001\"} })".to_string();
+            let expect_err:String = "error occur on remote peer 2: has to forward request to: Some(1), Some(ExampleNode { rpc_addr: \"127.0.0.1:22001\", api_addr: \"127.0.0.1:21001\" })".to_string();
 
             assert_eq!(s, expect_err);
         }

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -14,6 +14,7 @@ use openraft::storage::RaftLogReader;
 use openraft::storage::RaftSnapshotBuilder;
 use openraft::storage::Snapshot;
 use openraft::AnyError;
+use openraft::BasicNode;
 use openraft::EffectiveMembership;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -72,13 +73,13 @@ pub type MemNodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for `MemStore`.
-    pub Config: D = ClientRequest, R = ClientResponse, NodeId = MemNodeId
+    pub Config: D = ClientRequest, R = ClientResponse, NodeId = MemNodeId, Node = BasicNode
 );
 
 /// The application snapshot type which the `MemStore` works with.
 #[derive(Debug)]
 pub struct MemStoreSnapshot {
-    pub meta: SnapshotMeta<MemNodeId>,
+    pub meta: SnapshotMeta<MemNodeId, BasicNode>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -89,7 +90,7 @@ pub struct MemStoreSnapshot {
 pub struct MemStoreStateMachine {
     pub last_applied_log: Option<LogId<MemNodeId>>,
 
-    pub last_membership: EffectiveMembership<MemNodeId>,
+    pub last_membership: EffectiveMembership<MemNodeId, BasicNode>,
 
     /// A mapping of client IDs to their state info.
     pub client_serial_responses: HashMap<String, (u64, Option<String>)>,
@@ -187,7 +188,9 @@ impl RaftLogReader<Config> for Arc<MemStore> {
 #[async_trait]
 impl RaftSnapshotBuilder<Config, Cursor<Vec<u8>>> for Arc<MemStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<MemNodeId, Cursor<Vec<u8>>>, StorageError<MemNodeId>> {
+    async fn build_snapshot(
+        &mut self,
+    ) -> Result<Snapshot<MemNodeId, BasicNode, Cursor<Vec<u8>>>, StorageError<MemNodeId>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -266,7 +269,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
 
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<MemNodeId>>, EffectiveMembership<MemNodeId>), StorageError<MemNodeId>> {
+    ) -> Result<(Option<LogId<MemNodeId>>, EffectiveMembership<MemNodeId, BasicNode>), StorageError<MemNodeId>> {
         let sm = self.sm.read().await;
         Ok((sm.last_applied_log, sm.last_membership.clone()))
     }
@@ -362,7 +365,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<MemNodeId>,
+        meta: &SnapshotMeta<MemNodeId, BasicNode>,
         snapshot: Box<Self::SnapshotData>,
     ) -> Result<StateMachineChanges<Config>, StorageError<MemNodeId>> {
         tracing::info!(
@@ -407,7 +410,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<Snapshot<MemNodeId, Self::SnapshotData>>, StorageError<MemNodeId>> {
+    ) -> Result<Option<Snapshot<MemNodeId, BasicNode, Self::SnapshotData>>, StorageError<MemNodeId>> {
         match &*self.current_snapshot.read().await {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -65,6 +65,8 @@ use crate::raft::AddLearnerResponse;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::ClientWriteResponse;
+use crate::raft::ClientWriteTx;
+use crate::raft::RaftAddLearnerTx;
 use crate::raft::RaftMsg;
 use crate::raft::RaftRespTx;
 use crate::raft::VoteRequest;
@@ -86,7 +88,6 @@ use crate::EntryPayload;
 use crate::LogId;
 use crate::Membership;
 use crate::MessageSummary;
-use crate::Node;
 use crate::RPCTypes;
 use crate::RaftNetwork;
 use crate::RaftNetworkFactory;
@@ -101,7 +102,7 @@ use crate::Vote;
 /// It is created when RaftCore enters leader state, and will be dropped when it quits leader state.
 pub(crate) struct LeaderData<C: RaftTypeConfig> {
     /// Channels to send result back to client when logs are committed.
-    pub(crate) client_resp_channels: BTreeMap<u64, RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>>,
+    pub(crate) client_resp_channels: BTreeMap<u64, ClientWriteTx<C, C::NodeId, C::Node>>,
 
     /// A mapping of node IDs the replication state of the target node.
     // TODO(xp): make it a field of RaftCore. it does not have to belong to leader.
@@ -142,7 +143,7 @@ pub struct RaftCore<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<
     /// The `RaftStorage` implementation.
     pub(crate) storage: S,
 
-    pub(crate) engine: Engine<C::NodeId>,
+    pub(crate) engine: Engine<C::NodeId, C::Node>,
 
     pub(crate) leader_data: Option<LeaderData<C>>,
 
@@ -155,13 +156,14 @@ pub struct RaftCore<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<
     pub(crate) tx_api: mpsc::UnboundedSender<RaftMsg<C, N, S>>,
     pub(crate) rx_api: mpsc::UnboundedReceiver<RaftMsg<C, N, S>>,
 
-    tx_metrics: watch::Sender<RaftMetrics<C::NodeId>>,
+    tx_metrics: watch::Sender<RaftMetrics<C::NodeId, C::Node>>,
 
     pub(crate) rx_shutdown: oneshot::Receiver<()>,
 
     pub(crate) span: Span,
 }
 
+pub(crate) type RaftSpawnHandle<NID> = JoinHandle<Result<(), Fatal<NID>>>;
 impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C, N, S> {
     pub(crate) fn spawn(
         id: C::NodeId,
@@ -171,9 +173,9 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         storage: S,
         tx_api: mpsc::UnboundedSender<RaftMsg<C, N, S>>,
         rx_api: mpsc::UnboundedReceiver<RaftMsg<C, N, S>>,
-        tx_metrics: watch::Sender<RaftMetrics<C::NodeId>>,
+        tx_metrics: watch::Sender<RaftMetrics<C::NodeId, C::Node>>,
         rx_shutdown: oneshot::Receiver<()>,
-    ) -> JoinHandle<Result<(), Fatal<C::NodeId>>> {
+    ) -> RaftSpawnHandle<C::NodeId> {
         let span = tracing::span!(
             parent: tracing::Span::current(),
             Level::DEBUG,
@@ -338,7 +340,10 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// handles this by having the leader exchange heartbeat messages with a majority of the
     /// cluster before responding to read-only requests.
     #[tracing::instrument(level = "trace", skip(self, tx))]
-    pub(super) async fn handle_check_is_leader_request(&mut self, tx: RaftRespTx<(), CheckIsLeaderError<C::NodeId>>) {
+    pub(super) async fn handle_check_is_leader_request(
+        &mut self,
+        tx: RaftRespTx<(), CheckIsLeaderError<C::NodeId, C::Node>>,
+    ) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
         let em = &self.engine.state.membership_state.effective;
@@ -474,8 +479,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub(super) async fn add_learner(
         &mut self,
         target: C::NodeId,
-        node: Option<Node>,
-        tx: RaftRespTx<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId>>,
+        node: Option<C::Node>,
+        tx: RaftAddLearnerTx<C::NodeId, C::Node>,
     ) -> Result<(), Fatal<C::NodeId>> {
         if let Some(l) = &self.leader_data {
             tracing::debug!(
@@ -556,7 +561,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         changes: ChangeMembers<C::NodeId>,
         expectation: Option<Expectation>,
         turn_to_learner: bool,
-        tx: RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>,
+        tx: RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId, C::Node>>,
     ) -> Result<(), Fatal<C::NodeId>> {
         let last = self.engine.state.membership_state.effective.membership.get_joint_config().last().unwrap();
         let members = changes.apply_to(last);
@@ -686,7 +691,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub async fn write_entry(
         &mut self,
         payload: EntryPayload<C>,
-        resp_tx: Option<RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>>,
+        resp_tx: Option<ClientWriteTx<C, C::NodeId, C::Node>>,
     ) -> Result<LogId<C::NodeId>, Fatal<C::NodeId>> {
         tracing::debug!(payload = display(payload.summary()), "write_entry");
 
@@ -775,8 +780,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn handle_initialize(
         &mut self,
-        member_nodes: BTreeMap<C::NodeId, Option<Node>>,
-    ) -> Result<(), InitializeError<C::NodeId>> {
+        member_nodes: BTreeMap<C::NodeId, Option<C::Node>>,
+    ) -> Result<(), InitializeError<C::NodeId, C::Node>> {
         let membership = Membership::try_from(member_nodes)?;
         let payload = EntryPayload::<C>::Membership(membership);
 
@@ -932,7 +937,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     /// Reject a request due to the Raft node being in a state which prohibits the request.
     #[tracing::instrument(level = "trace", skip(self, tx))]
     pub(crate) fn reject_with_forward_to_leader<T, E>(&self, tx: RaftRespTx<T, E>)
-    where E: From<ForwardToLeader<C::NodeId>> {
+    where E: From<ForwardToLeader<C::NodeId, C::Node>> {
         let l = self.current_leader();
         let err = ForwardToLeader {
             leader_id: l,
@@ -961,7 +966,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         }
     }
 
-    pub(crate) fn get_leader_node(&self, leader_id: Option<C::NodeId>) -> Option<Node> {
+    pub(crate) fn get_leader_node(&self, leader_id: Option<C::NodeId>) -> Option<C::Node> {
         match leader_id {
             None => None,
             Some(id) => self.engine.state.membership_state.effective.get_node(&id).cloned(),
@@ -1017,11 +1022,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
     /// Send result of applying a log entry to its client.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(super) async fn send_response(
-        entry: &Entry<C>,
-        resp: C::R,
-        tx: Option<RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId>>>,
-    ) {
+    pub(super) async fn send_response(entry: &Entry<C>, resp: C::R, tx: Option<ClientWriteTx<C, C::NodeId, C::Node>>) {
         tracing::debug!(entry = display(entry.summary()), "send_response");
 
         let tx = match tx {
@@ -1553,7 +1554,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     async fn handle_needs_snapshot(
         &mut self,
         must_include: Option<LogId<C::NodeId>>,
-        tx: oneshot::Sender<Snapshot<C::NodeId, S::SnapshotData>>,
+        tx: oneshot::Sender<Snapshot<C::NodeId, C::Node, S::SnapshotData>>,
     ) -> Result<(), StorageError<C::NodeId>> {
         // Ensure snapshotting is configured, else do nothing.
         let threshold = match &self.config.snapshot_policy {
@@ -1621,7 +1622,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
         &mut self,
         input_ref_entries: &'e [Ent],
         cur: &mut usize,
-        cmd: &Command<C::NodeId>,
+        cmd: &Command<C::NodeId, C::Node>,
     ) -> Result<(), StorageError<C::NodeId>>
     where
         Ent: RaftLogId<C::NodeId> + Sync + Send + 'e,

--- a/openraft/src/engine/calc_purge_upto_test.rs
+++ b/openraft/src/engine/calc_purge_upto_test.rs
@@ -1,5 +1,6 @@
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::BasicNode;
 use crate::LeaderId;
 use crate::LogId;
 
@@ -10,8 +11,8 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64>::default();
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode>::default();
     eng.state.log_ids = LogIdList::new(vec![
         //
         log_id(0, 0),

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -5,13 +5,18 @@ use crate::raft::VoteRequest;
 use crate::EffectiveMembership;
 use crate::LogId;
 use crate::MetricsChangeFlags;
+use crate::Node;
 use crate::NodeId;
 use crate::ServerState;
 use crate::Vote;
 
 /// Commands to send to `RaftRuntime` to execute, to update the application state.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum Command<NID: NodeId> {
+pub(crate) enum Command<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     /// Update server state, e.g., Leader, Follower etc.
     /// TODO: consider removing this variant. A runtime does not need to know about this. It is only meant for metrics
     ///       report.
@@ -42,7 +47,7 @@ pub(crate) enum Command<NID: NodeId> {
     /// Membership config changed, need to update replication streams.
     UpdateMembership {
         // TODO: not used yet.
-        membership: Arc<EffectiveMembership<NID>>,
+        membership: Arc<EffectiveMembership<NID, N>>,
     },
 
     /// Membership config changed, need to update replication streams.
@@ -85,7 +90,11 @@ pub(crate) enum Command<NID: NodeId> {
     BuildSnapshot {},
 }
 
-impl<NID: NodeId> Command<NID> {
+impl<NID, N> Command<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     /// Update the flag of the metrics that needs to be updated when this command is executed.
     pub(crate) fn update_metrics_flags(&self, flags: &mut MetricsChangeFlags) {
         match &self {

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -8,6 +8,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -22,16 +23,16 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m1() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1}], None)
+fn m1() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None)
 }
 
-fn m12() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None)
 }
 
-fn eng() -> Engine<u64> {
-    Engine::<u64>::default()
+fn eng() -> Engine<u64, BasicNode> {
+    Engine::<u64, BasicNode>::default()
 }
 
 #[test]

--- a/openraft/src/engine/follower_commit_entries_test.rs
+++ b/openraft/src/engine/follower_commit_entries_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -15,7 +16,7 @@ use crate::MembershipState;
 use crate::MetricsChangeFlags;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node = BasicNode
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -32,16 +33,16 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64>::default();
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode>::default();
     eng.state.committed = Some(log_id(1, 1));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -15,7 +16,7 @@ use crate::MembershipState;
 use crate::MetricsChangeFlags;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node = BasicNode
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -32,24 +33,24 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
 }
 
-fn m45() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {4,5}], None)
+fn m45() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {4,5}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64> {
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -7,6 +7,7 @@ use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft::AppendEntriesResponse;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -18,7 +19,7 @@ use crate::MetricsChangeFlags;
 use crate::Vote;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -35,20 +36,20 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64> {
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -8,6 +8,7 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -22,12 +23,12 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64>::default();
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode>::default();
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -8,6 +8,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteResponse;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -22,16 +23,16 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m12() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m1234() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1,2,3,4}], None)
+fn m1234() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> Engine<u64> {
-    Engine::<u64>::default()
+fn eng() -> Engine<u64, BasicNode> {
+    Engine::<u64, BasicNode>::default()
 }
 
 #[test]

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -12,6 +12,7 @@ use crate::error::NotAMembershipEntry;
 use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
+use crate::BasicNode;
 use crate::EntryPayload;
 use crate::LeaderId;
 use crate::LogId;
@@ -21,14 +22,14 @@ use crate::Vote;
 
 #[test]
 fn test_initialize_single_node() -> anyhow::Result<()> {
-    let eng = Engine::<u64>::default;
+    let eng = Engine::<u64, BasicNode>::default;
 
     let log_id0 = LogId {
         leader_id: LeaderId::new(0, 0),
         index: 0,
     };
 
-    let m1 = || Membership::<u64>::new(vec![btreeset! {1}], None);
+    let m1 = || Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None);
     let payload = EntryPayload::<Config>::Membership(m1());
     let mut entries = [EntryRef::new(&payload)];
 
@@ -94,7 +95,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 
 #[test]
 fn test_initialize() -> anyhow::Result<()> {
-    let eng = Engine::<u64>::default;
+    let eng = Engine::<u64, BasicNode>::default;
 
     let log_id0 = LogId {
         leader_id: LeaderId::new(0, 0),
@@ -102,7 +103,7 @@ fn test_initialize() -> anyhow::Result<()> {
     };
     let vote0 = Vote::new(0, 0);
 
-    let m12 = || Membership::<u64>::new(vec![btreeset! {1,2}], None);
+    let m12 = || Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None);
     let payload = EntryPayload::<Config>::Membership(m12());
     let mut entries = [EntryRef::new(&payload)];
 

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -7,6 +7,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::error::RejectVoteRequest;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -21,12 +22,12 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64>::default();
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode>::default();
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -7,6 +7,7 @@ use maplit::btreeset;
 
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -18,7 +19,7 @@ use crate::MetricsChangeFlags;
 use crate::Vote;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -35,33 +36,33 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m1() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1}], None)
+fn m1() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None)
 }
 
 /// members: {1}, learners: {2}
-fn m1_2() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1}], Some(btreeset! {2}))
+fn m1_2() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], Some(btreeset! {2}))
 }
 
-fn m13() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1,3}], None)
+fn m13() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1,3}], None)
 }
 
-fn m23() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64> {
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode> {
         id: 1, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -20,7 +20,9 @@ pub struct LogIdList<NID: NodeId> {
     key_log_ids: Vec<LogId<NID>>,
 }
 
-impl<NID: NodeId> LogIdList<NID> {
+impl<NID> LogIdList<NID>
+where NID: NodeId
+{
     /// Load all log ids that are the first one proposed by a leader.
     ///
     /// E.g., log ids with the same leader id will be got rid of, except the smallest.

--- a/openraft/src/engine/purge_log_test.rs
+++ b/openraft/src/engine/purge_log_test.rs
@@ -1,6 +1,7 @@
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::BasicNode;
 use crate::LeaderId;
 use crate::LogId;
 
@@ -11,8 +12,8 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64>::default();
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode>::default();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 2), log_id(4, 4), log_id(4, 6)]);
     eng
 }

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -1,3 +1,5 @@
+use crate::BasicNode;
+
 /// Req for test
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -10,5 +12,5 @@ pub(crate) struct Resp {}
 
 // Config for test
 crate::declare_raft_types!(
-   pub(crate) Config: D = Req, R = Resp, NodeId = u64
+   pub(crate) Config: D = Req, R = Resp, NodeId = u64, Node=BasicNode
 );

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -20,20 +21,20 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m12() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m23() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64> {
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode> {
         id: 2,
         ..Default::default()
     };

--- a/openraft/src/engine/update_committed_membership_test.rs
+++ b/openraft/src/engine/update_committed_membership_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -13,7 +14,7 @@ use crate::MembershipState;
 use crate::MetricsChangeFlags;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -23,20 +24,20 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64> {
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -6,6 +6,7 @@ use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Progress;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -15,7 +16,7 @@ use crate::MetricsChangeFlags;
 use crate::Vote;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -25,28 +26,28 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m23_45() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {2,3}], Some(btreeset! {4,5}))
+fn m23_45() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], Some(btreeset! {4,5}))
 }
 
-fn m34() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
 }
 
-fn m4_356() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
+fn m4_356() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64> {
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -18,16 +19,16 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m123() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1,2,3}], None)
+fn m123() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3}], None)
 }
 
-fn eng() -> Engine<u64> {
-    let mut eng = Engine::<u64> {
+fn eng() -> Engine<u64, BasicNode> {
+    let mut eng = Engine::<u64, BasicNode> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/internal_server_state.rs
+++ b/openraft/src/internal_server_state.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::leader::Leader;
+use crate::node::Node;
 use crate::EffectiveMembership;
 use crate::NodeId;
 
@@ -16,11 +17,15 @@ use crate::NodeId;
 ///   become leader. A following state that is not a member is just a learner.
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
-pub(crate) enum InternalServerState<NID: NodeId> {
+pub(crate) enum InternalServerState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     /// Leader or candidate.
     ///
     /// `vote.committed==true` means it is a leader.
-    Leading(Leader<NID, Arc<EffectiveMembership<NID>>>),
+    Leading(Leader<NID, Arc<EffectiveMembership<NID, N>>>),
 
     /// Follower or learner.
     ///
@@ -28,21 +33,29 @@ pub(crate) enum InternalServerState<NID: NodeId> {
     Following,
 }
 
-impl<NID: NodeId> Default for InternalServerState<NID> {
+impl<NID, N> Default for InternalServerState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     fn default() -> Self {
         Self::Following
     }
 }
 
-impl<NID: NodeId> InternalServerState<NID> {
-    pub(crate) fn leading(&self) -> Option<&Leader<NID, Arc<EffectiveMembership<NID>>>> {
+impl<NID, N> InternalServerState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    pub(crate) fn leading(&self) -> Option<&Leader<NID, Arc<EffectiveMembership<NID, N>>>> {
         match self {
             InternalServerState::Leading(l) => Some(l),
             InternalServerState::Following => None,
         }
     }
 
-    pub(crate) fn leading_mut(&mut self) -> Option<&mut Leader<NID, Arc<EffectiveMembership<NID>>>> {
+    pub(crate) fn leading_mut(&mut self) -> Option<&mut Leader<NID, Arc<EffectiveMembership<NID, N>>>> {
         match self {
             InternalServerState::Leading(l) => Some(l),
             InternalServerState::Following => None,

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -70,6 +70,7 @@ pub use crate::metrics::RaftMetrics;
 pub use crate::network::RPCTypes;
 pub use crate::network::RaftNetwork;
 pub use crate::network::RaftNetworkFactory;
+pub use crate::node::BasicNode;
 pub use crate::node::Node;
 pub use crate::node::NodeId;
 pub use crate::raft::Raft;

--- a/openraft/src/membership/effective_membership_test.rs
+++ b/openraft/src/membership/effective_membership_test.rs
@@ -1,13 +1,14 @@
 use maplit::btreeset;
 
 use crate::quorum::QuorumSet;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Membership;
 
 #[test]
 fn test_effective_membership_majority() -> anyhow::Result<()> {
     {
-        let m12345 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }], None);
+        let m12345 = Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3,4,5 }], None);
         let m = EffectiveMembership::new(None, m12345);
 
         assert!(!m.is_quorum([0].iter()));
@@ -19,7 +20,7 @@ fn test_effective_membership_majority() -> anyhow::Result<()> {
     }
 
     {
-        let m12345_678 = Membership::<u64>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
+        let m12345_678 = Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
         let m = EffectiveMembership::new(None, m12345_678);
 
         assert!(!m.is_quorum([0].iter()));

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -6,39 +6,61 @@ use maplit::btreemap;
 
 use crate::error::MissingNodeInfo;
 use crate::membership::NodeRole;
+use crate::node::Node;
 use crate::quorum::AsJoint;
 use crate::quorum::FindCoherent;
 use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
 use crate::MessageSummary;
-use crate::Node;
 use crate::NodeId;
 
+/// BTreeMap for mapping node-id the node.
+pub type NodeMap<NID, N> = BTreeMap<NID, Option<N>>;
 /// Convert other types into the internal data structure for node infos
-pub trait IntoOptionNodes<NID: NodeId> {
-    fn into_option_nodes(self) -> BTreeMap<NID, Option<Node>>;
+pub trait IntoOptionNodes<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn into_option_nodes(self) -> NodeMap<NID, N>;
 }
 
-impl<NID: NodeId> IntoOptionNodes<NID> for () {
-    fn into_option_nodes(self) -> BTreeMap<NID, Option<Node>> {
+impl<NID, N> IntoOptionNodes<NID, N> for ()
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn into_option_nodes(self) -> NodeMap<NID, N> {
         btreemap! {}
     }
 }
 
-impl<NID: NodeId> IntoOptionNodes<NID> for BTreeSet<NID> {
-    fn into_option_nodes(self) -> BTreeMap<NID, Option<Node>> {
+impl<NID, N> IntoOptionNodes<NID, N> for BTreeSet<NID>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn into_option_nodes(self) -> NodeMap<NID, N> {
         self.into_iter().map(|node_id| (node_id, None)).collect()
     }
 }
 
-impl<NID: NodeId> IntoOptionNodes<NID> for BTreeMap<NID, Node> {
-    fn into_option_nodes(self) -> BTreeMap<NID, Option<Node>> {
+impl<NID, N> IntoOptionNodes<NID, N> for BTreeMap<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn into_option_nodes(self) -> NodeMap<NID, N> {
         self.into_iter().map(|(node_id, n)| (node_id, Some(n))).collect()
     }
 }
 
-impl<NID: NodeId> IntoOptionNodes<NID> for BTreeMap<NID, Option<Node>> {
-    fn into_option_nodes(self) -> BTreeMap<NID, Option<Node>> {
+impl<NID, N> IntoOptionNodes<NID, N> for NodeMap<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn into_option_nodes(self) -> NodeMap<NID, N> {
         self
     }
 }
@@ -49,7 +71,11 @@ impl<NID: NodeId> IntoOptionNodes<NID> for BTreeMap<NID, Option<Node>> {
 /// every config.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct Membership<NID: NodeId> {
+pub struct Membership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     /// Multi configs of members.
     ///
     /// AKA a joint config in original raft paper.
@@ -59,13 +85,17 @@ pub struct Membership<NID: NodeId> {
     ///
     /// A node-id key that is in `nodes` but is not in `configs` is a **learner**.
     /// The values in this map must all be `Some` or `None`.
-    nodes: BTreeMap<NID, Option<Node>>,
+    nodes: BTreeMap<NID, Option<N>>,
 }
 
-impl<NID: NodeId> TryFrom<BTreeMap<NID, Option<Node>>> for Membership<NID> {
+impl<NID, N> TryFrom<BTreeMap<NID, Option<N>>> for Membership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     type Error = MissingNodeInfo<NID>;
 
-    fn try_from(b: BTreeMap<NID, Option<Node>>) -> Result<Self, Self::Error> {
+    fn try_from(b: BTreeMap<NID, Option<N>>) -> Result<Self, Self::Error> {
         let member_ids = b.keys().cloned().collect::<BTreeSet<NID>>();
 
         let membership = Membership::with_nodes(vec![member_ids], b)?;
@@ -73,7 +103,11 @@ impl<NID: NodeId> TryFrom<BTreeMap<NID, Option<Node>>> for Membership<NID> {
     }
 }
 
-impl<NID: NodeId> MessageSummary<Membership<NID>> for Membership<NID> {
+impl<NID, N> MessageSummary<Membership<NID, N>> for Membership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     fn summary(&self) -> String {
         let mut res = vec!["members:[".to_string()];
         for (i, c) in self.configs.iter().enumerate() {
@@ -116,7 +150,11 @@ impl<NID: NodeId> MessageSummary<Membership<NID>> for Membership<NID> {
     }
 }
 
-impl<NID: NodeId> Membership<NID> {
+impl<NID, N> Membership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     /// Create a new Membership of multiple configs(joint) and optionally a set of learner node ids.
     ///
     /// A node id that is in `node_ids` but is not in `configs` is a **learner**.
@@ -144,7 +182,7 @@ impl<NID: NodeId> Membership<NID> {
     ///   ids not in `configs` are learner node ids. In this case, every node id in `configs` has to present in `nodes`
     ///   or an error will be returned.
     pub(crate) fn with_nodes<T>(configs: Vec<BTreeSet<NID>>, nodes: T) -> Result<Self, MissingNodeInfo<NID>>
-    where T: IntoOptionNodes<NID> {
+    where T: IntoOptionNodes<NID, N> {
         let nodes = nodes.into_option_nodes();
 
         for voter_id in configs.as_joint().ids() {
@@ -175,9 +213,9 @@ impl<NID: NodeId> Membership<NID> {
     /// Node that present in `old` will **NOT** be replaced because changing the address of a node potentially breaks
     /// consensus guarantee.
     pub(crate) fn extend_nodes(
-        old: BTreeMap<NID, Option<Node>>,
-        new: &BTreeMap<NID, Option<Node>>,
-    ) -> BTreeMap<NID, Option<Node>> {
+        old: BTreeMap<NID, Option<N>>,
+        new: &BTreeMap<NID, Option<N>>,
+    ) -> BTreeMap<NID, Option<N>> {
         let mut res = old;
 
         for (k, v) in new.iter() {
@@ -195,7 +233,7 @@ impl<NID: NodeId> Membership<NID> {
         self.configs.len() > 1
     }
 
-    pub(crate) fn add_learner(&self, node_id: NID, node: Option<Node>) -> Result<Self, MissingNodeInfo<NID>> {
+    pub(crate) fn add_learner(&self, node_id: NID, node: Option<N>) -> Result<Self, MissingNodeInfo<NID>> {
         let configs = self.configs.clone();
 
         let nodes = Self::extend_nodes(self.nodes.clone(), &btreemap! {node_id=>node});
@@ -207,7 +245,11 @@ impl<NID: NodeId> Membership<NID> {
 }
 
 /// Membership API
-impl<NID: NodeId> Membership<NID> {
+impl<NID, N> Membership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     /// Return if a node is a voter or learner, or not in this membership config at all.
     #[allow(dead_code)]
     pub(crate) fn get_node_role(&self, nid: &NID) -> Option<NodeRole> {
@@ -247,13 +289,13 @@ impl<NID: NodeId> Membership<NID> {
     }
 
     /// Get a the node(either voter or learner) by node id.
-    pub(crate) fn get_node(&self, node_id: &NID) -> Option<&Node> {
+    pub(crate) fn get_node(&self, node_id: &NID) -> Option<&N> {
         let x = self.nodes.get(node_id)?;
         x.as_ref()
     }
 
     /// Returns an Iterator of all nodes(voters and learners).
-    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &Option<Node>)> {
+    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &Option<N>)> {
         self.nodes.iter()
     }
 
@@ -267,7 +309,11 @@ impl<NID: NodeId> Membership<NID> {
 }
 
 /// Quorum related API
-impl<NID: NodeId> Membership<NID> {
+impl<NID, N> Membership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
     /// Returns the next safe membership to change to while the expected final membership is `goal`.
     ///
     /// E.g.(`cicj` is a joint membership of `ci` and `cj`):
@@ -286,7 +332,7 @@ impl<NID: NodeId> Membership<NID> {
     /// }
     /// ```
     pub(crate) fn next_safe<T>(&self, goal: T, turn_to_learner: bool) -> Result<Self, MissingNodeInfo<NID>>
-    where T: IntoOptionNodes<NID> {
+    where T: IntoOptionNodes<NID, N> {
         let goal = goal.into_option_nodes();
 
         let goal_ids = goal.keys().cloned().collect::<BTreeSet<_>>();

--- a/openraft/src/membership/membership_state.rs
+++ b/openraft/src/membership/membership_state.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::node::Node;
 use crate::EffectiveMembership;
 use crate::NodeId;
 
@@ -27,14 +28,22 @@ use crate::NodeId;
 // Thus a raft node will only need to store at most two recent membership logs.
 #[derive(Debug, Clone, Default)]
 #[derive(PartialEq, Eq)]
-pub struct MembershipState<NID: NodeId> {
-    pub committed: Arc<EffectiveMembership<NID>>,
+pub struct MembershipState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    pub committed: Arc<EffectiveMembership<NID, N>>,
 
     // Using `Arc` because the effective membership will be copied to RaftMetrics frequently.
-    pub effective: Arc<EffectiveMembership<NID>>,
+    pub effective: Arc<EffectiveMembership<NID, N>>,
 }
 
-impl<NID: NodeId> MembershipState<NID> {
+impl<NID, N> MembershipState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     pub(crate) fn is_voter(&self, id: &NID) -> bool {
         self.effective.membership.is_voter(id)
     }

--- a/openraft/src/membership/membership_state_test.rs
+++ b/openraft/src/membership/membership_state_test.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -15,12 +16,12 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m1() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1}], None)
+fn m1() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None)
 }
 
-fn m123_345() -> Membership<u64> {
-    Membership::<u64>::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None)
+fn m123_345() -> Membership<u64, BasicNode> {
+    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None)
 }
 
 #[test]

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -4,6 +4,7 @@ use crate::core::ServerState;
 use crate::error::Fatal;
 use crate::membership::EffectiveMembership;
 use crate::metrics::ReplicationMetrics;
+use crate::node::Node;
 use crate::summary::MessageSummary;
 use crate::versioned::Versioned;
 use crate::LogId;
@@ -12,7 +13,11 @@ use crate::NodeId;
 /// A set of metrics describing the current state of a Raft node.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct RaftMetrics<NID: NodeId> {
+pub struct RaftMetrics<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     pub running_state: Result<(), Fatal<NID>>,
 
     /// The ID of the Raft node.
@@ -44,7 +49,7 @@ pub struct RaftMetrics<NID: NodeId> {
     pub current_leader: Option<NID>,
 
     /// The current membership config of the cluster.
-    pub membership_config: Arc<EffectiveMembership<NID>>,
+    pub membership_config: Arc<EffectiveMembership<NID, N>>,
 
     // ---
     // --- replication ---
@@ -53,7 +58,11 @@ pub struct RaftMetrics<NID: NodeId> {
     pub replication: Option<Versioned<ReplicationMetrics<NID>>>,
 }
 
-impl<NID: NodeId> MessageSummary<RaftMetrics<NID>> for RaftMetrics<NID> {
+impl<NID, N> MessageSummary<RaftMetrics<NID, N>> for RaftMetrics<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     fn summary(&self) -> String {
         format!("Metrics{{id:{},{:?}, term:{}, last_log:{:?}, last_applied:{:?}, leader:{:?}, membership:{}, snapshot:{:?}, replication:{}",
                 self.id,
@@ -69,7 +78,11 @@ impl<NID: NodeId> MessageSummary<RaftMetrics<NID>> for RaftMetrics<NID> {
     }
 }
 
-impl<NID: NodeId> RaftMetrics<NID> {
+impl<NID, N> RaftMetrics<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     pub fn new_initial(id: NID) -> Self {
         Self {
             running_state: Ok(()),

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -15,7 +15,6 @@ use crate::raft::InstallSnapshotRequest;
 use crate::raft::InstallSnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
-use crate::Node;
 use crate::RaftTypeConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,19 +49,19 @@ where C: RaftTypeConfig
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse<C::NodeId>, RPCError<C::NodeId, AppendEntriesError<C::NodeId>>>;
+    ) -> Result<AppendEntriesResponse<C::NodeId>, RPCError<C::NodeId, C::Node, AppendEntriesError<C::NodeId>>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C::NodeId>, RPCError<C::NodeId, InstallSnapshotError<C::NodeId>>>;
+    ) -> Result<InstallSnapshotResponse<C::NodeId>, RPCError<C::NodeId, C::Node, InstallSnapshotError<C::NodeId>>>;
 
     /// Send a RequestVote RPC to the target Raft node (§5).
     async fn send_vote(
         &mut self,
         rpc: VoteRequest<C::NodeId>,
-    ) -> Result<VoteResponse<C::NodeId>, RPCError<C::NodeId, VoteError<C::NodeId>>>;
+    ) -> Result<VoteResponse<C::NodeId>, RPCError<C::NodeId, C::Node, VoteError<C::NodeId>>>;
 }
 
 /// A trait defining the interface for a Raft network factory to create connections between cluster members.
@@ -90,6 +89,9 @@ where C: RaftTypeConfig
     ///
     /// The method is intentionally async to give the implementation a chance to use asynchronous
     /// sync primitives to serialize access to the common internal object, if needed.
-    async fn connect(&mut self, target: C::NodeId, node: Option<&Node>)
-        -> Result<Self::Network, Self::ConnectionError>;
+    async fn connect(
+        &mut self,
+        target: C::NodeId,
+        node: Option<&C::Node>,
+    ) -> Result<Self::Network, Self::ConnectionError>;
 }

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -1,6 +1,7 @@
 use crate::engine::LogIdList;
 use crate::internal_server_state::InternalServerState;
 use crate::leader::Leader;
+use crate::node::Node;
 use crate::raft_types::RaftLogId;
 use crate::LogId;
 use crate::LogIdOptionExt;
@@ -11,7 +12,11 @@ use crate::Vote;
 
 /// A struct used to represent the raft state which a Raft node needs.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct RaftState<NID: NodeId> {
+pub struct RaftState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     /// The vote state of this node.
     pub vote: Vote<NID>,
 
@@ -22,13 +27,13 @@ pub struct RaftState<NID: NodeId> {
     pub log_ids: LogIdList<NID>,
 
     /// The latest cluster membership configuration found, in log or in state machine.
-    pub membership_state: MembershipState<NID>,
+    pub membership_state: MembershipState<NID, N>,
 
     // --
     // -- volatile fields: they are not persisted.
     // --
     /// The internal server state used by Engine.
-    pub(crate) internal_server_state: InternalServerState<NID>,
+    pub(crate) internal_server_state: InternalServerState<NID, N>,
 
     /// The log id of the last known committed entry.
     ///
@@ -42,8 +47,10 @@ pub struct RaftState<NID: NodeId> {
     pub server_state: ServerState,
 }
 
-impl<NID> RaftState<NID>
-where NID: NodeId
+impl<NID, N> RaftState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
 {
     /// Append a list of `log_id`.
     ///

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::engine::LogIdList;
+use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -17,13 +18,13 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m12() -> Membership<u64> {
+fn m12() -> Membership<u64, BasicNode> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
 #[test]
 fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
-    let rs = RaftState::default();
+    let rs = RaftState::<u64, BasicNode>::default();
 
     assert!(!rs.has_log_id(&log_id(0, 0)));
 
@@ -32,7 +33,7 @@ fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
-    let rs = RaftState {
+    let rs = RaftState::<u64, BasicNode> {
         committed: Some(log_id(2, 1)),
         ..Default::default()
     };
@@ -46,7 +47,7 @@ fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
-    let rs = RaftState {
+    let rs = RaftState::<u64, BasicNode> {
         committed: Some(log_id(2, 1)),
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
@@ -66,20 +67,20 @@ fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_last_log_id() -> anyhow::Result<()> {
-    let rs = RaftState::<u64> {
+    let rs = RaftState::<u64, BasicNode> {
         log_ids: LogIdList::new(vec![]),
         ..Default::default()
     };
 
     assert_eq!(None, rs.last_log_id());
 
-    let rs = RaftState {
+    let rs = RaftState::<u64, BasicNode> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_log_id());
 
-    let rs = RaftState {
+    let rs = RaftState::<u64, BasicNode> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
@@ -90,20 +91,20 @@ fn test_raft_state_last_log_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
-    let rs = RaftState::<u64> {
+    let rs = RaftState::<u64, BasicNode> {
         log_ids: LogIdList::new(vec![]),
         ..Default::default()
     };
 
     assert_eq!(None, rs.last_purged_log_id());
 
-    let rs = RaftState {
+    let rs = RaftState::<u64, BasicNode> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id());
 
-    let rs = RaftState {
+    let rs = RaftState::<u64, BasicNode> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
@@ -115,7 +116,7 @@ fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
 #[test]
 fn test_raft_state_is_membership_committed() -> anyhow::Result<()> {
     //
-    let rs = RaftState::<u64> {
+    let rs = RaftState::<u64, BasicNode> {
         committed: None,
         membership_state: MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -129,7 +130,7 @@ fn test_raft_state_is_membership_committed() -> anyhow::Result<()> {
         "committed == effective, but not consider this"
     );
 
-    let rs = RaftState::<u64> {
+    let rs = RaftState::<u64, BasicNode> {
         committed: Some(log_id(2, 2)),
         membership_state: MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -143,7 +144,7 @@ fn test_raft_state_is_membership_committed() -> anyhow::Result<()> {
         "committed != effective, but rs.committed == effective.log_id"
     );
 
-    let rs = RaftState::<u64> {
+    let rs = RaftState::<u64, BasicNode> {
         committed: Some(log_id(2, 2)),
         membership_state: MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -76,7 +76,7 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
         &mut self,
         input_entries: &'e [Ent],
         curr: &mut usize,
-        cmd: &Command<C::NodeId>,
+        cmd: &Command<C::NodeId, C::Node>,
     ) -> Result<(), StorageError<C::NodeId>>
     where
         Ent: RaftLogId<C::NodeId> + Sync + Send + 'e,

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -39,7 +39,7 @@ where
     ///
     /// When the Raft node is first started, it will call this interface to fetch the last known state from stable
     /// storage.
-    pub async fn get_initial_state(&mut self) -> Result<RaftState<C::NodeId>, StorageError<C::NodeId>> {
+    pub async fn get_initial_state(&mut self) -> Result<RaftState<C::NodeId, C::Node>, StorageError<C::NodeId>> {
         let vote = self.sto.read_vote().await?;
         let st = self.sto.get_log_state().await?;
         let mut last_purged_log_id = st.last_purged_log_id;
@@ -100,7 +100,7 @@ where
     /// a follower only need to revert at most one membership log.
     ///
     /// Thus a raft node will only need to store at most two recent membership logs.
-    pub async fn get_membership(&mut self) -> Result<MembershipState<C::NodeId>, StorageError<C::NodeId>> {
+    pub async fn get_membership(&mut self) -> Result<MembershipState<C::NodeId, C::Node>, StorageError<C::NodeId>> {
         let (_, sm_mem) = self.sto.last_applied_state().await?;
 
         let sm_mem_next_index = sm_mem.log_id.next_index();
@@ -138,7 +138,7 @@ where
     pub async fn last_membership_in_log(
         &mut self,
         since_index: u64,
-    ) -> Result<Vec<EffectiveMembership<C::NodeId>>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<EffectiveMembership<C::NodeId, C::Node>>, StorageError<C::NodeId>> {
         let st = self.sto.get_log_state().await?;
 
         let mut end = st.last_log_id.next_index();

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -14,6 +14,7 @@ use tokio::io::AsyncWrite;
 
 use crate::defensive::check_range_matches_entries;
 use crate::membership::EffectiveMembership;
+use crate::node::Node;
 use crate::raft_types::SnapshotId;
 use crate::raft_types::StateMachineChanges;
 use crate::Entry;
@@ -25,19 +26,27 @@ use crate::Vote;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct SnapshotMeta<NID: NodeId> {
+pub struct SnapshotMeta<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     /// Log entries upto which this snapshot includes, inclusive.
     pub last_log_id: LogId<NID>,
 
     /// The last applied membership config.
-    pub last_membership: EffectiveMembership<NID>,
+    pub last_membership: EffectiveMembership<NID, N>,
 
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be different in bytes.
     pub snapshot_id: SnapshotId,
 }
 
-impl<NID: NodeId> SnapshotMeta<NID> {
+impl<NID, N> SnapshotMeta<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
     pub fn signature(&self) -> SnapshotSignature<NID> {
         SnapshotSignature {
             last_log_id: Some(self.last_log_id),
@@ -49,13 +58,14 @@ impl<NID: NodeId> SnapshotMeta<NID> {
 
 /// The data associated with the current snapshot.
 #[derive(Debug)]
-pub struct Snapshot<NID, S>
+pub struct Snapshot<NID, N, S>
 where
     NID: NodeId,
+    N: Node,
     S: AsyncRead + AsyncSeek + Send + Unpin + 'static,
 {
     /// metadata of a snapshot
-    pub meta: SnapshotMeta<NID>,
+    pub meta: SnapshotMeta<NID, N>,
 
     /// A read handle to the associated snapshot.
     pub snapshot: Box<S>,
@@ -148,7 +158,7 @@ where
     /// Building snapshot can be done by:
     /// - Performing log compaction, e.g. merge log entries that operates on the same key, like a LSM-tree does,
     /// - or by fetching a snapshot from the state machine.
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C::NodeId, SD>, StorageError<C::NodeId>>;
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C::NodeId, C::Node, SD>, StorageError<C::NodeId>>;
 
     // NOTES:
     // This interface is geared toward small file-based snapshots. However, not all snapshots can
@@ -217,7 +227,7 @@ where C: RaftTypeConfig
     // NOTE: This can be made into sync, provided all state machines will use atomic read or the like.
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C::NodeId>>, EffectiveMembership<C::NodeId>), StorageError<C::NodeId>>;
+    ) -> Result<(Option<LogId<C::NodeId>>, EffectiveMembership<C::NodeId, C::Node>), StorageError<C::NodeId>>;
 
     /// Apply the given payload of entries to the state machine.
     ///
@@ -265,7 +275,7 @@ where C: RaftTypeConfig
     /// A snapshot created from an earlier call to `begin_receiving_snapshot` which provided the snapshot.
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<C::NodeId>,
+        meta: &SnapshotMeta<C::NodeId, C::Node>,
         snapshot: Box<Self::SnapshotData>,
     ) -> Result<StateMachineChanges<C>, StorageError<C::NodeId>>;
 
@@ -282,7 +292,7 @@ where C: RaftTypeConfig
     /// of the snapshot, which should be decoded for creating this method's response data.
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<Snapshot<C::NodeId, Self::SnapshotData>>, StorageError<C::NodeId>>;
+    ) -> Result<Option<Snapshot<C::NodeId, C::Node, Self::SnapshotData>>, StorageError<C::NodeId>>;
 }
 
 /// APIs for debugging a store.

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -9,7 +9,9 @@ use crate::NodeId;
 use crate::Vote;
 
 /// Convert error to StorageError::IO();
-pub trait ToStorageResult<NID: NodeId, T> {
+pub trait ToStorageResult<NID, T>
+where NID: NodeId
+{
     /// Convert Result<T, E> to Result<T, StorageError::IO(StorageIOError)>
     ///
     /// `f` provides error context for building the StorageIOError.
@@ -17,7 +19,9 @@ pub trait ToStorageResult<NID: NodeId, T> {
     where F: FnOnce() -> (ErrorSubject<NID>, ErrorVerb);
 }
 
-impl<NID: NodeId, T> ToStorageResult<NID, T> for Result<T, std::io::Error> {
+impl<NID, T> ToStorageResult<NID, T> for Result<T, std::io::Error>
+where NID: NodeId
+{
     fn sto_res<F>(self, f: F) -> Result<T, StorageError<NID>>
     where F: FnOnce() -> (ErrorSubject<NID>, ErrorVerb) {
         match self {
@@ -35,7 +39,9 @@ impl<NID: NodeId, T> ToStorageResult<NID, T> for Result<T, std::io::Error> {
 /// E.g. re-applying an log entry is a violation that may be a potential bug.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct DefensiveError<NID: NodeId> {
+pub struct DefensiveError<NID>
+where NID: NodeId
+{
     /// The subject that violates store defensive check, e.g. hard-state, log or state machine.
     pub subject: ErrorSubject<NID>,
 
@@ -45,7 +51,9 @@ pub struct DefensiveError<NID: NodeId> {
     pub backtrace: Option<String>,
 }
 
-impl<NID: NodeId> DefensiveError<NID> {
+impl<NID> DefensiveError<NID>
+where NID: NodeId
+{
     pub fn new(subject: ErrorSubject<NID>, violation: Violation<NID>) -> Self {
         Self {
             subject,
@@ -55,7 +63,9 @@ impl<NID: NodeId> DefensiveError<NID> {
     }
 }
 
-impl<NID: NodeId> std::fmt::Display for DefensiveError<NID> {
+impl<NID> std::fmt::Display for DefensiveError<NID>
+where NID: NodeId
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "'{:?}' violates: '{}'", self.subject, self.violation)
     }
@@ -63,7 +73,9 @@ impl<NID: NodeId> std::fmt::Display for DefensiveError<NID> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum ErrorSubject<NID: NodeId> {
+pub enum ErrorSubject<NID>
+where NID: NodeId
+{
     /// A general storage error
     Store,
 
@@ -155,7 +167,9 @@ pub enum Violation<NID: NodeId> {
 /// A storage error could be either a defensive check error or an error occurred when doing the actual io operation.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum StorageError<NID: NodeId> {
+pub enum StorageError<NID>
+where NID: NodeId
+{
     /// An error raised by defensive check.
     #[error(transparent)]
     Defensive {
@@ -173,7 +187,9 @@ pub enum StorageError<NID: NodeId> {
     },
 }
 
-impl<NID: NodeId> StorageError<NID> {
+impl<NID> StorageError<NID>
+where NID: NodeId
+{
     pub fn into_defensive(self) -> Option<DefensiveError<NID>> {
         match self {
             StorageError::Defensive { source } => Some(source),
@@ -197,20 +213,26 @@ impl<NID: NodeId> StorageError<NID> {
 /// Error that occurs when operating the store.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct StorageIOError<NID: NodeId> {
+pub struct StorageIOError<NID>
+where NID: NodeId
+{
     subject: ErrorSubject<NID>,
     verb: ErrorVerb,
     source: AnyError,
     backtrace: Option<String>,
 }
 
-impl<NID: NodeId> std::fmt::Display for StorageIOError<NID> {
+impl<NID> std::fmt::Display for StorageIOError<NID>
+where NID: NodeId
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "when {:?} {:?}: {}", self.verb, self.subject, self.source)
     }
 }
 
-impl<NID: NodeId> StorageIOError<NID> {
+impl<NID> StorageIOError<NID>
+where NID: NodeId
+{
     pub fn new(subject: ErrorSubject<NID>, verb: ErrorVerb, source: AnyError) -> Self {
         Self {
             subject,

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -124,7 +124,7 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C::NodeId>>, EffectiveMembership<C::NodeId>), StorageError<C::NodeId>> {
+    ) -> Result<(Option<LogId<C::NodeId>>, EffectiveMembership<C::NodeId, C::Node>), StorageError<C::NodeId>> {
         self.inner().last_applied_state().await
     }
 
@@ -167,7 +167,7 @@ where
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<C::NodeId>,
+        meta: &SnapshotMeta<C::NodeId, C::Node>,
         snapshot: Box<Self::SnapshotData>,
     ) -> Result<StateMachineChanges<C>, StorageError<C::NodeId>> {
         self.inner().install_snapshot(meta, snapshot).await
@@ -176,7 +176,7 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     async fn get_current_snapshot(
         &mut self,
-    ) -> Result<Option<Snapshot<C::NodeId, Self::SnapshotData>>, StorageError<C::NodeId>> {
+    ) -> Result<Option<Snapshot<C::NodeId, C::Node, Self::SnapshotData>>, StorageError<C::NodeId>> {
         self.inner().get_current_snapshot().await
     }
 
@@ -221,7 +221,9 @@ pub struct SnapshotBuilderExt<C: RaftTypeConfig, T: RaftStorage<C>> {
 #[async_trait]
 impl<C: RaftTypeConfig, T: RaftStorage<C>> RaftSnapshotBuilder<C, T::SnapshotData> for SnapshotBuilderExt<C, T> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C::NodeId, T::SnapshotData>, StorageError<C::NodeId>> {
+    async fn build_snapshot(
+        &mut self,
+    ) -> Result<Snapshot<C::NodeId, C::Node, T::SnapshotData>, StorageError<C::NodeId>> {
         self.inner.build_snapshot().await
     }
 }

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -5,8 +5,10 @@ pub use store_builder::DefensiveStoreBuilder;
 pub use store_builder::StoreBuilder;
 pub use suite::Suite;
 
+use crate::BasicNode;
+
 crate::declare_raft_types!(
     /// Dummy Raft types for the purpose of testing internal structures requiring
     /// `RaftTypeConfig`, like `MembershipConfig`.
-    pub(crate) DummyConfig: D = u64, R = u64, NodeId = u64
+    pub(crate) DummyConfig: D = u64, R = u64, NodeId = u64, Node = BasicNode
 );

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -1810,8 +1810,11 @@ where C::NodeId: From<u64> {
 
 /// Block until a future is finished.
 /// The future will be running in a clean tokio runtime, to prevent an unfinished task affecting the test.
-pub fn run_fut<NID: NodeId, F>(f: F) -> Result<(), StorageError<NID>>
-where F: Future<Output = Result<(), StorageError<NID>>> {
+pub fn run_fut<NID, F>(f: F) -> Result<(), StorageError<NID>>
+where
+    NID: NodeId,
+    F: Future<Output = Result<(), StorageError<NID>>>,
+{
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(f)?;
     Ok(())

--- a/openraft/tests/life_cycle/t20_shutdown.rs
+++ b/openraft/tests/life_cycle/t20_shutdown.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::error::ClientWriteError;
 use openraft::error::Fatal;
+use openraft::BasicNode;
 use openraft::Config;
 
 use crate::fixtures::init_default_ut_tracing;
@@ -73,7 +74,7 @@ async fn return_error_after_panic() -> Result<()> {
     {
         let res = router.client_request(0, "foo", 2).await;
         let err = res.unwrap_err();
-        assert_eq!(ClientWriteError::<u64>::Fatal(Fatal::Panicked), err);
+        assert_eq!(ClientWriteError::<u64, BasicNode>::Fatal(Fatal::Panicked), err);
     }
 
     Ok(())
@@ -106,7 +107,7 @@ async fn return_error_after_shutdown() -> Result<()> {
     {
         let res = router.client_request(0, "foo", 2).await;
         let err = res.unwrap_err();
-        assert_eq!(ClientWriteError::<u64>::Fatal(Fatal::Stopped), err);
+        assert_eq!(ClientWriteError::<u64, _>::Fatal(Fatal::Stopped), err);
     }
 
     Ok(())


### PR DESCRIPTION
When starting implementing a cluster with openraft I ran into the problem that `Node::data` is fixed to being a `BTreeMap<String, String>` that limits the usability for not data and forces it into a "stringly-typed" style removing much of the benefits rusts types give us here.

This change turns `Node` into a trait, this allows user level management of the information needed for the node. The two examples are updated to showcase two different styles:

1) The memstore example has no additional data and uses `BasicNode` as node implementation (including only the `addr`).
2) The raftstore example has a custom Struct for the node with a `rpc_addr` and a `api_addr`

The tests are all updated to reflect this change. This is a pure refactoring without functional change.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/480)
<!-- Reviewable:end -->
