### PR TITLE
Improve: panic hook for integration test should print error message to stderr, not only record it in log file

### DIFF
--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -116,6 +116,8 @@ pub fn log_panic(panic: &PanicInfo) {
         }
     };
 
+    eprintln!("{}", panic);
+
     if let Some(location) = panic.location() {
         tracing::error!(
             message = %panic,
@@ -124,9 +126,12 @@ pub fn log_panic(panic: &PanicInfo) {
             panic.line = location.line(),
             panic.column = location.column(),
         );
+        eprintln!("{}:{}:{}", location.file(), location.line(), location.column());
     } else {
         tracing::error!(message = %panic, backtrace = %backtrace);
     }
+
+    eprintln!("{}", backtrace);
 }
 
 /// A type which emulates a network transport and implements the `RaftNetworkFactory` trait.


### PR DESCRIPTION

## Changelog

##### Improve: panic hook for integration test should print error message to stderr, not only record it in log file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/659)
<!-- Reviewable:end -->
