### PR TITLE
Refactor: leader_loop does not need to report metric; its done by runtime_loop

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1161,16 +1161,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         // Commit the initial entry when new leader established.
         self.write_entry(EntryPayload::Blank, None).await?;
 
-        // report the leader metrics every time there came to a new leader
-        // if not `report_metrics` before the leader loop, the leader metrics may not be updated cause no coming event.
-
-        let replication_metrics = if let Some(l) = &self.leader_data {
-            l.replication_metrics.clone()
-        } else {
-            unreachable!("it has to be a leader!!!");
-        };
-        self.report_metrics(Update::Update(Some(replication_metrics)));
-
         self.runtime_loop(ServerState::Leader).await
     }
 


### PR DESCRIPTION

## Changelog

##### Refactor: leader_loop does not need to report metric; its done by runtime_loop

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/494)
<!-- Reviewable:end -->
