### PR TITLE
Refactor: add ProgressEntry as a container of replication state

### DIFF
--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use crate::progress::entry::ProgressEntry;
 use crate::raft::VoteRequest;
 use crate::EffectiveMembership;
 use crate::LogId;
@@ -64,7 +65,7 @@ where
     /// When membership config changes, the membership log id stored in ReplicationCore has to be updated.
     UpdateReplicationStreams {
         /// Targets to replicate to.
-        targets: Vec<(NID, Option<LogId<NID>>)>,
+        targets: Vec<(NID, ProgressEntry<NID>)>,
     },
 
     /// Move the cursor pointing to an entry in the input buffer.

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -7,6 +7,7 @@ use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::progress::entry::ProgressEntry;
 use crate::raft::VoteResponse;
 use crate::EffectiveMembership;
 use crate::LeaderId;
@@ -255,7 +256,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                     server_state: ServerState::Leader
                 },
                 Command::UpdateReplicationStreams {
-                    targets: vec![(2, None)]
+                    targets: vec![(2, ProgressEntry::empty(0))]
                 },
                 Command::AppendBlankLog {
                     log_id: LogId {

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -7,6 +7,7 @@ use maplit::btreeset;
 
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::progress::entry::ProgressEntry;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -292,7 +293,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
                 )),
             },
             Command::UpdateReplicationStreams {
-                targets: vec![(3, None), (4, None)]
+                targets: vec![(3, ProgressEntry::empty(7)), (4, ProgressEntry::empty(7))]
             },
             Command::ReplicateEntries {
                 upto: Some(log_id(3, 6))
@@ -374,7 +375,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                 )),
             },
             Command::UpdateReplicationStreams {
-                targets: vec![(2, None)]
+                targets: vec![(2, ProgressEntry::empty(7))]
             },
             // second commit upto the end.
             Command::ReplicateCommitted {
@@ -458,7 +459,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                 )),
             },
             Command::UpdateReplicationStreams {
-                targets: vec![(2, None)]
+                targets: vec![(2, ProgressEntry::empty(7))]
             },
             // It is correct to commit if the membership change ot a one node cluster.
             Command::ReplicateCommitted {

--- a/openraft/src/progress/entry.rs
+++ b/openraft/src/progress/entry.rs
@@ -1,0 +1,73 @@
+use std::borrow::Borrow;
+
+use crate::LogId;
+use crate::LogIdOptionExt;
+use crate::NodeId;
+
+#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct Searching {
+    /// Logs being sent to the target following node.
+    pub(crate) mid: u64,
+
+    /// One plus the max log index on the following node that might match the leader log.
+    pub(crate) end: u64,
+}
+
+/// State of replication to a target node.
+#[derive(Clone, Copy, Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct ProgressEntry<NID: NodeId> {
+    /// The id of the last matching log on the target following node.
+    pub(crate) matching: Option<LogId<NID>>,
+
+    /// The last matching log index has not yet been determined.
+    pub(crate) searching: Option<Searching>,
+}
+
+impl<NID: NodeId> ProgressEntry<NID> {
+    #[allow(dead_code)]
+    pub(crate) fn new(matching: Option<LogId<NID>>) -> Self {
+        Self {
+            matching,
+            searching: None,
+        }
+    }
+    pub(crate) fn empty(end: u64) -> Self {
+        Self {
+            matching: None,
+            searching: Some(Searching { mid: end / 2, end }),
+        }
+    }
+
+    pub(crate) fn update_matching(&mut self, matching: Option<LogId<NID>>) {
+        self.matching = matching;
+
+        if let Some(s) = &self.searching {
+            if matching.next_index() >= s.end {
+                self.searching = None;
+            } else {
+
+                // TODO: update mid
+            }
+        }
+    }
+
+    pub(crate) fn max_possible_matching(&self) -> Option<u64> {
+        if let Some(s) = &self.searching {
+            if s.end == 0 {
+                None
+            } else {
+                Some(s.end - 1)
+            }
+        } else {
+            self.matching.index()
+        }
+    }
+}
+
+impl<NID: NodeId> Borrow<Option<LogId<NID>>> for ProgressEntry<NID> {
+    fn borrow(&self) -> &Option<LogId<NID>> {
+        &self.matching
+    }
+}

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -7,6 +7,7 @@
 #[cfg(feature = "bench")]
 #[cfg(test)]
 mod bench;
+pub(crate) mod entry;
 
 use std::borrow::Borrow;
 use std::fmt::Debug;
@@ -128,7 +129,7 @@ where
 
     /// Find the index in of the specified id.
     #[inline(always)]
-    fn index(&self, target: &ID) -> Option<usize> {
+    pub(crate) fn index(&self, target: &ID) -> Option<usize> {
         for (i, elt) in self.vector.iter().enumerate() {
             if elt.0 == *target {
                 return Some(i);

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -103,8 +103,11 @@ where
     /// In openraft, Leader and Candidate shares the same state.
     pub(crate) fn new_leader(&mut self) {
         let em = &self.membership_state.effective;
-        self.internal_server_state =
-            InternalServerState::Leading(Leader::new(em.membership.to_quorum_set(), em.learner_ids()));
+        self.internal_server_state = InternalServerState::Leading(Leader::new(
+            em.membership.to_quorum_set(),
+            em.learner_ids(),
+            self.last_log_id().index(),
+        ));
     }
 
     /// Return true if the currently effective membership is committed.


### PR DESCRIPTION

## Changelog

##### Refactor: add ProgressEntry as a container of replication state

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/603)
<!-- Reviewable:end -->
