### PR TITLE
Build(deps): Update rocksdb requirement from 0.18.0 to 0.19.0

### DIFF
--- a/rocksstore/Cargo.toml
+++ b/rocksstore/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 openraft = { path = "../openraft", features = ["serde"] }
 
-rocksdb = "0.18.0"
+rocksdb = "0.19.0"
 byteorder = "1.4.3"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"


### PR DESCRIPTION

## Changelog

##### Build(deps): Update rocksdb requirement from 0.18.0 to 0.19.0

Updates the requirements on [rocksdb](https://github.com/rust-rocksdb/rust-rocksdb) to permit the latest version.
- [Release notes](https://github.com/rust-rocksdb/rust-rocksdb/releases)
- [Changelog](https://github.com/rust-rocksdb/rust-rocksdb/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-rocksdb/rust-rocksdb/compare/v0.18.0...v0.19.0)

---
updated-dependencies:
- dependency-name: rocksdb
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/579)
<!-- Reviewable:end -->
