### PR TITLE
Refactor: move leading state out of RaftState

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -251,7 +251,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         // Spawn parallel requests, all with the standard timeout for heartbeats.
         let mut pending = FuturesUnordered::new();
 
-        let voter_progresses = if let Some(l) = &self.engine.state.internal_server_state.leading() {
+        let voter_progresses = if let Some(l) = &self.engine.internal_server_state.leading() {
             l.progress
                 .iter()
                 .filter(|(id, _v)| l.progress.is_voter(id) == Some(true))
@@ -399,7 +399,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         let curr = &self.engine.state.membership_state.effective;
         if curr.contains(&target) {
-            let matched = if let Some(l) = &self.engine.state.internal_server_state.leading() {
+            let matched = if let Some(l) = &self.engine.internal_server_state.leading() {
                 *l.progress.get(&target)
             } else {
                 unreachable!("it has to be a leader!!!");
@@ -538,7 +538,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                 Expectation::AtLineRate => {
                     // Expect to be at line rate but not.
 
-                    let matched = if let Some(l) = &self.engine.state.internal_server_state.leading() {
+                    let matched = if let Some(l) = &self.engine.internal_server_state.leading() {
                         *l.progress.get(node_id)
                     } else {
                         unreachable!("it has to be a leader!!!");

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -47,7 +47,7 @@ fn test_elect() -> anyhow::Result<()> {
         assert_eq!(Vote::new_committed(1, 1), eng.state.vote);
         assert_eq!(
             Some(btreeset! {1},),
-            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+            eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
         );
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
@@ -106,15 +106,15 @@ fn test_elect() -> anyhow::Result<()> {
 
         // Build in-progress election state
         eng.state.vote = Vote::new_committed(1, 2);
-        eng.state.new_leader();
-        eng.state.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
+        eng.new_leader();
+        eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
 
         eng.elect();
 
         assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
         assert_eq!(
             Some(btreeset! {1},),
-            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+            eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
         );
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
@@ -177,7 +177,7 @@ fn test_elect() -> anyhow::Result<()> {
         assert_eq!(Vote::new(1, 1), eng.state.vote);
         assert_eq!(
             Some(btreeset! {1},),
-            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+            eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
         );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -31,7 +31,7 @@ fn eng() -> Engine<u64, ()> {
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
-    eng.state.new_leader();
+    eng.new_leader();
     eng
 }
 
@@ -54,7 +54,7 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
     );
 
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_leading());
+    assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(
@@ -91,7 +91,7 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     );
 
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_leading());
+    assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(
@@ -129,7 +129,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     );
 
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_following());
+    assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
@@ -174,7 +174,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     );
 
     assert_eq!(Vote::new(3, 1), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_following());
+    assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -50,7 +50,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new(2, 1), eng.state.vote);
-        assert!(eng.state.internal_server_state.is_following());
+        assert!(eng.internal_server_state.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
         assert_eq!(
@@ -71,8 +71,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
-        eng.state.new_leader();
-        eng.state.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
+        eng.new_leader();
+        eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -84,7 +84,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(Vote::new(2, 1), eng.state.vote);
         assert_eq!(
             Some(btreeset! {1},),
-            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+            eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
         );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -110,8 +110,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.vote = Vote::new(2, 1);
         eng.state.log_ids = LogIdList::new(vec![log_id(3, 3)]);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
-        eng.state.new_leader();
-        eng.state.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
+        eng.new_leader();
+        eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -121,7 +121,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         });
 
         assert_eq!(Vote::new(2, 2), eng.state.vote);
-        assert!(eng.state.internal_server_state.is_leading());
+        assert!(eng.internal_server_state.is_leading());
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
         assert_eq!(
@@ -148,8 +148,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
-        eng.state.new_leader();
-        eng.state.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
+        eng.new_leader();
+        eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -161,7 +161,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(Vote::new(2, 1), eng.state.vote);
         assert_eq!(
             Some(btreeset! {1},),
-            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+            eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
         );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -186,8 +186,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234()));
-        eng.state.new_leader();
-        eng.state.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
+        eng.new_leader();
+        eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -199,7 +199,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(Vote::new(2, 1), eng.state.vote);
         assert_eq!(
             Some(btreeset! {1,2},),
-            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+            eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
         );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -221,8 +221,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
-        eng.state.new_leader();
-        eng.state.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
+        eng.new_leader();
+        eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
 
         eng.handle_vote_resp(2, VoteResponse {
@@ -234,7 +234,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
         assert_eq!(
             Some(btreeset! {1,2},),
-            eng.state.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
+            eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
         );
 
         assert_eq!(ServerState::Leader, eng.state.server_state);

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -30,7 +30,7 @@ fn eng() -> Engine<u64, ()> {
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
-    eng.state.new_leader();
+    eng.new_leader();
     eng
 }
 
@@ -43,7 +43,7 @@ fn test_handle_vote_change_reject_smaller_vote() -> anyhow::Result<()> {
     assert_eq!(Err(RejectVoteRequest::ByVote(Vote::new(2, 1))), resp);
 
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_leading());
+    assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(
@@ -70,7 +70,7 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new_committed(3, 2), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_following());
+    assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
@@ -108,7 +108,7 @@ fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new(2, 1), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_following());
+    assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
@@ -142,7 +142,7 @@ fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new(3, 1), eng.state.vote);
-    assert!(eng.state.internal_server_state.is_following());
+    assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -171,7 +171,7 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
 fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m1()));
-    eng.state.new_leader();
+    eng.new_leader();
 
     // log id will be assigned by eng.
     eng.leader_append_entries(&mut [
@@ -238,7 +238,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
 fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m1()));
-    eng.state.new_leader();
+    eng.new_leader();
 
     // log id will be assigned by eng.
     eng.leader_append_entries(&mut [
@@ -321,7 +321,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
 fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m1()));
-    eng.state.new_leader();
+    eng.new_leader();
     eng.state.server_state = eng.calc_server_state();
 
     // log id will be assigned by eng.
@@ -417,7 +417,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
 fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m13()));
-    eng.state.new_leader();
+    eng.new_leader();
     eng.state.server_state = eng.calc_server_state();
 
     // log id will be assigned by eng.

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -100,7 +100,7 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
     eng.state.server_state = ServerState::Leader;
     // Make it a real leader: voted for itself and vote is committed.
     eng.state.vote = Vote::new_committed(2, 2);
-    eng.state.new_leader();
+    eng.new_leader();
 
     eng.update_effective_membership(&log_id(3, 4), &m34());
 
@@ -141,7 +141,7 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
     );
 
     assert!(
-        eng.state.internal_server_state.leading().unwrap().progress.get(&4).matching.is_none(),
+        eng.internal_server_state.leading().unwrap().progress.get(&4).matching.is_none(),
         "exists, but it is a None"
     );
 
@@ -158,9 +158,9 @@ fn test_update_effective_membership_update_learner_process() -> anyhow::Result<(
     // Make it a real leader: voted for itself and vote is committed.
     eng.state.vote = Vote::new_committed(2, 2);
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23_45()));
-    eng.state.new_leader();
+    eng.new_leader();
 
-    if let Some(l) = &mut eng.state.internal_server_state.leading_mut() {
+    if let Some(l) = &mut eng.internal_server_state.leading_mut() {
         assert_eq!(&ProgressEntry::empty(0), l.progress.get(&4));
         assert_eq!(&ProgressEntry::empty(0), l.progress.get(&5));
 
@@ -189,7 +189,7 @@ fn test_update_effective_membership_update_learner_process() -> anyhow::Result<(
         eng.state.membership_state
     );
 
-    if let Some(l) = &mut eng.state.internal_server_state.leading_mut() {
+    if let Some(l) = &mut eng.internal_server_state.leading_mut() {
         assert_eq!(
             &ProgressEntry::new(Some(log_id(1, 4))),
             l.progress.get(&4),

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -55,7 +55,7 @@ fn test_update_progress_no_leader() -> anyhow::Result<()> {
 #[test]
 fn test_update_progress_update_leader_progress() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.new_leader();
+    eng.new_leader();
 
     // progress: None, None, (1,2)
     eng.update_progress(3, Some(log_id(1, 2)));

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -1,6 +1,4 @@
 use crate::engine::LogIdList;
-use crate::internal_server_state::InternalServerState;
-use crate::leader::Leader;
 use crate::node::Node;
 use crate::raft_types::RaftLogId;
 use crate::LogId;
@@ -71,9 +69,6 @@ where
     // --
     // -- volatile fields: they are not persisted.
     // --
-    /// The internal server state used by Engine.
-    pub(crate) internal_server_state: InternalServerState<NID>,
-
     pub server_state: ServerState,
 }
 
@@ -136,17 +131,6 @@ where
         } else {
             false
         }
-    }
-
-    /// Create a new Leader, when raft enters candidate state.
-    /// In openraft, Leader and Candidate shares the same state.
-    pub(crate) fn new_leader(&mut self) {
-        let em = &self.membership_state.effective;
-        self.internal_server_state = InternalServerState::Leading(Leader::new(
-            em.membership.to_quorum_set(),
-            em.learner_ids(),
-            self.last_log_id().index(),
-        ));
     }
 
     /// Return true if the currently effective membership is committed.

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::engine::LogIdList;
-use crate::internal_server_state::InternalServerState;
 use crate::EffectiveMembership;
 use crate::EntryPayload;
 use crate::LogId;
@@ -68,7 +67,6 @@ where
             snapshot_meta,
 
             // -- volatile fields: they are not persisted.
-            internal_server_state: InternalServerState::default(),
             server_state: Default::default(),
         })
     }


### PR DESCRIPTION

## Changelog

##### Refactor: move leading state out of RaftState

The leading state data is independent of following state data, i.e., a
traditional raft leader has leading state data(replication state,
progress etc) and following state data(logs, snapshot), and  a
traditional follower has only following state data, an leading state can
also exist without following state data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/635)
<!-- Reviewable:end -->
