### PR TITLE
Change: remove error NodeNotFound

### DIFF
--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -4,13 +4,10 @@ use std::time::Duration;
 
 use maplit::btreemap;
 use maplit::btreeset;
-use openraft::error::NodeNotFound;
-use openraft::AnyError;
 use openraft::BasicNode;
 use raft_kv_memstore::client::ExampleClient;
 use raft_kv_memstore::start_example_raft_node;
 use raft_kv_memstore::store::ExampleRequest;
-use raft_kv_memstore::ExampleNodeId;
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
 
@@ -36,10 +33,7 @@ async fn test_cluster() -> anyhow::Result<()> {
             2 => "127.0.0.1:21002".to_string(),
             3 => "127.0.0.1:21003".to_string(),
             _ => {
-                return Err(NodeNotFound::<ExampleNodeId> {
-                    node_id,
-                    source: AnyError::error("node not found"),
-                });
+                return Err(anyhow::anyhow!("node {} not found", node_id));
             }
         };
         Ok(addr)

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -284,9 +284,6 @@ where
     StorageError(#[from] StorageError<NID>),
 
     #[error(transparent)]
-    NodeNotFound(#[from] NodeNotFound<NID>),
-
-    #[error(transparent)]
     Timeout(#[from] Timeout<NID>),
 
     #[error(transparent)]
@@ -303,9 +300,6 @@ where
     serde(bound = "T:serde::Serialize + for <'d> serde::Deserialize<'d>")
 )]
 pub enum RPCError<NID: NodeId, N: Node, T: Error> {
-    #[error(transparent)]
-    NodeNotFound(#[from] NodeNotFound<NID>),
-
     #[error(transparent)]
     Timeout(#[from] Timeout<NID>),
 
@@ -476,14 +470,6 @@ pub struct NotAMembershipEntry {}
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[error("new membership can not be empty")]
 pub struct EmptyMembership {}
-
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-#[error("node not found: {node_id}, source: {source}")]
-pub struct NodeNotFound<NID: NodeId> {
-    pub node_id: NID,
-    pub source: AnyError,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -183,9 +183,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                     let _ = self.tx_raft_core.send(RaftMsg::ReplicationFatal);
                     return;
                 }
-                ReplicationError::NodeNotFound(err) => {
-                    unreachable!("programming bug: {}", err)
-                }
                 ReplicationError::Timeout { .. } => {
                     // nothing to do
                 }
@@ -306,7 +303,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
                     tracing::warn!(error=%err, "error sending AppendEntries RPC to target");
 
                     let repl_err = match err {
-                        RPCError::NodeNotFound(e) => ReplicationError::NodeNotFound(e),
                         RPCError::Timeout(e) => {
                             let _ = self.tx_raft_core.send(RaftMsg::UpdateReplicationProgress {
                                 target: self.target,


### PR DESCRIPTION

## Changelog

##### Change: remove error NodeNotFound

A node is stored in `Membership` thus it should always be found.
Otherwise it is a bug of openraft.
In either case, there is no need for an application to deal with
`RPCError::NodeNotFound` error.

An application that needs such an error should define it as an
application error.

- Migration guide:
  if you do have been using it, you could just replace `NodeNotFound` with `NetworkError`.

- Fix: #623

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/624)
<!-- Reviewable:end -->
