### PR TITLE
Fix: Try to handle `AppendResponse::HigherVote` more correctly

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -1135,7 +1135,6 @@ where
         } else {
             return Err(RejectVoteRequest::ByVote(self.state.vote));
         }
-
         tracing::debug!(%vote, "vote is changing to" );
 
         // Grant the vote

--- a/openraft/src/entry.rs
+++ b/openraft/src/entry.rs
@@ -14,7 +14,7 @@ where
     N: Node,
     NID: NodeId,
 {
-    /// Return `Some(())` if the entry payload is blank.
+    /// Return `true` if the entry payload is blank.
     fn is_blank(&self) -> bool;
 
     /// Return `Some(&Membership)` if the entry payload is a membership payload.


### PR DESCRIPTION
During jepsen testing our little raft cluster, we found it regularly panicking upon network splits. It was hitting the assert given in the handling of `AppendEntriesResponse::HigherVote(vote)`. For some reason the current state `vote` was higher than the one reported in the `HigherVote` response.

It looks reasonable to only warn when the current vote is higher or equal to the one reported, assuming the raft engine will be in a valid state. But I am not 100% sure this is true. Any guidance is welcome.

Instead of panicking this PR tries to return the appropriate errors.


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/564)
<!-- Reviewable:end -->
