### PR TITLE
Change: RaftState: add field snapshot_meta

### DIFF
--- a/openraft/src/engine/calc_purge_upto_test.rs
+++ b/openraft/src/engine/calc_purge_upto_test.rs
@@ -62,7 +62,7 @@ fn test_calc_purge_upto() -> anyhow::Result<()> {
         if let Some(last_purged) = last_purged {
             eng.state.log_ids.purge(&last_purged);
         }
-        eng.snapshot_meta.last_log_id = snapshot_last_log_id;
+        eng.state.snapshot_meta.last_log_id = snapshot_last_log_id;
         let got = eng.calc_purge_upto();
 
         assert_eq!(

--- a/openraft/src/engine/update_snapshot_test.rs
+++ b/openraft/src/engine/update_snapshot_test.rs
@@ -25,14 +25,14 @@ fn m1234() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    Engine::<u64, ()> {
-        snapshot_meta: SnapshotMeta {
-            last_log_id: Some(log_id(2, 2)),
-            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
-            snapshot_id: "1-2-3-4".to_string(),
-        },
-        ..Default::default()
-    }
+    let mut eng = Engine::<u64, ()> { ..Default::default() };
+
+    eng.state.snapshot_meta = SnapshotMeta {
+        last_log_id: Some(log_id(2, 2)),
+        last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+        snapshot_id: "1-2-3-4".to_string(),
+    };
+    eng
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn test_update_snapshot_no_update() -> anyhow::Result<()> {
             last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        eng.snapshot_meta
+        eng.state.snapshot_meta
     );
 
     assert_eq!(
@@ -90,7 +90,7 @@ fn test_update_snapshot_updated() -> anyhow::Result<()> {
             last_membership: EffectiveMembership::new(Some(log_id(2, 2)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        eng.snapshot_meta
+        eng.state.snapshot_meta
     );
 
     assert_eq!(

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -8,6 +8,7 @@ use crate::LogIdOptionExt;
 use crate::MembershipState;
 use crate::NodeId;
 use crate::ServerState;
+use crate::SnapshotMeta;
 use crate::Vote;
 
 /// A struct used to represent the raft state which a Raft node needs.
@@ -32,6 +33,9 @@ where
 
     /// The latest cluster membership configuration found, in log or in state machine.
     pub membership_state: MembershipState<NID, N>,
+
+    /// The metadata of the last snapshot.
+    pub snapshot_meta: SnapshotMeta<NID, N>,
 
     // --
     // -- volatile fields: they are not persisted.

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -56,6 +56,8 @@ where
 
         let log_ids = LogIdList::load_log_ids(last_purged_log_id, last_log_id, self).await?;
 
+        let snapshot_meta = self.sto.get_current_snapshot().await?.map(|x| x.meta).unwrap_or_default();
+
         Ok(RaftState {
             committed: last_applied,
             // The initial value for `vote` is the minimal possible value.
@@ -63,6 +65,7 @@ where
             vote: vote.unwrap_or_default(),
             log_ids,
             membership_state: mem_state,
+            snapshot_meta,
 
             // -- volatile fields: they are not persisted.
             internal_server_state: InternalServerState::default(),


### PR DESCRIPTION

## Changelog

##### Change: RaftState: add field snapshot_meta

Snapshot meta should be part of the `RaftState`.
Move it from `Engine` to `RaftState`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/627)
<!-- Reviewable:end -->
