### PR TITLE
Fix: delay leader step down

### DIFF
--- a/openraft/tests/membership/t30_remove_leader.rs
+++ b/openraft/tests/membership/t30_remove_leader.rs
@@ -137,7 +137,12 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
 
         router
             .wait(&2, timeout())
-            .log(Some(log_index), "new leader node-2 commits 2 membership log")
+            // The last_applied may not be updated on follower nodes:
+            // because leader node-0 will steps down at once when the second membership log is committed.
+            .metrics(
+                |x| x.last_log_index == Some(log_index),
+                "new leader node-2 commits 2 membership log",
+            )
             .await?;
     }
 


### PR DESCRIPTION

## Changelog

##### Fix: delay leader step down

When a membership that removes the leader is committed,
the leader continue to work for a short while before reverting to a learner.
This way, let the leader replicate the `membership-log-is-committed` message to followers.

Otherwise, if the leader step down at once, the follower might have to re-commit the membership log
again.

After committing the membership log that does not contain the leader,
the leader will step down in the next `tick`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/598)
<!-- Reviewable:end -->
