### PR TITLE
Doc: add 0.6 to 0.7 upgrade guide to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ Currently openraft is the consensus engine of meta-service cluster in [databend]
   - `Feature:` if it introduces compatible non-breaking new features.
   - `Fix:` if it just fixes a bug.
 
-- **Branch [release-0.6](https://github.com/datafuselabs/openraft/tree/release-0.6)**: In this release branch, [v0.6.5](https://github.com/datafuselabs/openraft/tree/v0.6.5) is the latest
-    published version. `release-0.6` won't accept new features but only bug fixes.
+- **Branch [release-0.6](https://github.com/datafuselabs/openraft/tree/release-0.6)**:
+  In this release branch, [v0.6.8](https://github.com/datafuselabs/openraft/tree/v0.6.8) is the latest version.
+  `release-0.6` won't accept new features but only bug fixes.
 
-- **Branch [release-0.7](https://github.com/datafuselabs/openraft/tree/release-0.7)**: In this release branch, [v0.7.0-alpha.1](https://github.com/datafuselabs/openraft/tree/v0.7.0-alpha.1) is the latest version. `release-0.7` won't be published until the backward compatibility with `release-0.6` is ready.
+- **Branch [release-0.7](https://github.com/datafuselabs/openraft/tree/release-0.7)**:
+  In this release branch, [v0.7.0](https://github.com/datafuselabs/openraft/tree/v0.7.0) is the latest version.
+  [Upgrade guide from 0.6 to 0.7](https://datafuselabs.github.io/openraft/upgrade-v06-v07.html)
+
+  `release-0.7` won't accept new features but only bug fixes.
 
 - **Branch main** has been under active development.
 

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -21,4 +21,4 @@
     - [Effective Membership](./effective-membership.md)
 
 - [Upgrade Tips](./upgrade-tips.md)
-    - [Upgrade from 0.6 to 0.6](./upgrade-v06-v07.md)
+    - [Upgrade from 0.6 to 0.7](./upgrade-v06-v07.md)


### PR DESCRIPTION

## Changelog

##### Doc: add 0.6 to 0.7 upgrade guide to readme

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/521)
<!-- Reviewable:end -->
