### PR TITLE
Refactor: add ReplicationError::RPCError

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -284,13 +284,7 @@ where
     StorageError(#[from] StorageError<NID>),
 
     #[error(transparent)]
-    Timeout(#[from] Timeout<NID>),
-
-    #[error(transparent)]
-    Network(#[from] NetworkError),
-
-    #[error(transparent)]
-    RemoteError(#[from] RemoteError<NID, N, AppendEntriesError<NID>>),
+    RPCError(#[from] RPCError<NID, N, AppendEntriesError<NID>>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]


### PR DESCRIPTION

## Changelog

##### Refactor: add ReplicationError::RPCError

Replace `ReplicationError::{Timeout, Network, RemoteError}` with
`ReplicationError::RPCError`. Because these three errors are dealt with
in the same way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/625)
<!-- Reviewable:end -->
