### PR TITLE
Refactor: add ReplicationHandler::update_local_progress() to update progress just for local node

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1514,7 +1514,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
                     unreachable!("it has to be a leader!!!");
                 }
             }
-            Command::UpdateReplicationStreams { targets } => {
+            Command::RebuildReplicationStreams { targets } => {
                 self.remove_all_replication().await;
 
                 for (target, matching) in targets.iter() {

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -70,7 +70,7 @@ where
     /// The Runtime has to close all old replications and start new ones.
     /// Because a replication stream should only report state for one membership config.
     /// When membership config changes, the membership log id stored in ReplicationCore has to be updated.
-    UpdateReplicationStreams {
+    RebuildReplicationStreams {
         /// Targets to replicate to.
         targets: Vec<(NID, ProgressEntry<NID>)>,
     },
@@ -136,7 +136,7 @@ where
             Command::FollowerCommit { .. } => flags.set_data_changed(),
             Command::Replicate { .. } => {}
             Command::UpdateMembership { .. } => flags.set_cluster_changed(),
-            Command::UpdateReplicationStreams { .. } => flags.set_replication_changed(),
+            Command::RebuildReplicationStreams { .. } => flags.set_replication_changed(),
             Command::UpdateProgressMetrics { .. } => flags.set_replication_changed(),
             Command::MoveInputCursorBy { .. } => {}
             Command::SaveVote { .. } => flags.set_data_changed(),

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -72,7 +72,7 @@ fn test_elect() -> anyhow::Result<()> {
                     vote: Vote::new_committed(1, 1)
                 },
                 Command::BecomeLeader,
-                Command::UpdateReplicationStreams { targets: vec![] },
+                Command::RebuildReplicationStreams { targets: vec![] },
                 Command::AppendBlankLog {
                     log_id: LogId {
                         leader_id: LeaderId { term: 1, node_id: 1 },
@@ -135,7 +135,7 @@ fn test_elect() -> anyhow::Result<()> {
                     vote: Vote::new_committed(2, 1)
                 },
                 Command::BecomeLeader,
-                Command::UpdateReplicationStreams { targets: vec![] },
+                Command::RebuildReplicationStreams { targets: vec![] },
                 Command::AppendBlankLog {
                     log_id: LogId {
                         leader_id: LeaderId { term: 2, node_id: 1 },

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -142,7 +142,7 @@ where
             self.vote_handler().update_internal_server_state();
 
             let mut rh = self.replication_handler();
-            rh.update_replication_streams();
+            rh.rebuild_replication_streams();
             rh.initiate_replication();
 
             return;
@@ -629,31 +629,22 @@ where
             "Only leader is allowed to call update_effective_membership()"
         );
 
-        self.state.membership_state.append(Arc::new(EffectiveMembership::new(Some(*log_id), m.clone())));
+        self.state.membership_state.append(EffectiveMembership::new_arc(Some(*log_id), m.clone()));
+
         let em = self.state.membership_state.effective();
-
         self.output.push_command(Command::UpdateMembership { membership: em.clone() });
-
-        // If membership changes, the progress should be upgraded.
-        if let Some(leader) = &mut self.internal_server_state.leading_mut() {
-            let end = self.state.last_log_id().next_index();
-
-            let old_progress = leader.progress.clone();
-            let learner_ids = em.learner_ids().collect::<Vec<_>>();
-
-            leader.progress =
-                old_progress.upgrade_quorum_set(em.membership.to_quorum_set(), &learner_ids, ProgressEntry::empty(end));
-        }
-
-        // Leader should not quit at once.
-        // A leader should always keep replicating logs.
-        // A leader that is removed will be shut down when this membership log is committed.
 
         // TODO(9): currently only a leader has replication setup.
         //       It's better to setup replication for both leader and candidate.
         //       e.g.: if self.internal_server_state.is_leading() {
+
+        // Leader does not quit at once:
+        // A leader should always keep replicating logs.
+        // A leader that is removed will shut down replications when this membership log is committed.
+
         let mut rh = self.replication_handler();
-        rh.update_replication_streams();
+        rh.rebuild_progresses();
+        rh.rebuild_replication_streams();
         rh.initiate_replication();
     }
 
@@ -823,7 +814,13 @@ where
 
         let mut rh = self.replication_handler();
 
-        rh.update_replication_streams();
+        // It has to setup replication stream first because append_blank_log() may update the committed-log-id(a single
+        // leader with several learners), in which case the committed-log-id will be at once submitted to
+        // replicate before replication stream is built.
+        // TODO: But replication streams should be built when a node enters leading state.
+        //       Thus append_blank_log() can be moved before rebuild_replication_streams()
+
+        rh.rebuild_replication_streams();
         rh.append_blank_log();
         rh.initiate_replication();
     }

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -271,7 +271,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                     vote: Vote::new_committed(2, 1)
                 },
                 Command::BecomeLeader,
-                Command::UpdateReplicationStreams {
+                Command::RebuildReplicationStreams {
                     targets: vec![(2, ProgressEntry::empty(1))]
                 },
                 Command::AppendBlankLog {

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -95,7 +95,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                     },
                 },
                 Command::BecomeLeader,
-                Command::UpdateReplicationStreams { targets: vec![] },
+                Command::RebuildReplicationStreams { targets: vec![] },
                 Command::AppendBlankLog {
                     log_id: LogId {
                         leader_id: LeaderId { term: 1, node_id: 1 },

--- a/openraft/src/engine/leader_append_entries_test.rs
+++ b/openraft/src/engine/leader_append_entries_test.rs
@@ -307,7 +307,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
                     m34()
                 )),
             },
-            Command::UpdateReplicationStreams {
+            Command::RebuildReplicationStreams {
                 targets: vec![(3, ProgressEntry::empty(7)), (4, ProgressEntry::empty(7))]
             },
             Command::Replicate {
@@ -394,7 +394,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                     m1_2()
                 )),
             },
-            Command::UpdateReplicationStreams {
+            Command::RebuildReplicationStreams {
                 targets: vec![(2, ProgressEntry::empty(7))]
             },
             Command::Replicate {
@@ -470,7 +470,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                     m1_2()
                 )),
             },
-            Command::UpdateReplicationStreams {
+            Command::RebuildReplicationStreams {
                 targets: vec![(2, ProgressEntry::empty(7))]
             },
             Command::Replicate {

--- a/openraft/src/engine/leader_append_membership_test.rs
+++ b/openraft/src/engine/leader_append_membership_test.rs
@@ -98,7 +98,7 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
             Command::UpdateMembership {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
             },
-            Command::UpdateReplicationStreams {
+            Command::RebuildReplicationStreams {
                 targets: vec![(3, ProgressEntry::empty(0)), (4, ProgressEntry::empty(0))], /* node-2 is leader,
                                                                                             * won't be removed */
             }

--- a/openraft/src/engine/startup_test.rs
+++ b/openraft/src/engine/startup_test.rs
@@ -64,7 +64,7 @@ fn test_startup_as_leader() -> anyhow::Result<()> {
         vec![
             //
             Command::BecomeLeader,
-            Command::UpdateReplicationStreams {
+            Command::RebuildReplicationStreams {
                 targets: vec![(3, ProgressEntry {
                     matching: None,
                     curr_inflight_id: 0,


### PR DESCRIPTION

## Changelog

##### Refactor: add ReplicationHandler::update_local_progress() to update progress just for local node

Writing to local log store is different from writing to remote.
Local writing is serialized by the runtime(RaftCore) and can be
fast-committed.


##### Refactor: rebuilding replication progresses should be a job of ReplicationHandler

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/657)
<!-- Reviewable:end -->
