### PR TITLE
Refactor: Commond::ReplicateEntries use log id

### DIFF
--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -41,8 +41,8 @@ where
         upto: LogId<NID>,
     },
 
-    /// Replicate a `range` of entries in the input buffer.
-    ReplicateInputEntries { range: Range<usize> },
+    /// Replicate entries upto log id `upto`, inclusive.
+    ReplicateEntries { upto: Option<LogId<NID>> },
 
     /// Membership config changed, need to update replication streams.
     UpdateMembership {
@@ -104,7 +104,7 @@ where
             Command::ReplicateCommitted { .. } => {}
             Command::LeaderCommit { .. } => flags.set_data_changed(),
             Command::FollowerCommit { .. } => flags.set_data_changed(),
-            Command::ReplicateInputEntries { .. } => {}
+            Command::ReplicateEntries { .. } => {}
             Command::UpdateMembership { .. } => flags.set_cluster_changed(),
             Command::UpdateReplicationStreams { .. } => flags.set_replication_changed(),
             Command::MoveInputCursorBy { .. } => {}

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -335,7 +335,9 @@ where
         }
 
         // Still need to replicate to learners, even when it is fast-committed.
-        self.push_command(Command::ReplicateInputEntries { range: 0..l });
+        self.push_command(Command::ReplicateEntries {
+            upto: Some(*entries.last().unwrap().get_log_id()),
+        });
         self.push_command(Command::MoveInputCursorBy { n: l });
     }
 

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -150,7 +150,9 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::AppendInputEntries { range: 0..3 },
-            Command::ReplicateInputEntries { range: 0..3 },
+            Command::ReplicateEntries {
+                upto: Some(log_id(3, 6))
+            },
             Command::MoveInputCursorBy { n: 3 },
         ],
         eng.commands
@@ -209,7 +211,9 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
                 since: None,
                 upto: LogId::new(LeaderId::new(3, 1), 6)
             },
-            Command::ReplicateInputEntries { range: 0..3 },
+            Command::ReplicateEntries {
+                upto: Some(log_id(3, 6))
+            },
             Command::MoveInputCursorBy { n: 3 },
         ],
         eng.commands
@@ -287,7 +291,9 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
             Command::UpdateReplicationStreams {
                 targets: vec![(3, None), (4, None)]
             },
-            Command::ReplicateInputEntries { range: 0..3 },
+            Command::ReplicateEntries {
+                upto: Some(log_id(3, 6))
+            },
             Command::MoveInputCursorBy { n: 3 },
         ],
         eng.commands
@@ -374,7 +380,9 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                 since: Some(LogId::new(LeaderId::new(3, 1), 4)),
                 upto: LogId::new(LeaderId::new(3, 1), 6)
             },
-            Command::ReplicateInputEntries { range: 0..3 },
+            Command::ReplicateEntries {
+                upto: Some(log_id(3, 6))
+            },
             Command::MoveInputCursorBy { n: 3 },
         ],
         eng.commands
@@ -455,7 +463,9 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                 since: None,
                 upto: LogId::new(LeaderId::new(3, 1), 6)
             },
-            Command::ReplicateInputEntries { range: 0..3 },
+            Command::ReplicateEntries {
+                upto: Some(log_id(3, 6))
+            },
             Command::MoveInputCursorBy { n: 3 },
         ],
         eng.commands


### PR DESCRIPTION

## Changelog

##### Refactor: Commond::ReplicateEntries use log id

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/495)
<!-- Reviewable:end -->
