### PR TITLE
Fix: potential inconsistency when installing a snapshot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
-on: [push, pull_request]
 name: ci
+
+on:
+  push:
+  pull_request:
+  schedule: [cron: "40 1 * * *"]
+
 jobs:
   ut:
     name: unittest

--- a/openraft/src/core/append_entries.rs
+++ b/openraft/src/core/append_entries.rs
@@ -110,7 +110,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn delete_conflict_logs_since(&mut self, start: LogId) -> Result<(), StorageError> {
+    pub(crate) async fn delete_conflict_logs_since(&mut self, start: LogId) -> Result<(), StorageError> {
         // TODO(xp): add a StorageAdapter to provide auxiliary APIs.
         //           e.g.:
         //           - extract and manage membership config.


### PR DESCRIPTION
### Fix: potential inconsistency when installing a snapshot

The conflicting logs that are before `snapshot_meta.last_log_id` should
be deleted before installing a snapshot.

Otherwise, there is a chance the snapshot is installed but conflicting logs
are left in the store, when a node crashes.




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/561)
<!-- Reviewable:end -->
