### PR TITLE
Change: make Raft::new() async and let it return error during startup

### DIFF
--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -53,7 +53,7 @@ pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) 
     let network = ExampleNetwork {};
 
     // Create a local raft instance.
-    let raft = Raft::new(node_id, config.clone(), network, store.clone());
+    let raft = Raft::new(node_id, config.clone(), network, store.clone()).await.unwrap();
 
     // Create an application that will store all the instances created above, this will
     // be later used on the actix-web services.

--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -73,7 +73,7 @@ where
     let network = ExampleNetwork {};
 
     // Create a local raft instance.
-    let raft = Raft::new(node_id, config.clone(), network, store.clone());
+    let raft = Raft::new(node_id, config.clone(), network, store.clone()).await.unwrap();
 
     let app = Arc::new(ExampleApp {
         id: node_id,

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -39,7 +39,7 @@ fn test_elect() -> anyhow::Result<()> {
     tracing::info!("--- single node: become leader at once");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m1()));
 
         eng.elect();
@@ -101,7 +101,7 @@ fn test_elect() -> anyhow::Result<()> {
     tracing::info!("--- single node: electing again will override previous state");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m1()));
 
         // Build in-progress election state
@@ -168,7 +168,7 @@ fn test_elect() -> anyhow::Result<()> {
     tracing::info!("--- multi nodes: enter candidate state");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(0, 1)), m12()));
         eng.state.log_ids = LogIdList::new(vec![log_id(1, 1)]);
 

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -50,10 +50,8 @@ fn m45() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine {
-        id: 2, // make it a member
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 2;
     eng.state.log_ids.append(log_id(1, 1));
     eng.state.log_ids.append(log_id(2, 3));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
@@ -156,7 +154,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
     // - The membership entry in the input becomes effective membership. The previous effective becomes committed.
     // - Follower become Learner, since it is not in the new effective membership.
     let mut eng = eng();
-    eng.id = 2; // make it a member, the become learner
+    eng.config.id = 2; // make it a member, the become learner
 
     eng.follower_do_append_entries(
         &[
@@ -225,7 +223,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
     // - A learner become follower.
 
     let mut eng = eng();
-    eng.id = 5; // make it a learner, then become follower
+    eng.config.id = 5; // make it a learner, then become follower
     eng.state.server_state = eng.calc_server_state();
 
     eng.follower_do_append_entries(

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -49,10 +49,8 @@ fn m34() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine::<u64, ()> {
-        id: 2, // make it a member
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 2;
     eng.state.vote = Vote::new(2, 1);
     eng.state.log_ids.append(log_id(1, 1));
     eng.state.log_ids.append(log_id(2, 3));

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -205,7 +205,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         let st = ServerState::Learner;
 
         let mut eng = eng();
-        eng.id = 100; // make it a non-voter
+        eng.config.id = 100; // make it a non-voter
         eng.enter_following();
         eng.state.server_state = st;
         eng.commands = vec![];
@@ -230,7 +230,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         let st = ServerState::Follower;
 
         let mut eng = eng();
-        eng.id = 0; // make it a voter
+        eng.config.id = 0; // make it a voter
         eng.enter_following();
         eng.state.server_state = st;
         eng.commands = vec![];

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -68,7 +68,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     tracing::info!("--- recv a smaller vote. vote_granted==false always; keep trying in candidate state");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
         eng.new_leader();
@@ -106,7 +106,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     tracing::info!("--- seen a higher vote. keep trying in candidate state");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.log_ids = LogIdList::new(vec![log_id(3, 3)]);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
@@ -145,7 +145,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     tracing::info!("--- equal vote, rejected by higher last_log_id. keep trying in candidate state");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
         eng.new_leader();
@@ -183,7 +183,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     tracing::info!("--- equal vote, granted, but not constitute a quorum. nothing to do");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234()));
         eng.new_leader();
@@ -218,7 +218,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     tracing::info!("--- equal vote, granted, constitute a quorum. become leader");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
         eng.new_leader();

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -46,7 +46,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
     tracing::info!("--- expect OK result, check output commands and state changes");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
 
         eng.initialize(&mut entries)?;
 
@@ -148,7 +148,7 @@ fn test_initialize() -> anyhow::Result<()> {
     tracing::info!("--- expect OK result, check output commands and state changes");
     {
         let mut eng = eng();
-        eng.id = 1;
+        eng.config.id = 1;
 
         eng.initialize(&mut entries)?;
 

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -173,7 +173,7 @@ fn test_handle_vote_change_granted_follower_learner_does_not_emit_update_server_
         let st = ServerState::Learner;
 
         let mut eng = eng();
-        eng.id = 100; // make it a non-voter
+        eng.config.id = 100; // make it a non-voter
         eng.enter_following();
         eng.state.server_state = st;
         eng.commands = vec![];
@@ -197,7 +197,7 @@ fn test_handle_vote_change_granted_follower_learner_does_not_emit_update_server_
         let st = ServerState::Follower;
 
         let mut eng = eng();
-        eng.id = 0; // make it a voter
+        eng.config.id = 0; // make it a voter
         eng.enter_following();
         eng.state.server_state = st;
         eng.commands = vec![];

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -63,10 +63,8 @@ fn m34() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine::<u64, ()> {
-        id: 1, // make it a member
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 1;
     eng.state.committed = Some(log_id(0, 0));
     eng.state.vote = Vote::new_committed(3, 1);
     eng.state.log_ids.append(log_id(1, 1));

--- a/openraft/src/engine/startup_test.rs
+++ b/openraft/src/engine/startup_test.rs
@@ -26,10 +26,8 @@ fn m34() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine::<u64, ()> {
-        id: 2, // make it a member
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 2;
     // This will be overrided
     eng.state.server_state = ServerState::Leader;
     eng

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -34,10 +34,8 @@ fn m23() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine::<u64, ()> {
-        id: 2,
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 2;
     eng.state.log_ids = LogIdList::new(vec![
         log_id(2, 2), //
         log_id(4, 4),

--- a/openraft/src/engine/update_committed_membership_test.rs
+++ b/openraft/src/engine/update_committed_membership_test.rs
@@ -36,10 +36,8 @@ fn m34() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine::<u64, ()> {
-        id: 2, // make it a member
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 2;
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
     eng.state.server_state = eng.calc_server_state();

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -47,10 +47,8 @@ fn m4_356() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine::<u64, ()> {
-        id: 2, // make it a member
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 2;
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));
     eng.state.server_state = eng.calc_server_state();

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -26,10 +26,8 @@ fn m123() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    let mut eng = Engine::<u64, ()> {
-        id: 2, // make it a member
-        ..Default::default()
-    };
+    let mut eng = Engine::default();
+    eng.config.id = 2;
     eng.state.vote = Vote::new_committed(2, 1);
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m123()));

--- a/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/openraft/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -46,7 +46,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     // Expect conflict even if the message contains no entries.
 

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -32,7 +32,7 @@ async fn append_conflicts() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     tracing::info!("--- wait for init node to ready");
 

--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -43,7 +43,7 @@ async fn append_inconsistent_log() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
 
@@ -88,14 +88,14 @@ async fn append_inconsistent_log() -> Result<()> {
 
     tracing::info!("--- restart node 1 and isolate. To let node-2 to become leader, node-1 should not vote for node-0");
     {
-        router.new_raft_node_with_sto(1, sto1.clone());
+        router.new_raft_node_with_sto(1, sto1.clone()).await;
         router.isolate_node(1);
     }
 
     tracing::info!("--- restart node 0 and 2");
     {
-        router.new_raft_node_with_sto(0, sto0.clone());
-        router.new_raft_node_with_sto(2, sto2.clone());
+        router.new_raft_node_with_sto(0, sto0.clone()).await;
+        router.new_raft_node_with_sto(2, sto2.clone()).await;
     }
 
     // leader appends at least one blank log. There may be more than one transient leaders

--- a/openraft/tests/append_entries/t40_append_updates_membership.rs
+++ b/openraft/tests/append_entries/t40_append_updates_membership.rs
@@ -33,7 +33,7 @@ async fn append_updates_membership() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     tracing::info!("--- wait for init node to ready");
 

--- a/openraft/tests/client_api/t20_client_reads.rs
+++ b/openraft/tests/client_api/t20_client_reads.rs
@@ -29,9 +29,9 @@ async fn client_reads() -> Result<()> {
     // This test is sensitive to network delay.
     router.network_send_delay(0);
 
-    router.new_raft_node(0);
-    router.new_raft_node(1);
-    router.new_raft_node(2);
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
+    router.new_raft_node(2).await;
 
     let mut log_index = 0;
 

--- a/openraft/tests/client_api/t50_lagging_network_write.rs
+++ b/openraft/tests/client_api/t50_lagging_network_write.rs
@@ -31,7 +31,7 @@ async fn lagging_network_write() -> Result<()> {
     );
     let mut router = RaftRouter::builder(config).send_delay(50).build();
 
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
@@ -49,11 +49,11 @@ async fn lagging_network_write() -> Result<()> {
     router.assert_stable_cluster(Some(1), Some(log_index));
 
     // Sync some new nodes.
-    router.new_raft_node(1);
+    router.new_raft_node(1).await;
     router.add_learner(0, 1).await?;
     log_index += 1;
 
-    router.new_raft_node(2);
+    router.new_raft_node(2).await;
     router.add_learner(0, 2).await?;
     log_index += 1;
 

--- a/openraft/tests/elect/t10_elect_compare_last_log.rs
+++ b/openraft/tests/elect/t10_elect_compare_last_log.rs
@@ -79,8 +79,8 @@ async fn elect_compare_last_log() -> Result<()> {
 
     tracing::info!("--- bring up cluster and elect");
 
-    router.new_raft_node_with_sto(0, sto0.clone());
-    router.new_raft_node_with_sto(1, sto1.clone());
+    router.new_raft_node_with_sto(0, sto0.clone()).await;
+    router.new_raft_node_with_sto(1, sto1.clone()).await;
 
     router.wait(&0, timeout()).state(ServerState::Leader, "only node 0 becomes leader").await?;
 

--- a/openraft/tests/life_cycle/t20_initialization.rs
+++ b/openraft/tests/life_cycle/t20_initialization.rs
@@ -43,9 +43,9 @@ async fn initialization() -> anyhow::Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
-    router.new_raft_node(1);
-    router.new_raft_node(2);
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
+    router.new_raft_node(2).await;
 
     let mut log_index = 0;
 
@@ -166,8 +166,8 @@ async fn initialize_err_target_not_include_target() -> anyhow::Result<()> {
 
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
-    router.new_raft_node(1);
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
 
     for node in [0, 1] {
         router.external_request(node, |s, _sto, _net| {
@@ -201,7 +201,7 @@ async fn initialize_err_not_allowed() -> anyhow::Result<()> {
 
     let config = Arc::new(Config::default().validate()?);
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     for node in [0] {
         router.external_request(node, |s, _sto, _net| {

--- a/openraft/tests/life_cycle/t30_connect_error.rs
+++ b/openraft/tests/life_cycle/t30_connect_error.rs
@@ -30,7 +30,7 @@ async fn network_connection_error() -> anyhow::Result<()> {
 
     tracing::info!("--- failure to add unreachable learner to cluster");
     {
-        router.new_raft_node(3);
+        router.new_raft_node(3).await;
         router.set_connectable(3, false);
 
         let res = router.add_learner(0, 3).await;

--- a/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
+++ b/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
@@ -38,7 +38,7 @@ async fn single_restart() -> anyhow::Result<()> {
         let (node, sto) = router.remove_node(0).unwrap();
         node.shutdown().await?;
 
-        router.new_raft_node_with_sto(0, sto);
+        router.new_raft_node_with_sto(0, sto).await;
         // leader appends a blank log.
         log_index += 1;
 

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -46,7 +46,7 @@ async fn compaction() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index = 0;
 
@@ -100,7 +100,7 @@ async fn compaction() -> Result<()> {
     }])
     .await?;
 
-    router.new_raft_node_with_sto(1, sto1.clone());
+    router.new_raft_node_with_sto(1, sto1.clone()).await;
     router.add_learner(0, 1).await.expect("failed to add new node as learner");
     log_index += 1; // add_learner log
 

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -48,7 +48,7 @@ async fn learner_restart() -> Result<()> {
     node1.shutdown().await?;
 
     // restart node-1, assert the state as expected.
-    let restarted = Raft::new(1, config.clone(), router.clone(), sto1);
+    let restarted = Raft::new(1, config.clone(), router.clone(), sto1).await?;
     restarted.wait(timeout()).log(Some(log_index), "log after restart").await?;
     restarted.wait(timeout()).state(ServerState::Learner, "server state after restart").await?;
 

--- a/openraft/tests/membership/t01_single_node.rs
+++ b/openraft/tests/membership/t01_single_node.rs
@@ -31,7 +31,7 @@ async fn single_node() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index = 0;
 

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -51,7 +51,7 @@ async fn add_learner_basic() -> Result<()> {
             router.wait_for_log(&btreeset! {0}, Some(log_index), timeout(), "write 1000 logs to leader").await?;
         }
 
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         router.add_learner(0, 1).await?;
         log_index += 1;
 
@@ -108,7 +108,7 @@ async fn add_learner_non_blocking() -> Result<()> {
 
         router.wait(&0, timeout()).log(Some(log_index), "received 100 logs").await?;
 
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         let raft = router.get_raft_handle(&0)?;
         let res = raft.add_learner(1, (), false).await?;
 
@@ -141,8 +141,8 @@ async fn check_learner_after_leader_transferred() -> Result<()> {
     let orig_leader_id = router.leader().expect("expected the cluster to have a leader");
     assert_eq!(0, orig_leader_id, "expected original leader to be node 0");
 
-    router.new_raft_node(3);
-    router.new_raft_node(4);
+    router.new_raft_node(3).await;
+    router.new_raft_node(4).await;
     router.add_learner(orig_leader_id, 3).await?;
     router.add_learner(orig_leader_id, 4).await?;
     log_index += 2;

--- a/openraft/tests/membership/t12_concurrent_write_and_add_learner.rs
+++ b/openraft/tests/membership/t12_concurrent_write_and_add_learner.rs
@@ -49,7 +49,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index;
 
@@ -64,8 +64,8 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     tracing::info!("--- adding two candidate nodes");
     {
         // Sync some new nodes.
-        router.new_raft_node(1);
-        router.new_raft_node(2);
+        router.new_raft_node(1).await;
+        router.new_raft_node(2).await;
         router.add_learner(0, 1).await?;
         router.add_learner(0, 2).await?;
         log_index += 2; // two add_learner logs
@@ -93,7 +93,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     // Concurrently add Learner and write another log.
     tracing::info!("--- concurrently add learner and write another log");
     {
-        router.new_raft_node(3);
+        router.new_raft_node(3).await;
         let r = router.clone();
 
         let handle = {

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -131,7 +131,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: ChangeMembers<
     tracing::info!("--- change to {:?}", new);
     {
         for id in only_in_new {
-            router.new_raft_node(*id);
+            router.new_raft_node(*id).await;
             router.add_learner(0, *id).await?;
             log_index += 1;
             router.wait_for_log(&old, Some(log_index), timeout(), &format!("add learner, {}", mes)).await?;
@@ -275,7 +275,7 @@ async fn change_by_add(old: BTreeSet<MemNodeId>, add: &[MemNodeId]) -> anyhow::R
     tracing::info!("--- add learner before change-membership");
     {
         for id in only_in_new {
-            router.new_raft_node(*id);
+            router.new_raft_node(*id).await;
             router.add_learner(0, *id).await?;
             log_index += 1;
             router.wait(id, timeout()).log(Some(log_index), format!("add learner, {}", mes)).await?;

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -77,7 +77,7 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
 
     tracing::info!("--- change membership without adding-learner");
     {
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         router.add_learner(0, 1).await?;
         log_index += 1;
         router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "add learner").await?;
@@ -107,7 +107,7 @@ async fn change_without_adding_learner() -> anyhow::Result<()> {
     let log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
     router.wait(&0, timeout()).log(Some(log_index), "received 100 logs").await?;
 
-    router.new_raft_node(1);
+    router.new_raft_node(1).await;
     let leader = router.get_raft_handle(&0)?;
 
     tracing::info!("--- change membership without adding-learner, allow_lagging=true");

--- a/openraft/tests/membership/t30_commit_joint_config.rs
+++ b/openraft/tests/membership/t30_commit_joint_config.rs
@@ -28,7 +28,7 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     // router.assert_pristine_cluster().await;
 
@@ -41,8 +41,8 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
     router.wait_for_log(&btreeset![0], Some(log_index), None, "init node 0").await?;
 
     // Sync some new nodes.
-    router.new_raft_node(1);
-    router.new_raft_node(2);
+    router.new_raft_node(1).await;
+    router.new_raft_node(2).await;
 
     tracing::info!("--- adding new nodes to cluster");
     let mut new_nodes = futures::stream::FuturesUnordered::new();
@@ -102,7 +102,7 @@ async fn commit_joint_config_during_012_to_234() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 

--- a/openraft/tests/membership/t40_removed_follower.rs
+++ b/openraft/tests/membership/t40_removed_follower.rs
@@ -20,14 +20,14 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- add node 3,4");
 
-    router.new_raft_node(3);
-    router.new_raft_node(4);
+    router.new_raft_node(3).await;
+    router.new_raft_node(4).await;
 
     router.add_learner(0, 3).await?;
     router.add_learner(0, 4).await?;

--- a/openraft/tests/membership/t45_remove_unreachable_follower.rs
+++ b/openraft/tests/membership/t45_remove_unreachable_follower.rs
@@ -21,7 +21,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
     );
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 

--- a/openraft/tests/membership/t99_issue_471_adding_learner_uses_uninit_leader_id.rs
+++ b/openraft/tests/membership/t99_issue_471_adding_learner_uses_uninit_leader_id.rs
@@ -38,7 +38,7 @@ async fn adding_learner_do_not_use_matched_leader_id() -> Result<()> {
 
     tracing::info!("--- add learner: node-1");
     {
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         router.add_learner(0, 1).await?;
     }
 

--- a/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -56,8 +56,8 @@ async fn new_leader_auto_commit_uniform_config() -> Result<()> {
     let _ = log_index;
 
     // To let tne router not panic
-    router.new_raft_node(1);
-    router.new_raft_node(2);
+    router.new_raft_node(1).await;
+    router.new_raft_node(2).await;
 
     let node = Raft::new(0, config.clone(), router.clone(), sto.clone());
 

--- a/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/openraft/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -31,8 +31,8 @@ async fn metrics_state_machine_consistency() -> Result<()> {
 
     let mut log_index = 0;
 
-    router.new_raft_node(0);
-    router.new_raft_node(1);
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
 
     tracing::info!("--- initializing single node cluster");
     {

--- a/openraft/tests/metrics/t30_leader_metrics.rs
+++ b/openraft/tests/metrics/t30_leader_metrics.rs
@@ -41,7 +41,7 @@ async fn leader_metrics() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     // Assert all nodes are in learner state & have no entries.
     let mut log_index = 0;
@@ -75,10 +75,10 @@ async fn leader_metrics() -> Result<()> {
         .await?;
 
     // Sync some new nodes.
-    router.new_raft_node(1);
-    router.new_raft_node(2);
-    router.new_raft_node(3);
-    router.new_raft_node(4);
+    router.new_raft_node(1).await;
+    router.new_raft_node(2).await;
+    router.new_raft_node(3).await;
+    router.new_raft_node(4).await;
 
     tracing::info!("--- adding 4 new nodes to cluster");
 

--- a/openraft/tests/metrics/t40_metrics_wait.rs
+++ b/openraft/tests/metrics/t40_metrics_wait.rs
@@ -30,7 +30,7 @@ async fn metrics_wait() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     let cluster = btreeset![0];
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
     {
         let n0 = router.get_raft_handle(&0)?;
         n0.initialize(cluster.clone()).await?;

--- a/openraft/tests/snapshot/t20_api_install_snapshot.rs
+++ b/openraft/tests/snapshot/t20_api_install_snapshot.rs
@@ -36,7 +36,7 @@ async fn snapshot_arguments() -> Result<()> {
 
     tracing::info!("--- initializing cluster");
     {
-        router.new_raft_node(0);
+        router.new_raft_node(0).await;
 
         router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
         router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;

--- a/openraft/tests/snapshot/t23_snapshot_chunk_size.rs
+++ b/openraft/tests/snapshot/t23_snapshot_chunk_size.rs
@@ -38,7 +38,7 @@ async fn snapshot_chunk_size() -> Result<()> {
 
     tracing::info!("--- initializing cluster");
     {
-        router.new_raft_node(0);
+        router.new_raft_node(0).await;
 
         router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
         router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
@@ -85,7 +85,7 @@ async fn snapshot_chunk_size() -> Result<()> {
 
     tracing::info!("--- add learner to receive snapshot and logs");
     {
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
         log_index += 1;
 

--- a/openraft/tests/snapshot/t24_snapshot_when_lacking_log.rs
+++ b/openraft/tests/snapshot/t24_snapshot_when_lacking_log.rs
@@ -69,7 +69,7 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
 
     tracing::info!("--- add learner to receive snapshot and logs");
     {
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
         log_index += 1;
 

--- a/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
+++ b/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
@@ -68,7 +68,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
 
     tracing::info!("--- add learner to the cluster to receive snapshot, which overrides the learner storage");
     {
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
         log_index += 1;
 

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -84,7 +84,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
     tracing::info!("--- create learner");
     {
         tracing::info!("--- create learner");
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
         let mut sto = router.get_storage_handle(&1)?;
 
         tracing::info!("--- add a membership config log to the learner");

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -66,7 +66,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
         .await?;
         log_index = 1;
 
-        router.new_raft_node_with_sto(0, sto0);
+        router.new_raft_node_with_sto(0, sto0).await;
 
         router.wait(&0, timeout()).state(ServerState::Leader, "init node-0 server-state").await?;
         router.wait(&0, timeout()).log(Some(log_index), "init node-0 log").await?;
@@ -86,7 +86,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
 
     tracing::info!("--- create node-1 and add conflicting logs");
     {
-        router.new_raft_node(1);
+        router.new_raft_node(1).await;
 
         let req = AppendEntriesRequest {
             vote: Vote::new_committed(1, 0),

--- a/openraft/tests/state_machine/t10_total_order_apply.rs
+++ b/openraft/tests/state_machine/t10_total_order_apply.rs
@@ -26,8 +26,8 @@ async fn total_order_apply() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0);
-    router.new_raft_node(1);
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
 
     tracing::info!("--- initializing single node cluster");
     {

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -35,7 +35,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0);
+    router.new_raft_node(0).await;
 
     let mut log_index = 0;
 
@@ -64,10 +64,10 @@ async fn state_machine_apply_membership() -> Result<()> {
     }
 
     // Sync some new nodes.
-    router.new_raft_node(1);
-    router.new_raft_node(2);
-    router.new_raft_node(3);
-    router.new_raft_node(4);
+    router.new_raft_node(1).await;
+    router.new_raft_node(2).await;
+    router.new_raft_node(3).await;
+    router.new_raft_node(4).await;
 
     tracing::info!("--- adding new nodes to cluster");
     let mut new_nodes = futures::stream::FuturesUnordered::new();


### PR DESCRIPTION

## Changelog

##### Change: make Raft::new() async and let it return error during startup

- Change: move startup process from `RaftCore::do_main()` to `Raft::new()`, so
  that an error during startup can be returned earlier.

  Upgrade guide: application has to consume the returned future with
  `Raft::new().await`, and the error returned by the future.

- Refactor: move id from `Engine.id` to `Engine.config.id`, so that accessing
  constant attribute does not depend on a reference to `Engine`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/636)
<!-- Reviewable:end -->
