### PR TITLE
Refactor: use Joint in Leader state, instead of EffectiveMembership

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -664,7 +664,7 @@ where
 
             let learner_ids = em.learner_ids().collect::<Vec<_>>();
 
-            leader.progress = old_progress.upgrade_quorum_set(em, &learner_ids);
+            leader.progress = old_progress.upgrade_quorum_set(em.membership.to_quorum_set(), &learner_ids);
         }
 
         // A leader that is removed will be shut down when this membership log is committed.

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -81,7 +81,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new(2, 1), eng.state.vote);
-        assert!(eng.state.internal_server_state.is_leading());
+        assert_eq!(
+            Some(btreeset! {1},),
+            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+        );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
@@ -155,7 +158,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new(2, 1), eng.state.vote);
-        assert!(eng.state.internal_server_state.is_leading());
+        assert_eq!(
+            Some(btreeset! {1},),
+            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+        );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(

--- a/openraft/src/internal_server_state.rs
+++ b/openraft/src/internal_server_state.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
-
 use crate::leader::Leader;
-use crate::node::Node;
-use crate::EffectiveMembership;
+use crate::quorum::Joint;
 use crate::NodeId;
+
+/// The quorum set type used by `Leader`.
+pub(crate) type LeaderQuorumSet<NID> = Joint<NID, Vec<NID>, Vec<Vec<NID>>>;
 
 /// In openraft there are only two state for a server:
 /// Leading(raft leader or raft candidate) and following(raft follower or raft learner):
@@ -17,15 +17,13 @@ use crate::NodeId;
 ///   become leader. A following state that is not a member is just a learner.
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
-pub(crate) enum InternalServerState<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+pub(crate) enum InternalServerState<NID>
+where NID: NodeId
 {
     /// Leader or candidate.
     ///
     /// `vote.committed==true` means it is a leader.
-    Leading(Leader<NID, Arc<EffectiveMembership<NID, N>>>),
+    Leading(Leader<NID, LeaderQuorumSet<NID>>),
 
     /// Follower or learner.
     ///
@@ -33,29 +31,25 @@ where
     Following,
 }
 
-impl<NID, N> Default for InternalServerState<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<NID> Default for InternalServerState<NID>
+where NID: NodeId
 {
     fn default() -> Self {
         Self::Following
     }
 }
 
-impl<NID, N> InternalServerState<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<NID> InternalServerState<NID>
+where NID: NodeId
 {
-    pub(crate) fn leading(&self) -> Option<&Leader<NID, Arc<EffectiveMembership<NID, N>>>> {
+    pub(crate) fn leading(&self) -> Option<&Leader<NID, LeaderQuorumSet<NID>>> {
         match self {
             InternalServerState::Leading(l) => Some(l),
             InternalServerState::Following => None,
         }
     }
 
-    pub(crate) fn leading_mut(&mut self) -> Option<&mut Leader<NID, Arc<EffectiveMembership<NID, N>>>> {
+    pub(crate) fn leading_mut(&mut self) -> Option<&mut Leader<NID, LeaderQuorumSet<NID>>> {
         match self {
             InternalServerState::Leading(l) => Some(l),
             InternalServerState::Following => None,

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -321,4 +321,13 @@ where
         let m = Membership::with_nodes(config, nodes)?;
         Ok(m)
     }
+
+    /// Build a QuorumSet from current joint config
+    pub(crate) fn to_quorum_set(&self) -> Joint<NID, Vec<NID>, Vec<Vec<NID>>> {
+        let mut qs = vec![];
+        for c in self.get_joint_config().iter() {
+            qs.push(c.iter().copied().collect::<Vec<_>>());
+        }
+        Joint::new(qs)
+    }
 }

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -37,7 +37,7 @@ where
     // -- volatile fields: they are not persisted.
     // --
     /// The internal server state used by Engine.
-    pub(crate) internal_server_state: InternalServerState<NID, N>,
+    pub(crate) internal_server_state: InternalServerState<NID>,
 
     pub server_state: ServerState,
 }
@@ -103,7 +103,8 @@ where
     /// In openraft, Leader and Candidate shares the same state.
     pub(crate) fn new_leader(&mut self) {
         let em = &self.membership_state.effective;
-        self.internal_server_state = InternalServerState::Leading(Leader::new(em.clone(), em.learner_ids()));
+        self.internal_server_state =
+            InternalServerState::Leading(Leader::new(em.membership.to_quorum_set(), em.learner_ids()));
     }
 
     /// Return true if the currently effective membership is committed.


### PR DESCRIPTION

## Changelog

##### WIP: use Joint in Leader state, instead of EffectiveMembership

Leader state only needs a QuorumSet to determine quorum granted
progress. It does not need complete Membership information, e.g., it
does not need to know about `Node`, but only `NodeId`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/538)
<!-- Reviewable:end -->
