### PR TITLE
Refactor: specify the default value when building Progress

### DIFF
--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -221,9 +221,11 @@ impl ExampleStore {
     fn store(&self) -> &ColumnFamily {
         self.db.cf_handle("store").unwrap()
     }
+
     fn logs(&self) -> &ColumnFamily {
         self.db.cf_handle("logs").unwrap()
     }
+
     fn get_last_purged_(&self) -> StorageResult<Option<LogId<u64>>> {
         Ok(self
             .db

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -664,7 +664,7 @@ where
 
             let learner_ids = em.learner_ids().collect::<Vec<_>>();
 
-            leader.progress = old_progress.upgrade_quorum_set(em.membership.to_quorum_set(), &learner_ids);
+            leader.progress = old_progress.upgrade_quorum_set(em.membership.to_quorum_set(), &learner_ids, None);
         }
 
         // A leader that is removed will be shut down when this membership log is committed.

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -26,7 +26,7 @@ pub(crate) struct Leader<NID: NodeId, QS: QuorumSet<NID>> {
     pub(crate) vote_granted_by: BTreeSet<NID>,
 
     /// Tracks the replication progress and committed index
-    pub(crate) progress: VecProgress<NID, Option<LogId<NID>>, QS>,
+    pub(crate) progress: VecProgress<NID, Option<LogId<NID>>, Option<LogId<NID>>, QS>,
 }
 
 impl<NID, QS> Leader<NID, QS>

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -37,7 +37,7 @@ where
     pub(crate) fn new(quorum_set: QS, learner_ids: impl Iterator<Item = NID>) -> Self {
         Self {
             vote_granted_by: BTreeSet::new(),
-            progress: VecProgress::new(quorum_set, learner_ids),
+            progress: VecProgress::new(quorum_set, learner_ids, None),
         }
     }
 

--- a/openraft/src/progress/bench/vec_progress_update.rs
+++ b/openraft/src/progress/bench/vec_progress_update.rs
@@ -11,7 +11,7 @@ use crate::quorum::Joint;
 fn progress_update_01234_567(b: &mut Bencher) {
     let membership: Vec<Vec<u64>> = vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7]];
     let quorum_set = Joint::from(membership);
-    let mut progress = VecProgress::<u64, u64, _>::new(quorum_set, 0..=7);
+    let mut progress = VecProgress::<u64, u64, _>::new(quorum_set, 0..=7, 0);
 
     let mut id = 0u64;
     let mut values = vec![0, 1, 2, 3, 4, 5, 6, 7];

--- a/openraft/src/progress/bench/vec_progress_update.rs
+++ b/openraft/src/progress/bench/vec_progress_update.rs
@@ -11,7 +11,7 @@ use crate::quorum::Joint;
 fn progress_update_01234_567(b: &mut Bencher) {
     let membership: Vec<Vec<u64>> = vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7]];
     let quorum_set = Joint::from(membership);
-    let mut progress = VecProgress::<u64, u64, _>::new(quorum_set, 0..=7, 0);
+    let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, 0..=7, 0);
 
     let mut id = 0u64;
     let mut values = vec![0, 1, 2, 3, 4, 5, 6, 7];

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -214,11 +214,13 @@ where
             return Ok(&self.granted);
         }
 
+        // Sort and find the greatest value granted by a quorum set.
+
         if prev <= self.granted && self.granted < value {
             let new_index = self.move_up(index);
 
             // From high to low, find the max value that has constituted a quorum.
-            for i in new_index..self.vector.len() {
+            for i in new_index..self.voter_count {
                 // No need to re-calculate already committed value.
                 if self.vector[i].1 <= self.granted {
                     break;


### PR DESCRIPTION
## Changelog
### Refactor: let Progress store more info than just replication progress

The leader must keep track of addtional information such as the
`max_possible_matche` index, in order to give `Engine` full control over
replication.

##### Refactor: specify the default value when building Progress

This is the first step to extend Progress to hold complete replication
state: the `matching` log id and the `max_possible_matching` log index.
I.e., progress should be `Progress<ID, (Option<LogId>, Option<LogIndex>), _>`.

Because `max_possible_matching` is decided by the leader, the default
value of a progress entry must be specified when it is created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/601)
<!-- Reviewable:end -->
