### PR TITLE
Change: A restarted leader should enter leader state at once, without another round of election

### DIFF
--- a/openraft/src/core/server_state.rs
+++ b/openraft/src/core/server_state.rs
@@ -1,8 +1,10 @@
 /// All possible states of a Raft node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default)]
+#[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ServerState {
     /// The node is completely passive; replicating entries, but neither voting nor timing out.
+    #[default]
     Learner,
     /// The node is replicating logs from the leader.
     Follower,
@@ -12,12 +14,6 @@ pub enum ServerState {
     Leader,
     /// The Raft node is shutting down.
     Shutdown,
-}
-
-impl Default for ServerState {
-    fn default() -> Self {
-        Self::Follower
-    }
 }
 
 impl ServerState {

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -40,6 +40,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     tracing::info!("--- not in election. just ignore");
     {
         let mut eng = eng();
+        eng.state.server_state = ServerState::Follower;
         eng.state.vote = Vote::new(2, 1);
         eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12()));
 

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -29,6 +29,7 @@
 mod command;
 mod engine_impl;
 mod log_id_list;
+mod vote_handler;
 
 #[cfg(test)] mod calc_purge_upto_test;
 #[cfg(test)] mod elect_test;

--- a/openraft/src/engine/vote_handler.rs
+++ b/openraft/src/engine/vote_handler.rs
@@ -1,0 +1,34 @@
+use crate::engine::engine_impl::EngineOutput;
+use crate::engine::Command;
+use crate::Node;
+use crate::NodeId;
+use crate::RaftState;
+
+/// Handle raft vote related operations
+pub(crate) struct VoteHandler<'st, 'out, NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    pub(crate) state: &'st mut RaftState<NID, N>,
+    pub(crate) output: &'out mut EngineOutput<NID, N>,
+}
+
+impl<'st, 'out, NID, N> VoteHandler<'st, 'out, NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    /// Mark the vote as committed, i.e., being granted and saved by a quorum.
+    ///
+    /// The committed vote, is not necessary in original raft.
+    /// Openraft insists doing this because:
+    /// - Voting is not in the hot path, thus no performance penalty.
+    /// - Leadership won't be lost if a leader restarted quick enough.
+    pub(crate) fn commit(&mut self) {
+        debug_assert!(!self.state.vote.committed);
+
+        self.state.vote.commit();
+        self.output.push_command(Command::SaveVote { vote: self.state.vote });
+    }
+}

--- a/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
+++ b/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use maplit::btreeset;
 use openraft::Config;
-use openraft::ServerState;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -39,11 +38,6 @@ async fn single_restart() -> anyhow::Result<()> {
         node.shutdown().await?;
 
         router.new_raft_node_with_sto(0, sto).await;
-        // leader appends a blank log.
-        log_index += 1;
-
-        router.wait(&0, timeout()).state(ServerState::Leader, "node-0 is leader").await?;
-        router.wait(&0, timeout()).log(Some(log_index), "node-0 restarted").await?;
     }
 
     tracing::info!("--- write to 1 log after restart");


### PR DESCRIPTION

## Changelog

##### Change: A restarted leader should enter leader state at once, without another round of election

- Test: single-node restart test does not expect the node to run
  election any more.

- Refactor: add VoteHandler to handle vote related operations.

- Change: make ServerState default value `Learner`.

- Fix: #607

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/640)
<!-- Reviewable:end -->
