### PR TITLE
Refactor: merge loops for all server state into one loop

### DIFF
--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -25,6 +25,11 @@ where
     /// Append a `range` of entries in the input buffer.
     AppendInputEntries { range: Range<usize> },
 
+    /// Append a blank log.
+    ///
+    /// One of the usage is when a leader is established, a blank log is written to commit the state.
+    AppendBlankLog { log_id: LogId<NID> },
+
     /// Replicate the committed log id to other nodes
     ReplicateCommitted { committed: Option<LogId<NID>> },
 
@@ -101,6 +106,7 @@ where
         match &self {
             Command::UpdateServerState { .. } => flags.set_cluster_changed(),
             Command::AppendInputEntries { .. } => flags.set_data_changed(),
+            Command::AppendBlankLog { .. } => flags.set_data_changed(),
             Command::ReplicateCommitted { .. } => {}
             Command::LeaderCommit { .. } => flags.set_data_changed(),
             Command::FollowerCommit { .. } => flags.set_data_changed(),

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -70,6 +70,31 @@ fn test_elect() -> anyhow::Result<()> {
                     server_state: ServerState::Leader
                 },
                 Command::UpdateReplicationStreams { targets: vec![] },
+                Command::AppendBlankLog {
+                    log_id: LogId {
+                        leader_id: LeaderId { term: 1, node_id: 1 },
+                        index: 0,
+                    },
+                },
+                Command::ReplicateCommitted {
+                    committed: Some(LogId {
+                        leader_id: LeaderId { term: 1, node_id: 1 },
+                        index: 0,
+                    },),
+                },
+                Command::LeaderCommit {
+                    since: None,
+                    upto: LogId {
+                        leader_id: LeaderId { term: 1, node_id: 1 },
+                        index: 0,
+                    },
+                },
+                Command::ReplicateEntries {
+                    upto: Some(LogId {
+                        leader_id: LeaderId { term: 1, node_id: 1 },
+                        index: 0,
+                    },),
+                },
             ],
             eng.commands
         );
@@ -113,6 +138,31 @@ fn test_elect() -> anyhow::Result<()> {
                     server_state: ServerState::Leader
                 },
                 Command::UpdateReplicationStreams { targets: vec![] },
+                Command::AppendBlankLog {
+                    log_id: LogId {
+                        leader_id: LeaderId { term: 2, node_id: 1 },
+                        index: 0,
+                    },
+                },
+                Command::ReplicateCommitted {
+                    committed: Some(LogId {
+                        leader_id: LeaderId { term: 2, node_id: 1 },
+                        index: 0,
+                    },),
+                },
+                Command::LeaderCommit {
+                    since: None,
+                    upto: LogId {
+                        leader_id: LeaderId { term: 2, node_id: 1 },
+                        index: 0,
+                    },
+                },
+                Command::ReplicateEntries {
+                    upto: Some(LogId {
+                        leader_id: LeaderId { term: 2, node_id: 1 },
+                        index: 0,
+                    },),
+                },
             ],
             eng.commands
         );

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -245,7 +245,19 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 },
                 Command::UpdateReplicationStreams {
                     targets: vec![(2, None)]
-                }
+                },
+                Command::AppendBlankLog {
+                    log_id: LogId {
+                        leader_id: LeaderId { term: 2, node_id: 1 },
+                        index: 0,
+                    },
+                },
+                Command::ReplicateEntries {
+                    upto: Some(LogId {
+                        leader_id: LeaderId { term: 2, node_id: 1 },
+                        index: 0,
+                    },),
+                },
             ],
             eng.commands
         );

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -170,6 +170,7 @@ async fn leader_metrics() -> Result<()> {
         n1.enable_elect(true);
         n1.wait(timeout()).state(ServerState::Leader, "node-1 becomes leader").await?;
         n1.wait(timeout()).metrics(|x| x.replication.is_some(), "node-1 starts replication").await?;
+
         n0.wait(timeout()).metrics(|x| x.replication.is_none(), "node-0 stopped replication").await?;
         n0.wait(timeout())
             .metrics(|x| x.current_leader == Some(1), "node-0 receives leader-1 message")


### PR DESCRIPTION

## Changelog

##### Refactor: merge loops for all server state into one loop

`RaftCore` does not need to track `ServerState` and switch to different
loop any more. Server state will be tracked by `Engine`.

- Refactor: Add `Command::AppendBlankLog` for leader initialization.

- Leader initial blank log now is emitted by `Engine`. `RaftCore`
  becomes a pure runtime that just passively execute commands emitted by
  Engine.

- Fix: #496

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/497)
<!-- Reviewable:end -->
