### PR TITLE
Change: now RaftNetworkFactory::connect() returns a Result.

### DIFF
--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -52,13 +52,18 @@ impl ExampleNetwork {
 #[async_trait]
 impl RaftNetworkFactory<ExampleTypeConfig> for ExampleNetwork {
     type Network = ExampleNetworkConnection;
+    type ConnectionError = NetworkError;
 
-    async fn connect(&mut self, target: ExampleNodeId, node: Option<&Node>) -> Self::Network {
-        ExampleNetworkConnection {
+    async fn connect(
+        &mut self,
+        target: ExampleNodeId,
+        node: Option<&Node>,
+    ) -> Result<Self::Network, Self::ConnectionError> {
+        Ok(ExampleNetworkConnection {
             owner: ExampleNetwork {},
             target,
             target_node: node.cloned(),
-        }
+        })
     }
 }
 

--- a/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
@@ -63,12 +63,17 @@ impl ExampleNetwork {
 #[async_trait]
 impl RaftNetworkFactory<ExampleTypeConfig> for ExampleNetwork {
     type Network = ExampleNetworkConnection;
+    type ConnectionError = NetworkError;
 
-    async fn connect(&mut self, target: ExampleNodeId, node: Option<&Node>) -> Self::Network {
+    async fn connect(
+        &mut self,
+        target: ExampleNodeId,
+        node: Option<&Node>,
+    ) -> Result<Self::Network, Self::ConnectionError> {
         dbg!(&node);
         let addr = node.map(|x| format!("ws://{}", x.addr)).unwrap();
         let client = Client::dial_websocket(&addr).await.ok();
-        ExampleNetworkConnection { addr, client, target }
+        Ok(ExampleNetworkConnection { addr, client, target })
     }
 }
 

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -142,6 +142,9 @@ pub enum AddLearnerError<NID: NodeId> {
     MissingNodeInfo(#[from] MissingNodeInfo<NID>),
 
     #[error(transparent)]
+    NetworkError(#[from] NetworkError),
+
+    #[error(transparent)]
     Fatal(#[from] Fatal<NID>),
 }
 

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -1,5 +1,6 @@
 //! The Raft network interface.
 
+use std::error::Error;
 use std::fmt::Formatter;
 
 use async_trait::async_trait;
@@ -78,6 +79,10 @@ where C: RaftTypeConfig
     /// Actual type of the network handling a single connection.
     type Network: RaftNetwork<C>;
 
+    /// The error that an implementation returns when `connect()` fails.
+    // TODO: renaming it to `create()` would be better?
+    type ConnectionError: Error + Send + Sync;
+
     /// Create a new network instance sending RPCs to the target node.
     ///
     /// This doesn't have to be a "real" connection, the network instance is just configured to send
@@ -85,5 +90,6 @@ where C: RaftTypeConfig
     ///
     /// The method is intentionally async to give the implementation a chance to use asynchronous
     /// sync primitives to serialize access to the common internal object, if needed.
-    async fn connect(&mut self, target: C::NodeId, node: Option<&Node>) -> Self::Network;
+    async fn connect(&mut self, target: C::NodeId, node: Option<&Node>)
+        -> Result<Self::Network, Self::ConnectionError>;
 }

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -57,7 +57,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, None).await.send_append_entries(rpc).await?;
+    let resp = router.connect(0, None).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 
@@ -77,7 +77,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, None).await.send_append_entries(rpc).await?;
+    let resp = router.connect(0, None).await?.send_append_entries(rpc).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -90,7 +90,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, None).await.send_append_entries(rpc).await?;
+    let resp = router.connect(0, None).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -42,7 +42,7 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), log_index)),
     };
 
-    let resp = router.connect(0, None).await.send_append_entries(req).await?;
+    let resp = router.connect(0, None).await?.send_append_entries(req).await?;
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1

--- a/openraft/tests/life_cycle/main.rs
+++ b/openraft/tests/life_cycle/main.rs
@@ -9,3 +9,4 @@ mod fixtures;
 
 mod t20_initialization;
 mod t20_shutdown;
+mod t30_connect_error;

--- a/openraft/tests/life_cycle/t30_connect_error.rs
+++ b/openraft/tests/life_cycle/t30_connect_error.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Test error handling for `RaftNetworkFactory::connect()`.
+///
+/// - `connect()` that returns error should not panic a node.
+/// - Minority un-connectable nodes do not affect the cluster.
+/// - Majority un-connectable nodes break the raft cluster.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn network_connection_error() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    let log_index = router.new_nodes_from_single(btreeset! {0, 1, 2}, btreeset!()).await?;
+
+    tracing::info!("--- failure to add unreachable learner to cluster");
+    {
+        router.new_raft_node(3);
+        router.set_connectable(3, false);
+
+        let res = router.add_learner(0, 3).await;
+        assert!(res.is_err());
+
+        router
+            .wait_for_log(
+                &btreeset! {0, 1, 2},
+                Some(log_index),
+                timeout(),
+                "add learner fail, no logs",
+            )
+            .await?;
+    }
+
+    let n1 = router.get_raft_handle(&1)?;
+    let n2 = router.get_raft_handle(&2)?;
+
+    tracing::info!("--- block node-2, make it un-connectable");
+    {
+        router.set_connectable(2, false);
+    }
+
+    tracing::info!("--- since there are no heartbeat is sent, let node-1 to elect");
+    {
+        n1.enable_elect(true);
+        n1.wait(timeout()).state(ServerState::Leader, "node-1 become leader").await?;
+
+        tracing::info!("--- cluster should work with only a node-2 un-connectable");
+        router.client_request_many(1, "client", 1).await?;
+    }
+
+    tracing::info!("--- set node-1 un-connectable too. let node-2 to elect. It should fail");
+    {
+        router.set_connectable(1, false);
+        n1.enable_elect(false);
+        n2.enable_elect(true);
+
+        let res = n2.wait(timeout()).state(ServerState::Leader, "node-2 can not be leader").await;
+        assert!(res.is_err());
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
+}

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -138,7 +138,7 @@ async fn compaction() -> Result<()> {
     {
         let res = router
             .connect(1, None)
-            .await
+            .await?
             .send_append_entries(AppendEntriesRequest {
                 vote: Vote::new_committed(1, 0),
                 prev_log_id: Some(LogId::new(LeaderId::new(1, 0), 2)),

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -98,7 +98,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 }],
                 leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
             };
-            router.connect(1, None).await.send_append_entries(req).await?;
+            router.connect(1, None).await?.send_append_entries(req).await?;
 
             tracing::info!("--- check that learner membership is affected");
             {

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -115,7 +115,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             ],
             leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
         };
-        router.connect(1, None).await.send_append_entries(req).await?;
+        router.connect(1, None).await?.send_append_entries(req).await?;
 
         tracing::info!("--- check that learner membership is affected");
         {
@@ -146,7 +146,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             done: true,
         };
 
-        router.connect(1, None).await.send_install_snapshot(req).await?;
+        router.connect(1, None).await?.send_install_snapshot(req).await?;
 
         tracing::info!("--- DONE installing snapshot");
 


### PR DESCRIPTION

## Changelog

##### Change: now RaftNetworkFactory::connect() returns a Result.

`RaftNetworkFactory::connect()` let user specify an error when it fails
to create a new `RaftNetwork` instance, with associated type:
`RaftNetworkFactory::ConnectionError`.

- Fix: #466

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/488)
<!-- Reviewable:end -->
