### PR TITLE
Change: SnapshotMeta.last_log_id from LogId to Option of LogId

### DIFF
--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -147,23 +147,17 @@ impl RaftSnapshotBuilder<ExampleTypeConfig, Cursor<Vec<u8>>> for Arc<ExampleStor
             last_membership = state_machine.last_membership.clone();
         }
 
-        let last_applied_log = match last_applied_log {
-            None => {
-                panic!("can not compact empty state machine");
-            }
-            Some(x) => x,
-        };
-
         let snapshot_idx = {
             let mut l = self.snapshot_idx.lock().unwrap();
             *l += 1;
             *l
         };
 
-        let snapshot_id = format!(
-            "{}-{}-{}",
-            last_applied_log.leader_id, last_applied_log.index, snapshot_idx
-        );
+        let snapshot_id = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.leader_id, last.index, snapshot_idx)
+        } else {
+            format!("--{}", snapshot_idx)
+        };
 
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -380,21 +380,15 @@ impl RaftSnapshotBuilder<ExampleTypeConfig, Cursor<Vec<u8>>> for Arc<ExampleStor
             last_membership = state_machine.last_membership.clone();
         }
 
-        let last_applied_log = match last_applied_log {
-            None => {
-                panic!("can not compact empty state machine");
-            }
-            Some(x) => x,
-        };
-
         // TODO: we probably want thius to be atomic.
         let snapshot_idx: u64 = self.get_snapshot_index_()? + 1;
         self.set_snapshot_indesx_(snapshot_idx)?;
 
-        let snapshot_id = format!(
-            "{}-{}-{}",
-            last_applied_log.leader_id, last_applied_log.index, snapshot_idx
-        );
+        let snapshot_id = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.leader_id, last.index, snapshot_idx)
+        } else {
+            format!("--{}", snapshot_idx)
+        };
 
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -202,13 +202,6 @@ impl RaftSnapshotBuilder<Config, Cursor<Vec<u8>>> for Arc<MemStore> {
             last_membership = sm.last_membership.clone();
         }
 
-        let last_applied_log = match last_applied_log {
-            None => {
-                panic!("can not compact empty state machine");
-            }
-            Some(x) => x,
-        };
-
         let snapshot_size = data.len();
 
         let snapshot_idx = {
@@ -217,10 +210,11 @@ impl RaftSnapshotBuilder<Config, Cursor<Vec<u8>>> for Arc<MemStore> {
             *l
         };
 
-        let snapshot_id = format!(
-            "{}-{}-{}",
-            last_applied_log.leader_id, last_applied_log.index, snapshot_idx
-        );
+        let snapshot_id = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.leader_id, last.index, snapshot_idx)
+        } else {
+            format!("--{}", snapshot_idx)
+        };
 
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,

--- a/openraft/src/core/snapshot_state.rs
+++ b/openraft/src/core/snapshot_state.rs
@@ -3,15 +3,16 @@ use tokio::sync::broadcast;
 
 use crate::LogId;
 use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// The current snapshot state of the Raft node.
-pub(crate) enum SnapshotState<S> {
+pub(crate) enum SnapshotState<C: RaftTypeConfig, SD> {
     /// The Raft node is compacting itself.
     Snapshotting {
         /// A handle to abort the compaction process early if needed.
         handle: AbortHandle,
         /// A sender for notifying any other tasks of the completion of this compaction.
-        sender: broadcast::Sender<u64>,
+        sender: broadcast::Sender<Option<LogId<C::NodeId>>>,
     },
     /// The Raft node is streaming in a snapshot from the leader.
     Streaming {
@@ -20,7 +21,7 @@ pub(crate) enum SnapshotState<S> {
         /// The ID of the snapshot being written.
         id: String,
         /// A handle to the snapshot writer.
-        snapshot: Box<S>,
+        snapshot: Box<SD>,
     },
 }
 
@@ -28,7 +29,7 @@ pub(crate) enum SnapshotState<S> {
 #[derive(Debug, Clone)]
 pub(crate) enum SnapshotUpdate<NID: NodeId> {
     /// Snapshot creation has finished successfully and covers the given index.
-    SnapshotComplete(LogId<NID>),
+    SnapshotComplete(Option<LogId<NID>>),
 
     /// Snapshot creation failed.
     SnapshotFailed,

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -202,6 +202,6 @@ impl MetricsChangeFlags {
 /// E.g. when applying a log to state machine, or installing a state machine from snapshot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StateMachineChanges<C: RaftTypeConfig> {
-    pub last_applied: LogId<C::NodeId>,
+    pub last_applied: Option<LogId<C::NodeId>>,
     pub is_snapshot: bool,
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -779,12 +779,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
             // If we just sent the final chunk of the snapshot, then transition to lagging state.
             if done {
                 tracing::debug!(
-                    "done install snapshot: snapshot last_log_id: {}, matched: {:?}",
+                    "done install snapshot: snapshot last_log_id: {:?}, matched: {:?}",
                     snapshot.meta.last_log_id,
                     self.matched,
                 );
 
-                self.update_matched(Some(snapshot.meta.last_log_id));
+                self.update_matched(snapshot.meta.last_log_id);
 
                 return Ok(());
             }

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -32,7 +32,7 @@ where
     N: Node,
 {
     /// Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: LogId<NID>,
+    pub last_log_id: Option<LogId<NID>>,
 
     /// The last applied membership config.
     pub last_membership: EffectiveMembership<NID, N>,
@@ -49,7 +49,7 @@ where
 {
     pub fn signature(&self) -> SnapshotSignature<NID> {
         SnapshotSignature {
-            last_log_id: Some(self.last_log_id),
+            last_log_id: self.last_log_id,
             last_membership_log_id: self.last_membership.log_id,
             snapshot_id: self.snapshot_id.clone(),
         }

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -1054,7 +1054,7 @@ where
             let mut b = store.get_snapshot_builder().await;
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
-            assert_eq!(log_id(0, 0), meta.last_log_id);
+            assert_eq!(Some(log_id(0, 0)), meta.last_log_id);
             assert_eq!(Some(log_id(0, 0)), meta.last_membership.log_id);
             assert_eq!(
                 Membership::new(vec![btreeset! {1,2}], None),
@@ -1078,7 +1078,7 @@ where
             let mut b = store.get_snapshot_builder().await;
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
-            assert_eq!(log_id(2, 2), meta.last_log_id);
+            assert_eq!(Some(log_id(2, 2)), meta.last_log_id);
             assert_eq!(Some(log_id(2, 2)), meta.last_membership.log_id);
             assert_eq!(
                 Membership::new(vec![btreeset! {3,4}], None),

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -853,23 +853,29 @@ where
 
             match index_test {
                 ValueTest::Exact(index) => assert_eq!(
-                    &snap.meta.last_log_id.index, index,
-                    "expected node {} to have snapshot with index {}, got {}",
-                    id, index, snap.meta.last_log_id.index
+                    snap.meta.last_log_id.index(),
+                    Some(*index),
+                    "expected node {} to have snapshot with index {}, got {:?}",
+                    id,
+                    index,
+                    snap.meta.last_log_id
                 ),
                 ValueTest::Range(range) => assert!(
-                    range.contains(&snap.meta.last_log_id.index),
-                    "expected node {} to have snapshot within range {:?}, got {}",
+                    range.contains(&snap.meta.last_log_id.index().unwrap_or_default()),
+                    "expected node {} to have snapshot within range {:?}, got {:?}",
                     id,
                     range,
-                    snap.meta.last_log_id.index
+                    snap.meta.last_log_id
                 ),
             }
 
             assert_eq!(
-                &snap.meta.last_log_id.leader_id.term, term,
-                "expected node {} to have snapshot with term {}, got {}",
-                id, term, snap.meta.last_log_id.leader_id.term
+                &snap.meta.last_log_id.unwrap_or_default().leader_id.term,
+                term,
+                "expected node {} to have snapshot with term {}, got {:?}",
+                id,
+                term,
+                snap.meta.last_log_id
             );
         }
 

--- a/openraft/tests/snapshot/t20_api_install_snapshot.rs
+++ b/openraft/tests/snapshot/t20_api_install_snapshot.rs
@@ -53,10 +53,10 @@ async fn snapshot_arguments() -> Result<()> {
         vote: Vote::new_committed(1, 0),
         meta: SnapshotMeta {
             snapshot_id: "ss1".into(),
-            last_log_id: LogId {
+            last_log_id: Some(LogId {
                 leader_id: LeaderId::new(1, 0),
                 index: 0,
-            },
+            }),
             last_membership: Default::default(),
         },
         offset: 0,

--- a/rocksstore/src/lib.rs
+++ b/rocksstore/src/lib.rs
@@ -378,21 +378,15 @@ impl RaftSnapshotBuilder<Config, Cursor<Vec<u8>>> for Arc<RocksStore> {
             last_membership = state_machine.last_membership;
         }
 
-        let last_applied_log = match last_applied_log {
-            None => {
-                panic!("can not compact empty state machine");
-            }
-            Some(x) => x,
-        };
-
         // TODO: we probably want thius to be atomic.
         let snapshot_idx: u64 = self.get_snapshot_index_()? + 1;
         self.set_snapshot_indesx_(snapshot_idx)?;
 
-        let snapshot_id = format!(
-            "{}-{}-{}",
-            last_applied_log.leader_id, last_applied_log.index, snapshot_idx
-        );
+        let snapshot_id = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.leader_id, last.index, snapshot_idx)
+        } else {
+            format!("--{}", snapshot_idx)
+        };
 
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,


### PR DESCRIPTION

## Changelog

##### Change: SnapshotMeta.last_log_id from LogId to Option of LogId

`SnapshotMeta.last_log_id` should be the same type as
`StateMachine.last_applied`.

By making `SnapshotMeta.last_log_id` an Option of LogId, a snapshot can
be build on an empty state-machine(in which `last_applied` is None).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/517)
<!-- Reviewable:end -->
