### PR TITLE
Refactor: timeout control in votes

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1302,8 +1302,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                     "send_vote_req",
                     target = display(target)
                 )),
-            )
-            .map_err(move |e| (target, e));
+            );
         }
     }
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1252,6 +1252,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         let vote = vote_req.vote;
 
+        let mut tasks = FuturesUnordered::new();
+
         for target in members {
             if target == self.id {
                 continue;
@@ -1269,9 +1271,26 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
             let tx = self.tx_api.clone();
 
-            let _ = tokio::spawn(
+            let ttl = Duration::from_millis(self.config.heartbeat_interval);
+            let id = self.id;
+
+            let t = tokio::spawn(
                 async move {
-                    let res = network.send_vote(req).await;
+                    let tm_res = timeout(ttl, network.send_vote(req)).await;
+                    let res = match tm_res {
+                        Ok(res) => res,
+
+                        Err(_timeout) => {
+                            let timeout_err = Timeout {
+                                action: RPCTypes::Vote,
+                                id,
+                                target,
+                                timeout: ttl,
+                            };
+                            tracing::error!({error = %timeout_err, target = display(target)}, "timeout");
+                            return;
+                        }
+                    };
 
                     match res {
                         Ok(resp) => {
@@ -1285,7 +1304,14 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                     "send_vote_req",
                     target = display(target)
                 )),
-            );
+            )
+            .map_err(move |e| (target, e));
+
+            tasks.push(t);
+        }
+
+        while let Some(Err((target, error))) = tasks.next().await {
+            tracing::error!({error=%error, target=display(target)}, "while requesting vote");
         }
     }
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1252,8 +1252,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         let vote = vote_req.vote;
 
-        let mut tasks = FuturesUnordered::new();
-
         for target in members {
             if target == self.id {
                 continue;
@@ -1274,7 +1272,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             let ttl = Duration::from_millis(self.config.heartbeat_interval);
             let id = self.id;
 
-            let t = tokio::spawn(
+            let _ = tokio::spawn(
                 async move {
                     let tm_res = timeout(ttl, network.send_vote(req)).await;
                     let res = match tm_res {
@@ -1306,12 +1304,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 )),
             )
             .map_err(move |e| (target, e));
-
-            tasks.push(t);
-        }
-
-        while let Some(Err((target, error))) = tasks.next().await {
-            tracing::error!({error=%error, target=display(target)}, "while requesting vote");
         }
     }
 


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
This PR solves #467.

1. vote requests should not exceed the timeout of `heartbeat_interval`.
2. timeout will be logged
3. log `JoinError`s in parallel tasks

**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/486)
<!-- Reviewable:end -->
