### PR TITLE
Refactor: ProgressEntry: support updating matching and conflict

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -77,6 +77,7 @@ use crate::raft_types::LogIdOptionExt;
 use crate::raft_types::RaftLogId;
 use crate::replication::Replicate;
 use crate::replication::ReplicationCore;
+use crate::replication::ReplicationSessionId;
 use crate::replication::ReplicationStream;
 use crate::runtime::RaftRuntime;
 use crate::storage::RaftSnapshotBuilder;
@@ -944,10 +945,11 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         let membership_log_id = self.engine.state.membership_state.effective.log_id;
         let network = self.network.new_client(target, target_node).await?;
 
+        let session_id = ReplicationSessionId::new(self.engine.state.vote, membership_log_id);
+
         Ok(ReplicationCore::<C, N, S>::spawn(
             target,
-            self.engine.state.vote,
-            membership_log_id,
+            session_id,
             self.config.clone(),
             self.engine.state.committed,
             progress_entry,
@@ -1299,13 +1301,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             RaftMsg::UpdateReplicationMatched {
                 target,
                 result,
-                vote,
-                membership_log_id,
+                session_id,
             } => {
-                if self.does_vote_match(vote, "UpdateReplicationMatched") {
+                if self.does_vote_match(session_id.vote, "UpdateReplicationMatched") {
                     // If membership changes, ignore the message.
                     // There is chance delayed message reports a wrong state.
-                    if membership_log_id == self.engine.state.membership_state.effective.log_id {
+                    if session_id.membership_log_id == self.engine.state.membership_state.effective.log_id {
                         self.handle_update_matched(target, result).await?;
                     }
                 }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -644,7 +644,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             snapshot: self.engine.snapshot_meta.last_log_id,
 
             // --- cluster ---
-            state: self.engine.calc_server_state(),
+            state: self.engine.state.server_state,
             current_leader: self.current_leader(),
             membership_config: self.engine.state.membership_state.effective.clone(),
 

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -1226,7 +1226,7 @@ where
 
     /// The node is candidate or leader
     fn is_leading(&self) -> bool {
-        self.state.internal_server_state.is_leading()
+        self.state.vote.node_id == self.id
     }
 
     pub(crate) fn is_leader(&self) -> bool {

--- a/openraft/src/progress/entry.rs
+++ b/openraft/src/progress/entry.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 
+use crate::summary::MessageSummary;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::NodeId;
@@ -33,23 +34,81 @@ impl<NID: NodeId> ProgressEntry<NID> {
             searching: None,
         }
     }
+
+    /// Create a progress entry that does not have any matching log id.
+    ///
+    /// It's going to initiate a binary search to find the minimal matching log id.
     pub(crate) fn empty(end: u64) -> Self {
+        let searching = if end == 0 {
+            None
+        } else {
+            Some(Searching {
+                mid: Self::calc_mid(0, end),
+                end,
+            })
+        };
+
         Self {
             matching: None,
-            searching: Some(Searching { mid: end / 2, end }),
+            searching,
         }
     }
 
     pub(crate) fn update_matching(&mut self, matching: Option<LogId<NID>>) {
+        tracing::debug!(
+            self = debug(&self),
+            matching = display(matching.summary()),
+            "update_matching"
+        );
+
+        debug_assert!(matching >= self.matching);
+
         self.matching = matching;
 
-        if let Some(s) = &self.searching {
-            if matching.next_index() >= s.end {
+        if let Some(s) = &mut self.searching {
+            let next = matching.next_index();
+
+            if next >= s.end {
                 self.searching = None;
             } else {
-
-                // TODO: update mid
+                s.mid = Self::calc_mid(next, s.end);
             }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn update_conflicting(&mut self, conflict: u64) {
+        tracing::debug!(self = debug(&self), conflict = display(conflict), "update_conflict");
+
+        let matching_next = self.matching.next_index();
+
+        debug_assert!(conflict >= matching_next);
+
+        if let Some(s) = &mut self.searching {
+            debug_assert!(conflict < s.end);
+            debug_assert!(conflict >= s.mid);
+
+            s.end = conflict;
+
+            if matching_next >= s.end {
+                self.searching = None;
+            } else {
+                s.mid = Self::calc_mid(matching_next, s.end);
+            }
+        } else {
+            unreachable!("found conflict({}) when searching is None", conflict);
+        }
+    }
+
+    /// Return the starting log index range(`[start,end)`) for the next AppendEntries.
+    #[allow(dead_code)]
+    pub(crate) fn sending_start(&self) -> (u64, u64) {
+        match self.searching {
+            None => {
+                let next = self.matching.next_index();
+                (next, next)
+            }
+            Some(s) => (s.mid, s.end),
         }
     }
 
@@ -64,10 +123,90 @@ impl<NID: NodeId> ProgressEntry<NID> {
             self.matching.index()
         }
     }
+
+    fn calc_mid(matching_next: u64, end: u64) -> u64 {
+        debug_assert!(matching_next < end);
+        let d = end - matching_next;
+        let offset = d / 16 * 8;
+        matching_next + offset
+    }
 }
 
 impl<NID: NodeId> Borrow<Option<LogId<NID>>> for ProgressEntry<NID> {
     fn borrow(&self) -> &Option<LogId<NID>> {
         &self.matching
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Borrow;
+
+    use crate::progress::entry::ProgressEntry;
+    use crate::LeaderId;
+    use crate::LogId;
+
+    fn log_id(index: u64) -> LogId<u64> {
+        LogId {
+            leader_id: LeaderId { term: 1, node_id: 1 },
+            index,
+        }
+    }
+
+    #[test]
+    fn test_update_matching() -> anyhow::Result<()> {
+        let mut pe = ProgressEntry::empty(20);
+        assert_eq!(&None, pe.borrow());
+        assert_eq!((8, 20), pe.sending_start());
+
+        pe.update_matching(None);
+        assert_eq!(&None, pe.borrow());
+        assert_eq!((8, 20), pe.sending_start());
+
+        pe.update_matching(Some(log_id(0)));
+        assert_eq!(&Some(log_id(0)), pe.borrow());
+        assert_eq!((9, 20), pe.sending_start());
+
+        pe.update_matching(Some(log_id(0)));
+        assert_eq!(&Some(log_id(0)), pe.borrow());
+        assert_eq!((9, 20), pe.sending_start());
+
+        pe.update_matching(Some(log_id(1)));
+        assert_eq!(&Some(log_id(1)), pe.borrow());
+        assert_eq!((10, 20), pe.sending_start());
+
+        pe.update_matching(Some(log_id(4)));
+        assert_eq!(&Some(log_id(4)), pe.borrow());
+        assert_eq!((5, 20), pe.sending_start());
+
+        // All logs are matching
+        pe.update_matching(Some(log_id(19)));
+        assert_eq!(&Some(log_id(19)), pe.borrow());
+        assert_eq!((20, 20), pe.sending_start());
+
+        pe.update_matching(Some(log_id(20)));
+        assert_eq!(&Some(log_id(20)), pe.borrow());
+        assert_eq!((21, 21), pe.sending_start());
+        Ok(())
+    }
+
+    #[test]
+    fn test_update_conflict() -> anyhow::Result<()> {
+        let mut pe = ProgressEntry::empty(20);
+
+        pe.update_matching(Some(log_id(4)));
+        assert_eq!(&Some(log_id(4)), pe.borrow());
+        assert_eq!((5, 20), pe.sending_start());
+
+        pe.update_conflicting(19);
+        assert_eq!(&Some(log_id(4)), pe.borrow());
+        assert_eq!((5, 19), pe.sending_start());
+
+        pe.update_conflicting(5);
+        assert_eq!(&Some(log_id(4)), pe.borrow());
+        assert_eq!((5, 5), pe.sending_start());
+        assert!(pe.searching.is_none());
+
+        Ok(())
     }
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -556,10 +556,10 @@ impl<NID: NodeId> MessageSummary<Replicate<NID>> for Replicate<NID> {
     fn summary(&self) -> String {
         match self {
             Replicate::Committed(c) => {
-                format!("Replciate::Committed: {:?}", c)
+                format!("Replicate::Committed: {:?}", c)
             }
             Replicate::Entries(last) => {
-                format!("Replciate::Entries: upto: {:?}", last)
+                format!("Replicate::Entries: upto: {:?}", last)
             }
         }
     }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -1,9 +1,11 @@
 //! Replication stream.
 
+mod replication_session_id;
 use std::io::SeekFrom;
 use std::sync::Arc;
 
 use futures::future::FutureExt;
+pub(crate) use replication_session_id::ReplicationSessionId;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncSeekExt;
 use tokio::sync::mpsc;
@@ -43,7 +45,6 @@ use crate::RaftNetworkFactory;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::ToStorageResult;
-use crate::Vote;
 
 /// The handle to a spawned replication stream.
 pub(crate) struct ReplicationStream<NID: NodeId> {
@@ -63,29 +64,8 @@ pub(crate) struct ReplicationCore<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S
     /// The ID of the target Raft node which replication events are to be sent to.
     target: C::NodeId,
 
-    /// The vote of the leader.
-    vote: Vote<C::NodeId>,
-
-    /// The log id of the membership log this replication works for.
-    ///
-    /// Replication state belongs to a specific membership config.
-    /// E.g. given 3 membership log:
-    /// - `log_id=1, members={a,b,c}`
-    /// - `log_id=5, members={a,b}`
-    /// - `log_id=10, members={a,b,c}`
-    ///
-    /// When log_id=1 is appended, openraft spawns a replication to node `c`.
-    /// Then log_id=1 is replicated to node `c`.
-    /// Then a replication state update message `{target=c, matched=log_id-1}` is piped in message queue(`tx_api`),
-    /// waiting the raft core to process.
-    ///
-    /// Then log_id=5 is appended, replication to node `c` is dropped.
-    ///
-    /// Then log_id=10 is appended, another replication to node `c` is spawned.
-    /// Now node `c` is a new empty node, no log is replicated to it.
-    /// But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft core believe
-    /// node `c` already has `log_id=1`, and commit it.
-    membership_log_id: Option<LogId<C::NodeId>>,
+    /// Identifies which session this replication belongs to.
+    session_id: ReplicationSessionId<C::NodeId>,
 
     /// A channel for sending events to the Raft node.
     #[allow(clippy::type_complexity)]
@@ -132,8 +112,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn spawn(
         target: C::NodeId,
-        vote: Vote<C::NodeId>,
-        membership_log_id: Option<LogId<C::NodeId>>,
+        session_id: ReplicationSessionId<C::NodeId>,
         config: Arc<Config>,
         committed: Option<LogId<C::NodeId>>,
         progress_entry: ProgressEntry<C::NodeId>,
@@ -147,8 +126,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
 
         let this = Self {
             target,
-            vote,
-            membership_log_id,
+            session_id,
             network,
             log_reader,
             config,
@@ -166,7 +144,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
         ReplicationStream { handle, repl_tx }
     }
 
-    #[tracing::instrument(level="debug", skip(self), fields(vote=%self.vote, target=display(self.target), cluster=%self.config.cluster_name))]
+    #[tracing::instrument(level="debug", skip(self), fields(session=%self.session_id, target=display(self.target), cluster=%self.config.cluster_name))]
     async fn main(mut self) {
         loop {
             // If it returns Ok(), always go back to LineRate state.
@@ -193,7 +171,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                     let _ = self.raft_core_tx.send(RaftMsg::HigherVote {
                         target: self.target,
                         higher: h.higher,
-                        vote: self.vote,
+                        vote: self.session_id.vote,
                     });
                     return;
                 }
@@ -311,7 +289,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
 
         // Build the heartbeat frame to be sent to the follower.
         let payload = AppendEntriesRequest {
-            vote: self.vote,
+            vote: self.session_id.vote,
             prev_log_id,
             leader_commit: self.committed,
             entries: logs,
@@ -339,8 +317,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                             let _ = self.raft_core_tx.send(RaftMsg::UpdateReplicationMatched {
                                 target: self.target,
                                 result: Err(e.to_string()),
-                                vote: self.vote,
-                                membership_log_id: self.membership_log_id,
+                                session_id: self.session_id,
                             });
                             ReplicationError::Timeout(e)
                         }
@@ -348,8 +325,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                             let _ = self.raft_core_tx.send(RaftMsg::UpdateReplicationMatched {
                                 target: self.target,
                                 result: Err(e.to_string()),
-                                vote: self.vote,
-                                membership_log_id: self.membership_log_id,
+                                session_id: self.session_id,
                             });
                             ReplicationError::Network(e)
                         }
@@ -364,13 +340,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                 let _ = self.raft_core_tx.send(RaftMsg::UpdateReplicationMatched {
                     target: self.target,
                     result: Err(timeout_err.to_string()),
-                    vote: self.vote,
-                    membership_log_id: self.membership_log_id,
+                    session_id: self.session_id,
                 });
 
                 return Err(ReplicationError::Timeout(Timeout {
                     action: RPCTypes::AppendEntries,
-                    id: self.vote.node_id,
+                    id: self.session_id.vote.node_id,
                     target: self.target,
                     timeout: the_timeout,
                 }));
@@ -389,12 +364,15 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                 Ok(())
             }
             AppendEntriesResponse::HigherVote(vote) => {
-                assert!(vote > self.vote, "higher vote should be greater than leader's vote");
+                assert!(
+                    vote > self.session_id.vote,
+                    "higher vote should be greater than leader's vote"
+                );
                 tracing::debug!(%vote, "append entries failed. converting to follower");
 
                 Err(ReplicationError::HigherVote(HigherVote {
                     higher: vote,
-                    mine: self.vote,
+                    mine: self.session_id.vote,
                 }))
             }
             AppendEntriesResponse::Conflict => {
@@ -458,8 +436,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                 // `self.matched < new_matched` implies new_matched can not be None.
                 // Thus unwrap is safe.
                 result: Ok(self.matched.unwrap()),
-                vote: self.vote,
-                membership_log_id: self.membership_log_id,
+                session_id: self.session_id,
             });
         }
     }
@@ -665,7 +642,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
             let _ = self.raft_core_tx.send(RaftMsg::NeedsSnapshot {
                 target: self.target,
                 tx,
-                vote: self.vote,
+                vote: self.session_id.vote,
             });
 
             let mut waiting_for_snapshot = true;
@@ -728,7 +705,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
 
             let done = (offset + n_read as u64) == end; // If bytes read == 0, then we're done.
             let req = InstallSnapshotRequest {
-                vote: self.vote,
+                vote: self.session_id.vote,
                 meta: snapshot.meta.clone(),
                 offset,
                 data: Vec::from(&buf[..n_read]),
@@ -776,10 +753,10 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
             };
 
             // Handle response conditions.
-            if res.vote > self.vote {
+            if res.vote > self.session_id.vote {
                 return Err(ReplicationError::HigherVote(HigherVote {
                     higher: res.vote,
-                    mine: self.vote,
+                    mine: self.session_id.vote,
                 }));
             }
 

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -1,0 +1,53 @@
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use crate::LogId;
+use crate::MessageSummary;
+use crate::NodeId;
+use crate::Vote;
+
+/// Uniquely identifies a replication session.
+///
+/// A replication session is a group of replication stream, e.g., the leader(node-1) in a cluster of 3 nodes may have a
+/// replication config `{2,3}`.
+///
+/// Replication state can not be shared between two leaders(different `vote`) or between two membership configs:
+/// E.g. given 3 membership log:
+/// - `log_id=1, members={a,b,c}`
+/// - `log_id=5, members={a,b}`
+/// - `log_id=10, members={a,b,c}`
+///
+/// When log_id=1 is appended, openraft spawns a replication to node `c`.
+/// Then log_id=1 is replicated to node `c`.
+/// Then a replication state update message `{target=c, matched=log_id-1}` is piped in message queue(`tx_api`),
+/// waiting the raft core to process.
+///
+/// Then log_id=5 is appended, replication to node `c` is dropped.
+///
+/// Then log_id=10 is appended, another replication to node `c` is spawned.
+/// Now node `c` is a new empty node, no log is replicated to it.
+/// But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft core believe
+/// node `c` already has `log_id=1`, and commit it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReplicationSessionId<NID: NodeId> {
+    /// The vote of the leader.
+    pub(crate) vote: Vote<NID>,
+
+    /// The log id of the membership log this replication works for.
+    pub(crate) membership_log_id: Option<LogId<NID>>,
+}
+
+impl<NID: NodeId> Display for ReplicationSessionId<NID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.vote, self.membership_log_id.summary())
+    }
+}
+
+impl<NID: NodeId> ReplicationSessionId<NID> {
+    pub(crate) fn new(vote: Vote<NID>, membership_log_id: Option<LogId<NID>>) -> Self {
+        Self {
+            vote,
+            membership_log_id,
+        }
+    }
+}


### PR DESCRIPTION

## Changelog

##### Refactor: ProgressEntry: support updating matching and conflict

Provide methods to update a matching log id or conflicting log index that
is found on the replication target node.


##### Refactor: add ReplicationSessionId to identify a replication config


##### Refactor: determine server-state by "vote"


##### Refactor: fix typo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/612)
<!-- Reviewable:end -->
