### PR TITLE
Refactor: move Engine output entries to Engine.output

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -57,7 +57,7 @@ fn test_elect() -> anyhow::Result<()> {
                 local_data: true,
                 cluster: true,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
         assert_eq!(
@@ -94,7 +94,7 @@ fn test_elect() -> anyhow::Result<()> {
                     },),
                 },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
 
@@ -124,7 +124,7 @@ fn test_elect() -> anyhow::Result<()> {
                 local_data: true,
                 cluster: true,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
         assert_eq!(
@@ -161,7 +161,7 @@ fn test_elect() -> anyhow::Result<()> {
                     },),
                 },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
 
@@ -187,7 +187,7 @@ fn test_elect() -> anyhow::Result<()> {
                 local_data: true,
                 cluster: false,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
         assert_eq!(
@@ -198,7 +198,7 @@ fn test_elect() -> anyhow::Result<()> {
                 },
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
     Ok(())

--- a/openraft/src/engine/follower_commit_entries_test.rs
+++ b/openraft/src/engine/follower_commit_entries_test.rs
@@ -68,10 +68,10 @@ fn test_follower_commit_entries_empty() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -97,10 +97,10 @@ fn test_follower_commit_entries_no_update() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -126,7 +126,7 @@ fn test_follower_commit_entries_lt_last_entry() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -134,7 +134,7 @@ fn test_follower_commit_entries_lt_last_entry() -> anyhow::Result<()> {
             already_committed: Some(log_id(1, 1)),
             upto: log_id(2, 3)
         }],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -161,7 +161,7 @@ fn test_follower_commit_entries_gt_last_entry() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -169,7 +169,7 @@ fn test_follower_commit_entries_gt_last_entry() -> anyhow::Result<()> {
             already_committed: Some(log_id(1, 1)),
             upto: log_id(2, 3)
         }],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -91,10 +91,10 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -135,7 +135,7 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -143,7 +143,7 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
             Command::AppendInputEntries { range: 1..2 },
             Command::MoveInputCursorBy { n: 2 }
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -200,7 +200,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -211,7 +211,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
             },
             Command::MoveInputCursorBy { n: 5 }
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -280,7 +280,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -291,7 +291,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
             },
             Command::MoveInputCursorBy { n: 5 }
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -93,10 +93,10 @@ fn test_handle_append_entries_req_vote_is_rejected() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -141,7 +141,7 @@ fn test_handle_append_entries_req_prev_log_id_is_applied() -> anyhow::Result<()>
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -151,7 +151,7 @@ fn test_handle_append_entries_req_prev_log_id_is_applied() -> anyhow::Result<()>
             },
             Command::InstallElectionTimer { can_be_leader: false },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -193,7 +193,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -207,7 +207,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -250,7 +250,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -270,7 +270,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
                 upto: log_id(1, 1)
             },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -315,7 +315,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -325,7 +325,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
             },
             Command::InstallElectionTimer { can_be_leader: false },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -376,7 +376,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -399,7 +399,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
                 upto: log_id(3, 3)
             },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -63,10 +63,10 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -100,10 +100,10 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
     Ok(())
 }
 
@@ -138,7 +138,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -146,7 +146,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
             //
             Command::InstallElectionTimer { can_be_leader: true },
         ],
-        eng.commands
+        eng.output.commands
     );
     Ok(())
 }
@@ -183,7 +183,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -191,7 +191,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::InstallElectionTimer { can_be_leader: true },
         ],
-        eng.commands
+        eng.output.commands
     );
     Ok(())
 }
@@ -208,7 +208,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         eng.config.id = 100; // make it a non-voter
         eng.enter_following();
         eng.state.server_state = st;
-        eng.commands = vec![];
+        eng.output.commands = vec![];
 
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
@@ -222,7 +222,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
     // Follower
@@ -233,7 +233,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         eng.config.id = 0; // make it a voter
         eng.enter_following();
         eng.state.server_state = st;
-        eng.commands = vec![];
+        eng.output.commands = vec![];
 
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
@@ -247,7 +247,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
     Ok(())

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -59,10 +59,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 local_data: false,
                 cluster: false,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
-        assert_eq!(0, eng.commands.len());
+        assert_eq!(0, eng.output.commands.len());
     }
 
     tracing::info!("--- recv a smaller vote. vote_granted==false always; keep trying in candidate state");
@@ -94,12 +94,12 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 local_data: false,
                 cluster: false,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
         assert_eq!(
             vec![Command::InstallElectionTimer { can_be_leader: false },],
-            eng.commands
+            eng.output.commands
         );
     }
 
@@ -130,7 +130,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 local_data: true,
                 cluster: false,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
         assert_eq!(
@@ -138,7 +138,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 Command::SaveVote { vote: Vote::new(2, 2) },
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
 
@@ -171,12 +171,12 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 local_data: false,
                 cluster: false,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
         assert_eq!(
             vec![Command::InstallElectionTimer { can_be_leader: false },],
-            eng.commands
+            eng.output.commands
         );
     }
 
@@ -209,10 +209,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 local_data: false,
                 cluster: false,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
-        assert_eq!(0, eng.commands.len());
+        assert_eq!(0, eng.output.commands.len());
     }
 
     tracing::info!("--- equal vote, granted, constitute a quorum. become leader");
@@ -244,7 +244,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 local_data: true,
                 cluster: true,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
 
         assert_eq!(
@@ -269,7 +269,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                     },),
                 },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
 

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -63,7 +63,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                 local_data: true,
                 cluster: true,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
         assert_eq!(m1(), eng.state.membership_state.effective.membership);
 
@@ -120,7 +120,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                     },),
                 }
             ],
-            eng.commands
+            eng.output.commands
         );
     }
     Ok(())
@@ -163,7 +163,7 @@ fn test_initialize() -> anyhow::Result<()> {
                 local_data: true,
                 cluster: true,
             },
-            eng.metrics_flags
+            eng.output.metrics_flags
         );
         assert_eq!(m12(), eng.state.membership_state.effective.membership);
 
@@ -198,7 +198,7 @@ fn test_initialize() -> anyhow::Result<()> {
                 },
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
 

--- a/openraft/src/engine/install_snapshot_test.rs
+++ b/openraft/src/engine/install_snapshot_test.rs
@@ -75,7 +75,7 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -86,7 +86,7 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
                 snapshot_id: "1-2-3-4".to_string(),
             }
         }],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -120,7 +120,7 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -131,7 +131,7 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
                 snapshot_id: "1-2-3-4".to_string(),
             }
         }],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -169,7 +169,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -187,7 +187,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
             },
             Command::PurgeLog { upto: log_id(4, 6) },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -247,7 +247,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -266,7 +266,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
             },
             Command::PurgeLog { upto: log_id(5, 6) },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -308,7 +308,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -326,7 +326,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
             },
             Command::PurgeLog { upto: log_id(100, 100) },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -52,10 +52,10 @@ fn test_handle_vote_change_reject_smaller_vote() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -79,7 +79,7 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -90,7 +90,7 @@ fn test_handle_vote_change_committed_vote() -> anyhow::Result<()> {
             },
             Command::InstallElectionTimer { can_be_leader: false },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -117,7 +117,7 @@ fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -125,7 +125,7 @@ fn test_handle_vote_change_granted_equal_vote() -> anyhow::Result<()> {
             //
             Command::InstallElectionTimer { can_be_leader: true },
         ],
-        eng.commands
+        eng.output.commands
     );
     Ok(())
 }
@@ -151,7 +151,7 @@ fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -159,7 +159,7 @@ fn test_handle_vote_change_granted_greater_vote() -> anyhow::Result<()> {
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::InstallElectionTimer { can_be_leader: true },
         ],
-        eng.commands
+        eng.output.commands
     );
     Ok(())
 }
@@ -176,7 +176,7 @@ fn test_handle_vote_change_granted_follower_learner_does_not_emit_update_server_
         eng.config.id = 100; // make it a non-voter
         eng.enter_following();
         eng.state.server_state = st;
-        eng.commands = vec![];
+        eng.output.commands = vec![];
 
         let resp = eng.handle_vote_change(&Vote::new(3, 1));
 
@@ -189,7 +189,7 @@ fn test_handle_vote_change_granted_follower_learner_does_not_emit_update_server_
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
     // Follower
@@ -200,7 +200,7 @@ fn test_handle_vote_change_granted_follower_learner_does_not_emit_update_server_
         eng.config.id = 0; // make it a voter
         eng.enter_following();
         eng.state.server_state = st;
-        eng.commands = vec![];
+        eng.output.commands = vec![];
 
         let resp = eng.handle_vote_change(&Vote::new(3, 1));
 
@@ -213,7 +213,7 @@ fn test_handle_vote_change_granted_follower_learner_does_not_emit_update_server_
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::InstallElectionTimer { can_be_leader: true },
             ],
-            eng.commands
+            eng.output.commands
         );
     }
     Ok(())

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -102,10 +102,10 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -148,7 +148,7 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -159,7 +159,7 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
             },
             Command::MoveInputCursorBy { n: 3 },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -206,7 +206,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -224,7 +224,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
             },
             Command::MoveInputCursorBy { n: 3 },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -281,7 +281,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -308,7 +308,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
             },
             Command::MoveInputCursorBy { n: 3 },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -366,7 +366,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -402,7 +402,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
             },
             Command::MoveInputCursorBy { n: 3 },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -462,7 +462,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -490,7 +490,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
             },
             Command::MoveInputCursorBy { n: 3 },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/purge_log_test.rs
+++ b/openraft/src/engine/purge_log_test.rs
@@ -28,7 +28,7 @@ fn test_purge_log_already_purged() -> anyhow::Result<()> {
     assert_eq!(log_id(2, 2), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -43,7 +43,7 @@ fn test_purge_log_equal_prev_last_purged() -> anyhow::Result<()> {
     assert_eq!(log_id(2, 2), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -57,7 +57,7 @@ fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
     assert_eq!(log_id(2, 3), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(2, 3) }], eng.commands);
+    assert_eq!(vec![Command::PurgeLog { upto: log_id(2, 3) }], eng.output.commands);
 
     Ok(())
 }
@@ -72,7 +72,7 @@ fn test_purge_log_to_last_key_log() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 4), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 4) }], eng.commands);
+    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 4) }], eng.output.commands);
 
     Ok(())
 }
@@ -87,7 +87,7 @@ fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 5), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 5) }], eng.commands);
+    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 5) }], eng.output.commands);
 
     Ok(())
 }
@@ -102,7 +102,7 @@ fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 6), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(4, 6)), eng.state.last_log_id().copied());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 6) }], eng.commands);
+    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 6) }], eng.output.commands);
 
     Ok(())
 }
@@ -117,7 +117,7 @@ fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 7), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(4, 7)), eng.state.last_log_id().copied());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 7) }], eng.commands);
+    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 7) }], eng.output.commands);
 
     Ok(())
 }
@@ -132,7 +132,7 @@ fn test_purge_log_to_higher_leader_lgo() -> anyhow::Result<()> {
     assert_eq!(log_id(5, 7), eng.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(log_id(5, 7)), eng.state.last_log_id().copied());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(5, 7) }], eng.commands);
+    assert_eq!(vec![Command::PurgeLog { upto: log_id(5, 7) }], eng.output.commands);
 
     Ok(())
 }

--- a/openraft/src/engine/startup_test.rs
+++ b/openraft/src/engine/startup_test.rs
@@ -49,10 +49,10 @@ fn test_startup_as_follower() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -73,10 +73,10 @@ fn test_startup_as_learner() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -62,7 +62,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
     assert_eq!(
         MembershipState {
@@ -81,7 +81,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -101,7 +101,7 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
     assert_eq!(
         MembershipState {
@@ -112,7 +112,10 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
     );
     assert_eq!(ServerState::Follower, eng.state.server_state);
 
-    assert_eq!(vec![Command::DeleteConflictLog { since: log_id(4, 4) }], eng.commands);
+    assert_eq!(
+        vec![Command::DeleteConflictLog { since: log_id(4, 4) }],
+        eng.output.commands
+    );
 
     Ok(())
 }
@@ -131,10 +134,13 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(vec![Command::DeleteConflictLog { since: log_id(4, 5) }], eng.commands);
+    assert_eq!(
+        vec![Command::DeleteConflictLog { since: log_id(4, 5) }],
+        eng.output.commands
+    );
 
     Ok(())
 }
@@ -156,10 +162,13 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(vec![Command::DeleteConflictLog { since: log_id(4, 6) }], eng.commands);
+    assert_eq!(
+        vec![Command::DeleteConflictLog { since: log_id(4, 6) }],
+        eng.output.commands
+    );
 
     Ok(())
 }
@@ -181,10 +190,10 @@ fn test_truncate_logs_since_7() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert!(eng.commands.is_empty());
+    assert!(eng.output.commands.is_empty());
 
     Ok(())
 }
@@ -206,10 +215,10 @@ fn test_truncate_logs_since_8() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert!(eng.commands.is_empty());
+    assert!(eng.output.commands.is_empty());
 
     Ok(())
 }
@@ -233,7 +242,7 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
             local_data: true,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -244,7 +253,7 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m01()))
             },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/update_committed_membership_test.rs
+++ b/openraft/src/engine/update_committed_membership_test.rs
@@ -65,10 +65,10 @@ fn test_update_committed_membership_at_index_0() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -94,10 +94,10 @@ fn test_update_committed_membership_at_index_2() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -124,14 +124,14 @@ fn test_update_committed_membership_at_index_3() -> anyhow::Result<()> {
             local_data: false,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
         vec![Command::UpdateMembership {
             membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 3)), m34())),
         },],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -159,14 +159,14 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
             local_data: false,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
         vec![Command::UpdateMembership {
             membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
         },],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/update_effective_membership_test.rs
+++ b/openraft/src/engine/update_effective_membership_test.rs
@@ -76,7 +76,7 @@ fn test_update_effective_membership_at_index_0_is_allowed() -> anyhow::Result<()
             local_data: false,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -86,7 +86,7 @@ fn test_update_effective_membership_at_index_0_is_allowed() -> anyhow::Result<()
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(0, 0)), m34())),
             },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())
@@ -121,7 +121,7 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
             local_data: false,
             cluster: true,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
     assert_eq!(
@@ -135,7 +135,7 @@ fn test_update_effective_membership_for_leader() -> anyhow::Result<()> {
                                                                                             * won't be removed */
             }
         ],
-        eng.commands
+        eng.output.commands
     );
 
     assert!(

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -45,7 +45,7 @@ fn test_update_progress_no_leader() -> anyhow::Result<()> {
 
     assert_eq!(eng0, eng, "nothing changed");
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -66,17 +66,17 @@ fn test_update_progress_update_leader_progress() -> anyhow::Result<()> {
                 matching: log_id(1, 2),
             },
         ],
-        eng.commands
+        eng.output.commands
     );
 
     // progress: None, (2,1), (1,2); quorum-ed: (1,2), not at leader vote, not committed
-    eng.commands = vec![];
+    eng.output.commands = vec![];
     eng.update_progress(2, Some(log_id(2, 1)));
     assert_eq!(None, eng.state.committed);
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     // progress: None, (2,1), (2,3); committed: (2,1)
-    eng.commands = vec![];
+    eng.output.commands = vec![];
     eng.update_progress(3, Some(log_id(2, 3)));
     assert_eq!(Some(log_id(2, 1)), eng.state.committed);
     assert_eq!(
@@ -93,10 +93,10 @@ fn test_update_progress_update_leader_progress() -> anyhow::Result<()> {
                 upto: log_id(2, 1)
             }
         ],
-        eng.commands
+        eng.output.commands
     );
 
-    eng.commands = vec![];
+    eng.output.commands = vec![];
     // progress: (2,4), (2,1), (2,3); committed: (1,3)
     eng.update_progress(1, Some(log_id(2, 4)));
     assert_eq!(Some(log_id(2, 3)), eng.state.committed);
@@ -114,7 +114,7 @@ fn test_update_progress_update_leader_progress() -> anyhow::Result<()> {
                 upto: log_id(2, 3)
             }
         ],
-        eng.commands
+        eng.output.commands
     );
 
     Ok(())

--- a/openraft/src/engine/update_snapshot_test.rs
+++ b/openraft/src/engine/update_snapshot_test.rs
@@ -63,10 +63,10 @@ fn test_update_snapshot_no_update() -> anyhow::Result<()> {
             local_data: false,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }
@@ -99,10 +99,10 @@ fn test_update_snapshot_updated() -> anyhow::Result<()> {
             local_data: true,
             cluster: false,
         },
-        eng.metrics_flags
+        eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.commands.len());
+    assert_eq!(0, eng.output.commands.len());
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### Refactor: move Engine output entries to Engine.output

This way to output commands does not depend on the entire Engine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/637)
<!-- Reviewable:end -->
