### PR TITLE
simplify snapshot replication

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -121,9 +121,12 @@ pub struct Config {
 
     /// The distance behind in log replication a follower must fall before it is considered lagging
     ///
-    /// Once a replication stream transition into line-rate state, the target node will be considered safe to join a
-    /// cluster.
-    #[clap(long, default_value = "1000")]
+    /// A follower falls behind this index are replicated with snapshot.
+    /// A follower falls within this index are replicated with log entries.
+    ///
+    /// This value should be greater than snapshot_policy.SnapshotPolicy.LogsSinceLast, otherwise transmitting a
+    /// snapshot may not fix the lagging.
+    #[clap(long, default_value = "5000")]
     pub replication_lag_threshold: u64,
 
     /// The snapshot policy to use for a Raft node.

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -13,7 +13,7 @@ fn test_config_defaults() {
 
     assert_eq!(50, cfg.heartbeat_interval);
     assert_eq!(300, cfg.max_payload_entries);
-    assert_eq!(1000, cfg.replication_lag_threshold);
+    assert_eq!(5000, cfg.replication_lag_threshold);
 
     assert_eq!(3 * 1024 * 1024, cfg.snapshot_max_chunk_size);
     assert_eq!(SnapshotPolicy::LogsSinceLast(5000), cfg.snapshot_policy);
@@ -57,8 +57,8 @@ fn test_build() -> anyhow::Result<()> {
         "--send-snapshot-timeout=199",
         "--install-snapshot-timeout=200",
         "--max-payload-entries=201",
-        "--replication-lag-threshold=202",
-        "--snapshot-policy=since_last:203",
+        "--snapshot-policy=since_last:202",
+        "--replication-lag-threshold=203",
         "--snapshot-max-chunk-size=204",
         "--max-in-snapshot-log-to-keep=205",
         "--purge-batch-size=207",
@@ -71,8 +71,8 @@ fn test_build() -> anyhow::Result<()> {
     assert_eq!(199, config.send_snapshot_timeout);
     assert_eq!(200, config.install_snapshot_timeout);
     assert_eq!(201, config.max_payload_entries);
-    assert_eq!(202, config.replication_lag_threshold);
-    assert_eq!(SnapshotPolicy::LogsSinceLast(203), config.snapshot_policy);
+    assert_eq!(SnapshotPolicy::LogsSinceLast(202), config.snapshot_policy);
+    assert_eq!(203, config.replication_lag_threshold);
     assert_eq!(204, config.snapshot_max_chunk_size);
     assert_eq!(205, config.max_in_snapshot_log_to_keep);
     assert_eq!(207, config.purge_batch_size);

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1301,9 +1301,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                     self.handle_update_matched(target, result).await?;
                 }
             }
-            RaftMsg::NeedsSnapshot { target: _, tx, vote } => {
-                // TODO check session_id
-                if self.does_vote_match(&vote, "NeedsSnapshot") {
+            RaftMsg::NeedsSnapshot {
+                target: _,
+                tx,
+                session_id,
+            } => {
+                if self.does_replication_session_match(&session_id, "NeedsSnapshot") {
                     let snapshot = self.storage.get_current_snapshot().await?;
 
                     if let Some(snapshot) = snapshot {

--- a/openraft/src/core/snapshot_state.rs
+++ b/openraft/src/core/snapshot_state.rs
@@ -1,8 +1,6 @@
 use futures::future::AbortHandle;
-use tokio::sync::broadcast;
 
 use crate::core::streaming_state::StreamingState;
-use crate::LogId;
 use crate::Node;
 use crate::NodeId;
 use crate::RaftTypeConfig;
@@ -17,8 +15,6 @@ pub(crate) enum SnapshotState<C: RaftTypeConfig, SD> {
     Snapshotting {
         /// A handle to abort the compaction process early if needed.
         abort_handle: AbortHandle,
-        /// A sender for notifying any other tasks of the completion of this compaction.
-        sender: broadcast::Sender<Option<LogId<C::NodeId>>>,
     },
     /// The Raft node is streaming in a snapshot from the leader.
     Streaming(StreamingState<C, SD>),

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -956,8 +956,8 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
         /// The response channel for delivering the snapshot data.
         tx: oneshot::Sender<Snapshot<C::NodeId, C::Node, S::SnapshotData>>,
 
-        /// Which ServerState sent this message
-        vote: Vote<C::NodeId>,
+        /// Which replication session sent this message
+        session_id: ReplicationSessionId<C::NodeId>,
     },
 
     /// Some critical error has taken place, and Raft needs to shutdown.
@@ -1040,7 +1040,9 @@ where
                 )
             }
             RaftMsg::NeedsSnapshot {
-                ref target, ref vote, ..
+                ref target,
+                session_id: ref vote,
+                ..
             } => {
                 format!("NeedsSnapshot: target: {}, server_state_vote: {}", target, vote)
             }

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -43,17 +43,18 @@ async fn add_learner_basic() -> Result<()> {
     tracing::info!("--- add new node node-1");
     {
         tracing::info!("--- write up to 1000 logs");
+        {
+            router.client_request_many(0, "learner_add", 1000 - log_index as usize).await?;
+            log_index = 1000;
 
-        router.client_request_many(0, "learner_add", 1000 - log_index as usize).await?;
-        log_index = 1000;
-
-        tracing::info!("--- write up to 1000 logs done");
-
-        router.wait_for_log(&btreeset! {0}, Some(log_index), timeout(), "write 1000 logs to leader").await?;
+            tracing::info!("--- write up to 1000 logs done");
+            router.wait_for_log(&btreeset! {0}, Some(log_index), timeout(), "write 1000 logs to leader").await?;
+        }
 
         router.new_raft_node(1);
         router.add_learner(0, 1).await?;
         log_index += 1;
+
         router.wait_for_log(&btreeset! {0,1}, Some(log_index), timeout(), "add learner").await?;
 
         tracing::info!("--- add_learner blocks until the replication catches up");


### PR DESCRIPTION

## Changelog

##### Refactor: rename ReplicationCore fields


##### Refactor: ask for a snapshot for replication only when the last snapshot can fix replication lagging

`replication_lag_threshold >= config.SnapshotPolicy.LogsSinceLast`
should be held;
Asking for a snapshot only when a follower behind the `committed` index by `replication_lag_threshold`.


##### Refactor: use the last snapshot when ReplicationCore asks

When a ReplicationCore asks RaftCore for a snapshot, RaftCore just
sends back the last built snapshot, it does not have to build a new one.
ReplciationCore guarantees it asks for a snapshot only when the last
snapshot fulfill its need: i.e., when it tries to replicate a purged
log(which must be included in the last snapshot).


##### Refactor: no need to wait for building a snapshot when lacking a log

When `ReplicationCore` asks for a snapshot for replication, `RaftCore`
could just gives it the last built one. There is never need to rebuild
one. Because a log won't be purged until a snapshot including it is
built.


##### Refactor: add does_replication_session_match() to assert replication session id matches

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/613)
<!-- Reviewable:end -->
