### PR TITLE
Feature: add `Raft::trigger_elect()` and `Raft::trigger_heartbeat()` to let user manually trigger a election or send a heartbeat log

### DIFF
--- a/openraft/tests/life_cycle/t30_connect_error.rs
+++ b/openraft/tests/life_cycle/t30_connect_error.rs
@@ -56,7 +56,7 @@ async fn network_connection_error() -> anyhow::Result<()> {
 
     tracing::info!("--- since there are no heartbeat is sent, let node-1 to elect");
     {
-        n1.enable_elect(true);
+        n1.trigger_elect().await?;
         n1.wait(timeout()).state(ServerState::Leader, "node-1 become leader").await?;
 
         tracing::info!("--- cluster should work with only a node-2 un-connectable");
@@ -66,8 +66,7 @@ async fn network_connection_error() -> anyhow::Result<()> {
     tracing::info!("--- set node-1 un-connectable too. let node-2 to elect. It should fail");
     {
         router.set_connectable(1, false);
-        n1.enable_elect(false);
-        n2.enable_elect(true);
+        n2.trigger_elect().await?;
 
         let res = n2.wait(timeout()).state(ServerState::Leader, "node-2 can not be leader").await;
         assert!(res.is_err());

--- a/openraft/tests/membership/t25_elect_with_new_config.rs
+++ b/openraft/tests/membership/t25_elect_with_new_config.rs
@@ -40,7 +40,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
 
     // Let node-1 become leader.
     let node_1 = router.get_raft_handle(&1)?;
-    node_1.enable_elect(true);
+    node_1.trigger_elect().await?;
     log_index += 1; // leader initial blank log
 
     router

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -167,7 +167,7 @@ async fn leader_metrics() -> Result<()> {
 
     tracing::info!("--- let node-1 to elect to take leadership from node-0");
     {
-        n1.enable_elect(true);
+        n1.trigger_elect().await?;
         n1.wait(timeout()).state(ServerState::Leader, "node-1 becomes leader").await?;
         n1.wait(timeout()).metrics(|x| x.replication.is_some(), "node-1 starts replication").await?;
 


### PR DESCRIPTION

## Changelog

##### Feature: add `Raft::trigger_elect()` and `Raft::trigger_heartbeat()` to let user manually trigger a election or send a heartbeat log

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/503)
<!-- Reviewable:end -->
