### PR TITLE
Change: Membership.nodes remove Option from value

### DIFF
--- a/examples/raft-kv-memstore/src/network/management.rs
+++ b/examples/raft-kv-memstore/src/network/management.rs
@@ -28,7 +28,7 @@ pub async fn add_learner(
 ) -> actix_web::Result<impl Responder> {
     let node_id = req.0 .0;
     let node = BasicNode { addr: req.0 .1.clone() };
-    let res = app.raft.add_learner(node_id, Some(node), true).await;
+    let res = app.raft.add_learner(node_id, node, true).await;
     Ok(Json(res))
 }
 

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -90,9 +90,9 @@ async fn test_cluster() -> anyhow::Result<()> {
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
     assert_eq!(
         btreemap! {
-            1 => Some(BasicNode::new("127.0.0.1:21001")),
-            2 => Some(BasicNode::new("127.0.0.1:21002")),
-            3 => Some(BasicNode::new("127.0.0.1:21003")),
+            1 => BasicNode::new("127.0.0.1:21001"),
+            2 => BasicNode::new("127.0.0.1:21002"),
+            3 => BasicNode::new("127.0.0.1:21003"),
         },
         nodes_in_cluster
     );

--- a/examples/raft-kv-rocksdb/src/network/management.rs
+++ b/examples/raft-kv-rocksdb/src/network/management.rs
@@ -32,7 +32,7 @@ pub fn rest(app: &mut Server) {
 async fn add_learner(mut req: Request<Arc<ExampleApp>>) -> tide::Result {
     let (node_id, api_addr, rpc_addr): (ExampleNodeId, String, String) = req.body_json().await?;
     let node = ExampleNode { rpc_addr, api_addr };
-    let res = req.state().raft.add_learner(node_id, Some(node), true).await;
+    let res = req.state().raft.add_learner(node_id, node, true).await;
     Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
 }
 

--- a/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
@@ -68,10 +68,10 @@ impl RaftNetworkFactory<ExampleTypeConfig> for ExampleNetwork {
     async fn connect(
         &mut self,
         target: ExampleNodeId,
-        node: Option<&ExampleNode>,
+        node: &ExampleNode,
     ) -> Result<Self::Network, Self::ConnectionError> {
         dbg!(&node);
-        let addr = node.map(|x| format!("ws://{}", x.rpc_addr)).unwrap();
+        let addr = format!("ws://{}", node.rpc_addr);
         let client = Client::dial_websocket(&addr).await.ok();
         Ok(ExampleNetworkConnection { addr, client, target })
     }

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -91,9 +91,9 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
     assert_eq!(
         btreemap! {
-            1 => Some(ExampleNode{rpc_addr: get_rpc_addr(1), api_addr: get_addr(1)}),
-            2 => Some(ExampleNode{rpc_addr: get_rpc_addr(2), api_addr: get_addr(2)}),
-            3 => Some(ExampleNode{rpc_addr: get_rpc_addr(3), api_addr: get_addr(3)}),
+            1 => ExampleNode{rpc_addr: get_rpc_addr(1), api_addr: get_addr(1)},
+            2 => ExampleNode{rpc_addr: get_rpc_addr(2), api_addr: get_addr(2)},
+            3 => ExampleNode{rpc_addr: get_rpc_addr(3), api_addr: get_addr(3)},
         },
         nodes_in_cluster
     );

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -56,7 +56,6 @@ use crate::error::RPCError;
 use crate::error::Timeout;
 use crate::error::VoteError;
 use crate::metrics::RaftMetrics;
-use crate::metrics::RemoveTarget;
 use crate::metrics::ReplicationMetrics;
 use crate::metrics::UpdateMatchedLogId;
 use crate::progress::Progress;
@@ -1064,12 +1063,14 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         target: C::NodeId,
     ) -> Result<ReplicationStream<C::NodeId>, N::ConnectionError> {
         let target_node = self.engine.state.membership_state.effective.get_node(&target);
+        let membership_log_id = self.engine.state.membership_state.effective.log_id;
         let network = self.network.connect(target, target_node).await?;
 
         Ok(ReplicationCore::<C, N, S>::spawn(
             target,
             target_node.clone(),
             self.engine.state.vote,
+            membership_log_id,
             self.config.clone(),
             self.engine.state.last_log_id(),
             self.engine.state.committed,
@@ -1080,43 +1081,34 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         ))
     }
 
-    /// Remove a replication if the membership that does not include it has committed.
-    ///
-    /// Return true if removed.
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub async fn remove_replication(&mut self, target: C::NodeId) -> bool {
-        tracing::info!("removed_replication to: {}", target);
+    /// Remove all replication.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn remove_all_replication(&mut self) {
+        tracing::info!("remove all replication");
 
-        let repl_state = if let Some(l) = &mut self.leader_data {
-            l.nodes.remove(&target)
+        if let Some(l) = &mut self.leader_data {
+            let nodes = std::mem::take(&mut l.nodes);
+
+            tracing::debug!(
+                targets = debug(nodes.iter().map(|x| *x.0).collect::<Vec<_>>()),
+                "remove all targets from replication_metrics"
+            );
+
+            for (target, s) in nodes {
+                let handle = s.handle;
+
+                // Drop sender to notify the task to shutdown
+                drop(s.repl_tx);
+
+                tracing::debug!("joining removed replication: {}", target);
+                let _x = handle.await;
+                tracing::info!("Done joining removed replication : {}", target);
+            }
+
+            l.replication_metrics = Versioned::new(ReplicationMetrics::default());
         } else {
             unreachable!("it has to be a leader!!!");
         };
-
-        if let Some(s) = repl_state {
-            let handle = s.handle;
-
-            // Drop sender to notify the task to shutdown
-            drop(s.repl_tx);
-
-            tracing::debug!("joining removed replication: {}", target);
-            let _x = handle.await;
-            tracing::info!("Done joining removed replication : {}", target);
-        } else {
-            unreachable!("try to nonexistent replication to {}", target);
-        }
-
-        if let Some(l) = &mut self.leader_data {
-            l.replication_metrics.update(RemoveTarget { target });
-        } else {
-            unreachable!("It has to be a leader!!!");
-        }
-
-        // TODO(xp): set_replication_metrics_changed() can be removed.
-        //           Use self.replication_metrics.version to detect changes.
-        self.engine.metrics_flags.set_replication_changed();
-
-        true
     }
 
     /// Leader will keep working until the effective membership that removes it committed.
@@ -1457,9 +1449,18 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 }
             }
 
-            RaftMsg::UpdateReplicationMatched { target, result, vote } => {
+            RaftMsg::UpdateReplicationMatched {
+                target,
+                result,
+                vote,
+                membership_log_id,
+            } => {
                 if self.does_vote_match(vote, "UpdateReplicationMatched") {
-                    self.handle_update_matched(target, result).await?;
+                    // If membership changes, ignore the message.
+                    // There is chance delayed message reports a wrong state.
+                    if membership_log_id == self.engine.state.membership_state.effective.log_id {
+                        self.handle_update_matched(target, result).await?;
+                    }
                 }
             }
 
@@ -1533,11 +1534,16 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn update_replication_metrics(&mut self, target: C::NodeId, matched: LogId<C::NodeId>) {
         tracing::debug!(%target, ?matched, "update_leader_metrics");
 
         if let Some(l) = &mut self.leader_data {
+            tracing::debug!(
+                target = display(target),
+                matched = debug(&matched),
+                "update replication_metrics"
+            );
             l.replication_metrics.update(UpdateMatchedLogId { target, matched });
         } else {
             unreachable!("it has to be a leader!!!");
@@ -1713,11 +1719,11 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
                     }
                 }
             }
-            Command::UpdateReplicationStreams { remove, add } => {
-                for (node_id, _matched) in remove.iter() {
-                    self.remove_replication(*node_id).await;
-                }
-                for (node_id, _matched) in add.iter() {
+            Command::UpdateReplicationStreams { targets } => {
+                self.remove_all_replication().await;
+
+                // TODO: use _matched to initialize replication
+                for (node_id, _matched) in targets.iter() {
                     let state = match self.spawn_replication_stream(*node_id).await {
                         Ok(state) => state,
                         Err(e) => {

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -51,11 +51,12 @@ where
     },
 
     /// Membership config changed, need to update replication streams.
+    /// The Runtime has to close all old replications and start new ones.
+    /// Because a replication stream should only report state for one membership config.
+    /// When membership config changes, the membership log id stored in ReplicationCore has to be updated.
     UpdateReplicationStreams {
-        /// Replication to remove.
-        remove: Vec<(NID, Option<LogId<NID>>)>,
-        /// Replication to add.
-        add: Vec<(NID, Option<LogId<NID>>)>,
+        /// Targets to replicate to.
+        targets: Vec<(NID, Option<LogId<NID>>)>,
     },
 
     /// Move the cursor pointing to an entry in the input buffer.

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -285,8 +285,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
                 )),
             },
             Command::UpdateReplicationStreams {
-                remove: vec![],
-                add: vec![(3, None), (4, None)]
+                targets: vec![(3, None), (4, None)]
             },
             Command::ReplicateInputEntries { range: 0..3 },
             Command::MoveInputCursorBy { n: 3 },
@@ -365,8 +364,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                 )),
             },
             Command::UpdateReplicationStreams {
-                remove: vec![],
-                add: vec![(2, None)]
+                targets: vec![(2, None)]
             },
             // second commit upto the end.
             Command::ReplicateCommitted {
@@ -447,8 +445,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                 )),
             },
             Command::UpdateReplicationStreams {
-                remove: vec![(3, None)],
-                add: vec![(2, None)]
+                targets: vec![(2, None)]
             },
             // It is correct to commit if the membership change ot a one node cluster.
             Command::ReplicateCommitted {

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -133,8 +133,7 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
             },
             Command::UpdateReplicationStreams {
-                add: vec![(4, None)],
-                remove: vec![], // node-2 is leader, won't be removed
+                targets: vec![(3, None), (4, None)], // node-2 is leader, won't be removed
             }
         ],
         eng.commands

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -466,6 +466,7 @@ pub struct NotAllowed<NID: NodeId> {
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("node {node_id} {reason}")]
+// TODO: remove it
 pub struct MissingNodeInfo<NID: NodeId> {
     pub node_id: NID,
     pub reason: String,

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -151,12 +151,12 @@ where
     }
 
     /// Get a the node(either voter or learner) by node id.
-    pub fn get_node(&self, node_id: &NID) -> Option<&N> {
+    pub fn get_node(&self, node_id: &NID) -> &N {
         self.membership.get_node(node_id)
     }
 
     /// Returns an Iterator of all nodes(voters and learners).
-    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &Option<N>)> {
+    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &N)> {
         self.membership.nodes()
     }
 

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -15,7 +15,6 @@ mod wait;
 #[cfg(test)] mod wait_test;
 
 pub use raft_metrics::RaftMetrics;
-pub(crate) use replication_metrics::RemoveTarget;
 pub use replication_metrics::ReplicationMetrics;
 pub use replication_metrics::ReplicationTargetMetrics;
 pub(crate) use replication_metrics::UpdateMatchedLogId;

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -89,9 +89,5 @@ where C: RaftTypeConfig
     ///
     /// The method is intentionally async to give the implementation a chance to use asynchronous
     /// sync primitives to serialize access to the common internal object, if needed.
-    async fn connect(
-        &mut self,
-        target: C::NodeId,
-        node: Option<&C::Node>,
-    ) -> Result<Self::Network, Self::ConnectionError>;
+    async fn connect(&mut self, target: C::NodeId, node: &C::Node) -> Result<Self::Network, Self::ConnectionError>;
 }

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -856,6 +856,9 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
 
         /// Which ServerState sent this message
         vote: Vote<C::NodeId>,
+
+        /// The cluster this replication works for.
+        membership_log_id: Option<LogId<C::NodeId>>,
     },
 
     /// An event indicating that the Raft node needs to revert to follower state.
@@ -870,6 +873,9 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
 
         /// Which ServerState sent this message
         vote: Vote<C::NodeId>,
+        // TODO: need this?
+        // /// The cluster this replication works for.
+        // membership_log_id: Option<LogId<C::NodeId>>,
     },
 
     /// An event from a replication stream requesting snapshot info.
@@ -944,10 +950,14 @@ where
                 ref target,
                 ref result,
                 ref vote,
+                ref membership_log_id,
             } => {
                 format!(
-                    "UpdateMatchIndex: target: {}, result: {:?}, server_state_vote: {}",
-                    target, result, vote
+                    "UpdateMatchIndex: target: {}, result: {:?}, server_state_vote: {}, membership_log_id: {}",
+                    target,
+                    result,
+                    vote,
+                    membership_log_id.summary()
                 )
             }
             RaftMsg::RevertToFollower {

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -399,7 +399,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     pub async fn add_learner(
         &self,
         id: C::NodeId,
-        node: Option<C::Node>,
+        node: C::Node,
         blocking: bool,
     ) -> Result<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId, C::Node>> {
         let (tx, rx) = oneshot::channel();
@@ -807,14 +807,14 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
     },
 
     Initialize {
-        members: BTreeMap<C::NodeId, Option<C::Node>>,
+        members: BTreeMap<C::NodeId, C::Node>,
         tx: RaftRespTx<(), InitializeError<C::NodeId, C::Node>>,
     },
     /// Request raft core to setup a new replication to a learner.
     AddLearner {
         id: C::NodeId,
 
-        node: Option<C::Node>,
+        node: C::Node,
 
         /// Send the log id when the replication becomes line-rate.
         tx: RaftAddLearnerTx<C::NodeId, C::Node>,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -114,7 +114,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn spawn(
         target: C::NodeId,
-        target_node: Option<C::Node>,
+        target_node: C::Node,
         vote: Vote<C::NodeId>,
         config: Arc<Config>,
         last_log: Option<LogId<C::NodeId>>,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -64,6 +64,27 @@ pub(crate) struct ReplicationCore<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S
     /// The vote of the leader.
     vote: Vote<C::NodeId>,
 
+    /// The log id of the membership log this replication works for.
+    ///
+    /// Replication state belongs to a specific membership config.
+    /// E.g. given 3 membership log:
+    /// - `log_id=1, members={a,b,c}`
+    /// - `log_id=5, members={a,b}`
+    /// - `log_id=10, members={a,b,c}`
+    ///
+    /// When log_id=1 is appended, openraft spawns a replication to node `c`.
+    /// Then log_id=1 is replicated to node `c`.
+    /// Then a replication state update message `{target=c, matched=log_id-1}` is piped in message queue(`tx_api`),
+    /// waiting the raft core to process.
+    ///
+    /// Then log_id=5 is appended, replication to node `c` is dropped.
+    ///
+    /// Then log_id=10 is appended, another replication to node `c` is spawned.
+    /// Now node `c` is a new empty node, no log is replicated to it.
+    /// But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft core believe
+    /// node `c` already has `log_id=1`, and commit it.
+    membership_log_id: Option<LogId<C::NodeId>>,
+
     /// A channel for sending events to the Raft node.
     #[allow(clippy::type_complexity)]
     raft_core_tx: mpsc::UnboundedSender<RaftMsg<C, N, S>>,
@@ -116,6 +137,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
         target: C::NodeId,
         target_node: C::Node,
         vote: Vote<C::NodeId>,
+        membership_log_id: Option<LogId<C::NodeId>>,
         config: Arc<Config>,
         last_log: Option<LogId<C::NodeId>>,
         committed: Option<LogId<C::NodeId>>,
@@ -131,6 +153,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
         let this = Self {
             target,
             vote,
+            membership_log_id,
             network,
             log_reader,
             config,
@@ -328,6 +351,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                                 target: self.target,
                                 result: Err(e.to_string()),
                                 vote: self.vote,
+                                membership_log_id: self.membership_log_id,
                             });
                             ReplicationError::Timeout(e)
                         }
@@ -336,6 +360,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                                 target: self.target,
                                 result: Err(e.to_string()),
                                 vote: self.vote,
+                                membership_log_id: self.membership_log_id,
                             });
                             ReplicationError::Network(e)
                         }
@@ -351,6 +376,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                     target: self.target,
                     result: Err(timeout_err.to_string()),
                     vote: self.vote,
+                    membership_log_id: self.membership_log_id,
                 });
 
                 return Err(ReplicationError::Timeout(Timeout {
@@ -444,6 +470,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                 // Thus unwrap is safe.
                 result: Ok(self.matched.unwrap()),
                 vote: self.vote,
+                membership_log_id: self.membership_log_id,
             });
         }
     }

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use memstore::ClientRequest;
 use openraft::raft::AppendEntriesRequest;
+use openraft::BasicNode;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -57,7 +58,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, None).await?.send_append_entries(rpc).await?;
+    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 
@@ -77,7 +78,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, None).await?.send_append_entries(rpc).await?;
+    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(rpc).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -90,7 +91,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, None).await?.send_append_entries(rpc).await?;
+    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
+use openraft::BasicNode;
 use openraft::Config;
 use openraft::LeaderId;
 use openraft::LogId;
@@ -42,7 +43,7 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), log_index)),
     };
 
-    let resp = router.connect(0, None).await?.send_append_entries(req).await?;
+    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(req).await?;
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -572,7 +572,7 @@ where
         target: C::NodeId,
     ) -> Result<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId, C::Node>> {
         let node = self.get_raft_handle(&leader).unwrap();
-        node.add_learner(target, None, true).await
+        node.add_learner(target, C::Node::default(), true).await
     }
 
     /// Send a is_leader request to the target node.
@@ -943,7 +943,7 @@ where
     type Network = RaftRouterNetwork<C, S>;
     type ConnectionError = NetworkError;
 
-    async fn connect(&mut self, target: C::NodeId, _node: Option<&C::Node>) -> Result<Self::Network, NetworkError> {
+    async fn connect(&mut self, target: C::NodeId, _node: &C::Node) -> Result<Self::Network, NetworkError> {
         {
             let unreachable = self.unconnectable.lock().unwrap();
             if unreachable.contains(&target) {

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
+use openraft::BasicNode;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -137,7 +138,7 @@ async fn compaction() -> Result<()> {
     );
     {
         let res = router
-            .connect(1, None)
+            .connect(1, &BasicNode::default())
             .await?
             .send_append_entries(AppendEntriesRequest {
                 vote: Vote::new_committed(1, 0),

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::BasicNode;
 use openraft::Config;
 use openraft::LeaderId;
 use openraft::LogId;
@@ -110,7 +111,7 @@ async fn add_learner_non_blocking() -> Result<()> {
 
         router.new_raft_node(1);
         let raft = router.get_raft_handle(&0)?;
-        let res = raft.add_learner(1, None, false).await?;
+        let res = raft.add_learner(1, BasicNode::default(), false).await?;
 
         assert_eq!(None, res.matched);
     }

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::StorageHelper;
+use openraft::BasicNode;
 use openraft::Config;
 use openraft::EffectiveMembership;
 use openraft::Entry;
@@ -98,7 +99,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 }],
                 leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
             };
-            router.connect(1, None).await?.send_append_entries(req).await?;
+            router.connect(1, &BasicNode::default()).await?.send_append_entries(req).await?;
 
             tracing::info!("--- check that learner membership is affected");
             {

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::InstallSnapshotRequest;
+use openraft::BasicNode;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -115,7 +116,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             ],
             leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
         };
-        router.connect(1, None).await?.send_append_entries(req).await?;
+        router.connect(1, &BasicNode::default()).await?.send_append_entries(req).await?;
 
         tracing::info!("--- check that learner membership is affected");
         {
@@ -146,7 +147,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             done: true,
         };
 
-        router.connect(1, None).await?.send_install_snapshot(req).await?;
+        router.connect(1, &BasicNode::default()).await?.send_install_snapshot(req).await?;
 
         tracing::info!("--- DONE installing snapshot");
 


### PR DESCRIPTION

## Changelog

##### Refactor: replication state should be bound to membership config.

Replication state belongs to a specific membership config.
E.g. given 3 membership log:
- `log_id=1, members={a,b,c}`
- `log_id=5, members={a,b}`
- `log_id=10, members={a,b,c}`

When log_id=1 is appended, openraft spawns a replication to node `c`.
Then log_id=1 is replicated to node `c`.
Then a replication state update message `{target=c, matched=log_id-1}` is piped in message queue(`tx_api`),
waiting the raft core to process.

Then log_id=5 is appended, replication to node `c` is dropped.

Then log_id=10 is appended, another replication to node `c` is spawned.
Now node `c` is a new empty node, no log is replicated to it.
But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft core believe
node `c` already has `log_id=1`, and commit it.

In this commit, A `ReplicationCore` stores the membership log id it
works for.
When `RaftCore` receives a `UpdateMatchedLogId`, it must check the
membership log id before processing it.

When a new membership log is seen, the old replciation streams have to
be cleaned up and then spawn new ones.


##### Change: `Membership.nodes` remove `Option` from value

Before this commit, the value of `Membership.nodes` is `Option<N:
Node>`: `Membership.nodes: BTreeMap<NID, Option<N>>`

The value does not have to be an `Option`.
If an application does not need openraft to store the `Node` data, it
can just implement `trait Node` with an empty struct, or just use
`BasicNode` as a placeholder.

- Using `Option<N>` as the value is a legacy and since #480 is merged, we
  do not need the `Option` any more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/492)
<!-- Reviewable:end -->
