### PR TITLE
Change: change-membership does not return error when replication lags

### DIFF
--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -809,8 +809,8 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             RaftMsg::RemoveLearner { id, tx } => {
                 self.remove_learner(id, tx);
             }
-            RaftMsg::ChangeMembership { members, blocking, tx } => {
-                self.change_membership(members, blocking, tx).await?;
+            RaftMsg::ChangeMembership { members, tx } => {
+                self.change_membership(members, tx).await?;
             }
             RaftMsg::ForceSnapshotting { tx } => {
                 for node in self.nodes.values() {

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -102,12 +102,6 @@ pub enum ChangeMembershipError {
 
     #[error(transparent)]
     EmptyMembership(#[from] EmptyMembership),
-
-    #[error(transparent)]
-    LearnerNotFound(#[from] LearnerNotFound),
-
-    #[error(transparent)]
-    LearnerIsLagging(#[from] LearnerIsLagging),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
@@ -259,20 +253,6 @@ pub struct QuorumNotEnough {
 #[error("the cluster is already undergoing a configuration change at log {membership_log_id}")]
 pub struct InProgress {
     pub membership_log_id: LogId,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
-#[error("to add a member {node_id} first need to add it as learner")]
-pub struct LearnerNotFound {
-    pub node_id: NodeId,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
-#[error("replication to learner {node_id} is lagging {distance}, matched: {matched:?}, can not add as member")]
-pub struct LearnerIsLagging {
-    pub node_id: NodeId,
-    pub matched: Option<LogId>,
-    pub distance: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -115,9 +115,6 @@ pub enum AddLearnerError {
     #[error(transparent)]
     ForwardToLeader(#[from] ForwardToLeader),
 
-    #[error("node {0} is already a learner")]
-    Exists(NodeId),
-
     #[error(transparent)]
     Fatal(#[from] Fatal),
 }

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -317,10 +317,6 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
                 AddLearnerError::ForwardToLeader(forward_err) => {
                     return Err(ClientWriteError::ForwardToLeader(forward_err))
                 }
-                AddLearnerError::Exists(node_id) => {
-                    tracing::info!(%node_id, "add learner: already exists");
-                    continue;
-                }
                 AddLearnerError::Fatal(f) => return Err(ClientWriteError::Fatal(f)),
             }
         }

--- a/openraft/tests/membership/main.rs
+++ b/openraft/tests/membership/main.rs
@@ -10,6 +10,7 @@ mod t10_add_learner;
 mod t10_remove_learner;
 mod t15_add_remove_follower;
 mod t20_change_membership;
+mod t21_change_membership_keep_learner;
 mod t25_elect_with_new_config;
 mod t30_commit_joint_config;
 mod t30_step_down;

--- a/openraft/tests/membership/t21_change_membership_keep_learner.rs
+++ b/openraft/tests/membership/t21_change_membership_keep_learner.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::RaftRouter;
+
+/// Given a cluster of voter {0,1,2} and learners {3,4,5};
+/// Changing membership to {0,3,4} should not remove replication to node-5, should only remove replication to {1,2}
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn change_membership_keep_learners() -> anyhow::Result<()> {
+    let (_log_guard, ut_span) = init_ut!();
+    let _ent = ut_span.enter();
+
+    let lag_threshold = 1;
+
+    let config = Arc::new(
+        Config {
+            replication_lag_threshold: lag_threshold,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let router = Arc::new(RaftRouter::new(config.clone()));
+
+    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3,4,5}).await?;
+
+    tracing::info!("--- change membership to: 0,3,4");
+    router.change_membership(0, btreeset! {0,3,4}).await?;
+    log_index += 2;
+
+    tracing::info!("--- write 5 logs");
+    {
+        router.client_request_many(0, "foo", 5).await;
+        log_index += 5;
+
+        for id in [1, 2] {
+            assert!(router
+                .wait(&id, timeout())
+                .await?
+                .log(Some(log_index), "removed voters can not receive logs")
+                .await
+                .is_err());
+        }
+
+        for id in [0, 3, 4, 5] {
+            router
+                .wait(&id, timeout())
+                .await?
+                .log(Some(log_index), "other voters and learners receive all logs")
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(500))
+}


### PR DESCRIPTION
### Change: change-membership does not return an error when replication lags
If `blocking` is `true`, `Raft::change_membership(..., blocking)` will
block until replication to new nodes become up to date.
But it won't return an error when proposing a change-membership log.

- Change: remove two errors: `LearnerIsLagging` and `LearnerNotFound`.

- Fix: #581
- Part of https://github.com/datafuselabs/databend/issues/8386

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/582)
<!-- Reviewable:end -->
