### PR TITLE
Refactor: serialize snapshot building and streaming

### DIFF
--- a/openraft/src/core/snapshot_state.rs
+++ b/openraft/src/core/snapshot_state.rs
@@ -1,4 +1,5 @@
 use futures::future::AbortHandle;
+use tokio::task::JoinHandle;
 
 use crate::core::streaming_state::StreamingState;
 use crate::Node;
@@ -15,6 +16,7 @@ pub(crate) enum SnapshotState<C: RaftTypeConfig, SD> {
     Snapshotting {
         /// A handle to abort the compaction process early if needed.
         abort_handle: AbortHandle,
+        join_handle: JoinHandle<()>,
     },
     /// The Raft node is streaming in a snapshot from the leader.
     Streaming(StreamingState<C, SD>),


### PR DESCRIPTION

## Changelog

##### Refactor: serialize snapshot building and streaming

Before starting a new snapshot streaming, the previous building task has
to be finished. Otherwise there might be race condition that streaming a
snapshot and building a snapshot may be done in arbitrary order, i.e.,
old data overrides new data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/621)
<!-- Reviewable:end -->
