### PR TITLE
Refactor: Engine decide when to set up replication

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -54,7 +54,7 @@ fn test_elect() -> anyhow::Result<()> {
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
+                leader: true,
                 other_metrics: true
             },
             eng.metrics_flags
@@ -68,7 +68,8 @@ fn test_elect() -> anyhow::Result<()> {
                 },
                 Command::UpdateServerState {
                     server_state: ServerState::Leader
-                }
+                },
+                Command::UpdateReplicationStreams { targets: vec![] },
             ],
             eng.commands
         );
@@ -96,7 +97,7 @@ fn test_elect() -> anyhow::Result<()> {
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
+                leader: true,
                 other_metrics: true
             },
             eng.metrics_flags
@@ -110,7 +111,8 @@ fn test_elect() -> anyhow::Result<()> {
                 },
                 Command::UpdateServerState {
                     server_state: ServerState::Leader
-                }
+                },
+                Command::UpdateReplicationStreams { targets: vec![] },
             ],
             eng.commands
         );

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -229,7 +229,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
+                leader: true,
                 other_metrics: true
             },
             eng.metrics_flags
@@ -242,6 +242,9 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 },
                 Command::UpdateServerState {
                     server_state: ServerState::Leader
+                },
+                Command::UpdateReplicationStreams {
+                    targets: vec![(2, None)]
                 }
             ],
             eng.commands

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -48,7 +48,9 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
+                // Command::UpdateReplicationStreams will set this flag.
+                // Although there is no replication to create.
+                leader: true,
                 other_metrics: true
             },
             eng.metrics_flags
@@ -86,6 +88,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                 Command::UpdateServerState {
                     server_state: ServerState::Leader
                 },
+                Command::UpdateReplicationStreams { targets: vec![] },
             ],
             eng.commands
         );

--- a/openraft/tests/membership/t30_step_down.rs
+++ b/openraft/tests/membership/t30_step_down.rs
@@ -61,6 +61,7 @@ async fn step_down() -> Result<()> {
     {
         // leader commit a new log.
         log_index += 1;
+        tracing::debug!("--- expect log_index:{}", log_index);
 
         for id in [2, 3] {
             router


### PR DESCRIPTION

## Changelog

##### Refactor: Engine decide when to set up replication

`RaftCore::leader_loop()` does not need to setup replication.
`Engine` decides when to do it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/493)
<!-- Reviewable:end -->
