### PR TITLE
Refactor: do not emit QuitLeader command when switch between non-leader states

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -185,7 +185,7 @@ fn test_elect() -> anyhow::Result<()> {
             MetricsChangeFlags {
                 replication: false,
                 local_data: true,
-                cluster: true,
+                cluster: false,
             },
             eng.metrics_flags
         );
@@ -196,7 +196,6 @@ fn test_elect() -> anyhow::Result<()> {
                 Command::SendVote {
                     vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1)))
                 },
-                Command::QuitLeader,
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.commands

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -136,7 +136,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         MetricsChangeFlags {
             replication: false,
             local_data: false,
-            cluster: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -145,7 +145,6 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         vec![
             //
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -182,7 +181,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
         MetricsChangeFlags {
             replication: false,
             local_data: true,
-            cluster: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -191,7 +190,6 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
         vec![
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::QuitLeader,
         ],
         eng.commands
     );

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -21,7 +21,11 @@ use crate::Vote;
 
 #[test]
 fn test_initialize_single_node() -> anyhow::Result<()> {
-    let eng = Engine::<u64, ()>::default;
+    let eng = || {
+        let mut eng = Engine::<u64, ()>::default();
+        eng.state.server_state = eng.calc_server_state();
+        eng
+    };
 
     let log_id0 = LogId {
         leader_id: LeaderId::new(0, 0),
@@ -70,7 +74,6 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                 },
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output command.
-                Command::QuitLeader,
                 Command::MoveInputCursorBy { n: 1 },
                 Command::SaveVote {
                     vote: Vote {
@@ -124,7 +127,11 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 
 #[test]
 fn test_initialize() -> anyhow::Result<()> {
-    let eng = Engine::<u64, ()>::default;
+    let eng = || {
+        let mut eng = Engine::<u64, ()>::default();
+        eng.state.server_state = eng.calc_server_state();
+        eng
+    };
 
     let log_id0 = LogId {
         leader_id: LeaderId::new(0, 0),
@@ -167,7 +174,6 @@ fn test_initialize() -> anyhow::Result<()> {
                 },
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output command.
-                Command::QuitLeader,
                 Command::MoveInputCursorBy { n: 1 },
                 Command::SaveVote {
                     vote: Vote {
@@ -189,7 +195,6 @@ fn test_initialize() -> anyhow::Result<()> {
                         },),
                     },
                 },
-                Command::QuitLeader,
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.commands

--- a/openraft/src/engine/install_snapshot_test.rs
+++ b/openraft/src/engine/install_snapshot_test.rs
@@ -46,6 +46,7 @@ fn eng() -> Engine<u64, ()> {
         log_id(4, 6),
         log_id(4, 8),
     ]);
+    eng.state.server_state = eng.calc_server_state();
 
     eng
 }
@@ -216,6 +217,8 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
             log_id(4, 6),
             log_id(4, 8),
         ]);
+
+        eng.state.server_state = eng.calc_server_state();
 
         eng
     };

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -77,7 +77,7 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
         MetricsChangeFlags {
             replication: false,
             local_data: true,
-            cluster: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -89,7 +89,6 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
                 vote: Vote::new_committed(3, 2)
             },
             Command::InstallElectionTimer { can_be_leader: false },
-            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -116,7 +115,7 @@ fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
         MetricsChangeFlags {
             replication: false,
             local_data: false,
-            cluster: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -125,7 +124,6 @@ fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
         vec![
             //
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::QuitLeader,
         ],
         eng.commands
     );
@@ -151,7 +149,7 @@ fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
         MetricsChangeFlags {
             replication: false,
             local_data: true,
-            cluster: true,
+            cluster: false,
         },
         eng.metrics_flags
     );
@@ -160,7 +158,6 @@ fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
         vec![
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::InstallElectionTimer { can_be_leader: true },
-            Command::QuitLeader,
         ],
         eng.commands
     );

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -312,6 +312,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
     let mut eng = eng();
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m1()));
     eng.state.new_leader();
+    eng.state.server_state = eng.calc_server_state();
 
     // log id will be assigned by eng.
     eng.leader_append_entries(&mut [
@@ -404,6 +405,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
     let mut eng = eng();
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m13()));
     eng.state.new_leader();
+    eng.state.server_state = eng.calc_server_state();
 
     // log id will be assigned by eng.
     eng.leader_append_entries(&mut [

--- a/openraft/src/engine/update_committed_membership_test.rs
+++ b/openraft/src/engine/update_committed_membership_test.rs
@@ -40,9 +40,9 @@ fn eng() -> Engine<u64, ()> {
         id: 2, // make it a member
         ..Default::default()
     };
-    eng.state.server_state = ServerState::Follower;
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
+    eng.state.server_state = eng.calc_server_state();
     eng
 }
 
@@ -130,12 +130,9 @@ fn test_update_committed_membership_at_index_3() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        vec![
-            Command::UpdateMembership {
-                membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 3)), m34())),
-            },
-            Command::QuitLeader,
-        ],
+        vec![Command::UpdateMembership {
+            membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 3)), m34())),
+        },],
         eng.commands
     );
 
@@ -168,12 +165,9 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        vec![
-            Command::UpdateMembership {
-                membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
-            },
-            Command::QuitLeader,
-        ],
+        vec![Command::UpdateMembership {
+            membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
+        },],
         eng.commands
     );
 

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -51,9 +51,9 @@ fn eng() -> Engine<u64, ()> {
         id: 2, // make it a member
         ..Default::default()
     };
-    eng.state.server_state = ServerState::Follower;
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
+    eng.state.server_state = eng.calc_server_state();
     eng
 }
 
@@ -83,10 +83,10 @@ fn test_update_effective_membership_at_index_0_is_allowed() -> anyhow::Result<()
 
     assert_eq!(
         vec![
+            //
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(0, 0)), m34())),
             },
-            Command::QuitLeader,
         ],
         eng.commands
     );


### PR DESCRIPTION

## Changelog

##### Refactor: do not emit QuitLeader command when switch between non-leader states

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/611)
<!-- Reviewable:end -->
