### PR TITLE
Feature: add feature-flag: `bt` enables backtrace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,53 @@ jobs:
         with:
           path: |
             openraft/_log/
+
+  ut-on-stable-rust:
+    name: unittest on stable rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup | Toolchain
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: "stable"
+          override: true
+          components: rustfmt, clippy
+
+      - name: Unit Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          # Parallel tests block each other and result in timeout.
+          RUST_TEST_THREADS: 2
+          RUST_LOG: debug
+          RUST_BACKTRACE: full
+
+
+      - name: Build | Release Mode | No features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+
+      - name: Build | Release Mode | No features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+        env:
+          # Enable unstable feature on stalbe rust.
+          RUSTC_BOOTSTRAP: 1
+
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          path: |
+            openraft/_log/

--- a/change-log.md
+++ b/change-log.md
@@ -1,3 +1,19 @@
+## v0.7.1
+
+### Added:
+
+-   Added: [ea696474](https://github.com/datafuselabs/openraft/commit/ea696474191b82069fae465bb064a2e599537ede) add feature-flag: `bt` enables backtrace; by 张炎泼; 2022-03-12
+
+    `--features bt` enables backtrace when generating errors.
+    By default errors does not contain backtrace info.
+
+    Thus openraft can be built on stable rust by default.
+
+    To use on stable rust with backtrace, set `RUSTC_BOOTSTRAP=1`, e.g.:
+    ```
+    RUSTUP_TOOLCHAIN=stable RUSTC_BOOTSTRAP=1 make test
+    ```
+
 ## v0.7.0
 
 

--- a/change-log/v0.7.1.md
+++ b/change-log/v0.7.1.md
@@ -1,0 +1,13 @@
+### Added:
+
+-   Added: [ea696474](https://github.com/datafuselabs/openraft/commit/ea696474191b82069fae465bb064a2e599537ede) add feature-flag: `bt` enables backtrace; by 张炎泼; 2022-03-12
+
+    `--features bt` enables backtrace when generating errors.
+    By default errors does not contain backtrace info.
+
+    Thus openraft can be built on stable rust by default.
+
+    To use on stable rust with backtrace, set `RUSTC_BOOTSTRAP=1`, e.g.:
+    ```
+    RUSTUP_TOOLCHAIN=stable RUSTC_BOOTSTRAP=1 make test
+    ```

--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/datafuselabs/openraft"
 readme = "README.md"
 
 [dependencies]
-anyerror = { version = "0.1.1", features=["anyhow"]}
+anyerror = { version = "0.1.6", features = ["anyhow"]}
 anyhow = "1.0.32"
 openraft = { version="0.7.0", path= "../openraft" }
 async-trait = "0.1.36"

--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-memstore"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -18,7 +18,7 @@ readme = "README.md"
 [dependencies]
 anyerror = { version = "0.1.6", features = ["anyhow"]}
 anyhow = "1.0.32"
-openraft = { version="0.7.0", path= "../openraft" }
+openraft = { version="0.7.1", path= "../openraft" }
 async-trait = "0.1.36"
 serde = { version="1.0.114", features=["derive"] }
 serde_json = "1.0.57"

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(backtrace)]
-
 #[cfg(test)]
 mod test;
 
@@ -11,13 +9,13 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use anyerror::AnyError;
 use openraft::async_trait::async_trait;
 use openraft::raft::Entry;
 use openraft::raft::EntryPayload;
 use openraft::storage::HardState;
 use openraft::storage::LogState;
 use openraft::storage::Snapshot;
+use openraft::AnyError;
 use openraft::AppData;
 use openraft::AppDataResponse;
 use openraft::EffectiveMembership;

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -17,7 +17,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1.0.32"
-anyerror = { version = "0.1.1", features=["anyhow"]}
+anyerror = { version = "0.1.6", features = ["anyhow"]}
 async-trait = "0.1.36"
 byte-unit = "4.0.12"
 bytes = "1.0"
@@ -43,6 +43,10 @@ tracing-subscriber = { version = "0.3.3",  features=["env-filter"] }
 
 [features]
 docinclude = [] # Used only for activating `doc(include="...")` on nightly.
+
+# Enable backtrace when generating an error.
+# Stable rust does not support backtrace.
+bt  = ["anyerror/backtrace", "anyhow/backtrace"]
 
 [package.metadata.docs.rs]
 features = ["docinclude"] # Activate `docinclude` during docs.rs build.

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -491,7 +491,8 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
                     Ok(res) => match res {
                         Ok(snapshot) => {
                             let _ = tx_compaction.try_send(SnapshotUpdate::SnapshotComplete(snapshot.meta.last_log_id));
-                            let _ = chan_tx.send(snapshot.meta.last_log_id); // This will always succeed.
+                            // This will always succeed.
+                            let _ = chan_tx.send(snapshot.meta.last_log_id);
                         }
                         Err(err) => {
                             tracing::error!({error=%err}, "error while generating snapshot");

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -198,7 +198,7 @@ pub enum ReplicationError {
 
     #[error(transparent)]
     IO {
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         #[from]
         source: std::io::Error,
     },
@@ -212,7 +212,7 @@ pub enum ReplicationError {
 
     #[error(transparent)]
     Network {
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         source: anyhow::Error,
     },
 }

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -1,5 +1,11 @@
 #![doc = include_str!("../README.md")]
-#![feature(backtrace)]
+#![cfg_attr(feature = "bt", feature(backtrace))]
+
+//! # Feature flags
+//!
+//! - `bt`: Enable backtrace: generate backtrace for errors. This requires a unstable feature `backtrace` thus it can
+//!   not be used with stable rust, unless explicity allowing using unstable features in stable rust with
+//!   `RUSTC_BOOTSTRAP=1`.
 
 mod config;
 mod core;
@@ -24,6 +30,8 @@ pub mod types;
 mod metrics_wait_test;
 mod storage_helper;
 
+pub use anyerror;
+pub use anyerror::AnyError;
 pub use async_trait;
 
 pub use crate::config::Config;

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -1,4 +1,3 @@
-use std::backtrace::Backtrace;
 use std::fmt::Formatter;
 
 use anyerror::AnyError;
@@ -15,7 +14,7 @@ impl DefensiveError {
         DefensiveError {
             subject,
             violation,
-            backtrace: format!("{:?}", Backtrace::capture()),
+            backtrace: anyerror::backtrace_str(),
         }
     }
 }
@@ -59,8 +58,7 @@ impl StorageIOError {
             subject,
             verb,
             source,
-            // TODO: use crate backtrace instead of std::backtrace.
-            backtrace: format!("{:?}", Backtrace::capture()),
+            backtrace: anyerror::backtrace_str(),
         }
     }
 }

--- a/openraft/src/types/v070/storage_error.rs
+++ b/openraft/src/types/v070/storage_error.rs
@@ -18,7 +18,7 @@ pub struct DefensiveError {
     /// The description of the violation.
     pub violation: Violation,
 
-    pub backtrace: String,
+    pub backtrace: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -116,7 +116,7 @@ pub enum StorageError {
     #[error(transparent)]
     Defensive {
         #[from]
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         source: DefensiveError,
     },
 
@@ -124,7 +124,7 @@ pub enum StorageError {
     #[error(transparent)]
     IO {
         #[from]
-        #[backtrace]
+        #[cfg_attr(feature = "bt", backtrace)]
         source: StorageIOError,
     },
 }
@@ -135,5 +135,5 @@ pub struct StorageIOError {
     pub(crate) subject: ErrorSubject,
     pub(crate) verb: ErrorVerb,
     pub(crate) source: AnyError,
-    pub(crate) backtrace: String,
+    pub(crate) backtrace: Option<String>,
 }

--- a/scripts/build_change_log.py
+++ b/scripts/build_change_log.py
@@ -36,6 +36,7 @@ categories = {
         'Add:':          typs['new-feature'],
         'add:':          typs['new-feature'],
         'feature:':      typs['new-feature'],
+        'Feature:':      typs['new-feature'],
         'features:':     typs['new-feature'],
         'new-features:': typs['new-feature'],
         'docs:':         typs['doc'],


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

### Feature: add feature-flag: `bt` enables backtrace
`--features bt` enables backtrace when generating errors.
By default errors does not contain backtrace info.

Thus openraft can be built on stable rust by default.

To use on stable rust with backtrace, set `RUSTC_BOOTSTRAP=1`, e.g.:
```
RUSTUP_TOOLCHAIN=stable RUSTC_BOOTSTRAP=1 make test
```


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/522)
<!-- Reviewable:end -->
