### PR TITLE
Fix: snapshot with smaller last_log_id than last_applied should not be installed

### DIFF
--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-memstore"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -18,7 +18,7 @@ readme = "README.md"
 [dependencies]
 anyerror = { version = "0.1.6", features = ["anyhow"]}
 anyhow = "1.0.32"
-openraft = { version="0.7.1", path= "../openraft" }
+openraft = { version="0.7.2", path= "../openraft" }
 async-trait = "0.1.36"
 serde = { version="1.0.114", features=["derive"] }
 serde_json = "1.0.57"

--- a/memstore/README.md
+++ b/memstore/README.md
@@ -1,6 +1,6 @@
 # Openraft-memstore
 
 An in-memory storage system implementing the `RaftStorage` trait for
-[openraft-0.7.1](https://crates.io/crates/openraft/0.7.1).
+[openraft-0.7.2](https://crates.io/crates/openraft/0.7.2).
 
 This crate is built mainly for testing or demonstrating purpose.:)

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -196,12 +196,14 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     /// Finalize the installation of a new snapshot.
     ///
     /// Any errors which come up from this routine will cause the Raft node to go into shutdown.
-    #[tracing::instrument(level = "debug", skip(self, req, snapshot), fields(req=%req.summary()))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn finalize_snapshot_installation(
         &mut self,
         req: InstallSnapshotRequest,
         mut snapshot: Box<S::SnapshotData>,
     ) -> Result<(), StorageError> {
+        tracing::info!("finalize_snapshot_installation: req: {:?}", req);
+
         snapshot.as_mut().shutdown().await.map_err(|e| StorageError::IO {
             source: StorageIOError::new(
                 ErrorSubject::Snapshot(req.meta.clone()),

--- a/openraft/src/core/replication.rs
+++ b/openraft/src/core/replication.rs
@@ -94,6 +94,8 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn handle_update_matched(&mut self, target: NodeId, matched: Option<LogId>) -> Result<(), StorageError> {
+        tracing::debug!("handle_update_matched: target: {}, matched: {:?}", target, matched);
+
         // Update target's match index & check if it is awaiting removal.
 
         if let Some(state) = self.nodes.get_mut(&target) {
@@ -220,12 +222,14 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// A replication streams requesting for snapshot info.
     ///
     /// The snapshot has to include `must_include`.
-    #[tracing::instrument(level = "debug", skip(self, tx))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn handle_needs_snapshot(
         &mut self,
         must_include: Option<LogId>,
         tx: oneshot::Sender<Snapshot<S::SnapshotData>>,
     ) -> Result<(), StorageError> {
+        tracing::debug!("handle_needs_snapshot: must_include: {:?}", must_include);
+
         // Ensure snapshotting is configured, else do nothing.
         let threshold = match &self.core.config.snapshot_policy {
             SnapshotPolicy::LogsSinceLast(threshold) => *threshold,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -191,7 +191,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
         }
     }
 
-    #[tracing::instrument(level="trace", skip(self), fields(id=self.id, target=self.target, cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="debug", skip_all, fields(id=self.id, target=self.target, cluster=%self.config.cluster_name))]
     async fn main(mut self) {
         loop {
             // If it returns Ok(), always go back to LineRate state.
@@ -411,7 +411,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
     }
 
     /// max_possible_matched_index is the least index for `prev_log_id` to form a consecutive log sequence
-    #[tracing::instrument(level = "trace", skip(self), fields(max_possible_matched_index=self.max_possible_matched_index))]
+    #[tracing::instrument(level = "debug", skip(self), fields(max_possible_matched_index=self.max_possible_matched_index))]
     fn check_consecutive(&self, last_purged: Option<LogId>) -> Result<(), ReplicationError> {
         tracing::debug!(?last_purged, ?self.max_possible_matched_index, "check_consecutive");
 
@@ -512,9 +512,9 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self), fields(event=%event.summary()))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn process_raft_event(&mut self, event: RaftEvent) -> Result<(), ReplicationError> {
-        tracing::debug!(event=%event.summary(), "process_raft_event");
+        tracing::debug!("process_raft_event: {}", event.summary());
 
         match event {
             RaftEvent::UpdateCommittedLogId { committed } => {
@@ -711,7 +711,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self), fields(state = "snapshotting"))]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn replicate_snapshot(&mut self, snapshot_must_include: Option<LogId>) -> Result<(), ReplicationError> {
         let snapshot = self.wait_for_snapshot(snapshot_must_include).await?;
         self.stream_snapshot(snapshot).await?;

--- a/openraft/src/storage_helper.rs
+++ b/openraft/src/storage_helper.rs
@@ -88,7 +88,7 @@ where
     ///
     /// This method should returns membership with the greatest log index which is `>=since_index`.
     /// If no such membership log is found, it returns `None`, e.g., when logs are cleaned after being applied.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn last_membership_in_log(&self, since_index: u64) -> Result<Option<EffectiveMembership>, StorageError> {
         let st = self.sto.as_ref().get_log_state().await?;
 

--- a/openraft/tests/snapshot/main.rs
+++ b/openraft/tests/snapshot/main.rs
@@ -5,6 +5,7 @@ mod fixtures;
 mod after_snapshot_add_learner_and_request_a_log;
 mod snapshot_chunk_size;
 mod snapshot_ge_half_threshold;
+mod snapshot_le_last_applied;
 mod snapshot_line_rate_to_snapshot;
 mod snapshot_overrides_membership;
 mod snapshot_uses_prev_snap_membership;

--- a/openraft/tests/snapshot/snapshot_le_last_applied.rs
+++ b/openraft/tests/snapshot/snapshot_le_last_applied.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::Config;
+use openraft::LogId;
+use openraft::RaftStorage;
+use openraft::SnapshotMeta;
+
+use crate::fixtures::RaftRouter;
+
+/// Snapshot with smaller last_log_id than local last_applied should not be installed.
+/// Otherwise state machine will revert to a older state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn snapshot_le_last_applied() -> Result<()> {
+    let (_log_guard, ut_span) = init_ut!();
+    let _ent = ut_span.enter();
+
+    let config = Arc::new(Config { ..Default::default() }.validate()?);
+    let router = Arc::new(RaftRouter::new(config.clone()));
+
+    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!("--- send logs to increase last_applied");
+    {
+        router.client_request_many(0, "0", 10).await;
+        log_index += 10;
+
+        router
+            .wait_for_log(
+                &btreeset![0],
+                Some(log_index),
+                timeout(),
+                "send log to trigger snapshot",
+            )
+            .await?;
+
+        router.assert_stable_cluster(Some(1), Some(log_index)).await;
+    }
+
+    tracing::info!("--- it should fail to install a snapshot with smaller last_log_id");
+    {
+        assert!(log_index > 3);
+        let req = InstallSnapshotRequest {
+            term: 100,
+            leader_id: 1,
+            meta: SnapshotMeta {
+                snapshot_id: "ss1".into(),
+                last_log_id: Some(LogId { term: 1, index: 3 }),
+            },
+            offset: 0,
+            data: vec![1, 2, 3],
+            done: true,
+        };
+
+        let n = router.remove_node(0).await.unwrap();
+        n.0.install_snapshot(req).await?;
+        let st = n.1.last_applied_state().await?;
+        assert_eq!(
+            Some(LogId {
+                term: 1,
+                index: log_index
+            }),
+            st.0,
+            "last_applied is not affected"
+        );
+
+        let wait_rs =
+            n.0.wait(timeout())
+                .metrics(
+                    |x| {
+                        x.last_applied
+                            != Some(LogId {
+                                term: 1,
+                                index: log_index,
+                            })
+                    },
+                    "in-memory last_applied is not affected",
+                )
+                .await;
+
+        assert!(wait_rs.is_err());
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION
### Fix: snapshot with smaller last_log_id than last_applied should not be installed

Otherwise, the state machine will revert to an older state, while the
in-memory `last_applied` is unchanged.
This finally causes logs that fall in range `(snapshot.last_log_id, last_applied]` can not be applied.



**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)
