### PR TITLE
Fix: check_is_leader() should return at once if encountering StorageError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ async-trait = "0.1.36"
 byte-unit = "4.0.12"
 bytes = "1.0"
 clap = { version = "~3.2", features = ["derive", "env"] }
-derivative = "2.2.0"
 derive_more = { version="0.99.9" }
 futures = "0.3"
 lazy_static = "1.4.0"

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -17,7 +17,6 @@ repository    = { workspace = true }
 anyerror        = { workspace = true }
 async-trait     = { workspace = true }
 byte-unit       = { workspace = true }
-derivative      = { workspace = true }
 derive_more     = { workspace = true }
 futures         = { workspace = true }
 maplit          = { workspace = true }

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -44,6 +44,7 @@ mod log_id_list;
 #[cfg(test)] mod update_progress_test;
 
 pub(crate) use command::Command;
+pub(crate) use command::SendResult;
 pub(crate) use engine_impl::Engine;
 pub(crate) use engine_impl::EngineConfig;
 pub use log_id_list::LogIdList;

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -33,34 +33,6 @@ where NID: NodeId
     Stopped,
 }
 
-/// Extract Fatal from a Result.
-///
-/// Fatal will shutdown the raft and needs to be dealt separately,
-/// such as StorageError.
-pub trait ExtractFatal<NID>
-where
-    Self: Sized,
-    NID: NodeId,
-{
-    fn extract_fatal(self) -> Result<Self, Fatal<NID>>;
-}
-
-impl<NID, T, E> ExtractFatal<NID> for Result<T, E>
-where
-    NID: NodeId,
-    E: TryInto<Fatal<NID>> + Clone,
-{
-    fn extract_fatal(self) -> Result<Self, Fatal<NID>> {
-        if let Err(e) = &self {
-            let fatal = e.clone().try_into();
-            if let Ok(f) = fatal {
-                return Err(f);
-            }
-        }
-        Ok(self)
-    }
-}
-
 // TODO: not used, remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
 #[derive(PartialEq, Eq)]


### PR DESCRIPTION

## Changelog

##### Fix: check_is_leader() should return at once if encountering StorageError

Refactor: ExtractFatal is not used any more. Fatal error should only be
raised by Command executor, no more by API handler. There is no need to
extract Fatal error from an API error.


##### Refactor: add SendResult for sending result to API caller

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/668)
<!-- Reviewable:end -->
