### PR TITLE
Change: remove AsyncSeek trait from snapshot

### DIFF
--- a/openraft/src/defensive.rs
+++ b/openraft/src/defensive.rs
@@ -32,6 +32,7 @@ pub trait DefensiveCheckBase<C: RaftTypeConfig> {
         if !self.is_defensive() {
             return Ok(());
         }
+
         let start = match range.start_bound() {
             Bound::Included(i) => Some(*i),
             Bound::Excluded(i) => Some(*i + 1),

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 pub use helper::StorageHelper;
 pub use snapshot_signature::SnapshotSignature;
 use tokio::io::AsyncRead;
-use tokio::io::AsyncSeek;
 use tokio::io::AsyncWrite;
 
 use crate::defensive::check_range_matches_entries;
@@ -77,7 +76,7 @@ pub struct Snapshot<NID, N, S>
 where
     NID: NodeId,
     N: Node,
-    S: AsyncRead + AsyncSeek + Send + Unpin + 'static,
+    S: AsyncRead + Send + Unpin + 'static,
 {
     /// metadata of a snapshot
     pub meta: SnapshotMeta<NID, N>,
@@ -164,7 +163,7 @@ where C: RaftTypeConfig
 pub trait RaftSnapshotBuilder<C, SD>: Send + Sync + 'static
 where
     C: RaftTypeConfig,
-    SD: AsyncRead + AsyncWrite + AsyncSeek + Send + Sync + Unpin + 'static,
+    SD: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
 {
     /// Build snapshot
     ///
@@ -201,7 +200,7 @@ where C: RaftTypeConfig
     ///
     /// See the [storage chapter of the guide](https://datafuselabs.github.io/openraft/getting-started.html#implement-raftstorage)
     /// for details on where and how this is used.
-    type SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + Send + Sync + Unpin + 'static;
+    type SnapshotData: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static;
 
     /// Log reader type.
     type LogReader: RaftLogReader<C>;

--- a/openraft/tests/snapshot/t20_api_install_snapshot.rs
+++ b/openraft/tests/snapshot/t20_api_install_snapshot.rs
@@ -111,8 +111,13 @@ async fn snapshot_arguments() -> Result<()> {
         let mut req = req0.clone();
         req.offset = 8;
         req.meta.snapshot_id = "ss2".into();
-        n.0.install_snapshot(req).await?;
+        let res = n.0.install_snapshot(req).await;
+        assert_eq!(
+            r#"when Write Snapshot(SnapshotSignature { last_log_id: Some(LogId { leader_id: LeaderId { term: 1, node_id: 0 }, index: 0 }), last_membership_log_id: None, snapshot_id: "ss2" }): offsets do not match 6:8"#,
+            res.unwrap_err().to_string()
+        );
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
Snapshots don't really need to be AsyncSeek. Simplifying the trait bounds for a snapshot.
**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/605)
<!-- Reviewable:end -->
