### PR TITLE
Fix: when handling append-entries, if `prev_log_id` is purged, it should not treat it as a **conflict**

### DIFF
--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -254,9 +254,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         if st.committed < Some(last_applied) {
             st.committed = Some(last_applied);
         }
-        if st.last_applied < Some(last_applied) {
-            st.last_applied = Some(last_applied);
-        }
 
         debug_assert!(st.last_purged_log_id() <= Some(last_applied));
 

--- a/openraft/src/engine/calc_purge_upto_test.rs
+++ b/openraft/src/engine/calc_purge_upto_test.rs
@@ -24,7 +24,7 @@ fn eng() -> Engine<u64, ()> {
 
 #[test]
 fn test_calc_purge_upto() -> anyhow::Result<()> {
-    // last_purged_log_id, last_applied, max_keep, want
+    // last_purged_log_id, committed, max_keep, want
     let cases = vec![
         //
         (None, None, 0, None),

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -36,13 +36,15 @@ where
     /// Commit entries that are already in the store, upto `upto`, inclusive.
     /// And send applied result to the client that proposed the entry.
     LeaderCommit {
-        since: Option<LogId<NID>>,
+        // TODO: pass the log id list?
+        // TODO: merge LeaderCommit and FollowerCommit
+        already_committed: Option<LogId<NID>>,
         upto: LogId<NID>,
     },
 
     /// Commit entries that are already in the store, upto `upto`, inclusive.
     FollowerCommit {
-        since: Option<LogId<NID>>,
+        already_committed: Option<LogId<NID>>,
         upto: LogId<NID>,
     },
 

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -83,7 +83,7 @@ fn test_elect() -> anyhow::Result<()> {
                     },),
                 },
                 Command::LeaderCommit {
-                    since: None,
+                    already_committed: None,
                     upto: LogId {
                         leader_id: LeaderId { term: 1, node_id: 1 },
                         index: 0,
@@ -152,7 +152,7 @@ fn test_elect() -> anyhow::Result<()> {
                     },),
                 },
                 Command::LeaderCommit {
-                    since: None,
+                    already_committed: None,
                     upto: LogId {
                         leader_id: LeaderId { term: 2, node_id: 1 },
                         index: 0,

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -365,7 +365,7 @@ where
         tracing::debug!(
             my_vote = display(self.state.vote),
             my_last_log_id = display(self.state.last_log_id().summary()),
-            my_last_applied = display(self.state.last_applied.summary()),
+            my_committed = display(self.state.committed.summary()),
             "local state"
         );
 
@@ -431,7 +431,7 @@ where
         if let Some(prev_committed) = self.state.update_committed(&committed) {
             self.push_command(Command::FollowerCommit {
                 // TODO(xp): when restart, commit is reset to None. Use last_applied instead.
-                since: prev_committed,
+                already_committed: prev_committed,
                 upto: committed.unwrap(),
             });
             self.purge_applied_log();
@@ -741,7 +741,7 @@ where
                 committed: self.state.committed,
             });
             self.push_command(Command::LeaderCommit {
-                since: prev_committed,
+                already_committed: prev_committed,
                 upto: self.state.committed.unwrap(),
             });
             self.purge_applied_log();

--- a/openraft/src/engine/follower_commit_entries_test.rs
+++ b/openraft/src/engine/follower_commit_entries_test.rs
@@ -132,7 +132,7 @@ fn test_follower_commit_entries_lt_last_entry() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![Command::FollowerCommit {
-            since: Some(log_id(1, 1)),
+            already_committed: Some(log_id(1, 1)),
             upto: log_id(2, 3)
         }],
         eng.commands
@@ -167,7 +167,7 @@ fn test_follower_commit_entries_gt_last_entry() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![Command::FollowerCommit {
-            since: Some(log_id(1, 1)),
+            already_committed: Some(log_id(1, 1)),
             upto: log_id(2, 3)
         }],
         eng.commands
@@ -191,7 +191,7 @@ fn test_follower_commit_entries_purge_to_committed() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::FollowerCommit {
-                since: Some(log_id(1, 1)),
+                already_committed: Some(log_id(1, 1)),
                 upto: log_id(2, 3)
             },
             Command::PurgeLog { upto: log_id(2, 3) },
@@ -217,7 +217,7 @@ fn test_follower_commit_entries_purge_to_committed_minus_1() -> anyhow::Result<(
     assert_eq!(
         vec![
             Command::FollowerCommit {
-                since: Some(log_id(1, 1)),
+                already_committed: Some(log_id(1, 1)),
                 upto: log_id(2, 3)
             },
             Command::PurgeLog { upto: log_id(1, 2) },

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -107,7 +107,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                     },),
                 },
                 Command::LeaderCommit {
-                    since: None,
+                    already_committed: None,
                     upto: LogId {
                         leader_id: LeaderId { term: 1, node_id: 1 },
                         index: 1,

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -65,7 +65,7 @@ fn eng() -> Engine<u64, ()> {
         id: 1, // make it a member
         ..Default::default()
     };
-    eng.state.last_applied = Some(log_id(0, 0));
+    eng.state.committed = Some(log_id(0, 0));
     eng.state.vote = Vote::new_committed(3, 1);
     eng.state.log_ids.append(log_id(1, 1));
     eng.state.log_ids.append(log_id(2, 3));
@@ -210,7 +210,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
                 committed: Some(log_id(3, 6))
             },
             Command::LeaderCommit {
-                since: None,
+                already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(LeaderId::new(3, 1), 6)
             },
             Command::ReplicateEntries {
@@ -282,7 +282,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
                 committed: Some(log_id(3, 4))
             },
             Command::LeaderCommit {
-                since: None,
+                already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(LeaderId::new(3, 1), 4)
             },
             Command::UpdateMembership {
@@ -364,7 +364,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                 committed: Some(log_id(3, 4))
             },
             Command::LeaderCommit {
-                since: None,
+                already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(LeaderId::new(3, 1), 4)
             },
             Command::UpdateMembership {
@@ -381,7 +381,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                 committed: Some(log_id(3, 6))
             },
             Command::LeaderCommit {
-                since: Some(LogId::new(LeaderId::new(3, 1), 4)),
+                already_committed: Some(LogId::new(LeaderId::new(3, 1), 4)),
                 upto: LogId::new(LeaderId::new(3, 1), 6)
             },
             Command::ReplicateEntries {
@@ -465,7 +465,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                 committed: Some(log_id(3, 6))
             },
             Command::LeaderCommit {
-                since: None,
+                already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(LeaderId::new(3, 1), 6)
             },
             Command::ReplicateEntries {

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -76,7 +76,7 @@ fn test_update_progress_update_leader_progress() -> anyhow::Result<()> {
                 committed: Some(log_id(2, 1))
             },
             Command::LeaderCommit {
-                since: None,
+                already_committed: None,
                 upto: log_id(2, 1)
             }
         ],
@@ -93,7 +93,7 @@ fn test_update_progress_update_leader_progress() -> anyhow::Result<()> {
                 committed: Some(log_id(2, 3))
             },
             Command::LeaderCommit {
-                since: Some(log_id(2, 1)),
+                already_committed: Some(log_id(2, 1)),
                 upto: log_id(2, 3)
             }
         ],
@@ -123,7 +123,7 @@ fn test_update_progress_purge_upto_committed() -> anyhow::Result<()> {
                 committed: Some(log_id(2, 1))
             },
             Command::LeaderCommit {
-                since: None,
+                already_committed: None,
                 upto: log_id(2, 1)
             },
             Command::PurgeLog { upto: log_id(2, 1) },
@@ -154,7 +154,7 @@ fn test_update_progress_purge_upto_committed_minus_1() -> anyhow::Result<()> {
                 committed: Some(log_id(2, 2))
             },
             Command::LeaderCommit {
-                since: None,
+                already_committed: None,
                 upto: log_id(2, 2)
             },
             Command::PurgeLog { upto: log_id(2, 1) },

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -20,8 +20,12 @@ where
     /// The vote state of this node.
     pub vote: Vote<NID>,
 
-    /// The LogId of the last log applied to the state machine.
-    pub last_applied: Option<LogId<NID>>,
+    /// The LogId of the last log committed(AKA applied) to the state machine.
+    ///
+    /// - Committed means: a log that is replicated to a quorum of the cluster and it is of the term of the leader.
+    ///
+    /// - A quorum could be a uniform quorum or joint quorum.
+    pub committed: Option<LogId<NID>>,
 
     /// All log ids this node has.
     pub log_ids: LogIdList<NID>,
@@ -34,15 +38,6 @@ where
     // --
     /// The internal server state used by Engine.
     pub(crate) internal_server_state: InternalServerState<NID, N>,
-
-    /// The log id of the last known committed entry.
-    ///
-    /// - Committed means: a log that is replicated to a quorum of the cluster and it is of the term of the leader.
-    ///
-    /// - A quorum could be a uniform quorum or joint quorum.
-    ///
-    /// - `committed` in raft is volatile and will not be persisted.
-    pub committed: Option<LogId<NID>>,
 
     pub server_state: ServerState,
 }

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -57,7 +57,7 @@ where
         let log_ids = LogIdList::load_log_ids(last_purged_log_id, last_log_id, self).await?;
 
         Ok(RaftState {
-            last_applied,
+            committed: last_applied,
             // The initial value for `vote` is the minimal possible value.
             // See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
             vote: vote.unwrap_or_default(),
@@ -66,7 +66,6 @@ where
 
             // -- volatile fields: they are not persisted.
             internal_server_state: InternalServerState::default(),
-            committed: None,
             server_state: Default::default(),
         })
     }

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -435,7 +435,7 @@ where
             "state machine has higher log"
         );
         assert_eq!(
-            initial.last_applied,
+            initial.committed,
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 1)),
             "unexpected value for last applied log"
         );


### PR DESCRIPTION

## Changelog

##### Fix: when handling append-entries, if `prev_log_id` is purged, it should not treat it as a **conflict**

- Fix: when handling append-entries, if `prev_log_id` is purged, it
  should not treat it as a **conflict** log and should not delete any
  log.

  This bug is caused by using `committed` as `last_applied`.
  `committed` may be smaller than `last_applied` when a follower just
  starts up.

  The solution is merging `committed` and `last_applied` into one field:
  `committed`, which is always greater than or equal the actually
  committed(applied).

- Change: remove `RaftState.last_applied`, use `committed` to represent
  the already committed and applied log id.

- Refactor: Command::LeaderCommit and Command::FollowerCommit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/510)
<!-- Reviewable:end -->
