### PR TITLE
CI: in tests: check reachability before faking network delay

### DIFF
--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -990,9 +990,8 @@ where
         RPCError<C::NodeId, C::Node, AppendEntriesError<C::NodeId>>,
     > {
         tracing::debug!("append_entries to id={} {:?}", self.target, rpc);
-        self.owner.rand_send_delay().await;
-
         self.owner.check_reachable(rpc.vote.node_id, self.target)?;
+        self.owner.rand_send_delay().await;
 
         let node = self.owner.get_raft_handle(&self.target)?;
 
@@ -1011,9 +1010,8 @@ where
         InstallSnapshotResponse<C::NodeId>,
         RPCError<C::NodeId, C::Node, InstallSnapshotError<C::NodeId>>,
     > {
-        self.owner.rand_send_delay().await;
-
         self.owner.check_reachable(rpc.vote.node_id, self.target)?;
+        self.owner.rand_send_delay().await;
 
         let node = self.owner.get_raft_handle(&self.target)?;
 
@@ -1027,9 +1025,8 @@ where
         &mut self,
         rpc: VoteRequest<C::NodeId>,
     ) -> std::result::Result<VoteResponse<C::NodeId>, RPCError<C::NodeId, C::Node, VoteError<C::NodeId>>> {
-        self.owner.rand_send_delay().await;
-
         self.owner.check_reachable(rpc.vote.node_id, self.target)?;
+        self.owner.rand_send_delay().await;
 
         let node = self.owner.get_raft_handle(&self.target)?;
 


### PR DESCRIPTION

## Changelog

##### CI: in tests: check reachability before faking network delay

If faking network delay first, when a node is restored(with `router.restore()`),
a previous delayed RPC with stale state will be sent out.
But in tests, `router.restore()` should be a **barrier**: no RPC built
with the state before the barrier should **NOT** be reordered after the
barrier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/536)
<!-- Reviewable:end -->
