### PR TITLE
Improve: add LogStateReader::prev_log_id() to return a log id at specfied index-1

### DIFF
--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -18,6 +18,15 @@ use crate::Vote;
 ///
 /// See: https://datafuselabs.github.io/openraft/log-data-layout
 pub(crate) trait LogStateReader<NID: NodeId> {
+    /// Get previous log id, i.e., the log id at index - 1
+    fn prev_log_id(&self, index: u64) -> Option<LogId<NID>> {
+        if index == 0 {
+            None
+        } else {
+            self.get_log_id(index - 1)
+        }
+    }
+
     /// Get the log id at the specified index.
     ///
     /// It will return `last_purged_log_id` if index is at the last purged index.


### PR DESCRIPTION

## Changelog

##### Improve: add LogStateReader::prev_log_id() to return a log id at specfied index-1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/648)
<!-- Reviewable:end -->
