### PR TITLE
Refactor: make replication metrics update an engine command

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1354,8 +1354,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         self.engine.update_progress(target, Some(progress.matching.unwrap()));
         self.run_engine_commands::<Entry<C>>(&[]).await?;
 
-        self.update_replication_metrics(target, progress.matching.unwrap());
-
         Ok(())
     }
 
@@ -1531,6 +1529,9 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
                         }
                     };
                 }
+            }
+            Command::UpdateReplicationMetrics { target, matching } => {
+                self.update_replication_metrics(*target, *matching);
             }
             Command::UpdateMembership { .. } => {
                 // TODO: not used

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -69,6 +69,9 @@ where
         targets: Vec<(NID, ProgressEntry<NID>)>,
     },
 
+    /// The state of replication to `target` is updated, the metrics should be updated.
+    UpdateReplicationMetrics { target: NID, matching: LogId<NID> },
+
     /// Move the cursor pointing to an entry in the input buffer.
     MoveInputCursorBy { n: usize },
 
@@ -125,6 +128,7 @@ where
             Command::ReplicateEntries { .. } => {}
             Command::UpdateMembership { .. } => flags.set_cluster_changed(),
             Command::UpdateReplicationStreams { .. } => flags.set_replication_changed(),
+            Command::UpdateReplicationMetrics { .. } => flags.set_replication_changed(),
             Command::MoveInputCursorBy { .. } => {}
             Command::SaveVote { .. } => flags.set_data_changed(),
             Command::SendVote { .. } => {}

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -742,6 +742,15 @@ where
 
         tracing::debug!(committed = debug(&committed), "committed after updating progress");
 
+        debug_assert!(log_id.is_some(), "a valid update can never set matching to None");
+
+        if node_id != self.id {
+            self.push_command(Command::UpdateReplicationMetrics {
+                target: node_id,
+                matching: log_id.unwrap(),
+            });
+        }
+
         // Only when the log id is proposed by current leader, it is committed.
         if let Some(c) = committed {
             if c.leader_id.term != self.state.vote.term || c.leader_id.node_id != self.state.vote.node_id {


### PR DESCRIPTION

## Changelog

##### Refactor: make replication metrics update an engine command

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/632)
<!-- Reviewable:end -->
