### PR TITLE
Fix: become non-leader when restarting single node cluster

### DIFF
--- a/openraft/tests/life_cycle/main.rs
+++ b/openraft/tests/life_cycle/main.rs
@@ -11,3 +11,4 @@ mod fixtures;
 mod t20_initialization;
 mod t20_shutdown;
 mod t30_connect_error;
+mod t90_issue_607_single_restart;

--- a/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
+++ b/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Brings up a cluster of 1 node and restart it.
+///
+/// Assert that `RaftCore.engine.state.server_state` and `RaftCore.leader_data` are consistent:
+/// `server_state == Leader && leader_data.is_some() || server_state != Leader && leader_data.is_none()`
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn single_restart() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up cluster of 1 node");
+    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!("--- write to 1 log");
+    {
+        router.client_request_many(0, "foo", 1).await?;
+        log_index += 1;
+    }
+
+    tracing::info!("--- restart node 0");
+    {
+        let (node, sto) = router.remove_node(0).unwrap();
+        node.shutdown().await?;
+
+        router.new_raft_node_with_sto(0, sto);
+        // leader appends a blank log.
+        log_index += 1;
+
+        router.wait(&0, timeout()).state(ServerState::Leader, "node-0 is leader").await?;
+        router.wait(&0, timeout()).log(Some(log_index), "node-0 restarted").await?;
+    }
+
+    tracing::info!("--- write to 1 log after restart");
+    {
+        router.client_request_many(0, "foo", 1).await?;
+        log_index += 1;
+
+        router.wait(&0, timeout()).log(Some(log_index), "node-0 works").await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
+}


### PR DESCRIPTION

## Changelog

##### Fix: become non-leader when restarting single node cluster

A node should not set `server_state` to `Leader` when just starting up,
even when it's the only voter in a cluster. It still needs several step
to initialize leader related fields to become a leader.

- Fix: #607

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/609)
<!-- Reviewable:end -->
