### PR TITLE
Refactor: add trait LogStateReader to define API for getting log ids reflecting the raft state

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -71,6 +71,7 @@ use crate::raft::RaftMsg;
 use crate::raft::RaftRespTx;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
+use crate::raft_state::LogStateReader;
 use crate::raft_types::LogIdOptionExt;
 use crate::raft_types::RaftLogId;
 use crate::replication::Replicate;

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -17,6 +17,7 @@ use crate::progress::Progress;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
+use crate::raft_state::LogStateReader;
 use crate::raft_state::RaftState;
 use crate::raft_types::RaftLogId;
 use crate::summary::MessageSummary;

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::raft_state::LogStateReader;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -7,6 +7,7 @@ use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft::AppendEntriesResponse;
+use crate::raft_state::LogStateReader;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -12,6 +12,7 @@ use crate::error::NotAMembershipEntry;
 use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
+use crate::raft_state::LogStateReader;
 use crate::EntryPayload;
 use crate::LeaderId;
 use crate::LogId;

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -8,6 +8,7 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::entry::ProgressEntry;
+use crate::raft_state::LogStateReader;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;

--- a/openraft/src/engine/purge_log_test.rs
+++ b/openraft/src/engine/purge_log_test.rs
@@ -1,6 +1,7 @@
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::raft_state::LogStateReader;
 use crate::LeaderId;
 use crate::LogId;
 

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::raft_state::LogStateReader;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::engine::LogIdList;
+use crate::raft_state::LogStateReader;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -6,6 +6,7 @@ use std::option::Option::None;
 use maplit::btreeset;
 
 use crate::membership::EffectiveMembership;
+use crate::raft_state::LogStateReader;
 use crate::raft_state::RaftState;
 use crate::storage::LogState;
 use crate::storage::StorageHelper;


### PR DESCRIPTION

## Changelog

##### Refactor: add trait LogStateReader to define API for getting log ids reflecting the raft state

Openraft components need information of significant log ids to
function, there should be a standard interface for them to read these
log ids.

```
old                           new
øøøøøøLLLLLLLLLLLLLLLLLLLL
+----+----+----+----+----+--->
     |    |    |    |    |
     |    |    |    |    '--- last_log_id
     |    |    |    '-------- committed
     |    |    '------------- applied
     |    '------------------ snapshot_last_log_id
     '----------------------- last_purged_log_id
```

- See: https://datafuselabs.github.io/openraft/log-data-layout

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/630)
<!-- Reviewable:end -->
