### PR TITLE
Refactor: in tests using `()` for type `Node`

### DIFF
--- a/openraft/src/engine/calc_purge_upto_test.rs
+++ b/openraft/src/engine/calc_purge_upto_test.rs
@@ -1,6 +1,5 @@
 use crate::engine::Engine;
 use crate::engine::LogIdList;
-use crate::BasicNode;
 use crate::LeaderId;
 use crate::LogId;
 
@@ -11,8 +10,8 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode>::default();
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::default();
     eng.state.log_ids = LogIdList::new(vec![
         //
         log_id(0, 0),

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -8,7 +8,6 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -23,16 +22,16 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m1() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None)
+fn m1() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {1}], None)
 }
 
-fn m12() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {1,2}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    Engine::<u64, BasicNode>::default()
+fn eng() -> Engine<u64, ()> {
+    Engine::default()
 }
 
 #[test]

--- a/openraft/src/engine/follower_commit_entries_test.rs
+++ b/openraft/src/engine/follower_commit_entries_test.rs
@@ -5,7 +5,6 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -16,7 +15,7 @@ use crate::MembershipState;
 use crate::MetricsChangeFlags;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64, Node = BasicNode
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node = ()
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -33,16 +32,16 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode>::default();
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::default();
     eng.state.committed = Some(log_id(1, 1));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -5,7 +5,6 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -16,7 +15,7 @@ use crate::MembershipState;
 use crate::MetricsChangeFlags;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64, Node = BasicNode
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node = ()
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -33,24 +32,24 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {3,4}], None)
 }
 
-fn m45() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {4,5}], None)
+fn m45() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {4,5}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode> {
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -7,7 +7,6 @@ use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft::AppendEntriesResponse;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -19,7 +18,7 @@ use crate::MetricsChangeFlags;
 use crate::Vote;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=()
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -36,20 +35,20 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode> {
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -8,7 +8,6 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -23,12 +22,12 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode>::default();
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()>::default();
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -8,7 +8,6 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteResponse;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -23,16 +22,16 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m12() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m1234() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3,4}], None)
+fn m1234() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    Engine::<u64, BasicNode>::default()
+fn eng() -> Engine<u64, ()> {
+    Engine::<u64, ()>::default()
 }
 
 #[test]

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -12,7 +12,6 @@ use crate::error::NotAMembershipEntry;
 use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
-use crate::BasicNode;
 use crate::EntryPayload;
 use crate::LeaderId;
 use crate::LogId;
@@ -22,7 +21,7 @@ use crate::Vote;
 
 #[test]
 fn test_initialize_single_node() -> anyhow::Result<()> {
-    let eng = Engine::<u64, BasicNode>::default;
+    let eng = Engine::<u64, ()>::default;
 
     let log_id0 = LogId {
         leader_id: LeaderId::new(0, 0),
@@ -34,7 +33,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
         index,
     };
 
-    let m1 = || Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None);
+    let m1 = || Membership::<u64, ()>::new(vec![btreeset! {1}], None);
     let payload = EntryPayload::<Config>::Membership(m1());
     let mut entries = [EntryRef::new(&payload)];
 
@@ -129,7 +128,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 
 #[test]
 fn test_initialize() -> anyhow::Result<()> {
-    let eng = Engine::<u64, BasicNode>::default;
+    let eng = Engine::<u64, ()>::default;
 
     let log_id0 = LogId {
         leader_id: LeaderId::new(0, 0),
@@ -137,7 +136,7 @@ fn test_initialize() -> anyhow::Result<()> {
     };
     let vote0 = Vote::new(0, 0);
 
-    let m12 = || Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None);
+    let m12 = || Membership::<u64, ()>::new(vec![btreeset! {1,2}], None);
     let payload = EntryPayload::<Config>::Membership(m12());
     let mut entries = [EntryRef::new(&payload)];
 

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -7,7 +7,6 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::error::RejectVoteRequest;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -22,12 +21,12 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode>::default();
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()>::default();
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -7,7 +7,6 @@ use maplit::btreeset;
 
 use crate::engine::Command;
 use crate::engine::Engine;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -19,7 +18,7 @@ use crate::MetricsChangeFlags;
 use crate::Vote;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=()
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -36,33 +35,33 @@ fn blank(term: u64, index: u64) -> Entry<Foo> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m1() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None)
+fn m1() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1}], None)
 }
 
 /// members: {1}, learners: {2}
-fn m1_2() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], Some(btreeset! {2}))
+fn m1_2() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1}], Some(btreeset! {2}))
 }
 
-fn m13() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1,3}], None)
+fn m13() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,3}], None)
 }
 
-fn m23() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode> {
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
         id: 1, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/purge_log_test.rs
+++ b/openraft/src/engine/purge_log_test.rs
@@ -1,7 +1,6 @@
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
-use crate::BasicNode;
 use crate::LeaderId;
 use crate::LogId;
 
@@ -12,8 +11,8 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode>::default();
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()>::default();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 2), log_id(4, 4), log_id(4, 6)]);
     eng
 }

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -1,5 +1,3 @@
-use crate::BasicNode;
-
 /// Req for test
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -12,5 +10,5 @@ pub(crate) struct Resp {}
 
 // Config for test
 crate::declare_raft_types!(
-   pub(crate) Config: D = Req, R = Resp, NodeId = u64, Node=BasicNode
+   pub(crate) Config: D = Req, R = Resp, NodeId = u64, Node=()
 );

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -5,7 +5,6 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -21,20 +20,20 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m12() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m23() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode> {
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
         id: 2,
         ..Default::default()
     };

--- a/openraft/src/engine/update_committed_membership_test.rs
+++ b/openraft/src/engine/update_committed_membership_test.rs
@@ -5,7 +5,6 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -14,7 +13,7 @@ use crate::MembershipState;
 use crate::MetricsChangeFlags;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=()
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -24,20 +23,20 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode> {
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -6,7 +6,6 @@ use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Progress;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -16,7 +15,7 @@ use crate::MetricsChangeFlags;
 use crate::Vote;
 
 crate::declare_raft_types!(
-    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=BasicNode
+    pub(crate) Foo: D=(), R=(), NodeId=u64, Node=()
 );
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -26,28 +25,28 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m23_45() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {2,3}], Some(btreeset! {4,5}))
+fn m23_45() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], Some(btreeset! {4,5}))
 }
 
-fn m34() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn m4_356() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
+fn m4_356() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode> {
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -5,7 +5,6 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -19,16 +18,16 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m01() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m123() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3}], None)
+fn m123() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2,3}], None)
 }
 
-fn eng() -> Engine<u64, BasicNode> {
-    let mut eng = Engine::<u64, BasicNode> {
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
         id: 2, // make it a member
         ..Default::default()
     };

--- a/openraft/src/membership/effective_membership_test.rs
+++ b/openraft/src/membership/effective_membership_test.rs
@@ -1,14 +1,13 @@
 use maplit::btreeset;
 
 use crate::quorum::QuorumSet;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::Membership;
 
 #[test]
 fn test_effective_membership_majority() -> anyhow::Result<()> {
     {
-        let m12345 = Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3,4,5 }], None);
+        let m12345 = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5 }], None);
         let m = EffectiveMembership::new(None, m12345);
 
         assert!(!m.is_quorum([0].iter()));
@@ -20,7 +19,7 @@ fn test_effective_membership_majority() -> anyhow::Result<()> {
     }
 
     {
-        let m12345_678 = Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
+        let m12345_678 = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
         let m = EffectiveMembership::new(None, m12345_678);
 
         assert!(!m.is_quorum([0].iter()));

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -108,7 +108,7 @@ where
                 res.push(format!("{}", node_id));
 
                 let n = self.get_node(node_id);
-                res.push(format!(":{{{}}}", n));
+                res.push(format!(":{{{:?}}}", n));
             }
             res.push("}".to_string());
         }
@@ -126,7 +126,7 @@ where
             res.push(format!("{}", learner_id));
 
             let n = self.get_node(learner_id);
-            res.push(format!(":{{{}}}", n));
+            res.push(format!(":{{{:?}}}", n));
         }
         res.push("]".to_string());
         res.join("")

--- a/openraft/src/membership/membership_state_test.rs
+++ b/openraft/src/membership/membership_state_test.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -16,12 +15,12 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m1() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1}], None)
+fn m1() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {1}], None)
 }
 
-fn m123_345() -> Membership<u64, BasicNode> {
-    Membership::<u64, BasicNode>::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None)
+fn m123_345() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None)
 }
 
 #[test]

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -10,7 +10,6 @@ use crate::membership::EffectiveMembership;
 use crate::metrics::Wait;
 use crate::metrics::WaitError;
 use crate::raft_types::LogIdOptionExt;
-use crate::BasicNode;
 use crate::LeaderId;
 use crate::LogId;
 use crate::Membership;
@@ -23,7 +22,7 @@ use crate::RaftMetrics;
 async fn test_wait() -> anyhow::Result<()> {
     {
         // wait for leader
-        let (init, w, tx) = init_wait_test::<u64, BasicNode>();
+        let (init, w, tx) = init_wait_test::<u64, ()>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -39,7 +38,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for log
-        let (init, w, tx) = init_wait_test::<u64, BasicNode>();
+        let (init, w, tx) = init_wait_test::<u64, ()>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -67,7 +66,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for state
-        let (init, w, tx) = init_wait_test::<u64, BasicNode>();
+        let (init, w, tx) = init_wait_test::<u64, ()>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -84,7 +83,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for members
-        let (init, w, tx) = init_wait_test::<u64, BasicNode>();
+        let (init, w, tx) = init_wait_test::<u64, ()>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -107,7 +106,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     tracing::info!("--- wait for snapshot, Ok");
     {
-        let (init, w, tx) = init_wait_test::<u64, BasicNode>();
+        let (init, w, tx) = init_wait_test::<u64, ()>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -124,7 +123,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     tracing::info!("--- wait for snapshot, only index matches");
     {
-        let (init, w, tx) = init_wait_test::<u64, BasicNode>();
+        let (init, w, tx) = init_wait_test::<u64, ()>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -149,7 +148,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // timeout
-        let (_init, w, _tx) = init_wait_test::<u64, BasicNode>();
+        let (_init, w, _tx) = init_wait_test::<u64, ()>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(200)).await;

--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -43,8 +43,8 @@ pub trait NodeId: NodeIdEssential {}
 impl<T> NodeId for T where T: NodeIdEssential {}
 
 /// Essential trait bound for application level node-data, except serde.
-pub trait NodeEssential: Sized + Send + Sync + Eq + PartialEq + Debug + Display + Clone + Default + 'static {}
-impl<T> NodeEssential for T where T: Sized + Send + Sync + Eq + PartialEq + Debug + Display + Clone + Default + 'static {}
+pub trait NodeEssential: Sized + Send + Sync + Eq + PartialEq + Debug + Clone + Default + 'static {}
+impl<T> NodeEssential for T where T: Sized + Send + Sync + Eq + PartialEq + Debug + Clone + Default + 'static {}
 
 /// A Raft `Node`, this trait holds all relevant node information.
 ///

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::engine::LogIdList;
-use crate::BasicNode;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -18,13 +17,13 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m12() -> Membership<u64, BasicNode> {
+fn m12() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
 #[test]
 fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, BasicNode>::default();
+    let rs = RaftState::<u64, ()>::default();
 
     assert!(!rs.has_log_id(&log_id(0, 0)));
 
@@ -33,7 +32,7 @@ fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         committed: Some(log_id(2, 1)),
         ..Default::default()
     };
@@ -47,7 +46,7 @@ fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         committed: Some(log_id(2, 1)),
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
@@ -67,20 +66,20 @@ fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_last_log_id() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![]),
         ..Default::default()
     };
 
     assert_eq!(None, rs.last_log_id());
 
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_log_id());
 
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
@@ -91,20 +90,20 @@ fn test_raft_state_last_log_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![]),
         ..Default::default()
     };
 
     assert_eq!(None, rs.last_purged_log_id());
 
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id());
 
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
@@ -116,7 +115,7 @@ fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
 #[test]
 fn test_raft_state_is_membership_committed() -> anyhow::Result<()> {
     //
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState {
         committed: None,
         membership_state: MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -130,7 +129,7 @@ fn test_raft_state_is_membership_committed() -> anyhow::Result<()> {
         "committed == effective, but not consider this"
     );
 
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState {
         committed: Some(log_id(2, 2)),
         membership_state: MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -144,7 +143,7 @@ fn test_raft_state_is_membership_committed() -> anyhow::Result<()> {
         "committed != effective, but rs.committed == effective.log_id"
     );
 
-    let rs = RaftState::<u64, BasicNode> {
+    let rs = RaftState {
         committed: Some(log_id(2, 2)),
         membership_state: MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use memstore::ClientRequest;
 use openraft::raft::AppendEntriesRequest;
-use openraft::BasicNode;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -58,7 +57,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(rpc).await?;
+    let resp = router.connect(0, &()).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 
@@ -78,7 +77,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(rpc).await?;
+    let resp = router.connect(0, &()).await?.send_append_entries(rpc).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -91,7 +90,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(rpc).await?;
+    let resp = router.connect(0, &()).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 

--- a/openraft/tests/append_entries/t10_see_higher_vote.rs
+++ b/openraft/tests/append_entries/t10_see_higher_vote.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use memstore::ClientRequest;
 use openraft::raft::VoteRequest;
-use openraft::BasicNode;
 use openraft::Config;
 use openraft::LeaderId;
 use openraft::LogId;
@@ -36,7 +35,7 @@ async fn append_sees_higher_vote() -> Result<()> {
     tracing::info!("--- upgrade vote on node-1");
     {
         router
-            .connect(1, &BasicNode::default())
+            .connect(1, &())
             .await?
             .send_vote(VoteRequest {
                 vote: Vote::new(10, 1),

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
-use openraft::BasicNode;
 use openraft::Config;
 use openraft::LeaderId;
 use openraft::LogId;
@@ -43,7 +42,7 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), log_index)),
     };
 
-    let resp = router.connect(0, &BasicNode::default()).await?.send_append_entries(req).await?;
+    let resp = router.connect(0, &()).await?.send_append_entries(req).await?;
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1

--- a/openraft/tests/life_cycle/t20_shutdown.rs
+++ b/openraft/tests/life_cycle/t20_shutdown.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::error::ClientWriteError;
 use openraft::error::Fatal;
-use openraft::BasicNode;
 use openraft::Config;
 
 use crate::fixtures::init_default_ut_tracing;
@@ -74,7 +73,7 @@ async fn return_error_after_panic() -> Result<()> {
     {
         let res = router.client_request(0, "foo", 2).await;
         let err = res.unwrap_err();
-        assert_eq!(ClientWriteError::<u64, BasicNode>::Fatal(Fatal::Panicked), err);
+        assert_eq!(ClientWriteError::<u64, ()>::Fatal(Fatal::Panicked), err);
     }
 
     Ok(())

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
-use openraft::BasicNode;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -138,7 +137,7 @@ async fn compaction() -> Result<()> {
     );
     {
         let res = router
-            .connect(1, &BasicNode::default())
+            .connect(1, &())
             .await?
             .send_append_entries(AppendEntriesRequest {
                 vote: Vote::new_committed(1, 0),

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::BasicNode;
 use openraft::Config;
 use openraft::LeaderId;
 use openraft::LogId;
@@ -111,7 +110,7 @@ async fn add_learner_non_blocking() -> Result<()> {
 
         router.new_raft_node(1);
         let raft = router.get_raft_handle(&0)?;
-        let res = raft.add_learner(1, BasicNode::default(), false).await?;
+        let res = raft.add_learner(1, (), false).await?;
 
         assert_eq!(None, res.matched);
     }

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::StorageHelper;
-use openraft::BasicNode;
 use openraft::Config;
 use openraft::EffectiveMembership;
 use openraft::Entry;
@@ -99,7 +98,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 }],
                 leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
             };
-            router.connect(1, &BasicNode::default()).await?.send_append_entries(req).await?;
+            router.connect(1, &()).await?.send_append_entries(req).await?;
 
             tracing::info!("--- check that learner membership is affected");
             {

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::InstallSnapshotRequest;
-use openraft::BasicNode;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -116,7 +115,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             ],
             leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
         };
-        router.connect(1, &BasicNode::default()).await?.send_append_entries(req).await?;
+        router.connect(1, &()).await?.send_append_entries(req).await?;
 
         tracing::info!("--- check that learner membership is affected");
         {
@@ -147,7 +146,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             done: true,
         };
 
-        router.connect(1, &BasicNode::default()).await?.send_install_snapshot(req).await?;
+        router.connect(1, &()).await?.send_install_snapshot(req).await?;
 
         tracing::info!("--- DONE installing snapshot");
 


### PR DESCRIPTION

## Changelog

##### Refactor: in tests using `()` for type `Node`

Tests in openraft does not rely on the implementation of `Node`.

`Display` is removed from `Node`.
Some basic type such as `()` can not implement `Display`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/502)
<!-- Reviewable:end -->
