### PR TITLE
Refactor: let StoreExt deref to inner storage implementation

### DIFF
--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::ops::RangeBounds;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -42,6 +43,14 @@ impl<C: RaftTypeConfig, T: RaftStorage<C> + Clone> Clone for StoreExt<C, T> {
             inner: self.inner.clone(),
             c: PhantomData,
         }
+    }
+}
+
+impl<C: RaftTypeConfig, T: RaftStorage<C>> Deref for StoreExt<C, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 


### PR DESCRIPTION

## Changelog

##### Refactor: let StoreExt deref to inner storage implementation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/513)
<!-- Reviewable:end -->
