### PR TITLE
Change: `ErrorSubject::Snapshot(SnapshotSignature)`

### DIFF
--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -320,7 +320,7 @@ impl RaftStorage<ExampleTypeConfig> for Arc<ExampleStore> {
             let updated_state_machine: ExampleStateMachine =
                 serde_json::from_slice(&new_snapshot.data).map_err(|e| {
                     StorageIOError::new(
-                        ErrorSubject::Snapshot(new_snapshot.meta.clone()),
+                        ErrorSubject::Snapshot(new_snapshot.meta.signature()),
                         ErrorVerb::Read,
                         AnyError::new(&e),
                     )

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -302,7 +302,11 @@ impl ExampleStore {
         self.db
             .put_cf(self.store(), b"snapshot", serde_json::to_vec(&snap).unwrap().as_slice())
             .map_err(|e| StorageError::IO {
-                source: StorageIOError::new(ErrorSubject::Snapshot(snap.meta), ErrorVerb::Write, AnyError::new(&e)),
+                source: StorageIOError::new(
+                    ErrorSubject::Snapshot(snap.meta.signature()),
+                    ErrorVerb::Write,
+                    AnyError::new(&e),
+                ),
             })?;
         Ok(())
     }
@@ -538,7 +542,7 @@ impl RaftStorage<ExampleTypeConfig> for Arc<ExampleStore> {
             let updated_state_machine: SerializableExampleStateMachine = serde_json::from_slice(&new_snapshot.data)
                 .map_err(|e| {
                     StorageIOError::new(
-                        ErrorSubject::Snapshot(new_snapshot.meta.clone()),
+                        ErrorSubject::Snapshot(new_snapshot.meta.signature()),
                         ErrorVerb::Read,
                         AnyError::new(&e),
                     )

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -386,7 +386,7 @@ impl RaftStorage<Config> for Arc<MemStore> {
         {
             let new_sm: MemStoreStateMachine = serde_json::from_slice(&new_snapshot.data).map_err(|e| {
                 StorageIOError::new(
-                    ErrorSubject::Snapshot(new_snapshot.meta.clone()),
+                    ErrorSubject::Snapshot(new_snapshot.meta.signature()),
                     ErrorVerb::Read,
                     AnyError::new(&e),
                 )

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -696,7 +696,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
         &mut self,
         mut snapshot: Snapshot<C::NodeId, S::SnapshotData>,
     ) -> Result<(), ReplicationError<C::NodeId>> {
-        let err_x = || (ErrorSubject::Snapshot(snapshot.meta.clone()), ErrorVerb::Read);
+        let err_x = || (ErrorSubject::Snapshot(snapshot.meta.signature()), ErrorVerb::Read);
 
         let end = snapshot.snapshot.seek(SeekFrom::End(0)).await.sto_res(err_x)?;
 

--- a/openraft/src/storage/snapshot_signature.rs
+++ b/openraft/src/storage/snapshot_signature.rs
@@ -1,0 +1,17 @@
+use crate::LogId;
+use crate::NodeId;
+use crate::SnapshotId;
+
+/// A small piece of information for identifying a snapshot and error tracing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub struct SnapshotSignature<NID: NodeId> {
+    /// Log entries upto which this snapshot includes, inclusive.
+    pub last_log_id: Option<LogId<NID>>,
+
+    /// The last applied membership log id.
+    pub last_membership_log_id: Option<LogId<NID>>,
+
+    /// To identify a snapshot when transferring.
+    pub snapshot_id: SnapshotId,
+}

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -3,9 +3,9 @@ use std::ops::Bound;
 
 use anyerror::AnyError;
 
+use crate::storage::SnapshotSignature;
 use crate::LogId;
 use crate::NodeId;
-use crate::SnapshotMeta;
 use crate::Vote;
 
 /// Convert error to StorageError::IO();
@@ -86,7 +86,7 @@ pub enum ErrorSubject<NID: NodeId> {
     StateMachine,
 
     /// Error happened when operating snapshot.
-    Snapshot(SnapshotMeta<NID>),
+    Snapshot(SnapshotSignature<NID>),
 
     None,
 }

--- a/rocksstore/src/lib.rs
+++ b/rocksstore/src/lib.rs
@@ -300,7 +300,11 @@ impl RocksStore {
         self.db
             .put_cf(self.store(), b"snapshot", serde_json::to_vec(&snap).unwrap().as_slice())
             .map_err(|e| StorageError::IO {
-                source: StorageIOError::new(ErrorSubject::Snapshot(snap.meta), ErrorVerb::Write, AnyError::new(&e)),
+                source: StorageIOError::new(
+                    ErrorSubject::Snapshot(snap.meta.signature()),
+                    ErrorVerb::Write,
+                    AnyError::new(&e),
+                ),
             })?;
         Ok(())
     }
@@ -534,7 +538,7 @@ impl RaftStorage<Config> for Arc<RocksStore> {
             let updated_state_machine: SerializableRocksStateMachine = serde_json::from_slice(&new_snapshot.data)
                 .map_err(|e| {
                     StorageIOError::new(
-                        ErrorSubject::Snapshot(new_snapshot.meta.clone()),
+                        ErrorSubject::Snapshot(new_snapshot.meta.signature()),
                         ErrorVerb::Read,
                         AnyError::new(&e),
                     )


### PR DESCRIPTION

## Changelog

##### Change: `ErrorSubject::Snapshot(SnapshotSignature)`

Change `ErrorSubject::Snapshot(SnapshotMeta)` to `ErrorSubject::Snapshot(SnapshotSignature)`.

`SnapshotSignature` is the same as `SnapshotMeta` except it does not include
`Membership` information.
This way errors do not have to depend on type `Node`, which is used in
`Membership` and it is a application specific type.

Then when a user-defined generic type `NodeData` is introduced, error
types do not need to change.

- Part of: #480

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/487)
<!-- Reviewable:end -->
