### PR TITLE
Refactor: Engine handles install-snapshot

### DIFF
--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -11,14 +11,15 @@ mod replication_expectation;
 mod replication_state;
 mod server_state;
 mod snapshot_state;
+mod streaming_state;
 mod tick;
 
 pub use raft_core::RaftCore;
 pub(crate) use replication_expectation::Expectation;
 pub(crate) use replication_state::replication_lag;
 pub use server_state::ServerState;
+pub(crate) use snapshot_state::SnapshotResult;
 pub(crate) use snapshot_state::SnapshotState;
-pub(crate) use snapshot_state::SnapshotUpdate;
 pub(crate) use tick::Tick;
 pub(crate) use tick::TickHandle;
 pub(crate) use tick::VoteWiseTime;

--- a/openraft/src/core/streaming_state.rs
+++ b/openraft/src/core/streaming_state.rs
@@ -1,0 +1,68 @@
+use std::io::SeekFrom;
+use std::marker::PhantomData;
+
+use tokio::io::AsyncSeek;
+use tokio::io::AsyncSeekExt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+
+use crate::raft::InstallSnapshotRequest;
+use crate::ErrorSubject;
+use crate::ErrorVerb;
+use crate::RaftTypeConfig;
+use crate::SnapshotId;
+use crate::StorageError;
+
+/// The Raft node is streaming in a snapshot from the leader.
+pub(crate) struct StreamingState<C: RaftTypeConfig, SD> {
+    /// The offset of the last byte written to the snapshot.
+    pub(crate) offset: u64,
+    /// The ID of the snapshot being written.
+    pub(crate) snapshot_id: SnapshotId,
+    /// A handle to the snapshot writer.
+    pub(crate) snapshot_data: Box<SD>,
+
+    _p: PhantomData<C>,
+}
+
+impl<C: RaftTypeConfig, SD> StreamingState<C, SD>
+where SD: AsyncSeek + AsyncWrite + Unpin
+{
+    pub(crate) fn new(snapshot_id: SnapshotId, snapshot_data: Box<SD>) -> Self {
+        Self {
+            offset: 0,
+            snapshot_id,
+            snapshot_data,
+            _p: Default::default(),
+        }
+    }
+
+    /// Receive a chunk of snapshot data.
+    pub(crate) async fn receive(&mut self, req: InstallSnapshotRequest<C>) -> Result<bool, StorageError<C::NodeId>> {
+        // TODO: check id?
+
+        // Always seek to the target offset if not an exact match.
+        if req.offset != self.offset {
+            if let Err(err) = self.snapshot_data.as_mut().seek(SeekFrom::Start(req.offset)).await {
+                return Err(StorageError::from_io_error(
+                    ErrorSubject::Snapshot(req.meta.signature()),
+                    ErrorVerb::Seek,
+                    err,
+                ));
+            }
+            self.offset = req.offset;
+        }
+
+        // Write the next segment & update offset.
+        let res = self.snapshot_data.as_mut().write_all(&req.data).await;
+        if let Err(err) = res {
+            return Err(StorageError::from_io_error(
+                ErrorSubject::Snapshot(req.meta.signature()),
+                ErrorVerb::Write,
+                err,
+            ));
+        }
+        self.offset += req.data.len() as u64;
+        Ok(req.done)
+    }
+}

--- a/openraft/src/engine/calc_purge_upto_test.rs
+++ b/openraft/src/engine/calc_purge_upto_test.rs
@@ -108,7 +108,7 @@ fn test_keep_unsnapshoted() -> anyhow::Result<()> {
             eng.state.log_ids.purge(&last_purged);
         }
         eng.state.committed = committed;
-        eng.snapshot_last_log_id = snapshot;
+        eng.snapshot_meta.last_log_id = snapshot;
 
         let got = eng.calc_purge_upto();
 

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -8,6 +8,7 @@ use crate::MetricsChangeFlags;
 use crate::Node;
 use crate::NodeId;
 use crate::ServerState;
+use crate::SnapshotMeta;
 use crate::Vote;
 
 /// Commands to send to `RaftRuntime` to execute, to update the application state.
@@ -90,6 +91,12 @@ where
     /// Delete logs that conflict with the leader from a follower/learner since log id `since`, inclusive.
     DeleteConflictLog { since: LogId<NID> },
 
+    /// Install a snapshot data file: e.g., replace state machine with snapshot, save snapshot data.
+    InstallSnapshot { snapshot_meta: SnapshotMeta<NID, N> },
+
+    /// A received snapshot does not need to be installed, just drop buffered snapshot data.
+    CancelSnapshot { snapshot_meta: SnapshotMeta<NID, N> },
+
     //
     // --- Draft unimplemented commands:
 
@@ -121,6 +128,8 @@ where
             Command::InstallElectionTimer { .. } => {}
             Command::PurgeLog { .. } => flags.set_data_changed(),
             Command::DeleteConflictLog { .. } => flags.set_data_changed(),
+            Command::InstallSnapshot { .. } => flags.set_data_changed(),
+            Command::CancelSnapshot { .. } => {}
             Command::BuildSnapshot { .. } => flags.set_data_changed(),
         }
     }

--- a/openraft/src/engine/install_snapshot_test.rs
+++ b/openraft/src/engine/install_snapshot_test.rs
@@ -1,0 +1,312 @@
+use std::sync::Arc;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::EffectiveMembership;
+use crate::LeaderId;
+use crate::LogId;
+use crate::Membership;
+use crate::MetricsChangeFlags;
+use crate::SnapshotMeta;
+
+fn log_id(term: u64, index: u64) -> LogId<u64> {
+    LogId::<u64> {
+        leader_id: LeaderId { term, node_id: 1 },
+        index,
+    }
+}
+
+fn m12() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+}
+
+fn m1234() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
+}
+
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
+        snapshot_meta: SnapshotMeta {
+            last_log_id: Some(log_id(2, 2)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        ..Default::default()
+    };
+
+    eng.state.committed = Some(log_id(4, 5));
+    eng.state.log_ids = LogIdList::new(vec![
+        //
+        log_id(2, 2),
+        log_id(3, 5),
+        log_id(4, 6),
+        log_id(4, 8),
+    ]);
+
+    eng
+}
+
+#[test]
+fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
+    // Snapshot will not be installed because new `last_log_id` is less or equal current `snapshot_meta.last_log_id`.
+    let mut eng = eng();
+
+    eng.install_snapshot(SnapshotMeta {
+        last_log_id: Some(log_id(2, 2)),
+        last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+        snapshot_id: "1-2-3-4".to_string(),
+    });
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(2, 2)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.snapshot_meta
+    );
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: false,
+            cluster: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(
+        vec![Command::CancelSnapshot {
+            snapshot_meta: SnapshotMeta {
+                last_log_id: Some(log_id(2, 2)),
+                last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+                snapshot_id: "1-2-3-4".to_string(),
+            }
+        }],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
+    // Snapshot will not be installed because new `last_log_id` is less or equal current `committed`.
+    // TODO: The snapshot should be able to be updated if `new_snapshot.last_log_id > engine.snapshot_meta.last_log_id`.
+    //       Although in this case the state machine is not affected.
+    let mut eng = eng();
+
+    eng.install_snapshot(SnapshotMeta {
+        last_log_id: Some(log_id(4, 5)),
+        last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+        snapshot_id: "1-2-3-4".to_string(),
+    });
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(2, 2)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.snapshot_meta
+    );
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: false,
+            cluster: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(
+        vec![Command::CancelSnapshot {
+            snapshot_meta: SnapshotMeta {
+                last_log_id: Some(log_id(4, 5)),
+                last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+                snapshot_id: "1-2-3-4".to_string(),
+            }
+        }],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
+    // Snapshot will be installed and there are no conflicting logs.
+    let mut eng = eng();
+
+    eng.install_snapshot(SnapshotMeta {
+        last_log_id: Some(log_id(4, 6)),
+        last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+        snapshot_id: "1-2-3-4".to_string(),
+    });
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(4, 6)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.snapshot_meta
+    );
+    assert_eq!(&[log_id(4, 6), log_id(4, 8)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(log_id(4, 6)), eng.state.committed);
+    assert_eq!(
+        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        eng.state.membership_state.committed
+    );
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: true,
+            cluster: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(
+        vec![
+            Command::UpdateMembership {
+                membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234()))
+            },
+            //
+            Command::InstallSnapshot {
+                snapshot_meta: SnapshotMeta {
+                    last_log_id: Some(log_id(4, 6)),
+                    last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+                    snapshot_id: "1-2-3-4".to_string(),
+                }
+            },
+            Command::PurgeLog { upto: log_id(4, 6) },
+        ],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_snapshot_conflict() -> anyhow::Result<()> {
+    // Snapshot will be installed and there are no conflicting logs.
+    let mut eng = eng();
+
+    eng.install_snapshot(SnapshotMeta {
+        last_log_id: Some(log_id(5, 6)),
+        last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+        snapshot_id: "1-2-3-4".to_string(),
+    });
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(5, 6)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.snapshot_meta
+    );
+    assert_eq!(&[log_id(5, 6)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(log_id(5, 6)), eng.state.committed);
+    assert_eq!(
+        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        eng.state.membership_state.committed
+    );
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: true,
+            cluster: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(
+        vec![
+            Command::DeleteConflictLog { since: log_id(4, 6) },
+            Command::UpdateMembership {
+                membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234()))
+            },
+            //
+            Command::InstallSnapshot {
+                snapshot_meta: SnapshotMeta {
+                    last_log_id: Some(log_id(5, 6)),
+                    last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+                    snapshot_id: "1-2-3-4".to_string(),
+                }
+            },
+            Command::PurgeLog { upto: log_id(5, 6) },
+        ],
+        eng.commands
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
+    // Snapshot will be installed and there are no conflicting logs.
+    let mut eng = eng();
+
+    eng.install_snapshot(SnapshotMeta {
+        last_log_id: Some(log_id(100, 100)),
+        last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+        snapshot_id: "1-2-3-4".to_string(),
+    });
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(100, 100)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.snapshot_meta
+    );
+    assert_eq!(&[log_id(100, 100)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(log_id(100, 100)), eng.state.committed);
+    assert_eq!(
+        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        eng.state.membership_state.committed
+    );
+    assert_eq!(
+        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        eng.state.membership_state.effective
+    );
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: true,
+            cluster: true,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(
+        vec![
+            Command::UpdateMembership {
+                membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234()))
+            },
+            //
+            Command::InstallSnapshot {
+                snapshot_meta: SnapshotMeta {
+                    last_log_id: Some(log_id(100, 100)),
+                    last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+                    snapshot_id: "1-2-3-4".to_string(),
+                }
+            },
+            Command::PurgeLog { upto: log_id(100, 100) },
+        ],
+        eng.commands
+    );
+
+    Ok(())
+}

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -38,6 +38,7 @@ mod log_id_list;
 #[cfg(test)] mod handle_vote_req_test;
 #[cfg(test)] mod handle_vote_resp_test;
 #[cfg(test)] mod initialize_test;
+#[cfg(test)] mod install_snapshot_test;
 #[cfg(test)] mod internal_handle_vote_req_test;
 #[cfg(test)] mod leader_append_entries_test;
 #[cfg(test)] mod log_id_list_test;
@@ -47,6 +48,7 @@ mod log_id_list;
 #[cfg(test)] mod update_committed_membership_test;
 #[cfg(test)] mod update_effective_membership_test;
 #[cfg(test)] mod update_progress_test;
+#[cfg(test)] mod update_snapshot_test;
 
 pub(crate) use command::Command;
 pub(crate) use engine_impl::Engine;

--- a/openraft/src/engine/update_snapshot_test.rs
+++ b/openraft/src/engine/update_snapshot_test.rs
@@ -1,0 +1,108 @@
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::engine::Engine;
+use crate::EffectiveMembership;
+use crate::LeaderId;
+use crate::LogId;
+use crate::Membership;
+use crate::MetricsChangeFlags;
+use crate::SnapshotMeta;
+
+fn log_id(term: u64, index: u64) -> LogId<u64> {
+    LogId::<u64> {
+        leader_id: LeaderId { term, node_id: 1 },
+        index,
+    }
+}
+
+fn m12() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+}
+
+fn m1234() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
+}
+
+fn eng() -> Engine<u64, ()> {
+    Engine::<u64, ()> {
+        snapshot_meta: SnapshotMeta {
+            last_log_id: Some(log_id(2, 2)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_update_snapshot_no_update() -> anyhow::Result<()> {
+    // snapshot will not be updated because of equal or less `last_log_id`.
+    let mut eng = eng();
+
+    let got = eng.update_snapshot(SnapshotMeta {
+        last_log_id: Some(log_id(2, 2)),
+        last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+        snapshot_id: "1-2-3-4".to_string(),
+    });
+
+    assert_eq!(false, got);
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(2, 2)),
+            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.snapshot_meta
+    );
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: false,
+            cluster: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(0, eng.commands.len());
+
+    Ok(())
+}
+
+#[test]
+fn test_update_snapshot_updated() -> anyhow::Result<()> {
+    // snapshot will be updated to a new one with greater `last_log_id`.
+    let mut eng = eng();
+
+    let got = eng.update_snapshot(SnapshotMeta {
+        last_log_id: Some(log_id(2, 3)),
+        last_membership: EffectiveMembership::new(Some(log_id(2, 2)), m1234()),
+        snapshot_id: "1-2-3-4".to_string(),
+    });
+
+    assert_eq!(true, got);
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(2, 3)),
+            last_membership: EffectiveMembership::new(Some(log_id(2, 2)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.snapshot_meta
+    );
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: true,
+            cluster: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(0, eng.commands.len());
+
+    Ok(())
+}

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -22,7 +22,7 @@ use crate::config::RuntimeConfig;
 use crate::core::replication_lag;
 use crate::core::Expectation;
 use crate::core::RaftCore;
-use crate::core::SnapshotUpdate;
+use crate::core::SnapshotResult;
 use crate::core::Tick;
 use crate::core::TickHandle;
 use crate::error::AddLearnerError;
@@ -838,8 +838,10 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
         tx: InstallSnapshotTx<C::NodeId>,
     },
 
-    SnapshotUpdate {
-        update: SnapshotUpdate<C::NodeId>,
+    BuildingSnapshotResult {
+        // TODO: building snapshot session id
+        // snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+        result: SnapshotResult<C::NodeId, C::Node>,
     },
 
     ClientWriteRequest {
@@ -965,7 +967,7 @@ where
             RaftMsg::InstallSnapshot { rpc, .. } => {
                 format!("InstallSnapshot: {}", rpc.summary())
             }
-            RaftMsg::SnapshotUpdate { update } => {
+            RaftMsg::BuildingSnapshotResult { result: update } => {
                 format!("SnapshotUpdate: {:?}", update)
             }
             RaftMsg::ClientWriteRequest { payload: rpc, .. } => {

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -62,7 +62,6 @@ where
     /// Get the log id at the specified index.
     ///
     /// It will return `last_purged_log_id` if index is at the last purged index.
-    #[allow(dead_code)]
     pub(crate) fn get_log_id(&self, index: u64) -> Option<LogId<NID>> {
         self.log_ids.get(index)
     }

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -19,12 +19,13 @@ use crate::raft_types::SnapshotId;
 use crate::raft_types::StateMachineChanges;
 use crate::Entry;
 use crate::LogId;
+use crate::MessageSummary;
 use crate::NodeId;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::Vote;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct SnapshotMeta<NID, N>
 where
@@ -40,6 +41,21 @@ where
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be different in bytes.
     pub snapshot_id: SnapshotId,
+}
+
+impl<NID, N> MessageSummary<SnapshotMeta<NID, N>> for SnapshotMeta<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn summary(&self) -> String {
+        format!(
+            "{{snapshot_id: {}, last_membership: {}, last_log_id: {}}}",
+            self.snapshot_id,
+            self.last_log_id.summary(),
+            self.last_membership.summary()
+        )
+    }
 }
 
 impl<NID, N> SnapshotMeta<NID, N>

--- a/openraft/tests/snapshot/t20_api_install_snapshot.rs
+++ b/openraft/tests/snapshot/t20_api_install_snapshot.rs
@@ -88,7 +88,7 @@ async fn snapshot_arguments() -> Result<()> {
         req.meta.snapshot_id = "ss2".into();
         let res = n.0.install_snapshot(req).await;
         assert_eq!(
-            "snapshot segment id mismatch, expect: ss1+3, got: ss2+3",
+            "snapshot segment id mismatch, expect: ss2+0, got: ss2+3",
             res.unwrap_err().to_string()
         );
     }

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -171,10 +171,15 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
         assert_eq!(
             Membership::new(vec![btreeset! {0}], None),
             m.effective.membership,
-            "membership should be overridden by the snapshot"
+            "conflicting effective membership does not have to be clear"
         );
 
         let log_st = sto1.get_log_state().await?;
+        assert_eq!(
+            Some(LogId::new(LeaderId::new(5, 0), snapshot_threshold - 1)),
+            log_st.last_purged_log_id,
+            "purge up to last log id in snapshot"
+        );
         assert_eq!(
             Some(LogId::new(LeaderId::new(5, 0), snapshot_threshold - 1)),
             log_st.last_log_id,


### PR DESCRIPTION

## Changelog

##### Refactor: Engine handles install-snapshot

- Refactor: change `Option<SnapshotState>` to `SnapshotState`.
  Let `SnapshotState` itself include a `None` state.

- Refactor: `Engine::install_snapshot()` handles snapshot installation,
  and decides what to do next.
  `RaftCore` as a runtime for the Engine, it is still in charge of with
  snapshot fragmentation when streaming a snapshot.

- Refactor: rename `RaftMsg::SnapshotUpdate` to
  `RaftMsg::BuildingSnapshotResult`. To be clear, it's only about
  the state of building a snapshot locally.
  And more info are added: complete snapshot meta is sent when succeeded
  building snapshot, or exact error when it failed buliding a snapshot.

- Refactor: change `Engine.snapshot_last_log_id` to
  `Engine.snapshot_meta`. Now Engine has all snapshot information
  execpt the snapshot data.

- Fix: #498

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/529)
<!-- Reviewable:end -->
