### PR TITLE
Refactor: replace Command::UpdateServerState with BecomeLeader and QuitLeader

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -66,9 +66,7 @@ fn test_elect() -> anyhow::Result<()> {
                 Command::SaveVote {
                     vote: Vote::new_committed(1, 1)
                 },
-                Command::UpdateServerState {
-                    server_state: ServerState::Leader
-                },
+                Command::BecomeLeader,
                 Command::UpdateReplicationStreams { targets: vec![] },
                 Command::AppendBlankLog {
                     log_id: LogId {
@@ -135,9 +133,7 @@ fn test_elect() -> anyhow::Result<()> {
                 Command::SaveVote {
                     vote: Vote::new_committed(2, 1)
                 },
-                Command::UpdateServerState {
-                    server_state: ServerState::Leader
-                },
+                Command::BecomeLeader,
                 Command::UpdateReplicationStreams { targets: vec![] },
                 Command::AppendBlankLog {
                     log_id: LogId {
@@ -200,9 +196,7 @@ fn test_elect() -> anyhow::Result<()> {
                 Command::SendVote {
                     vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1)))
                 },
-                Command::UpdateServerState {
-                    server_state: ServerState::Candidate
-                },
+                Command::QuitLeader,
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.commands

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -1097,7 +1097,13 @@ where
 
         if prev_server_state != server_state {
             self.state.server_state = server_state;
-            self.push_command(Command::UpdateServerState { server_state })
+
+            let cmd = if server_state == ServerState::Leader {
+                Command::BecomeLeader
+            } else {
+                Command::QuitLeader
+            };
+            self.push_command(cmd);
         }
     }
 
@@ -1110,7 +1116,12 @@ where
         }
 
         self.state.server_state = server_state;
-        self.push_command(Command::UpdateServerState { server_state });
+        let cmd = if server_state == ServerState::Leader {
+            Command::BecomeLeader
+        } else {
+            Command::QuitLeader
+        };
+        self.push_command(cmd);
     }
 
     /// Check if a raft node is in a state that allows to initialize.

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -100,6 +100,23 @@ where
         }
     }
 
+    // TODO: test it
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) fn startup(&mut self) {
+        // On startup, do not assume a leader. Becoming a leader require initialization on several fields.
+        // TODO: allows starting up as a leader. After `server_state` is removed from Engine.
+
+        let server_state = if self.state.membership_state.effective.is_voter(&self.id) {
+            ServerState::Follower
+        } else {
+            ServerState::Learner
+        };
+
+        tracing::debug!("startup: id={} target_state: {:?}", self.id, self.state.server_state);
+
+        self.state.server_state = server_state;
+    }
+
     /// Initialize a node by appending the first log.
     ///
     /// - The first log has to be membership config log.
@@ -1217,7 +1234,7 @@ where
         self.state.internal_server_state.is_leading()
     }
 
-    fn is_leader(&self) -> bool {
+    pub(crate) fn is_leader(&self) -> bool {
         self.state.vote.node_id == self.id && self.state.vote.committed
     }
 

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -210,9 +210,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 5)), m34())),
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
             Command::MoveInputCursorBy { n: 5 }
         ],
         eng.commands
@@ -292,9 +290,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(4, 7)), m45())),
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            },
+            Command::QuitLeader,
             Command::MoveInputCursorBy { n: 5 }
         ],
         eng.commands

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -151,9 +151,7 @@ fn test_handle_append_entries_req_prev_log_id_is_applied() -> anyhow::Result<()>
                 vote: Vote::new_committed(2, 1)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -210,9 +208,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -270,9 +266,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
             Command::AppendInputEntries { range: 1..2 },
             Command::MoveInputCursorBy { n: 2 },
             Command::FollowerCommit {
@@ -334,9 +328,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
                 vote: Vote::new_committed(2, 1)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -402,9 +394,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
             Command::AppendInputEntries { range: 1..2 },
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 3)), m34()))

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -145,9 +145,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         vec![
             //
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            }
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -193,9 +191,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
         vec![
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            }
+            Command::QuitLeader,
         ],
         eng.commands
     );

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -252,9 +252,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 Command::SaveVote {
                     vote: Vote::new_committed(2, 1)
                 },
-                Command::UpdateServerState {
-                    server_state: ServerState::Leader
-                },
+                Command::BecomeLeader,
                 Command::UpdateReplicationStreams {
                     targets: vec![(2, ProgressEntry::empty(0))]
                 },

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -70,9 +70,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                 },
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output command.
-                Command::UpdateServerState {
-                    server_state: ServerState::Follower,
-                },
+                Command::QuitLeader,
                 Command::MoveInputCursorBy { n: 1 },
                 Command::SaveVote {
                     vote: Vote {
@@ -90,9 +88,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                         committed: true,
                     },
                 },
-                Command::UpdateServerState {
-                    server_state: ServerState::Leader
-                },
+                Command::BecomeLeader,
                 Command::UpdateReplicationStreams { targets: vec![] },
                 Command::AppendBlankLog {
                     log_id: LogId {
@@ -171,9 +167,7 @@ fn test_initialize() -> anyhow::Result<()> {
                 },
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output command.
-                Command::UpdateServerState {
-                    server_state: ServerState::Follower,
-                },
+                Command::QuitLeader,
                 Command::MoveInputCursorBy { n: 1 },
                 Command::SaveVote {
                     vote: Vote {
@@ -195,9 +189,7 @@ fn test_initialize() -> anyhow::Result<()> {
                         },),
                     },
                 },
-                Command::UpdateServerState {
-                    server_state: ServerState::Candidate
-                },
+                Command::QuitLeader,
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.commands

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -89,9 +89,7 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
                 vote: Vote::new_committed(3, 2)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            }
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -127,9 +125,7 @@ fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
         vec![
             //
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            }
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -164,9 +160,7 @@ fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
         vec![
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::UpdateServerState {
-                server_state: ServerState::Follower
-            }
+            Command::QuitLeader,
         ],
         eng.commands
     );

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -43,6 +43,7 @@ mod log_id_list;
 #[cfg(test)] mod leader_append_entries_test;
 #[cfg(test)] mod log_id_list_test;
 #[cfg(test)] mod purge_log_test;
+#[cfg(test)] mod startup_test;
 #[cfg(test)] mod testing;
 #[cfg(test)] mod truncate_logs_test;
 #[cfg(test)] mod update_committed_membership_test;

--- a/openraft/src/engine/startup_test.rs
+++ b/openraft/src/engine/startup_test.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use maplit::btreeset;
+
+use crate::engine::Engine;
+use crate::EffectiveMembership;
+use crate::LeaderId;
+use crate::LogId;
+use crate::Membership;
+use crate::MetricsChangeFlags;
+use crate::ServerState;
+
+fn log_id(term: u64, index: u64) -> LogId<u64> {
+    LogId::<u64> {
+        leader_id: LeaderId { term, node_id: 1 },
+        index,
+    }
+}
+
+fn m23() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+}
+
+fn m34() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
+}
+
+fn eng() -> Engine<u64, ()> {
+    let mut eng = Engine::<u64, ()> {
+        id: 2, // make it a member
+        ..Default::default()
+    };
+    // This will be overrided
+    eng.state.server_state = ServerState::Leader;
+    eng
+}
+
+#[test]
+fn test_startup_as_follower() -> anyhow::Result<()> {
+    let mut eng = eng();
+    // self.id==2 is a voter:
+    eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
+
+    eng.startup();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: false,
+            cluster: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(0, eng.commands.len());
+
+    Ok(())
+}
+
+#[test]
+fn test_startup_as_learner() -> anyhow::Result<()> {
+    let mut eng = eng();
+    // self.id==2 is not a voter:
+    eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m34()));
+
+    eng.startup();
+
+    assert_eq!(ServerState::Learner, eng.state.server_state);
+
+    assert_eq!(
+        MetricsChangeFlags {
+            replication: false,
+            local_data: false,
+            cluster: false,
+        },
+        eng.metrics_flags
+    );
+
+    assert_eq!(0, eng.commands.len());
+
+    Ok(())
+}

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -80,9 +80,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -245,9 +243,7 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m01()))
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );

--- a/openraft/src/engine/update_committed_membership_test.rs
+++ b/openraft/src/engine/update_committed_membership_test.rs
@@ -134,9 +134,7 @@ fn test_update_committed_membership_at_index_3() -> anyhow::Result<()> {
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 3)), m34())),
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -174,9 +172,7 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -86,9 +86,7 @@ fn test_update_effective_membership_at_index_0_is_allowed() -> anyhow::Result<()
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(0, 0)), m34())),
             },
-            Command::UpdateServerState {
-                server_state: ServerState::Learner
-            },
+            Command::QuitLeader,
         ],
         eng.commands
     );


### PR DESCRIPTION

## Changelog

##### Refactor: replace Command::UpdateServerState with BecomeLeader and QuitLeader

A runtime(RaftCore) should always run in a passive mode and should not
depend on `server_state` to run.


##### Refactor: avoid using engine.state.server_state

`engine.state.server_state` should be only used for metrics reporting.
Flow control does not depend on it. Because `server_state` is a
duplicated information in `Engine`, and using it makes it difficult to
verify that it is consistent with other fields.


##### Refactor: remove RaftCore::spawn()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/610)
<!-- Reviewable:end -->
