### PR TITLE
Change: remove ClientWriteRequest, client_write() parameter now is an AppData

### DIFF
--- a/openraft/src/core/client.rs
+++ b/openraft/src/core/client.rs
@@ -16,7 +16,6 @@ use crate::error::ClientReadError;
 use crate::error::ClientWriteError;
 use crate::error::QuorumNotEnough;
 use crate::raft::AppendEntriesRequest;
-use crate::raft::ClientWriteRequest;
 use crate::raft::ClientWriteResponse;
 use crate::raft::Entry;
 use crate::raft::EntryPayload;
@@ -167,13 +166,13 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     }
 
     /// Handle client write requests.
-    #[tracing::instrument(level = "trace", skip(self, tx), fields(rpc=%rpc.summary()))]
+    #[tracing::instrument(level = "trace", skip_all, fields(payload=%payload.summary()))]
     pub(super) async fn handle_client_write_request(
         &mut self,
-        rpc: ClientWriteRequest<D>,
+        payload: EntryPayload<D>,
         tx: RaftRespTx<ClientWriteResponse<R>, ClientWriteError>,
     ) -> Result<(), StorageError> {
-        let entry = self.core.append_payload_to_log(rpc.payload).await?;
+        let entry = self.core.append_payload_to_log(payload).await?;
         let entry = ClientRequestEntry {
             entry: Arc::new(entry),
             tx: Some(tx),

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -795,7 +795,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             RaftMsg::ClientReadRequest { tx } => {
                 self.handle_client_read_request(tx).await;
             }
-            RaftMsg::ClientWriteRequest { rpc, tx } => {
+            RaftMsg::ClientWriteRequest { payload: rpc, tx } => {
                 self.handle_client_write_request(rpc, tx).await?;
             }
             RaftMsg::Initialize { tx, .. } => {
@@ -933,7 +933,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             RaftMsg::ClientReadRequest { tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
-            RaftMsg::ClientWriteRequest { rpc: _, tx } => {
+            RaftMsg::ClientWriteRequest { payload: _, tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
             RaftMsg::Initialize { tx, .. } => {
@@ -1009,7 +1009,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             RaftMsg::ClientReadRequest { tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
-            RaftMsg::ClientWriteRequest { rpc: _, tx } => {
+            RaftMsg::ClientWriteRequest { payload: _, tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
             RaftMsg::Initialize { tx, .. } => {
@@ -1080,7 +1080,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             RaftMsg::ClientReadRequest { tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
-            RaftMsg::ClientWriteRequest { rpc: _, tx } => {
+            RaftMsg::ClientWriteRequest { payload: _, tx } => {
                 self.core.reject_with_forward_to_leader(tx);
             }
             RaftMsg::Initialize { members, tx } => {

--- a/openraft/src/types/v070/mod.rs
+++ b/openraft/src/types/v070/mod.rs
@@ -28,7 +28,6 @@ pub use network::RaftNetwork;
 pub use rpc::AddLearnerResponse;
 pub use rpc::AppendEntriesRequest;
 pub use rpc::AppendEntriesResponse;
-pub use rpc::ClientWriteRequest;
 pub use rpc::ClientWriteResponse;
 pub use rpc::InstallSnapshotRequest;
 pub use rpc::InstallSnapshotResponse;

--- a/openraft/src/types/v070/rpc.rs
+++ b/openraft/src/types/v070/rpc.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 use super::AppData;
 use super::AppDataResponse;
 use super::Entry;
-use super::EntryPayload;
 use super::LogId;
 use super::Membership;
 use super::SnapshotMeta;
@@ -90,17 +89,6 @@ pub struct InstallSnapshotRequest {
 pub struct InstallSnapshotResponse {
     /// The receiving node's current term, for leader to update itself.
     pub term: u64,
-}
-
-/// An application specific client request to update the state of the system (§5.1).
-///
-/// The entry of this payload will be appended to the Raft log and then applied to the Raft state
-/// machine according to the Raft protocol.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ClientWriteRequest<D: AppData> {
-    /// The application specific contents of this client request.
-    #[serde(bound = "D: AppData")]
-    pub(crate) payload: EntryPayload<D>,
 }
 
 /// The response to a `ClientRequest`.

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -24,7 +24,6 @@ use openraft::metrics::Wait;
 use openraft::raft::AddLearnerResponse;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
-use openraft::raft::ClientWriteRequest;
 use openraft::raft::ClientWriteResponse;
 use openraft::raft::Entry;
 use openraft::raft::EntryPayload;
@@ -513,9 +512,7 @@ impl RaftRouter {
         let rt = self.routing_table.read().await;
         let node = rt.get(&target).unwrap_or_else(|| panic!("node '{}' does not exist in routing table", target));
 
-        let payload = EntryPayload::Normal(req);
-
-        node.0.client_write(ClientWriteRequest::new(payload)).await.map(|res| res.data)
+        node.0.client_write(req).await.map(|res| res.data)
     }
 
     /// Assert that the cluster is in a pristine state, with all nodes as learners.


### PR DESCRIPTION


ClientWriteRequest is nothing more than a wrapper of entry payload.

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/515)
<!-- Reviewable:end -->
