### PR TITLE
Fix: workaround cargo leaking SSL_CERT_FILE issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,6 +183,8 @@ jobs:
         with:
           command: test
           args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
+        env:
+          RUST_LOG: debug
 
 
       - name: Test demo script of examples/${{ matrix.example }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,8 @@ jobs:
         with:
           command: doc
           args: --all --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
 
 
   test-examples:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ fix:
 	cargo fix --allow-staged
 
 doc:
-	cargo doc --all --no-deps
+	RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps
 
 guide:
 	mdbook build

--- a/examples/raft-kv-memstore/src/client.rs
+++ b/examples/raft-kv-memstore/src/client.rs
@@ -170,7 +170,7 @@ impl ExampleClient {
         }
         .send();
 
-        let res = timeout(Duration::from_millis(500), fu).await;
+        let res = timeout(Duration::from_millis(3_000), fu).await;
         let resp = match res {
             Ok(x) => x.map_err(|e| RPCError::Network(NetworkError::new(&e)))?,
             Err(timeout_err) => {

--- a/examples/raft-kv-memstore/src/client.rs
+++ b/examples/raft-kv-memstore/src/client.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use openraft::error::AddLearnerError;
 use openraft::error::CheckIsLeaderError;
@@ -19,6 +20,7 @@ use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::time::timeout;
 
 use crate::ExampleNodeId;
 use crate::ExampleRequest;
@@ -155,23 +157,30 @@ impl ExampleClient {
             (t.0, format!("http://{}/{}", target_addr, uri))
         };
 
-        let resp = if let Some(r) = req {
-            println!(
+        let fu = if let Some(r) = req {
+            tracing::debug!(
                 ">>> client send request to {}: {}",
                 url,
                 serde_json::to_string_pretty(&r).unwrap()
             );
             self.inner.post(url.clone()).json(r)
         } else {
-            println!(">>> client send request to {}", url,);
+            tracing::debug!(">>> client send request to {}", url,);
             self.inner.get(url.clone())
         }
-        .send()
-        .await
-        .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        .send();
+
+        let res = timeout(Duration::from_millis(500), fu).await;
+        let resp = match res {
+            Ok(x) => x.map_err(|e| RPCError::Network(NetworkError::new(&e)))?,
+            Err(timeout_err) => {
+                tracing::error!("timeout {} to url: {}", timeout_err, url);
+                return Err(RPCError::Network(NetworkError::new(&timeout_err)));
+            }
+        };
 
         let res: Result<Resp, Err> = resp.json().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
-        println!(
+        tracing::debug!(
             "<<< client recv reply from {}: {}",
             url,
             serde_json::to_string_pretty(&res).unwrap()

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -36,7 +36,14 @@ pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, Arc<ExampleStore>
 
 pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) -> std::io::Result<()> {
     // Create a configuration for the raft instance.
-    let config = Arc::new(Config::default().validate().unwrap());
+    let config = Config {
+        heartbeat_interval: 500,
+        election_timeout_min: 1500,
+        election_timeout_max: 3000,
+        ..Default::default()
+    };
+
+    let config = Arc::new(config.validate().unwrap());
 
     // Create a instance of where the Raft data will be stored.
     let store = Arc::new(ExampleStore::default());

--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -38,9 +38,16 @@ impl ExampleNetwork {
         let addr = &target_node.addr;
 
         let url = format!("http://{}/{}", addr, uri);
+
+        tracing::debug!("send_rpc to url: {}", url);
+
         let client = reqwest::Client::new();
 
+        tracing::debug!("client is created for: {}", url);
+
         let resp = client.post(url).json(&req).send().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+
+        tracing::debug!("client.post() is sent");
 
         let res: Result<Resp, Err> = resp.json().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
 

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -12,6 +12,7 @@ use raft_kv_memstore::start_example_raft_node;
 use raft_kv_memstore::store::ExampleRequest;
 use raft_kv_memstore::ExampleNodeId;
 use tokio::runtime::Runtime;
+use tracing_subscriber::EnvFilter;
 
 /// Setup a cluster of 3 nodes.
 /// Write to it and read from it.
@@ -20,6 +21,14 @@ async fn test_cluster() -> anyhow::Result<()> {
     // --- The client itself does not store addresses for all nodes, but just node id.
     //     Thus we need a supporting component to provide mapping from node id to node address.
     //     This is only used by the client. A raft node in this example stores node addresses in its store.
+
+    tracing_subscriber::fmt()
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true)
+        .with_ansi(false)
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
 
     let get_addr = |node_id| {
         let addr = match node_id {

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -209,7 +209,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     println!("=== change-membership to 3, ");
     let _x = client.change_membership(&btreeset! {3}).await?;
 
-    tokio::time::sleep(Duration::from_millis(1_000)).await;
+    tokio::time::sleep(Duration::from_millis(8_000)).await;
 
     println!("=== metrics after change-membership to {{3}}");
     let x = client.metrics().await?;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1408,8 +1408,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         if session_id.membership_log_id != self.engine.state.membership_state.effective.log_id {
             tracing::warn!(
-                "membership_log_id changed: msg sent by: {:?}; curr: {}; ignore when ({})",
-                session_id.membership_log_id,
+                "membership_log_id changed: msg sent by: {}; curr: {}; ignore when ({})",
+                session_id.membership_log_id.summary(),
                 self.engine.state.membership_state.effective.log_id.summary(),
                 msg
             );


### PR DESCRIPTION
## Changelog

### Fix: workaround cargo leaking SSL_CERT_FILE issue
On Linux: command `cargo run` pollutes environment variables: It leaks
`SSL_CERT_FILE` and `SSL_CERT_DIR` to the testing sub progress it runs.
Which cause `reqwest` spending ~50 ms loading the certificates for every
RPC.

We just extend the RPC timeout to work around.

- Fix: #550


### Refactor: add logging and timeout to example
- Test examples on debug level. Initialize logging for example

- Add timeout control to client in the example. Do not let it block for
  ever.


### CI: quit with error if fail to build doc in Makefile and CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/615)
<!-- Reviewable:end -->
