### PR TITLE
Fix: when responding ForwardToLeader, make `leader_id` a None if the leader is no longer in the cluster

### DIFF
--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -664,7 +664,7 @@ where
         Ok(count as u64)
     }
 
-    async fn send_client_request(
+    pub async fn send_client_request(
         &self,
         target: C::NodeId,
         req: C::D,

--- a/openraft/tests/membership/main.rs
+++ b/openraft/tests/membership/main.rs
@@ -17,7 +17,7 @@ mod t16_change_membership_cases;
 mod t20_change_membership;
 mod t25_elect_with_new_config;
 mod t30_commit_joint_config;
-mod t30_step_down;
+mod t30_remove_leader;
 mod t40_removed_follower;
 mod t45_remove_unreachable_follower;
 mod t99_issue_471_adding_learner_uses_uninit_leader_id;


### PR DESCRIPTION

## Changelog

##### Fix: when responding ForwardToLeader, make `leader_id` a None if the leader is no longer in the cluster

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/594)
<!-- Reviewable:end -->
