### PR TITLE
Fix: reconnect to unreachable nodes.

### DIFF
--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -54,7 +54,7 @@ impl RaftNetworkFactory<ExampleTypeConfig> for ExampleNetwork {
     type Network = ExampleNetworkConnection;
     type ConnectionError = NetworkError;
 
-    async fn connect(
+    async fn new_client(
         &mut self,
         target: ExampleNodeId,
         node: &BasicNode,

--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -55,7 +55,11 @@ where
     P: AsRef<Path>,
 {
     // Create a configuration for the raft instance.
-    let config = Arc::new(Config::default().validate().unwrap());
+    let mut config = Config::default();
+    config.heartbeat_interval = 250;
+    config.election_timeout_min = 299;
+
+    let config = Arc::new(config.validate().unwrap());
 
     // Create a instance of where the Raft data will be stored.
     let store = ExampleStore::new(&dir).await;

--- a/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
@@ -65,12 +65,11 @@ impl RaftNetworkFactory<ExampleTypeConfig> for ExampleNetwork {
     type Network = ExampleNetworkConnection;
     type ConnectionError = NetworkError;
 
-    async fn connect(
+    async fn new_client(
         &mut self,
         target: ExampleNodeId,
         node: &ExampleNode,
     ) -> Result<Self::Network, Self::ConnectionError> {
-        dbg!(&node);
         let addr = format!("ws://{}", node.rpc_addr);
         let client = Client::dial_websocket(&addr).await.ok();
         Ok(ExampleNetworkConnection { addr, client, target })

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -90,8 +90,8 @@ where
             }
 
             let send_res = self.tx.send(RaftMsg::Tick { i });
-            if let Err(_e) = send_res {
-                tracing::info!("Tick fails to send, receiving end quit.");
+            if let Err(e) = send_res {
+                tracing::info!("Tick fails to send, receiving end quit: {e}");
             } else {
                 tracing::debug!("Tick sent: {}", i)
             }

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -84,10 +84,16 @@ where C: RaftTypeConfig
 
     /// Create a new network instance sending RPCs to the target node.
     ///
-    /// This doesn't have to be a "real" connection, the network instance is just configured to send
-    /// RPCs to the specified target node.
+    /// This function should **not** create a connection but rather a client that will connect when
+    /// required
     ///
     /// The method is intentionally async to give the implementation a chance to use asynchronous
     /// sync primitives to serialize access to the common internal object, if needed.
-    async fn connect(&mut self, target: C::NodeId, node: &C::Node) -> Result<Self::Network, Self::ConnectionError>;
+    ///
+    /// # Errors
+    /// When this function errors, it indicates a non-recoverable error in the network, no retries
+    /// will be attempted, and the corresponding node will be constantly unavailable.
+    /// Any recoverable error (such as unreachable host) should be returned as `Ok` with a client
+    /// that will perform the reconnect
+    async fn new_client(&mut self, target: C::NodeId, node: &C::Node) -> Result<Self::Network, Self::ConnectionError>;
 }

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -42,7 +42,7 @@ impl<NID: NodeId> MessageSummary<LogId<NID>> for Option<LogId<NID>> {
         match self {
             None => "None".to_string(),
             Some(x) => {
-                format!("{}", x)
+                format!("{x}")
             }
         }
     }

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -57,7 +57,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, &()).await?.send_append_entries(rpc).await?;
+    let resp = router.new_client(0, &()).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 
@@ -77,7 +77,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, &()).await?.send_append_entries(rpc).await?;
+    let resp = router.new_client(0, &()).await?.send_append_entries(rpc).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -90,7 +90,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.connect(0, &()).await?.send_append_entries(rpc).await?;
+    let resp = router.new_client(0, &()).await?.send_append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 

--- a/openraft/tests/append_entries/t10_see_higher_vote.rs
+++ b/openraft/tests/append_entries/t10_see_higher_vote.rs
@@ -35,7 +35,7 @@ async fn append_sees_higher_vote() -> Result<()> {
     tracing::info!("--- upgrade vote on node-1");
     {
         router
-            .connect(1, &())
+            .new_client(1, &())
             .await?
             .send_vote(VoteRequest {
                 vote: Vote::new(10, 1),

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -42,7 +42,7 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         leader_commit: Some(LogId::new(LeaderId::new(1, 0), log_index)),
     };
 
-    let resp = router.connect(0, &()).await?.send_append_entries(req).await?;
+    let resp = router.new_client(0, &()).await?.send_append_entries(req).await?;
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -949,7 +949,7 @@ where
     type Network = RaftRouterNetwork<C, S>;
     type ConnectionError = NetworkError;
 
-    async fn connect(&mut self, target: C::NodeId, _node: &C::Node) -> Result<Self::Network, NetworkError> {
+    async fn new_client(&mut self, target: C::NodeId, _node: &C::Node) -> Result<Self::Network, NetworkError> {
         {
             let unreachable = self.unconnectable.lock().unwrap();
             if unreachable.contains(&target) {

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -137,7 +137,7 @@ async fn compaction() -> Result<()> {
     );
     {
         let res = router
-            .connect(1, &())
+            .new_client(1, &())
             .await?
             .send_append_entries(AppendEntriesRequest {
                 vote: Vote::new_committed(1, 0),

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -98,7 +98,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 }],
                 leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
             };
-            router.connect(1, &()).await?.send_append_entries(req).await?;
+            router.new_client(1, &()).await?.send_append_entries(req).await?;
 
             tracing::info!("--- check that learner membership is affected");
             {

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -115,7 +115,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             ],
             leader_commit: Some(LogId::new(LeaderId::new(0, 0), 0)),
         };
-        router.connect(1, &()).await?.send_append_entries(req).await?;
+        router.new_client(1, &()).await?.send_append_entries(req).await?;
 
         tracing::info!("--- check that learner membership is affected");
         {
@@ -146,7 +146,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             done: true,
         };
 
-        router.connect(1, &()).await?.send_install_snapshot(req).await?;
+        router.new_client(1, &()).await?.send_install_snapshot(req).await?;
 
         tracing::info!("--- DONE installing snapshot");
 


### PR DESCRIPTION
This change introduces a reconnect logic for when
RaftNetworkFactory::connect fails. This way, nodes that are down during
leader promotion are eventually connected to when they are brought back
up.

Fixes: #525

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/526)
<!-- Reviewable:end -->
