### PR TITLE
Refactor: FollowingHandler split logic

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -8,6 +8,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
+use crate::raft_state::VoteStateReader;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -49,7 +50,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         eng.elect();
 
-        assert_eq!(Vote::new_committed(1, 1), eng.state.vote);
+        assert_eq!(Vote::new_committed(1, 1), *eng.state.get_vote());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -112,7 +113,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         eng.elect();
 
-        assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
+        assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -171,7 +172,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         eng.elect();
 
-        assert_eq!(Vote::new(1, 1), eng.state.vote);
+        assert_eq!(Vote::new(1, 1), *eng.state.get_vote());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -466,7 +466,7 @@ where
         );
 
         let l = entries.len();
-        let since = self.following_handler().first_conflicting_index(entries);
+        let since = self.following_handler().state.first_conflicting_index(entries);
         if since < l {
             // Before appending, if an entry overrides an conflicting one,
             // the entries after it has to be deleted first.

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -8,6 +8,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft::AppendEntriesResponse;
 use crate::raft_state::LogStateReader;
+use crate::raft_state::VoteStateReader;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -79,7 +80,7 @@ fn test_handle_append_entries_req_vote_is_rejected() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new(2, 1), eng.state.vote);
+    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
     assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -127,7 +128,7 @@ fn test_handle_append_entries_req_prev_log_id_is_applied() -> anyhow::Result<()>
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
     assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -179,7 +180,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
     assert_eq!(Some(&log_id(1, 1)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -236,7 +237,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
     assert_eq!(Some(&log_id(2, 2)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(1, 1)), eng.state.committed());
     assert_eq!(
@@ -301,7 +302,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
     assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -362,7 +363,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
     assert_eq!(Some(&log_id(3, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(3, 3)), eng.state.committed());
     assert_eq!(

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -8,6 +8,7 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
+use crate::raft_state::VoteStateReader;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -58,7 +59,7 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
         resp
     );
 
-    assert_eq!(Vote::new(2, 1), eng.state.vote);
+    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
     assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -95,7 +96,7 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
         resp
     );
 
-    assert_eq!(Vote::new(2, 1), eng.state.vote);
+    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
     assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -137,7 +138,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         resp
     );
 
-    assert_eq!(Vote::new(2, 1), eng.state.vote);
+    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
     assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -186,7 +187,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
         resp
     );
 
-    assert_eq!(Vote::new(3, 1), eng.state.vote);
+    assert_eq!(Vote::new(3, 1), *eng.state.get_vote());
     assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -10,6 +10,7 @@ use crate::engine::LogIdList;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft::VoteResponse;
+use crate::raft_state::VoteStateReader;
 use crate::EffectiveMembership;
 use crate::LeaderId;
 use crate::LogId;
@@ -57,7 +58,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), eng.state.vote);
+        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
         assert!(eng.internal_server_state.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -91,7 +92,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), eng.state.vote);
+        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -132,7 +133,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 2), eng.state.vote);
+        assert_eq!(Vote::new(2, 2), *eng.state.get_vote());
         assert!(eng.internal_server_state.is_leading());
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -172,7 +173,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), eng.state.vote);
+        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -212,7 +213,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), eng.state.vote);
+        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
         assert_eq!(
             Some(btreeset! {1,2},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -249,7 +250,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new_committed(2, 1), eng.state.vote);
+        assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
         assert_eq!(
             Some(btreeset! {1,2},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())

--- a/openraft/src/engine/handler/following_handler.rs
+++ b/openraft/src/engine/handler/following_handler.rs
@@ -38,10 +38,8 @@ where
 {
     /// Append membership log if membership config entries are found, after appending entries to
     /// log.
-    fn follower_append_membership<'a, Ent: RaftEntry<NID, N> + 'a>(
-        &mut self,
-        entries: impl DoubleEndedIterator<Item = &'a Ent>,
-    ) {
+    fn follower_append_membership<'a, Ent>(&mut self, entries: impl DoubleEndedIterator<Item = &'a Ent>)
+    where Ent: RaftEntry<NID, N> + 'a {
         let memberships = Self::last_two_memberships(entries);
         if memberships.is_empty() {
             return;

--- a/openraft/src/engine/handler/following_handler.rs
+++ b/openraft/src/engine/handler/following_handler.rs
@@ -8,7 +8,6 @@ use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::entry::RaftEntry;
 use crate::raft_state::LogStateReader;
-use crate::raft_types::RaftLogId;
 use crate::EffectiveMembership;
 use crate::LogId;
 use crate::LogIdOptionExt;
@@ -308,31 +307,6 @@ where
         }
 
         memberships
-    }
-
-    // TODO: move to RaftState
-    /// Find the first entry in the input that does not exist on local raft-log,
-    /// by comparing the log id.
-    pub(crate) fn first_conflicting_index<Ent: RaftLogId<NID>>(&self, entries: &[Ent]) -> usize {
-        let l = entries.len();
-
-        for (i, ent) in entries.iter().enumerate() {
-            let log_id = ent.get_log_id();
-            // for i in 0..l {
-            // let log_id = entries[i].get_log_id();
-
-            if !self.state.has_log_id(log_id) {
-                tracing::debug!(
-                    at = display(i),
-                    entry_log_id = display(log_id),
-                    "found nonexistent log id"
-                );
-                return i;
-            }
-        }
-
-        tracing::debug!("not found nonexistent");
-        l
     }
 
     pub(crate) fn log_handler(&mut self) -> LogHandler<NID, N> {

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -42,6 +42,7 @@ use crate::membership::IntoNodes;
 use crate::metrics::RaftMetrics;
 use crate::metrics::Wait;
 use crate::node::Node;
+use crate::raft_state::VoteStateReader;
 use crate::replication::ReplicationResult;
 use crate::replication::ReplicationSessionId;
 use crate::AppData;
@@ -227,7 +228,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         };
 
         // TODO(xp): this is not necessary.
-        storage.save_vote(&state.vote).await?;
+        storage.save_vote(state.get_vote()).await?;
 
         let engine = Engine::new(state, EngineConfig {
             id,

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -79,6 +79,12 @@ pub(crate) trait LogStateReader<NID: NodeId> {
     fn last_purged_log_id(&self) -> Option<&LogId<NID>>;
 }
 
+/// APIs to get vote.
+pub(crate) trait VoteStateReader<NID: NodeId> {
+    /// Get the current vote.
+    fn get_vote(&self) -> &Vote<NID>;
+}
+
 /// A struct used to represent the raft state which a Raft node needs.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RaftState<NID, N>
@@ -150,6 +156,16 @@ where
             return None;
         }
         self.log_ids.first()
+    }
+}
+
+impl<NID, N> VoteStateReader<NID> for RaftState<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn get_vote(&self) -> &Vote<NID> {
+        &self.vote
     }
 }
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -8,6 +8,7 @@ use maplit::btreeset;
 use crate::membership::EffectiveMembership;
 use crate::raft_state::LogStateReader;
 use crate::raft_state::RaftState;
+use crate::raft_state::VoteStateReader;
 use crate::storage::LogState;
 use crate::storage::StorageHelper;
 use crate::testing::DefensiveStoreBuilder;
@@ -447,7 +448,7 @@ where
                 node_id: NODE_ID.into(),
                 committed: false,
             },
-            initial.vote,
+            *initial.get_vote(),
             "unexpected value for default hard state"
         );
         Ok(())


### PR DESCRIPTION

## Changelog

##### Refactor: split logic: vote checking is done by Engine, append-entries is done by FollowingHandler


##### Improve: add trait VoteStateReader to read vote


##### Refactor: move first_conflicting_index() to RaftState

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/664)
<!-- Reviewable:end -->
