### PR TITLE
Fix: when leader reverts to follower, send error to waiting clients

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1585,7 +1585,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
         Ent: RaftLogId<C::NodeId> + Sync + Send + 'e,
         &'e Ent: Into<Entry<C>>,
     {
-        // Run non-role-specific command.
         match cmd {
             Command::UpdateServerState { server_state } => {
                 if server_state == &ServerState::Leader {

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -752,16 +752,10 @@ where
 
     // --- Draft API ---
 
-    // // --- app API ---
-    //
-    // /// Write a new log entry.
-    // pub(crate) fn write(&mut self) -> Result<Vec<AlgoCmd<NID>>, ForwardToLeader<NID>> {}
-    //
     // // --- raft protocol API ---
     //
     // pub(crate) fn handle_install_snapshot() {}
     //
-    // pub(crate) fn handle_append_entries_resp() {}
     // pub(crate) fn handle_install_snapshot_resp() {}
 }
 
@@ -788,6 +782,10 @@ where
     /// Leader state has two phase: election phase and replication phase, similar to paxos phase-1 and phase-2
     pub(crate) fn enter_leading(&mut self) {
         debug_assert_eq!(self.state.vote.node_id, self.id);
+        // debug_assert!(
+        //     self.state.internal_server_state.is_following(),
+        //     "can not enter leading twice"
+        // );
 
         self.state.new_leader();
     }
@@ -802,6 +800,11 @@ where
         //       It should just sleep in leading state(candidate state for an application).
         //       This way it holds that 'vote.node_id != self.id <=> following state`.
         // debug_assert_ne!(self.state.vote.node_id, self.id);
+
+        // debug_assert!(
+        //     self.state.internal_server_state.is_leading(),
+        //     "can not enter following twice"
+        // );
 
         let vote = &self.state.vote;
 
@@ -1108,7 +1111,6 @@ where
 
     /// The node is candidate or leader
     fn is_becoming_leader(&self) -> bool {
-        // self.state.vote.node_id == self.id
         self.state.internal_server_state.is_leading()
     }
 

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -269,7 +269,7 @@ where
 /// Error variants related to the Replication.
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::large_enum_variant)]
-pub enum ReplicationError<NID, N>
+pub(crate) enum ReplicationError<NID, N>
 where
     NID: NodeId,
     N: Node,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -199,9 +199,9 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                     return;
                 }
                 ReplicationError::HigherVote(h) => {
-                    let _ = self.raft_core_tx.send(RaftMsg::RevertToFollower {
+                    let _ = self.raft_core_tx.send(RaftMsg::HigherVote {
                         target: self.target,
-                        new_vote: h.higher,
+                        higher: h.higher,
                         vote: self.vote,
                     });
                     return;

--- a/openraft/tests/append_entries/main.rs
+++ b/openraft/tests/append_entries/main.rs
@@ -8,6 +8,7 @@ mod fixtures;
 // The later tests may depend on the earlier ones.
 
 mod t10_conflict_with_empty_entries;
+mod t10_see_higher_vote;
 mod t20_append_conflicts;
 mod t30_append_inconsistent_log;
 mod t40_append_updates_membership;

--- a/openraft/tests/append_entries/t10_see_higher_vote.rs
+++ b/openraft/tests/append_entries/t10_see_higher_vote.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use memstore::ClientRequest;
+use openraft::raft::VoteRequest;
+use openraft::BasicNode;
+use openraft::Config;
+use openraft::LeaderId;
+use openraft::LogId;
+use openraft::RaftNetwork;
+use openraft::RaftNetworkFactory;
+use openraft::ServerState;
+use openraft::Vote;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// A leader reverts to follower if a higher vote is seen when append-entries.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn append_sees_higher_vote() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    let _log_index = router.new_nodes_from_single(btreeset! {0,1}, btreeset! {}).await?;
+
+    tracing::info!("--- upgrade vote on node-1");
+    {
+        router
+            .connect(1, &BasicNode::default())
+            .await?
+            .send_vote(VoteRequest {
+                vote: Vote::new(10, 1),
+                last_log_id: Some(LogId::new(LeaderId::new(10, 1), 5)),
+            })
+            .await?;
+    }
+
+    tracing::info!("--- a write operation will see a higher vote, then the leader revert to follower");
+    {
+        router.wait(&0, timeout()).state(ServerState::Leader, "node-0 is leader").await?;
+
+        let n0 = router.get_raft_handle(&0)?;
+        let res = n0
+            .client_write(ClientRequest {
+                client: "0".to_string(),
+                serial: 1,
+                status: "2".to_string(),
+            })
+            .await;
+
+        tracing::debug!("--- client_write res: {:?}", res);
+
+        router
+            .wait(&0, timeout())
+            .state(ServerState::Follower, "node-0 becomes follower due to a higher vote")
+            .await?;
+
+        router.external_request(0, |st, _, _| {
+            assert_eq!(Vote::new(10, 1), st.vote, "higher vote is stored");
+        });
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### Fix: when leader reverts to follower, send error to waiting clients

When a leader reverts to follower, e.g., if a higher vote is seen,
it should inform waiting clients that leadership is lost.

- Let Engine deals with vote change event.

- Add test for reverting to follower behavior.


##### Refactor: remove unused TargetReplState::Shutdown

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/500)
<!-- Reviewable:end -->
