### PR TITLE
Change: remove ClientWriteRequest

### DIFF
--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -4,8 +4,6 @@ use actix_web::web::Data;
 use actix_web::Responder;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
-use openraft::raft::ClientWriteRequest;
-use openraft::EntryPayload;
 use web::Json;
 
 use crate::app::ExampleApp;
@@ -23,8 +21,7 @@ use crate::ExampleNodeId;
  */
 #[post("/write")]
 pub async fn write(app: Data<ExampleApp>, req: Json<ExampleRequest>) -> actix_web::Result<impl Responder> {
-    let request = ClientWriteRequest::new(EntryPayload::Normal(req.0));
-    let response = app.raft.client_write(request).await;
+    let response = app.raft.client_write(req.0).await;
     Ok(Json(response))
 }
 

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -2,8 +2,6 @@ use std::sync::Arc;
 
 use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
-use openraft::raft::ClientWriteRequest;
-use openraft::EntryPayload;
 use tide::Body;
 use tide::Request;
 use tide::Response;
@@ -30,8 +28,7 @@ pub fn rest(app: &mut Server) {
  */
 async fn write(mut req: Request<Arc<ExampleApp>>) -> tide::Result {
     let body = req.body_json().await?;
-    let request = ClientWriteRequest::new(EntryPayload::Normal(body));
-    let res = req.state().raft.client_write(request).await;
+    let res = req.state().raft.client_write(body).await;
     Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
 }
 

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -255,6 +255,8 @@ impl<NID: NodeId> Engine<NID> {
         }
 
         // Seen a higher log.
+        // TODO: if already installed a timer with can_be_leader==false, it should not install a timer with
+        //       can_be_leader==true.
         if resp.last_log_id > self.state.last_log_id() {
             self.push_command(Command::InstallElectionTimer { can_be_leader: false });
         } else {

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -40,7 +40,6 @@ use openraft::metrics::Wait;
 use openraft::raft::AddLearnerResponse;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
-use openraft::raft::ClientWriteRequest;
 use openraft::raft::InstallSnapshotRequest;
 use openraft::raft::InstallSnapshotResponse;
 use openraft::raft::VoteRequest;
@@ -651,9 +650,7 @@ where
                 .clone()
         };
 
-        let payload = EntryPayload::<C>::Normal(req);
-
-        node.0.client_write(ClientWriteRequest::<C>::new(payload)).await.map(|res| res.data)
+        node.0.client_write(req).await.map(|res| res.data)
     }
 
     /// Assert that the cluster is in a pristine state, with all nodes as learners.


### PR DESCRIPTION

## Changelog

##### Change: remove ClientWriteRequest

Remove struct `ClientWriteRequest`.
`ClientWriteRequest` is barely a wrapper that does not provide any
additional function.

`Raft::client_write(ClientWriteRequest)` is changed to
`Raft::client_write(app_data: D)`, where `D` is application defined
`AppData` implementation.

- Fix: #171

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/485)
<!-- Reviewable:end -->
