### PR TITLE
Fix: last_purged_log_id is not loaded correctly

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -31,7 +31,9 @@ fn m12() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    Engine::default()
+    let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+    eng
 }
 
 #[test]

--- a/openraft/src/engine/follower_commit_entries_test.rs
+++ b/openraft/src/engine/follower_commit_entries_test.rs
@@ -41,6 +41,8 @@ fn m23() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.state.committed = Some(log_id(1, 1));
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()));

--- a/openraft/src/engine/follower_do_append_entries_test.rs
+++ b/openraft/src/engine/follower_do_append_entries_test.rs
@@ -51,6 +51,8 @@ fn m45() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.config.id = 2;
     eng.state.log_ids.append(log_id(1, 1));
     eng.state.log_ids.append(log_id(2, 3));

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -50,6 +50,8 @@ fn m34() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.config.id = 2;
     eng.state.vote = Vote::new(2, 1);
     eng.state.log_ids.append(log_id(1, 1));

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -28,6 +28,8 @@ fn m01() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::<u64, ()>::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -32,7 +32,10 @@ fn m1234() -> Membership<u64, ()> {
 }
 
 fn eng() -> Engine<u64, ()> {
-    Engine::<u64, ()>::default()
+    let mut eng = Engine::<u64, ()>::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
+    eng
 }
 
 #[test]

--- a/openraft/src/engine/handler/snapshot_handler.rs
+++ b/openraft/src/engine/handler/snapshot_handler.rs
@@ -74,6 +74,7 @@ mod tests {
 
     fn eng() -> Engine<u64, ()> {
         let mut eng = Engine::<u64, ()> { ..Default::default() };
+        eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.snapshot_meta = SnapshotMeta {
             last_log_id: Some(log_id(2, 2)),

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -24,6 +24,8 @@ use crate::Vote;
 fn test_initialize_single_node() -> anyhow::Result<()> {
     let eng = || {
         let mut eng = Engine::<u64, ()>::default();
+        eng.state.enable_validate = false; // Disable validation for incomplete state
+
         eng.state.server_state = eng.calc_server_state();
         eng
     };
@@ -130,6 +132,8 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 fn test_initialize() -> anyhow::Result<()> {
     let eng = || {
         let mut eng = Engine::<u64, ()>::default();
+        eng.state.enable_validate = false; // Disable validation for incomplete state
+
         eng.state.server_state = eng.calc_server_state();
         eng
     };

--- a/openraft/src/engine/install_snapshot_test.rs
+++ b/openraft/src/engine/install_snapshot_test.rs
@@ -30,6 +30,7 @@ fn m1234() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::<u64, ()> { ..Default::default() };
+    eng.state.enable_validate = false; // Disable validation for incomplete state
 
     eng.state.committed = Some(log_id(4, 5));
     eng.state.log_ids = LogIdList::new(vec![
@@ -199,6 +200,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     // And there should be no conflicting logs left.
     let mut eng = {
         let mut eng = Engine::<u64, ()> { ..Default::default() };
+        eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.committed = Some(log_id(2, 3));
         eng.state.log_ids = LogIdList::new(vec![

--- a/openraft/src/engine/internal_handle_vote_req_test.rs
+++ b/openraft/src/engine/internal_handle_vote_req_test.rs
@@ -27,6 +27,8 @@ fn m01() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::<u64, ()>::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.state.vote = Vote::new(2, 1);
     eng.state.server_state = ServerState::Candidate;
     eng.state.membership_state.effective = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -64,6 +64,8 @@ fn m34() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.config.id = 1;
     eng.state.committed = Some(log_id(0, 0));
     eng.state.vote = Vote::new_committed(3, 1);

--- a/openraft/src/engine/purge_log_test.rs
+++ b/openraft/src/engine/purge_log_test.rs
@@ -14,7 +14,10 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::<u64, ()>::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 2), log_id(4, 4), log_id(4, 6)]);
+    eng.state.next_purge = 3;
     eng
 }
 

--- a/openraft/src/engine/truncate_logs_test.rs
+++ b/openraft/src/engine/truncate_logs_test.rs
@@ -35,6 +35,8 @@ fn m23() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.config.id = 2;
     eng.state.log_ids = LogIdList::new(vec![
         log_id(2, 2), //

--- a/openraft/src/engine/update_progress_test.rs
+++ b/openraft/src/engine/update_progress_test.rs
@@ -27,6 +27,8 @@ fn m123() -> Membership<u64, ()> {
 
 fn eng() -> Engine<u64, ()> {
     let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
     eng.config.id = 2;
     eng.state.vote = Vote::new_committed(2, 1);
     eng.state.membership_state.committed = Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()));

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -45,6 +45,7 @@ mod runtime;
 pub mod storage;
 pub mod testing;
 pub mod timer;
+pub(crate) mod valid;
 pub mod versioned;
 
 #[cfg(test)] mod raft_state_test;

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -228,7 +228,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         // TODO(xp): this is not necessary.
         storage.save_vote(&state.vote).await?;
 
-        let engine = Engine::new(&state, EngineConfig {
+        let engine = Engine::new(state, EngineConfig {
             id,
             max_in_snapshot_log_to_keep: config.max_in_snapshot_log_to_keep,
             purge_batch_size: config.purge_batch_size,

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -100,12 +100,14 @@ fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
 
     let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
+        next_purge: 3,
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());
 
     let rs = RaftState::<u64, ()> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
+        next_purge: 3,
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -53,7 +53,10 @@ where
             last_purged_log_id = last_applied;
         }
 
+        println!("purged: {:?}", last_purged_log_id);
+        println!("last: {:?}", last_log_id);
         let log_ids = LogIdList::load_log_ids(last_purged_log_id, last_log_id, self).await?;
+        println!("log_ids: {:?}", log_ids);
 
         let snapshot_meta = self.sto.get_current_snapshot().await?.map(|x| x.meta).unwrap_or_default();
 
@@ -62,6 +65,7 @@ where
             // The initial value for `vote` is the minimal possible value.
             // See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
             vote: vote.unwrap_or_default(),
+            next_purge: last_purged_log_id.next_index(),
             log_ids,
             membership_state: mem_state,
             snapshot_meta,

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -69,6 +69,11 @@ where
             snapshot_id: self.snapshot_id.clone(),
         }
     }
+
+    /// Returns a ref to the id of the last log that is included in this snasphot.
+    pub fn last_log_id(&self) -> Option<&LogId<NID>> {
+        self.last_log_id.as_ref()
+    }
 }
 
 /// The data associated with the current snapshot.

--- a/openraft/src/valid/bench/mod.rs
+++ b/openraft/src/valid/bench/mod.rs
@@ -1,0 +1,1 @@
+mod valid_deref;

--- a/openraft/src/valid/bench/valid_deref.rs
+++ b/openraft/src/valid/bench/valid_deref.rs
@@ -1,0 +1,32 @@
+extern crate test;
+use std::error::Error;
+
+use maplit::btreeset;
+use test::black_box;
+use test::Bencher;
+
+use crate::less_equal;
+use crate::quorum::AsJoint;
+use crate::quorum::QuorumSet;
+use crate::valid::Valid;
+use crate::valid::Validate;
+
+struct Foo {
+    a: u64,
+}
+
+impl Validate for Foo {
+    fn validate(&self) -> Result<(), Box<dyn Error>> {
+        less_equal!(self.a, 10);
+        Ok(())
+    }
+}
+
+#[bench]
+fn valid_deref(b: &mut Bencher) {
+    let f = Valid::new(Foo { a: 5 });
+
+    b.iter(|| {
+        let _x = black_box(f.a);
+    })
+}

--- a/openraft/src/valid/mod.rs
+++ b/openraft/src/valid/mod.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "bench")]
+#[cfg(test)]
+mod bench;
+
+mod valid_impl;
+
+pub(crate) use valid_impl::Valid;
+pub(crate) use valid_impl::Validate;

--- a/openraft/src/valid/valid_impl.rs
+++ b/openraft/src/valid/valid_impl.rs
@@ -1,0 +1,234 @@
+use std::error::Error;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+#[macro_export]
+macro_rules! less_equal {
+    ($a: expr, $b: expr) => {{
+        let a = $a;
+        let b = $b;
+        if (a <= b) {
+            // Ok
+        } else {
+            Err(::anyerror::AnyError::error(format!(
+                "expect: {}({:?}) {} {}({:?})",
+                stringify!($a),
+                a,
+                "<=",
+                stringify!($b),
+                b,
+            )))?;
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! equal {
+    ($a: expr, $b: expr) => {{
+        let a = $a;
+        let b = $b;
+        if (a == b) {
+            // Ok
+        } else {
+            Err(::anyerror::AnyError::error(format!(
+                "expect: {}({:?}) {} {}({:?})",
+                stringify!($a),
+                a,
+                "==",
+                stringify!($b),
+                b,
+            )))?;
+        }
+    }};
+}
+
+/// A type that validates its internal state.
+///
+/// An example of defining field `a` whose value must not exceed `10`.
+/// ```ignore
+/// # use std::error::Error;
+/// # use openraft::less_equal;
+/// struct Foo { a: u64 }
+/// impl Validate for Foo {
+///     fn validate(&self) -> Result<(), Box<dyn Error>> {
+///         less_equal!(self.a, 10);
+///         Ok(())
+///     }
+/// }
+/// ```
+pub(crate) trait Validate {
+    fn validate(&self) -> Result<(), Box<dyn Error>>;
+}
+
+/// A wrapper of T that validate the state of T every time accessing it.
+///
+/// - It validates the state before accessing it, i.e., if when a invalid state is written to it, it won't panic until
+///   next time accessing it.
+/// - The validation is turned on only when `debug_assertions` is enabled.
+///
+/// An example of defining field `a` whose value must not exceed `10`.
+/// ```ignore
+/// # use std::error::Error;
+/// # use openraft::less_equal;
+/// struct Foo { a: u64 }
+/// impl Validate for Foo {
+///     fn validate(&self) -> Result<(), Box<dyn Error>> {
+///         less_equal!(self.a, 10);
+///         Ok(())
+///     }
+/// }
+///
+/// let f = Valid::new(Foo { a: 20 });
+/// let _x = f.a; // panic: panicked at 'invalid state: expect: self.a(20) <= 10(10) ...
+/// ```
+pub(crate) struct Valid<T>
+where T: Validate
+{
+    pub(crate) enable_validate: bool,
+    inner: T,
+}
+
+impl<T: Validate> Valid<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
+            enable_validate: true,
+            inner,
+        }
+    }
+}
+
+impl<T> Deref for Valid<T>
+where T: Validate
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        #[cfg(debug_assertions)]
+        if self.enable_validate {
+            if let Err(e) = self.inner.validate() {
+                panic!("invalid state: {}", e);
+            }
+        }
+
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for Valid<T>
+where T: Validate
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        #[cfg(debug_assertions)]
+        if self.enable_validate {
+            if let Err(e) = self.inner.validate() {
+                panic!("invalid state: {}", e);
+            }
+        }
+
+        &mut self.inner
+    }
+}
+
+impl<T: PartialEq> PartialEq for Valid<T>
+where T: Validate
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl<T: Eq> Eq for Valid<T> where T: Validate {}
+
+impl<T: Debug> Debug for Valid<T>
+where T: Validate
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl<T: Clone> Clone for Valid<T>
+where T: Validate
+{
+    fn clone(&self) -> Self {
+        Self {
+            enable_validate: self.enable_validate,
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T: Default> Default for Valid<T>
+where T: Validate
+{
+    fn default() -> Self {
+        Self {
+            enable_validate: true,
+            inner: T::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use crate::valid::Valid;
+    use crate::valid::Validate;
+
+    struct Foo {
+        a: u64,
+    }
+
+    impl Validate for Foo {
+        fn validate(&self) -> Result<(), Box<dyn Error>> {
+            less_equal!(self.a, 10);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_validate() {
+        // panic when reading an invalid state
+        let res = std::panic::catch_unwind(|| {
+            let f = Valid::new(Foo { a: 20 });
+            let _x = f.a;
+        });
+        tracing::info!("res: {:?}", res);
+        assert!(res.is_err());
+
+        // Disable validation
+        let res = std::panic::catch_unwind(|| {
+            let mut f = Valid::new(Foo { a: 20 });
+            f.enable_validate = false;
+            let _x = f.a;
+        });
+        tracing::info!("res: {:?}", res);
+        assert!(res.is_ok());
+
+        // valid state
+        let res = std::panic::catch_unwind(|| {
+            let f = Valid::new(Foo { a: 10 });
+            let _x = f.a;
+        });
+        assert!(res.is_ok());
+
+        // no panic when just becoming invalid
+        let res = std::panic::catch_unwind(|| {
+            let mut f = Valid::new(Foo { a: 10 });
+            f.a += 3;
+        });
+        assert!(res.is_ok());
+
+        // panic on next write access
+        let res = std::panic::catch_unwind(|| {
+            let mut f = Valid::new(Foo { a: 10 });
+            f.a += 3;
+            f.a += 1;
+        });
+        tracing::info!("res: {:?}", res);
+        assert!(res.is_err());
+    }
+}


### PR DESCRIPTION

## Changelog

##### Fix: last_purged_log_id is not loaded correctly

- Fix: `last_purged_log_id` should be `None`, but not `LogId{index=0,
  ..}` when raft startup with a store with log at index 0.

  This is fixed by adding another field `next_purge` to distinguish
  `last_purged_log_id` value `None` and `LogId{index=0, ..}`, because
  `RaftState.log_ids` stores `LogId` but not `Option<LogId>`.

- Add a wrapper `Valid<RaftState>` of `RaftState` to check if the state
  is valid every time accessing it. This check is done only when
  `debug_assertions` is turned on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/643)
<!-- Reviewable:end -->
