### PR TITLE
Refactor: move append_blank_log() to ReplicationHandler

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -140,7 +140,6 @@ where
         // Previously it is a leader. restore it as leader at once
         if self.state.is_leader(&self.config.id) {
             self.vote_handler().update_internal_server_state();
-            self.server_state_handler().update_server_state_if_changed();
 
             let mut rh = self.replication_handler();
             rh.update_replication_streams();


### PR DESCRIPTION

## Changelog

##### Refactor: move append_blank_log() to ReplicationHandler


##### Refactor: remove duplicated server-state update when startup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/656)
<!-- Reviewable:end -->
