### PR TITLE
Feature: use blank log for heartbeat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ jobs:
         store_defensive:
           - "on"
           - "off"
+        send_delay:
+          - "0"
+          - "60"
 
     steps:
       - name: Setup | Checkout
@@ -31,7 +34,8 @@ jobs:
           RUST_TEST_THREADS: 2
           RUST_LOG: debug
           RUST_BACKTRACE: full
-          RAFT_STORE_DEFENSIVE: ${{ matrix.store_defensive }}
+          OPENRAFT_STORE_DEFENSIVE: ${{ matrix.store_defensive }}
+          OPENRAFT_NETWORK_SEND_DELAY: ${{ matrix.send_delay }}
 
 
       - name: Build | Release Mode

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
           - "off"
         send_delay:
           - "0"
-          - "60"
+          - "30"
 
     steps:
       - name: Setup | Checkout

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ queue_rules:
       # - '#check-pending=0'
       - '#check-success>=2'
       - check-success=check-subject
-      - check-success=unittest (on)
+      - check-success=unittest (on, 0)
       - check-success~=unittest
 
 pull_request_rules:
@@ -14,7 +14,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - check-success=check-subject
-      - check-success=unittest (on)
+      - check-success=unittest (on, 0)
     actions:
       queue:
         name: feature_queue

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ defensive_test:
 	OPENRAFT_STORE_DEFENSIVE=on cargo test
 
 send_delay_test:
-	OPENRAFT_NETWORK_SEND_DELAY=60 cargo test
+	OPENRAFT_NETWORK_SEND_DELAY=30 cargo test
 
 test: lint fmt
 	cargo test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-all: test lint fmt defensive_test doc
+all: test lint fmt defensive_test send_delay_test doc
 
 defensive_test:
-	RAFT_STORE_DEFENSIVE=on cargo test
+	OPENRAFT_STORE_DEFENSIVE=on cargo test
+
+send_delay_test:
+	OPENRAFT_NETWORK_SEND_DELAY=60 cargo test
 
 test: lint fmt
 	cargo test

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Internal](./internal.md)
     - [Architecture](./architecture.md)
     - [Threads](./threading.md)
+    - [Heartbeat](./heartbeat.md)
     - [Vote](./vote.md)
     - [Replication](./replication.md)
       - [Delete-conflicting-logs](./delete_log.md)

--- a/guide/src/heartbeat.md
+++ b/guide/src/heartbeat.md
@@ -1,0 +1,40 @@
+# Heartbeat in openraft
+
+## Heartbeat in standard raft
+
+Heartbeat in standard raft is the way for a leader to assert it is still alive:
+- A leader send heartbeat at a regular interval.
+- A follower that receives a heartbeat believes there is an active leader thus it rejects election request(`send_vote`) from another node unreachable to the leader, for a short period.
+
+## Openraft heartbeat is a blank log
+
+Such a heartbeat mechanism depends on clock time.
+But raft as a distributed consensus already has its own **pseudo time** defined very well.
+The **pseudo time** in openraft is a tuple `(vote, last_log_id)`, compared in dictionary order.
+
+### Why it works
+
+To refuse the election by a node that does not receive recent messages from the current leader,
+just let the active leader send a **blank log** to increase the **pseudo time** on a quorum.
+
+Because the leader must have the greatest **pseudo time**,
+thus by comparing the **pseudo time**, a follower automatically refuse election request from a node unreachable to the leader.
+
+And comparing the **pseudo time** is already done by `handle_vote_request()`,
+there is no need to add another timer for the active leader. 
+
+Thus making heartbeat request a blank log is the simplest way.
+
+## Why blank log heartbeat?
+
+- Simple, get rid of a timer.
+- Easy to prove, and reduce code complexity.
+
+## Other Concerns
+
+- More raft logs are generated.
+
+
+
+
+

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -79,12 +79,63 @@ fn test_build() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_config_build_() -> anyhow::Result<()> {
+fn test_config_keep_unsnapshoted_log() -> anyhow::Result<()> {
     let config = Config::build(&["foo", "--keep-unsnapshoted-log"])?;
     assert_eq!(true, config.keep_unsnapshoted_log);
 
     let config = Config::build(&["foo"])?;
     assert_eq!(false, config.keep_unsnapshoted_log);
+
+    Ok(())
+}
+
+#[test]
+fn test_config_enable_tick() -> anyhow::Result<()> {
+    let config = Config::build(&["foo", "--enable-tick=false"])?;
+    assert_eq!(false, config.enable_tick);
+
+    let config = Config::build(&["foo", "--enable-tick=true"])?;
+    assert_eq!(true, config.enable_tick);
+
+    let config = Config::build(&["foo", "--enable-tick"])?;
+    assert_eq!(true, config.enable_tick);
+
+    let config = Config::build(&["foo"])?;
+    assert_eq!(true, config.enable_tick);
+
+    Ok(())
+}
+
+#[test]
+fn test_config_enable_heartbeat() -> anyhow::Result<()> {
+    let config = Config::build(&["foo", "--enable-heartbeat=false"])?;
+    assert_eq!(false, config.enable_heartbeat);
+
+    let config = Config::build(&["foo", "--enable-heartbeat=true"])?;
+    assert_eq!(true, config.enable_heartbeat);
+
+    let config = Config::build(&["foo", "--enable-heartbeat"])?;
+    assert_eq!(true, config.enable_heartbeat);
+
+    let config = Config::build(&["foo"])?;
+    assert_eq!(true, config.enable_heartbeat);
+
+    Ok(())
+}
+
+#[test]
+fn test_config_enable_elect() -> anyhow::Result<()> {
+    let config = Config::build(&["foo", "--enable-elect=false"])?;
+    assert_eq!(false, config.enable_elect);
+
+    let config = Config::build(&["foo", "--enable-elect=true"])?;
+    assert_eq!(true, config.enable_elect);
+
+    let config = Config::build(&["foo", "--enable-elect"])?;
+    assert_eq!(true, config.enable_elect);
+
+    let config = Config::build(&["foo"])?;
+    assert_eq!(true, config.enable_elect);
 
     Ok(())
 }

--- a/openraft/src/config/mod.rs
+++ b/openraft/src/config/mod.rs
@@ -4,5 +4,6 @@ mod error;
 #[cfg(test)] mod config_test;
 
 pub use config::Config;
+pub(crate) use config::RuntimeConfig;
 pub use config::SnapshotPolicy;
 pub use error::ConfigError;

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -44,7 +44,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         }
 
         self.set_next_election_time(false);
-        self.reject_election_for_a_while();
 
         if req.vote > self.engine.state.vote {
             self.engine.state.vote = req.vote;

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -71,13 +71,6 @@ pub(crate) enum Command<NID: NodeId> {
         can_be_leader: bool,
     },
 
-    /// Reject election by other candidate for a while.
-    /// The interval is decided by the runtime.
-    ///
-    /// When a leader is established and has not yet timeout,
-    /// A candidate should not take the leadership.
-    RejectElection {},
-
     /// Purge log from the beginning to `upto`, inclusive.
     PurgeLog { upto: LogId<NID> },
 
@@ -108,7 +101,6 @@ impl<NID: NodeId> Command<NID> {
             Command::SaveVote { .. } => flags.set_data_changed(),
             Command::SendVote { .. } => {}
             Command::InstallElectionTimer { .. } => {}
-            Command::RejectElection { .. } => {}
             Command::PurgeLog { .. } => flags.set_data_changed(),
             Command::DeleteConflictLog { .. } => flags.set_data_changed(),
             Command::BuildSnapshot { .. } => flags.set_data_changed(),

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -819,9 +819,6 @@ impl<NID: NodeId> Engine<NID> {
             // Do not elect for a longer while.
             // TODO: Installing a timer should not be part of the Engine's job.
             self.push_command(Command::InstallElectionTimer { can_be_leader: false });
-            // There is an active leader, reject election for a while.
-            // TODO: remove this when heartbeat log is ready.
-            self.push_command(Command::RejectElection {});
         } else {
             // There is an active candidate.
             // Do not elect for a short while.

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -146,7 +146,6 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::DeleteConflictLog { since: log_id(1, 2) },
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
@@ -206,7 +205,6 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
                 vote: Vote::new_committed(2, 1)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::DeleteConflictLog { since: log_id(1, 2) },
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
@@ -274,7 +272,6 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
                 vote: Vote::new_committed(2, 1)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::UpdateServerState {
                 server_state: ServerState::Follower
             },
@@ -338,7 +335,6 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::DeleteConflictLog { since: log_id(2, 3) },
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -87,7 +87,6 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
                 vote: Vote::new_committed(3, 2)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::RejectElection {},
             Command::UpdateServerState {
                 server_state: ServerState::Follower
             }

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -434,7 +434,6 @@ mod t {
         assert_eq!(&5, p012_345.granted());
 
         let p345 = p012_345.upgrade_quorum_set(qs345, &[1]);
-        println!("{:?}", p345.vector);
 
         assert_eq!(&8, p345.granted(), "shrink quorum set, greater value becomes committed");
         assert_eq!(&6, p345.get(&1), "inherit voter progress");

--- a/openraft/tests/append_entries/main.rs
+++ b/openraft/tests/append_entries/main.rs
@@ -13,5 +13,6 @@ mod t30_append_inconsistent_log;
 mod t40_append_updates_membership;
 mod t50_append_entries_with_bigger_term;
 mod t50_replication_1_voter_to_isolated_learner;
+mod t60_enable_heartbeat;
 mod t60_large_heartbeat;
 mod t90_issue_216_stale_last_log_id;

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -36,8 +36,14 @@ use crate::fixtures::RaftRouter;
 /// - asserts that a response with ConflictOpt set.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn conflict_with_empty_entries() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     router.new_raft_node(0);

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -23,8 +23,14 @@ use crate::fixtures::RaftRouter;
 /// - bring up a learner and send to it append_entries request. Check the response in every case.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_conflicts() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -35,7 +35,13 @@ use crate::fixtures::RaftRouter;
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_inconsistent_log() -> Result<()> {
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/append_entries/t40_append_updates_membership.rs
+++ b/openraft/tests/append_entries/t40_append_updates_membership.rs
@@ -24,8 +24,14 @@ use crate::fixtures::RaftRouter;
 /// - bring up a learner and send to it append_entries request. Check the membership updated.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_updates_membership() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -19,7 +19,13 @@ use crate::fixtures::RaftRouter;
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_entries_with_bigger_term() -> Result<()> {
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
     let log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
 

--- a/openraft/tests/append_entries/t50_replication_1_voter_to_isolated_learner.rs
+++ b/openraft/tests/append_entries/t50_replication_1_voter_to_isolated_learner.rs
@@ -17,7 +17,13 @@ use crate::fixtures::RaftRouter;
 /// - client write should not be blocked.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn replication_1_voter_to_isolated_learner() -> Result<()> {
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;

--- a/openraft/tests/append_entries/t60_enable_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_enable_heartbeat.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Enable heartbeat, heartbeat log should be replicated.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn enable_heartbeat() -> Result<()> {
+    // Setup test dependencies.
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3}).await?;
+
+    let node0 = router.get_raft_handle(&0)?;
+    node0.enable_heartbeat(true);
+
+    for _i in 0..10 {
+        log_index += 1; // new heartbeat log
+        router.wait(&0, timeout()).log_at_least(Some(log_index), "node 0 emit heartbeat log").await?;
+        router.wait(&1, timeout()).log_at_least(Some(log_index), "node 1 receives heartbeat").await?;
+        router.wait(&3, timeout()).log_at_least(Some(log_index), "node 1 receives heartbeat").await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}

--- a/openraft/tests/append_entries/t60_large_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_large_heartbeat.rs
@@ -27,10 +27,10 @@ async fn large_heartbeat() -> Result<()> {
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
 
-    router.client_request_many(0, "foo", 100).await?;
-    log_index += 100;
+    router.client_request_many(0, "foo", 10).await?;
+    log_index += 10;
 
-    router.wait(&1, Some(Duration::from_millis(1000))).log(Some(log_index), "").await?;
+    router.wait(&1, Some(Duration::from_millis(3_000))).log(Some(log_index), "").await?;
 
     Ok(())
 }

--- a/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
+++ b/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
@@ -20,12 +20,12 @@ async fn stale_last_log_id() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(
         Config {
-            heartbeat_interval: 50,
             election_timeout_min: 500,
             election_timeout_max: 1000,
             max_payload_entries: 1,
             max_applied_log_to_keep: 0,
             purge_batch_size: 1,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -17,9 +17,18 @@ use crate::fixtures::RaftRouter;
 /// - call the is_leader interface on the followers, and assert failure.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn client_reads() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
+    // This test is sensitive to network delay.
+    router.network_send_delay(0);
+
     router.new_raft_node(0);
     router.new_raft_node(1);
     router.new_raft_node(2);

--- a/openraft/tests/client_api/t50_lagging_network_write.rs
+++ b/openraft/tests/client_api/t50_lagging_network_write.rs
@@ -24,6 +24,7 @@ async fn lagging_network_write() -> Result<()> {
             heartbeat_interval: 100,
             election_timeout_min: 300,
             election_timeout_max: 600,
+            enable_tick: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/elect/t10_elect_compare_last_log.rs
+++ b/openraft/tests/elect/t10_elect_compare_last_log.rs
@@ -24,8 +24,14 @@ use crate::fixtures::RaftRouter;
 /// - Bring up the cluster and only node 0 can become leader.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn elect_compare_last_log() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     let mut sto0 = router.new_store();

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -172,11 +172,21 @@ where
     }
 
     pub fn build(self) -> TypedRaftRouter<C, S> {
+        let send_delay = {
+            let send_delay = env::var("OPENRAFT_NETWORK_SEND_DELAY").ok();
+
+            if let Some(d) = send_delay {
+                tracing::info!("OPENRAFT_NETWORK_SEND_DELAY set send-delay to {} ms", d);
+                d.parse::<u64>().unwrap()
+            } else {
+                self.send_delay
+            }
+        };
         TypedRaftRouter {
             config: self.config,
             routing_table: Default::default(),
             isolated_nodes: Default::default(),
-            send_delay: Arc::new(AtomicU64::new(self.send_delay)),
+            send_delay: Arc::new(AtomicU64::new(send_delay)),
         }
     }
 }
@@ -318,19 +328,19 @@ where
     }
 
     pub fn new_store(&mut self) -> StoreWithDefensive<C, S> {
-        let defensive = env::var("RAFT_STORE_DEFENSIVE").ok();
+        let defensive = env::var("OPENRAFT_STORE_DEFENSIVE").ok();
 
         let sto = StoreExt::<C, S>::new(S::default());
 
         if let Some(d) = defensive {
-            tracing::info!("RAFT_STORE_DEFENSIVE set store defensive to {}", d);
+            tracing::info!("OPENRAFT_STORE_DEFENSIVE set store defensive to {}", d);
 
             let want = if d == "on" {
                 true
             } else if d == "off" {
                 false
             } else {
-                tracing::warn!("unknown value of RAFT_STORE_DEFENSIVE: {}", d);
+                tracing::warn!("unknown value of OPENRAFT_STORE_DEFENSIVE: {}", d);
                 return sto;
             };
 

--- a/openraft/tests/life_cycle/t20_initialization.rs
+++ b/openraft/tests/life_cycle/t20_initialization.rs
@@ -32,8 +32,14 @@ use crate::fixtures::RaftRouter;
 ///   successfully replicated the payload.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn initialization() -> anyhow::Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
     router.new_raft_node(1);

--- a/openraft/tests/life_cycle/t20_shutdown.rs
+++ b/openraft/tests/life_cycle/t20_shutdown.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::anyhow;
 use anyhow::Result;
@@ -7,7 +6,6 @@ use maplit::btreeset;
 use openraft::error::ClientWriteError;
 use openraft::error::Fatal;
 use openraft::Config;
-use openraft::ServerState;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -20,28 +18,17 @@ use crate::fixtures::RaftRouter;
 /// - after the cluster has been initialize, it performs a shutdown routine on each node, asserting that the shutdown
 ///   routine succeeded.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
-async fn initialization() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+async fn shutdown() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
-    router.new_raft_node(1);
-    router.new_raft_node(2);
-
-    let mut log_index = 0;
-
-    // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0, 1, 2], None, timeout(), "empty").await?;
-    router.wait_for_state(&btreeset![0, 1, 2], ServerState::Learner, timeout(), "empty").await?;
-    router.assert_pristine_cluster();
-
-    // Initialize the cluster, then assert that a stable cluster was formed & held.
-    tracing::info!("--- initializing cluster");
-    router.initialize_from_single_node(0).await?;
-    log_index += 1;
-
-    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "init").await?;
-    router.assert_stable_cluster(Some(1), Some(1));
+    let _log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- performing node shutdowns");
     {
@@ -56,10 +43,6 @@ async fn initialization() -> Result<()> {
     }
 
     Ok(())
-}
-
-fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(1000))
 }
 
 /// A panicked RaftCore should also return a proper error the next time accessing the `Raft`.

--- a/openraft/tests/life_cycle/t20_shutdown.rs
+++ b/openraft/tests/life_cycle/t20_shutdown.rs
@@ -48,7 +48,14 @@ async fn shutdown() -> Result<()> {
 /// A panicked RaftCore should also return a proper error the next time accessing the `Raft`.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn return_error_after_panic() -> Result<()> {
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");
@@ -75,7 +82,14 @@ async fn return_error_after_panic() -> Result<()> {
 /// After shutdown(), access to Raft should return a Fatal::Stopped error.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn return_error_after_shutdown() -> Result<()> {
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -40,6 +40,7 @@ async fn compaction() -> Result<()> {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 2,
             purge_batch_size: 1,
+            enable_tick: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -1,20 +1,13 @@
-use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use memstore::IntoMemClientRequest;
 use openraft::Config;
-use openraft::LogIdOptionExt;
 use openraft::Raft;
-use openraft::RaftStorage;
-use openraft::RaftTypeConfig;
 use openraft::ServerState;
-use tokio::time::sleep;
 
 use crate::fixtures::init_default_ut_tracing;
-use crate::fixtures::MemRaft;
 use crate::fixtures::RaftRouter;
 
 /// Cluster learner_restart test.
@@ -26,72 +19,40 @@ use crate::fixtures::RaftRouter;
 /// - asserts that the leader was able to successfully commit its initial payload and that the learner has successfully
 ///   replicated the payload.
 /// - shutdown all and restart the learner node.
-/// - asserts the learner stays in non-vtoer state.
+/// - asserts the learner stays in non-voter state.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn learner_restart() -> Result<()> {
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0);
-    router.new_raft_node(1);
+    tracing::info!("--- initializing");
+    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
 
-    let mut log_index = 0;
-
-    // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0, 1], None, None, "empty").await?;
-    router.wait_for_state(&btreeset![0, 1], ServerState::Learner, None, "empty").await?;
-    router.assert_pristine_cluster();
-
-    tracing::info!("--- initializing single node cluster");
-    {
-        let n0 = router.get_raft_handle(&0)?;
-        n0.initialize(btreeset! {0}).await?;
-        log_index += 1;
-
-        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
-    }
-
-    router.add_learner(0, 1).await?;
     router.client_request(0, "foo", 1).await?;
-    log_index += 2;
+    log_index += 1;
 
     router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "write one log").await?;
 
     let (node0, _sto0) = router.remove_node(0).unwrap();
-    assert_node_state(0, &node0, 1, log_index, ServerState::Leader);
     node0.shutdown().await?;
 
     let (node1, sto1) = router.remove_node(1).unwrap();
-    assert_node_state(0, &node1, 1, log_index, ServerState::Learner);
     node1.shutdown().await?;
 
     // restart node-1, assert the state as expected.
     let restarted = Raft::new(1, config.clone(), router.clone(), sto1);
-    sleep(Duration::from_secs(2)).await;
-    assert_node_state(1, &restarted, 1, log_index, ServerState::Learner);
+    restarted.wait(timeout()).log(Some(log_index), "log after restart").await?;
+    restarted.wait(timeout()).state(ServerState::Learner, "server state after restart").await?;
 
     Ok(())
-}
-
-fn assert_node_state<C: RaftTypeConfig, S: RaftStorage<C>>(
-    id: C::NodeId,
-    node: &MemRaft<C, S>,
-    expected_term: u64,
-    expected_log: u64,
-    state: ServerState,
-) where
-    C::D: Debug + IntoMemClientRequest<C::D>,
-    C::R: Debug,
-    S: Default + Clone,
-{
-    let m = node.metrics().borrow().clone();
-    tracing::info!("node {} metrics: {:?}", id, m);
-
-    assert_eq!(expected_term, m.current_term, "node {} term", id);
-    assert_eq!(Some(expected_log), m.last_log_index, "node {} last_log_index", id);
-    assert_eq!(Some(expected_log), m.last_applied.index(), "node {} last_log_index", id);
-    assert_eq!(state, m.state, "node {} state", id);
 }
 
 fn timeout() -> Option<Duration> {

--- a/openraft/tests/membership/t01_singlenode.rs
+++ b/openraft/tests/membership/t01_singlenode.rs
@@ -23,7 +23,13 @@ use crate::fixtures::RaftRouter;
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn single_node() -> Result<()> {
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -26,6 +26,7 @@ async fn add_learner_basic() -> Result<()> {
             replication_lag_threshold: 0,
             max_applied_log_to_keep: 2000, // prevent snapshot
             purge_batch_size: 1,
+            enable_tick: false,
             ..Default::default()
         }
         .validate()?,
@@ -89,6 +90,7 @@ async fn add_learner_non_blocking() -> Result<()> {
     let config = Arc::new(
         Config {
             replication_lag_threshold: 0,
+            enable_tick: false,
             ..Default::default()
         }
         .validate()?,
@@ -125,6 +127,7 @@ async fn check_learner_after_leader_transfered() -> Result<()> {
         Config {
             election_timeout_min: 200,
             election_timeout_max: 250,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/membership/t12_concurrent_write_and_add_learner.rs
+++ b/openraft/tests/membership/t12_concurrent_write_and_add_learner.rs
@@ -40,7 +40,13 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     let candidates = btreeset![0, 1, 2];
 
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     router.new_raft_node(0);

--- a/openraft/tests/membership/t15_add_remove_follower.rs
+++ b/openraft/tests/membership/t15_add_remove_follower.rs
@@ -21,7 +21,13 @@ async fn add_remove_voter() -> Result<()> {
     let c01234 = btreeset![0, 1, 2, 3, 4];
     let c0123 = btreeset![0, 1, 2, 3];
 
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = router.new_nodes_from_single(c01234.clone(), btreeset! {}).await?;

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -106,7 +106,13 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
     let only_in_old = old.difference(&new);
     let only_in_new = new.difference(&old);
 
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = router.new_nodes_from_single(old.clone(), btreeset! {}).await?;
@@ -234,7 +240,13 @@ async fn change_by_add(old: BTreeSet<MemNodeId>, add: &[MemNodeId]) -> anyhow::R
     let new = change.clone().apply_to(&old);
     let only_in_new = new.difference(&old);
 
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = router.new_nodes_from_single(old.clone(), btreeset! {}).await?;
@@ -296,7 +308,13 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
     let new = change.clone().apply_to(&old);
     let only_in_old = old.difference(&new);
 
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = router.new_nodes_from_single(old.clone(), btreeset! {}).await?;

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -17,7 +17,13 @@ use crate::fixtures::RaftRouter;
 /// When a change-membership log is committed, the membership_state should be updated.
 #[async_entry::test(worker_threads = 3, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn update_membership_state() -> anyhow::Result<()> {
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3,4}).await?;
@@ -52,6 +58,7 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
     let config = Arc::new(
         Config {
             replication_lag_threshold: lag_threshold,
+            enable_tick: false,
             ..Default::default()
         }
         .validate()?,
@@ -141,6 +148,7 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
     let config = Arc::new(
         Config {
             replication_lag_threshold: lag_threshold,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,
@@ -192,7 +200,13 @@ async fn change_with_lagging_learner_non_blocking() -> anyhow::Result<()> {
 async fn change_with_turn_removed_voter_to_learner() -> anyhow::Result<()> {
     // Add a member without adding it as learner, in blocking mode it should finish successfully.
 
-    let config = Arc::new(Config { ..Default::default() }.validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
     let timeout = Some(Duration::from_millis(1000));
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;

--- a/openraft/tests/membership/t30_commit_joint_config.rs
+++ b/openraft/tests/membership/t30_commit_joint_config.rs
@@ -19,7 +19,14 @@ use crate::fixtures::RaftRouter;
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn commit_joint_config_during_0_to_012() -> Result<()> {
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 
@@ -87,7 +94,13 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn commit_joint_config_during_012_to_234() -> Result<()> {
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -22,6 +22,7 @@ async fn step_down() -> Result<()> {
         Config {
             election_timeout_min: 800,
             election_timeout_max: 1000,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/membership/t40_removed_follower.rs
+++ b/openraft/tests/membership/t40_removed_follower.rs
@@ -12,8 +12,13 @@ use crate::fixtures::RaftRouter;
 /// Replication should stop after a follower is removed from membership.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn stop_replication_to_removed_follower() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -24,8 +24,14 @@ use crate::fixtures::RaftRouter;
 /// membership changing
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn new_leader_auto_commit_uniform_config() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;

--- a/openraft/tests/metrics/t10_current_leader.rs
+++ b/openraft/tests/metrics/t10_current_leader.rs
@@ -15,8 +15,14 @@ use crate::fixtures::RaftRouter;
 /// - call the current_leader interface on the all nodes, and assert success.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn current_leader() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     let _log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -19,8 +19,14 @@ use crate::fixtures::RaftRouter;
 /// - asserts that when metrics.last_applied is upto date, the state machine should be upto date too.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn metrics_state_machine_consistency() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = 0;

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -36,7 +36,13 @@ async fn leader_metrics() -> Result<()> {
     let c0123 = btreeset![0, 1, 2, 3];
 
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/metrics/t40_metrics_wait.rs
+++ b/openraft/tests/metrics/t40_metrics_wait.rs
@@ -20,7 +20,13 @@ use crate::fixtures::RaftRouter;
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn metrics_wait() -> Result<()> {
     // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
     let mut router = RaftRouter::new(config.clone());
 
     let cluster = btreeset![0];

--- a/openraft/tests/snapshot/t20_api_install_snapshot.rs
+++ b/openraft/tests/snapshot/t20_api_install_snapshot.rs
@@ -22,7 +22,14 @@ use crate::fixtures::RaftRouter;
 /// - send install_snapshot request with matched/mismatched id and offset
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn snapshot_arguments() -> Result<()> {
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     let mut log_index = 0;

--- a/openraft/tests/snapshot/t23_snapshot_chunk_size.rs
+++ b/openraft/tests/snapshot/t23_snapshot_chunk_size.rs
@@ -27,6 +27,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             snapshot_max_chunk_size: 10,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t24_snapshot_ge_half_threshold.rs
+++ b/openraft/tests/snapshot/t24_snapshot_ge_half_threshold.rs
@@ -30,6 +30,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 6,
             purge_batch_size: 1,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t25_snapshot_line_rate_to_snapshot.rs
+++ b/openraft/tests/snapshot/t25_snapshot_line_rate_to_snapshot.rs
@@ -58,7 +58,6 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
         router.isolate_node(1);
 
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
-
         log_index = snapshot_threshold - 1;
 
         router
@@ -82,8 +81,6 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
     tracing::info!("--- restore node 1 and replication");
     {
         router.restore_node(1);
-        let leader = router.get_raft_handle(&0)?;
-        leader.enable_heartbeat(true);
 
         router.wait_for_log(&btreeset![1], Some(log_index), timeout(), "replicate by snapshot").await?;
         router

--- a/openraft/tests/snapshot/t25_snapshot_line_rate_to_snapshot.rs
+++ b/openraft/tests/snapshot/t25_snapshot_line_rate_to_snapshot.rs
@@ -28,6 +28,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
     let config = Arc::new(
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,
@@ -81,6 +82,8 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
     tracing::info!("--- restore node 1 and replication");
     {
         router.restore_node(1);
+        let leader = router.get_raft_handle(&0)?;
+        leader.enable_heartbeat(true);
 
         router.wait_for_log(&btreeset![1], Some(log_index), timeout(), "replicate by snapshot").await?;
         router
@@ -97,5 +100,5 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(5000))
+    Some(Duration::from_millis(2_000))
 }

--- a/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
+++ b/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
@@ -21,6 +21,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 1, // not 0: do not let add-learner log to trigger a snapshot.
             purge_batch_size: 1,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
+++ b/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
@@ -19,7 +19,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
     let config = Arc::new(
         Config {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
-            max_applied_log_to_keep: 1, // not 0: do not let add-learner log to trigger a snapshot.
+            max_applied_log_to_keep: 2, // do not let add-learner log and client-write log to trigger a snapshot.
             purge_batch_size: 1,
             enable_heartbeat: false,
             ..Default::default()

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -38,6 +38,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 0,
             purge_batch_size: 1,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,
@@ -103,7 +104,6 @@ async fn snapshot_overrides_membership() -> Result<()> {
             {
                 let m = StorageHelper::new(&mut sto).get_membership().await?;
 
-                println!("{:?}", m);
                 assert_eq!(&EffectiveMembership::default(), m.committed.as_ref());
                 assert_eq!(Membership::new(vec![btreeset! {2,3}], None), m.effective.membership);
             }

--- a/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
@@ -38,6 +38,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             // because ent-0 is removed.
             max_applied_log_to_keep: 3,
             purge_batch_size: 1,
+            enable_tick: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -41,6 +41,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
             max_applied_log_to_keep: 0,
             purge_batch_size: 1,
+            enable_heartbeat: false,
             ..Default::default()
         }
         .validate()?,

--- a/openraft/tests/state_machine/t10_total_order_apply.rs
+++ b/openraft/tests/state_machine/t10_total_order_apply.rs
@@ -16,8 +16,14 @@ use crate::fixtures::RaftRouter;
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 #[ignore]
 async fn total_order_apply() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate().expect("failed to build Raft config"));
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
 
     router.new_raft_node(0);

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -26,8 +26,14 @@ use crate::fixtures::RaftRouter;
 
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn state_machine_apply_membership() -> Result<()> {
-    // Setup test dependencies.
-    let config = Arc::new(Config::default().validate()?);
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0);
 

--- a/openraft/tests/state_machine/t40_clean_applied_logs.rs
+++ b/openraft/tests/state_machine/t40_clean_applied_logs.rs
@@ -21,6 +21,7 @@ async fn clean_applied_logs() -> Result<()> {
         Config {
             max_applied_log_to_keep: 2,
             purge_batch_size: 1,
+            enable_tick: false,
             ..Default::default()
         }
         .validate()?,


### PR DESCRIPTION

## Changelog

##### Feature: use blank log for heartbeat

Heartbeat in standard raft is the way for a leader to assert it is still alive.
- A leader send heartbeat at a regular interval.
- A follower that receives a heartbeat believes there is an active leader thus it rejects election request(`send_vote`) from another node unreachable to the leader, for a short period.

Openraft heartbeat is a blank log

Such a heartbeat mechanism depends on clock time.
But raft as a distributed consensus already has its own **pseudo time** defined very well.
The **pseudo time** in openraft is a tuple `(vote, last_log_id)`, compared in dictionary order.

Why it works

To refuse the election by a node that does not receive recent messages from the current leader,
just let the active leader send a **blank log** to increase the **pseudo time** on a quorum.

Because the leader must have the greatest **pseudo time**,
thus by comparing the **pseudo time**, a follower automatically refuse election request from a node unreachable to the leader.

And comparing the **pseudo time** is already done by `handle_vote_request()`,
there is no need to add another timer for the active leader.

Other changes:

- Feature: add API to switch timeout based events:
  - `Raft::enable_tick()`: switch on/off election and heartbeat.
  - `Raft::enable_heartbeat()`: switch on/off heartbeat.
  - `Raft::enable_elect()`: switch on/off election.

  These methods make some testing codes easier to write.
  The corresponding `Config` entries are also added:
  `Config::enable_tick`
  `Config::enable_heartbeat`
  `Config::enable_elect`

- Refactor: remove Engine `Command::RejectElection`.
  Rejecting election now is part of `handle_vote_req()` as blank-log
  heartbeat is introduced.

- Refactor: heartbeat is removed from `ReplicationCore`.
  Instead, heartbeat is emitted by `RaftCore`.

- Fix: when failed to sending append-entries, do not clear
  `need_to_replicate` flag.

- CI: add test with higher network delay.

- Doc: explain why using blank log as heartbeat.

- Fix: #151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/483)
<!-- Reviewable:end -->
