### PR TITLE
Refactor: RaftState::last_log_id() and RaftState::last_purged_log_id() returns an ref of log-id

### DIFF
--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -76,7 +76,7 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id().copied());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -120,7 +120,7 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(3, 4)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(3, 4)), eng.state.last_log_id().copied());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -180,7 +180,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(3, 5)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(3, 5)), eng.state.last_log_id().copied());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
@@ -260,7 +260,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id().copied());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(4, 6)), m34())),

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -77,7 +77,7 @@ fn test_handle_append_entries_req_vote_is_rejected() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id().copied());
     assert_eq!(Some(log_id(0, 0)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -125,7 +125,7 @@ fn test_handle_append_entries_req_prev_log_id_is_applied() -> anyhow::Result<()>
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id().copied());
     assert_eq!(Some(log_id(0, 0)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -177,7 +177,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(1, 1)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(1, 1)), eng.state.last_log_id().copied());
     assert_eq!(Some(log_id(0, 0)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -234,7 +234,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id().copied());
     assert_eq!(Some(log_id(1, 1)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -299,7 +299,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id().copied());
     assert_eq!(Some(log_id(0, 0)), eng.state.committed);
     assert_eq!(
         MembershipState {
@@ -360,7 +360,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
-    assert_eq!(Some(log_id(3, 3)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(3, 3)), eng.state.last_log_id().copied());
     assert_eq!(Some(log_id(3, 3)), eng.state.committed);
     assert_eq!(
         MembershipState {

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -51,7 +51,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 
         assert_eq!(Some(log_id0), eng.state.get_log_id(0));
         assert_eq!(Some(log_id(1, 1)), eng.state.get_log_id(1));
-        assert_eq!(Some(log_id(1, 1)), eng.state.last_log_id());
+        assert_eq!(Some(log_id(1, 1)), eng.state.last_log_id().copied());
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
         assert_eq!(
@@ -153,7 +153,7 @@ fn test_initialize() -> anyhow::Result<()> {
 
         assert_eq!(Some(log_id0), eng.state.get_log_id(0));
         assert_eq!(None, eng.state.get_log_id(1));
-        assert_eq!(Some(log_id0), eng.state.last_log_id());
+        assert_eq!(Some(log_id0), eng.state.last_log_id().copied());
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -88,7 +88,7 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id());
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id().copied());
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -131,7 +131,10 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 1), 6)), eng.state.last_log_id());
+    assert_eq!(
+        Some(LogId::new(LeaderId::new(3, 1), 6)),
+        eng.state.last_log_id().copied()
+    );
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
@@ -185,7 +188,10 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 1), 6)), eng.state.last_log_id());
+    assert_eq!(
+        Some(LogId::new(LeaderId::new(3, 1), 6)),
+        eng.state.last_log_id().copied()
+    );
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m1())),
@@ -252,7 +258,10 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 1), 6)), eng.state.last_log_id());
+    assert_eq!(
+        Some(LogId::new(LeaderId::new(3, 1), 6)),
+        eng.state.last_log_id().copied()
+    );
     assert_eq!(
         MembershipState {
             // previous effective become committed.
@@ -333,7 +342,10 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 1), 6)), eng.state.last_log_id());
+    assert_eq!(
+        Some(LogId::new(LeaderId::new(3, 1), 6)),
+        eng.state.last_log_id().copied()
+    );
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(
@@ -426,7 +438,10 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(LogId::new(LeaderId::new(3, 1), 6)), eng.state.last_log_id());
+    assert_eq!(
+        Some(LogId::new(LeaderId::new(3, 1), 6)),
+        eng.state.last_log_id().copied()
+    );
     assert_eq!(
         MembershipState {
             committed: Arc::new(EffectiveMembership::new(

--- a/openraft/src/engine/purge_log_test.rs
+++ b/openraft/src/engine/purge_log_test.rs
@@ -23,9 +23,9 @@ fn test_purge_log_already_purged() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(1, 1));
 
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id().copied(),);
     assert_eq!(log_id(2, 2), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
     assert_eq!(0, eng.commands.len());
 
@@ -38,9 +38,9 @@ fn test_purge_log_equal_prev_last_purged() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(2, 2));
 
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_purged_log_id().copied());
     assert_eq!(log_id(2, 2), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
     assert_eq!(0, eng.commands.len());
 
@@ -52,9 +52,9 @@ fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(2, 3));
 
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_purged_log_id().copied(),);
     assert_eq!(log_id(2, 3), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(2, 3) }], eng.commands);
 
@@ -67,9 +67,9 @@ fn test_purge_log_to_last_key_log() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 4));
 
-    assert_eq!(Some(log_id(4, 4)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(4, 4)), eng.state.last_purged_log_id().copied(),);
     assert_eq!(log_id(4, 4), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 4) }], eng.commands);
 
@@ -82,9 +82,9 @@ fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 5));
 
-    assert_eq!(Some(log_id(4, 5)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(4, 5)), eng.state.last_purged_log_id().copied(),);
     assert_eq!(log_id(4, 5), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 5) }], eng.commands);
 
@@ -97,9 +97,9 @@ fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 6));
 
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_purged_log_id().copied(),);
     assert_eq!(log_id(4, 6), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 6) }], eng.commands);
 
@@ -112,9 +112,9 @@ fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(4, 7));
 
-    assert_eq!(Some(log_id(4, 7)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(4, 7)), eng.state.last_purged_log_id().copied(),);
     assert_eq!(log_id(4, 7), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id().copied());
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 7) }], eng.commands);
 
@@ -127,9 +127,9 @@ fn test_purge_log_to_higher_leader_lgo() -> anyhow::Result<()> {
 
     eng.purge_log(log_id(5, 7));
 
-    assert_eq!(Some(log_id(5, 7)), eng.state.last_purged_log_id(),);
+    assert_eq!(Some(log_id(5, 7)), eng.state.last_purged_log_id().copied(),);
     assert_eq!(log_id(5, 7), eng.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(log_id(5, 7)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(5, 7)), eng.state.last_log_id().copied());
 
     assert_eq!(vec![Command::PurgeLog { upto: log_id(5, 7) }], eng.commands);
 

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -55,7 +55,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
 
     eng.truncate_logs(3);
 
-    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(2, 2)), eng.state.last_log_id().copied());
     assert_eq!(&[log_id(2, 2)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
@@ -94,7 +94,7 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
 
     eng.truncate_logs(4);
 
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id().copied());
     assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
@@ -124,7 +124,7 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
 
     eng.truncate_logs(5);
 
-    assert_eq!(Some(log_id(4, 4)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 4)), eng.state.last_log_id().copied());
     assert_eq!(&[log_id(2, 2), log_id(4, 4)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {
@@ -146,7 +146,7 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
 
     eng.truncate_logs(6);
 
-    assert_eq!(Some(log_id(4, 5)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 5)), eng.state.last_log_id().copied());
     assert_eq!(
         &[log_id(2, 2), log_id(4, 4), log_id(4, 5)],
         eng.state.log_ids.key_log_ids()
@@ -171,7 +171,7 @@ fn test_truncate_logs_since_7() -> anyhow::Result<()> {
 
     eng.truncate_logs(7);
 
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
     assert_eq!(
         &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
         eng.state.log_ids.key_log_ids()
@@ -196,7 +196,7 @@ fn test_truncate_logs_since_8() -> anyhow::Result<()> {
 
     eng.truncate_logs(8);
 
-    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
     assert_eq!(
         &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
         eng.state.log_ids.key_log_ids()
@@ -226,7 +226,7 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
 
     eng.truncate_logs(4);
 
-    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id(),);
+    assert_eq!(Some(log_id(2, 3)), eng.state.last_log_id().copied());
     assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MetricsChangeFlags {

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -89,18 +89,20 @@ where
     }
 
     /// The last known log id in the store.
-    pub(crate) fn last_log_id(&self) -> Option<LogId<NID>> {
-        self.log_ids.last().cloned()
+    ///
+    /// The range of all stored log ids are `(last_purged_log_id(), last_log_id()]`, left open right close.
+    pub(crate) fn last_log_id(&self) -> Option<&LogId<NID>> {
+        self.log_ids.last()
     }
 
     /// The greatest log id that has been purged after being applied to state machine, i.e., the oldest known log id.
     ///
-    /// The range of log entries that exist in storage is `(last_purged_log_id, last_log_id]`,
+    /// The range of log entries that exist in storage is `(last_purged_log_id(), last_log_id()]`,
     /// left open and right close.
     ///
     /// `last_purged_log_id == last_log_id` means there is no log entry in the storage.
-    pub(crate) fn last_purged_log_id(&self) -> Option<LogId<NID>> {
-        self.log_ids.first().cloned()
+    pub(crate) fn last_purged_log_id(&self) -> Option<&LogId<NID>> {
+        self.log_ids.first()
     }
 
     /// Create a new Leader, when raft enters candidate state.

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -77,13 +77,13 @@ fn test_raft_state_last_log_id() -> anyhow::Result<()> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         ..Default::default()
     };
-    assert_eq!(Some(log_id(1, 2)), rs.last_log_id());
+    assert_eq!(Some(log_id(1, 2)), rs.last_log_id().copied());
 
     let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
-    assert_eq!(Some(log_id(3, 4)), rs.last_log_id());
+    assert_eq!(Some(log_id(3, 4)), rs.last_log_id().copied());
 
     Ok(())
 }
@@ -101,13 +101,13 @@ fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         ..Default::default()
     };
-    assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id());
+    assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());
 
     let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
-    assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id());
+    assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());
 
     Ok(())
 }

--- a/openraft/src/raft_types.rs
+++ b/openraft/src/raft_types.rs
@@ -36,14 +36,9 @@ impl<NID: NodeId> Display for LogId<NID> {
     }
 }
 
-impl<NID: NodeId> MessageSummary<LogId<NID>> for Option<LogId<NID>> {
+impl<NID: NodeId> MessageSummary<LogId<NID>> for LogId<NID> {
     fn summary(&self) -> String {
-        match self {
-            None => "None".to_string(),
-            Some(x) => {
-                format!("{x}")
-            }
-        }
+        format!("{}", self)
     }
 }
 
@@ -78,6 +73,19 @@ pub trait LogIdOptionExt {
 }
 
 impl<NID: NodeId> LogIdOptionExt for Option<LogId<NID>> {
+    fn index(&self) -> Option<u64> {
+        self.map(|x| x.index)
+    }
+
+    fn next_index(&self) -> u64 {
+        match self {
+            None => 0,
+            Some(log_id) => log_id.index + 1,
+        }
+    }
+}
+
+impl<NID: NodeId> LogIdOptionExt for Option<&LogId<NID>> {
     fn index(&self) -> Option<u64> {
         self.map(|x| x.index)
     }

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -430,7 +430,7 @@ where
         let initial = StorageHelper::new(&mut store).get_initial_state().await?;
 
         assert_eq!(
-            initial.last_log_id(),
+            initial.last_log_id().copied(),
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 2)),
             "state machine has higher log"
         );
@@ -544,7 +544,7 @@ where
         let initial = StorageHelper::new(&mut store).get_initial_state().await?;
 
         assert_eq!(
-            initial.last_log_id(),
+            initial.last_log_id().copied(),
             Some(LogId::new(LeaderId::new(2, NODE_ID.into()), 1)),
             "state machine has higher log"
         );
@@ -561,12 +561,12 @@ where
         let initial = StorageHelper::new(&mut store).get_initial_state().await?;
 
         assert_eq!(
-            initial.last_log_id(),
+            initial.last_log_id().copied(),
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 1)),
             "state machine has higher log"
         );
         assert_eq!(
-            initial.last_purged_log_id(),
+            initial.last_purged_log_id().copied(),
             Some(LogId::new(LeaderId::new(3, NODE_ID.into()), 1)),
             "state machine has higher log"
         );


### PR DESCRIPTION

## Changelog

##### Refactor: RaftState::last_log_id() and RaftState::last_purged_log_id() returns an ref of log-id

Returns `Option<&LogId>` instead of `Option<LogId>`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/628)
<!-- Reviewable:end -->
