### PR TITLE
Refactor: split metrics change flags to three: data changes, replication changes and cluster info changes

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -692,7 +692,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             return;
         }
 
-        let leader_metrics = if self.engine.metrics_flags.leader {
+        let leader_metrics = if self.engine.metrics_flags.replication {
             let replication_metrics = self.leader_data.as_ref().map(|x| x.replication_metrics.clone());
             Update::Update(replication_metrics)
         } else {

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -54,8 +54,9 @@ fn test_elect() -> anyhow::Result<()> {
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: true,
-                other_metrics: true
+                replication: true,
+                local_data: true,
+                cluster: true,
             },
             eng.metrics_flags
         );
@@ -122,8 +123,9 @@ fn test_elect() -> anyhow::Result<()> {
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: true,
-                other_metrics: true
+                replication: true,
+                local_data: true,
+                cluster: true,
             },
             eng.metrics_flags
         );
@@ -186,8 +188,9 @@ fn test_elect() -> anyhow::Result<()> {
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
-                other_metrics: true
+                replication: false,
+                local_data: true,
+                cluster: true,
             },
             eng.metrics_flags
         );

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -661,8 +661,6 @@ where
     pub(crate) fn update_effective_membership(&mut self, log_id: &LogId<NID>, m: &Membership<NID, N>) {
         tracing::debug!("update effective membership: log_id:{} {}", log_id, m.summary());
 
-        self.metrics_flags.set_cluster_changed();
-
         let server_state = self.calc_server_state();
 
         let em = Arc::new(EffectiveMembership::new(Some(*log_id), m.clone()));

--- a/openraft/src/engine/follower_commit_entries_test.rs
+++ b/openraft/src/engine/follower_commit_entries_test.rs
@@ -66,8 +66,9 @@ fn test_follower_commit_entries_empty() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -94,8 +95,9 @@ fn test_follower_commit_entries_no_update() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -122,8 +124,9 @@ fn test_follower_commit_entries_lt_last_entry() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -156,8 +159,9 @@ fn test_follower_commit_entries_gt_last_entry() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -89,8 +89,9 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -132,8 +133,9 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -196,8 +198,9 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -277,8 +280,9 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -92,8 +92,9 @@ fn test_handle_append_entries_req_vote_is_rejected() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -135,8 +136,9 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -194,8 +196,9 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -261,8 +264,9 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -324,8 +328,9 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -60,8 +60,9 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -96,8 +97,9 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -133,8 +135,9 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: false,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -180,8 +183,9 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -55,8 +55,9 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Follower, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
-                other_metrics: false
+                replication: false,
+                local_data: false,
+                cluster: false,
             },
             eng.metrics_flags
         );
@@ -86,8 +87,9 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
-                other_metrics: false
+                replication: false,
+                local_data: false,
+                cluster: false,
             },
             eng.metrics_flags
         );
@@ -121,8 +123,9 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
-                other_metrics: true
+                replication: false,
+                local_data: true,
+                cluster: false,
             },
             eng.metrics_flags
         );
@@ -158,8 +161,9 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
-                other_metrics: false
+                replication: false,
+                local_data: false,
+                cluster: false,
             },
             eng.metrics_flags
         );
@@ -195,8 +199,9 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
-                other_metrics: false
+                replication: false,
+                local_data: false,
+                cluster: false,
             },
             eng.metrics_flags
         );
@@ -229,8 +234,9 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: true,
-                other_metrics: true
+                replication: true,
+                local_data: true,
+                cluster: true,
             },
             eng.metrics_flags
         );

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -55,8 +55,9 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
             MetricsChangeFlags {
                 // Command::UpdateReplicationStreams will set this flag.
                 // Although there is no replication to create.
-                leader: true,
-                other_metrics: true
+                replication: true,
+                local_data: true,
+                cluster: true,
             },
             eng.metrics_flags
         );
@@ -155,8 +156,9 @@ fn test_initialize() -> anyhow::Result<()> {
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
             MetricsChangeFlags {
-                leader: false,
-                other_metrics: true
+                replication: false,
+                local_data: true,
+                cluster: true,
             },
             eng.metrics_flags
         );

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -49,8 +49,9 @@ fn test_handle_vote_change_reject_smaller_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -75,8 +76,9 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -115,8 +117,9 @@ fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: false,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -151,8 +154,9 @@ fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -99,8 +99,9 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -141,8 +142,9 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -195,8 +197,9 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -266,8 +269,9 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: true,
-            other_metrics: true
+            replication: true,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -346,8 +350,9 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: true,
-            other_metrics: true
+            replication: true,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -437,8 +442,9 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: true,
-            other_metrics: true
+            replication: true,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -59,8 +59,9 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
     assert_eq!(&[log_id(2, 2)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true,
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -100,8 +101,9 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
     assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true,
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -129,8 +131,9 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
     assert_eq!(&[log_id(2, 2), log_id(4, 4)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true,
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -153,8 +156,9 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
     );
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true,
+            replication: false,
+            local_data: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -177,8 +181,9 @@ fn test_truncate_logs_since_7() -> anyhow::Result<()> {
     );
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false,
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -201,8 +206,9 @@ fn test_truncate_logs_since_8() -> anyhow::Result<()> {
     );
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false,
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -226,8 +232,9 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
     assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true,
+            replication: false,
+            local_data: true,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/update_committed_membership_test.rs
+++ b/openraft/src/engine/update_committed_membership_test.rs
@@ -64,8 +64,9 @@ fn test_update_committed_membership_at_index_0() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -92,8 +93,9 @@ fn test_update_committed_membership_at_index_2() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: false
+            replication: false,
+            local_data: false,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -121,8 +123,9 @@ fn test_update_committed_membership_at_index_3() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: false,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -160,8 +163,9 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: false,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -74,8 +74,9 @@ fn test_update_effective_membership_at_index_0_is_allowed() -> anyhow::Result<()
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: false,
-            other_metrics: true
+            replication: false,
+            local_data: false,
+            cluster: true,
         },
         eng.metrics_flags
     );
@@ -120,8 +121,9 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
 
     assert_eq!(
         MetricsChangeFlags {
-            leader: true,
-            other_metrics: true
+            replication: true,
+            local_data: false,
+            cluster: true,
         },
         eng.metrics_flags
     );

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -161,34 +161,40 @@ pub enum Update<T> {
 /// Describes the need to update some aspect of the metrics.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct MetricsChangeFlags {
-    pub leader: bool,
-    // TODO: split other_metrics into data metrics and cluster metrics
-    pub other_metrics: bool,
+    /// Replication state changes. E.g., adding/removing replication, progress update.
+    pub(crate) replication: bool,
+
+    /// Local data changes. Such as vote, log, snapshot.
+    pub(crate) local_data: bool,
+
+    /// State related to cluster: server state, leader, membership etc.
+    pub(crate) cluster: bool,
 }
 
 impl MetricsChangeFlags {
     pub(crate) fn changed(&self) -> bool {
-        self.leader || self.other_metrics
+        self.replication || self.local_data || self.cluster
     }
 
     pub(crate) fn reset(&mut self) {
-        self.leader = false;
-        self.other_metrics = false;
+        self.replication = false;
+        self.local_data = false;
+        self.cluster = false;
     }
 
     /// Includes state of replication to other nodes.
     pub(crate) fn set_replication_changed(&mut self) {
-        self.leader = true
+        self.replication = true
     }
 
     /// Includes raft log, snapshot, state machine etc.
     pub(crate) fn set_data_changed(&mut self) {
-        self.other_metrics = true
+        self.local_data = true
     }
 
     /// Includes node role, membership config, leader node etc.
     pub(crate) fn set_cluster_changed(&mut self) {
-        self.other_metrics = true
+        self.cluster = true
     }
 }
 

--- a/openraft/tests/membership/t25_elect_with_new_config.rs
+++ b/openraft/tests/membership/t25_elect_with_new_config.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::LogIdOptionExt;
-use tokio::time::sleep;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -33,50 +32,45 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");
-    let log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
-
-    router.assert_stable_cluster(Some(1), Some(log_index)); // Still in term 1, so leader is still node 0.
+    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
     // Isolate old leader and assert that a new leader takes over.
-    tracing::info!("--- isolating master node 0");
+    tracing::info!("--- isolating leader node 0");
     router.isolate_node(0);
 
     // Let node-1 become leader.
     let node_1 = router.get_raft_handle(&1)?;
     node_1.enable_elect(true);
+    log_index += 1; // leader initial blank log
 
     router
         .wait_for_metrics(&1, |x| x.current_leader == Some(1), timeout(), "wait for new leader")
         .await?;
 
-    // need some time to stabilize.
-    // TODO: it can not be sure that no new leader is elected after a leader detected on node-1
-    // Wait for election and for everything to stabilize (this is way longer than needed).
-    sleep(Duration::from_millis(1000)).await;
+    for node_id in [1, 2, 3, 4] {
+        router
+            .wait(&node_id, timeout())
+            .log(Some(log_index), "replicate and apply log to every node")
+            .await?;
+    }
 
-    let metrics = &router.latest_metrics()[1];
-    let term = metrics.current_term;
-    let applied = metrics.last_applied;
-    let leader_id = metrics.current_leader;
-
-    router.assert_stable_cluster(Some(term), applied.index());
-    let leader = router.leader().expect("expected new leader");
+    let leader_id = 1;
 
     tracing::info!("--- restore node 0");
     router.restore_node(0);
     router
-        .wait_for_metrics(
-            &0,
-            |x| x.current_leader == leader_id && x.last_applied == applied,
-            timeout(),
+        .wait(&0, timeout())
+        .metrics(
+            |x| x.current_leader == Some(leader_id) && x.last_applied.index() == Some(log_index),
             "wait for restored node-0 to sync",
         )
         .await?;
 
-    router.assert_stable_cluster(Some(term), applied.index());
-
     let current_leader = router.leader().expect("expected to find current leader");
-    assert_eq!(leader, current_leader, "expected cluster leadership to stay the same");
+    assert_eq!(
+        leader_id, current_leader,
+        "expected cluster leadership to stay the same"
+    );
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### Refactor: split metrics change flags to three: data changes, replication changes and cluster info changes

And remove unnecessary `sleep()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/501)
<!-- Reviewable:end -->
