### PR TITLE
Improve: make sending rpc-response a command and enqueue it in the command list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1.36"
 byte-unit = "4.0.12"
 bytes = "1.0"
 clap = { version = "~3.2", features = ["derive", "env"] }
+derivative = "2.2.0"
 derive_more = { version="0.99.9" }
 futures = "0.3"
 lazy_static = "1.4.0"

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -17,6 +17,7 @@ repository    = { workspace = true }
 anyerror        = { workspace = true }
 async-trait     = { workspace = true }
 byte-unit       = { workspace = true }
+derivative      = { workspace = true }
 derive_more     = { workspace = true }
 futures         = { workspace = true }
 maplit          = { workspace = true }

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -48,8 +48,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             });
         }
 
-        self.set_next_election_time(false);
-
         // Clear the state to None if it is building a snapshot locally.
         if let SnapshotState::Snapshotting {
             abort_handle,

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -60,7 +60,7 @@ impl<NID: NodeId> Default for EngineConfig<NID> {
 }
 
 /// The entry of output from Engine to the runtime.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct EngineOutput<NID, N>
 where
@@ -94,7 +94,7 @@ where
 /// This structure only contains necessary information to run raft algorithm,
 /// but none of the application specific data.
 /// TODO: make the fields private
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct Engine<NID, N>
 where

--- a/openraft/src/engine/handler/replication_handler.rs
+++ b/openraft/src/engine/handler/replication_handler.rs
@@ -434,11 +434,10 @@ mod tests {
 
         #[test]
         fn test_update_matching_no_leader() -> anyhow::Result<()> {
-            let mut eng = eng();
-
             // There is no leader, it should panic.
 
             let res = std::panic::catch_unwind(move || {
+                let mut eng = eng();
                 eng.replication_handler().update_matching(3, 0, Some(log_id(1, 2)));
             });
             tracing::info!("res: {:?}", res);

--- a/openraft/src/engine/handler/vote_handler.rs
+++ b/openraft/src/engine/handler/vote_handler.rs
@@ -43,7 +43,8 @@ where
     pub(crate) fn commit_vote(&mut self) {
         debug_assert!(!self.state.get_vote().committed);
         debug_assert_eq!(
-            self.state.get_vote().node_id == self.config.id,
+            self.state.get_vote().node_id,
+            self.config.id,
             "it can only commit its own vote"
         );
 

--- a/openraft/src/engine/handler/vote_handler.rs
+++ b/openraft/src/engine/handler/vote_handler.rs
@@ -42,6 +42,10 @@ where
     /// - Leadership won't be lost if a leader restarted quick enough.
     pub(crate) fn commit_vote(&mut self) {
         debug_assert!(!self.state.get_vote().committed);
+        debug_assert_eq!(
+            self.state.get_vote().node_id == self.config.id,
+            "it can only commit its own vote"
+        );
 
         let mut v = *self.state.get_vote();
         v.commit();

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -63,6 +63,7 @@ where
 
 // TODO: not used, remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+#[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum AppendEntriesError<NID>
 where NID: NodeId
@@ -73,6 +74,7 @@ where NID: NodeId
 
 // TODO: not used, remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+#[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum VoteError<NID>
 where NID: NodeId
@@ -83,6 +85,7 @@ where NID: NodeId
 
 // TODO: remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+#[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum InstallSnapshotError<NID>
 where NID: NodeId

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -17,6 +17,20 @@
 //! - `serde`: Add serde::Serialize and serde:Deserialize bound to data types. If you'd like to use
 //!   `serde` to serialize messages.
 
+macro_rules! func_name {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        let n = &name[..name.len() - 3];
+        let nn = n.replace("::{{closure}}", "");
+        nn
+        // nn.split("::").last().unwrap_or_default()
+    }};
+}
+
 mod change_members;
 mod config;
 mod core;

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -857,7 +857,7 @@ pub struct AddLearnerResponse<NID: NodeId> {
     pub matched: Option<LogId<NID>>,
 }
 
-/// TX for Add Learner Respose
+/// TX for Add Learner Response
 pub(crate) type RaftAddLearnerTx<NID, N> = RaftRespTx<AddLearnerResponse<NID>, AddLearnerError<NID, N>>;
 
 /// TX for Install Snapshot Response
@@ -1239,6 +1239,7 @@ impl<C: RaftTypeConfig> MessageSummary<InstallSnapshotRequest<C>> for InstallSna
 
 /// The response to an `InstallSnapshotRequest`.
 #[derive(Debug)]
+#[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct InstallSnapshotResponse<NID: NodeId> {
     pub vote: Vote<NID>,

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -77,7 +77,7 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
         &mut self,
         input_entries: &'e [Ent],
         curr: &mut usize,
-        cmd: &Command<C::NodeId, C::Node>,
+        cmd: Command<C::NodeId, C::Node>,
     ) -> Result<(), StorageError<C::NodeId>>
     where
         Ent: RaftLogId<C::NodeId> + Sync + Send + 'e,


### PR DESCRIPTION

## Changelog

##### Improve: make sending rpc-response a command and enqueue it in the command list

Sending rpc(vote, append-entries and install-snapshot) response must be
after executing the commands generated by Engine.
Thus introduce `Command` for doing such actions, e.g., `tx.send(res)`.

Command execution can be reordered or batched for performance.

Because `oneshot::Sender` is not `Clone`, `Command` and other related types that includes it are adjusted.


##### Refactor: vote checking and handling is same for every incoming event.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/667)
<!-- Reviewable:end -->
