### PR TITLE
Change: add RaftError as API return error type.

### DIFF
--- a/examples/raft-kv-memstore/src/client.rs
+++ b/examples/raft-kv-memstore/src/client.rs
@@ -3,17 +3,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use openraft::error::AddLearnerError;
-use openraft::error::CheckIsLeaderError;
-use openraft::error::ClientWriteError;
 use openraft::error::ForwardToLeader;
-use openraft::error::InitializeError;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
-use openraft::error::RaftError;
 use openraft::error::RemoteError;
-use openraft::raft::AddLearnerResponse;
-use openraft::raft::ClientWriteResponse;
 use openraft::BasicNode;
 use openraft::RaftMetrics;
 use openraft::TryAsRef;
@@ -23,9 +16,9 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::time::timeout;
 
+use crate::typ;
 use crate::ExampleNodeId;
 use crate::ExampleRequest;
-use crate::ExampleTypeConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Empty {}
@@ -59,33 +52,21 @@ impl ExampleClient {
     pub async fn write(
         &self,
         req: &ExampleRequest,
-    ) -> Result<
-        ClientWriteResponse<ExampleTypeConfig>,
-        RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, ClientWriteError<ExampleNodeId, BasicNode>>>,
-    > {
+    ) -> Result<typ::ClientWriteResponse, typ::RPCError<typ::ClientWriteError>> {
         self.send_rpc_to_leader("write", Some(req)).await
     }
 
     /// Read value by key, in an inconsistent mode.
     ///
     /// This method may return stale value because it does not force to read on a legal leader.
-    pub async fn read(
-        &self,
-        req: &String,
-    ) -> Result<String, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId>>> {
+    pub async fn read(&self, req: &String) -> Result<String, typ::RPCError> {
         self.do_send_rpc_to_leader("read", Some(req)).await
     }
 
     /// Consistent Read value by key, in an inconsistent mode.
     ///
     /// This method MUST return consitent value or CheckIsLeaderError.
-    pub async fn consistent_read(
-        &self,
-        req: &String,
-    ) -> Result<
-        String,
-        RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, CheckIsLeaderError<ExampleNodeId, BasicNode>>>,
-    > {
+    pub async fn consistent_read(&self, req: &String) -> Result<String, typ::RPCError<typ::CheckIsLeaderError>> {
         self.do_send_rpc_to_leader("consistent_read", Some(req)).await
     }
 
@@ -97,12 +78,7 @@ impl ExampleClient {
     /// With a initialized cluster, new node can be added with [`write`].
     /// Then setup replication with [`add_learner`].
     /// Then make the new node a member with [`change_membership`].
-    pub async fn init(
-        &self,
-    ) -> Result<
-        (),
-        RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, InitializeError<ExampleNodeId, BasicNode>>>,
-    > {
+    pub async fn init(&self) -> Result<(), typ::RPCError<typ::InitializeError>> {
         self.do_send_rpc_to_leader("init", Some(&Empty {})).await
     }
 
@@ -112,10 +88,7 @@ impl ExampleClient {
     pub async fn add_learner(
         &self,
         req: (ExampleNodeId, String),
-    ) -> Result<
-        AddLearnerResponse<ExampleNodeId>,
-        RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, AddLearnerError<ExampleNodeId, BasicNode>>>,
-    > {
+    ) -> Result<typ::AddLearnerResponse, typ::RPCError<typ::AddLearnerError>> {
         self.send_rpc_to_leader("add-learner", Some(&req)).await
     }
 
@@ -126,10 +99,7 @@ impl ExampleClient {
     pub async fn change_membership(
         &self,
         req: &BTreeSet<ExampleNodeId>,
-    ) -> Result<
-        ClientWriteResponse<ExampleTypeConfig>,
-        RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, ClientWriteError<ExampleNodeId, BasicNode>>>,
-    > {
+    ) -> Result<typ::ClientWriteResponse, typ::RPCError<typ::ClientWriteError>> {
         self.send_rpc_to_leader("change-membership", Some(req)).await
     }
 
@@ -138,10 +108,7 @@ impl ExampleClient {
     /// Metrics contains various information about the cluster, such as current leader,
     /// membership config, replication status etc.
     /// See [`RaftMetrics`].
-    pub async fn metrics(
-        &self,
-    ) -> Result<RaftMetrics<ExampleNodeId, BasicNode>, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId>>>
-    {
+    pub async fn metrics(&self) -> Result<RaftMetrics<ExampleNodeId, BasicNode>, typ::RPCError> {
         self.do_send_rpc_to_leader("metrics", None::<&()>).await
     }
 
@@ -156,7 +123,7 @@ impl ExampleClient {
         &self,
         uri: &str,
         req: Option<&Req>,
-    ) -> Result<Resp, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, Err>>>
+    ) -> Result<Resp, typ::RPCError<Err>>
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,
@@ -190,7 +157,7 @@ impl ExampleClient {
             }
         };
 
-        let res: Result<Resp, RaftError<ExampleNodeId, Err>> =
+        let res: Result<Resp, typ::RaftError<Err>> =
             resp.json().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         tracing::debug!(
             "<<< client recv reply from {}: {}",
@@ -205,51 +172,37 @@ impl ExampleClient {
     ///
     /// If the target node is not a leader, a `ForwardToLeader` error will be
     /// returned and this client will retry at most 3 times to contact the updated leader.
-    async fn send_rpc_to_leader<Req, Resp, Err>(
-        &self,
-        uri: &str,
-        req: Option<&Req>,
-    ) -> Result<Resp, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, Err>>>
+    async fn send_rpc_to_leader<Req, Resp, Err>(&self, uri: &str, req: Option<&Req>) -> Result<Resp, typ::RPCError<Err>>
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,
-        Err: std::error::Error
-            + Serialize
-            + DeserializeOwned
-            + TryAsRef<ForwardToLeader<ExampleNodeId, BasicNode>>
-            + Clone,
+        Err: std::error::Error + Serialize + DeserializeOwned + TryAsRef<typ::ForwardToLeader> + Clone,
     {
         // Retry at most 3 times to find a valid leader.
         let mut n_retry = 3;
 
         loop {
-            let res: Result<Resp, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, Err>>> =
-                self.do_send_rpc_to_leader(uri, req).await;
+            let res: Result<Resp, typ::RPCError<Err>> = self.do_send_rpc_to_leader(uri, req).await;
 
             let rpc_err = match res {
                 Ok(x) => return Ok(x),
                 Err(rpc_err) => rpc_err,
             };
 
-            if let RPCError::RemoteError(remote_err) = &rpc_err {
-                let raft_err = &remote_err.source;
-
-                if let Some(ForwardToLeader {
-                    leader_id: Some(leader_id),
-                    leader_node: Some(leader_node),
-                    ..
-                }) = raft_err.forward_to_leader()
+            if let Some(ForwardToLeader {
+                leader_id: Some(leader_id),
+                leader_node: Some(leader_node),
+            }) = rpc_err.forward_to_leader()
+            {
+                // Update target to the new leader.
                 {
-                    // Update target to the new leader.
-                    {
-                        let mut t = self.leader.lock().unwrap();
-                        *t = (*leader_id, leader_node.addr.clone());
-                    }
+                    let mut t = self.leader.lock().unwrap();
+                    *t = (*leader_id, leader_node.addr.clone());
+                }
 
-                    n_retry -= 1;
-                    if n_retry > 0 {
-                        continue;
-                    }
+                n_retry -= 1;
+                if n_retry > 0 {
+                    continue;
                 }
             }
 

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -34,6 +34,26 @@ openraft::declare_raft_types!(
 
 pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, Arc<ExampleStore>>;
 
+pub mod typ {
+    use openraft::BasicNode;
+
+    use crate::ExampleNodeId;
+    use crate::ExampleTypeConfig;
+
+    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<ExampleNodeId, E>;
+    pub type RPCError<E = openraft::error::Infallible> =
+        openraft::error::RPCError<ExampleNodeId, BasicNode, RaftError<E>>;
+
+    pub type ClientWriteError = openraft::error::ClientWriteError<ExampleNodeId, BasicNode>;
+    pub type AddLearnerError = openraft::error::AddLearnerError<ExampleNodeId, BasicNode>;
+    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<ExampleNodeId, BasicNode>;
+    pub type ForwardToLeader = openraft::error::ForwardToLeader<ExampleNodeId, BasicNode>;
+    pub type InitializeError = openraft::error::InitializeError<ExampleNodeId, BasicNode>;
+
+    pub type AddLearnerResponse = openraft::raft::AddLearnerResponse<ExampleNodeId>;
+    pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<ExampleTypeConfig>;
+}
+
 pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) -> std::io::Result<()> {
     // Create a configuration for the raft instance.
     let config = Config {

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -4,6 +4,7 @@ use actix_web::web::Data;
 use actix_web::Responder;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
+use openraft::error::RaftError;
 use openraft::BasicNode;
 use web::Json;
 
@@ -46,7 +47,8 @@ pub async fn consistent_read(app: Data<ExampleApp>, req: Json<String>) -> actix_
             let key = req.0;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, CheckIsLeaderError<ExampleNodeId, BasicNode>> = Ok(value.unwrap_or_default());
+            let res: Result<String, RaftError<ExampleNodeId, CheckIsLeaderError<ExampleNodeId, BasicNode>>> =
+                Ok(value.unwrap_or_default());
             Ok(Json(res))
         }
         Err(e) => Ok(Json(Err(e))),

--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -1,10 +1,9 @@
 use async_trait::async_trait;
-use openraft::error::AppendEntriesError;
 use openraft::error::InstallSnapshotError;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
+use openraft::error::RaftError;
 use openraft::error::RemoteError;
-use openraft::error::VoteError;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
 use openraft::raft::InstallSnapshotRequest;
@@ -86,10 +85,8 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_append_entries(
         &mut self,
         req: AppendEntriesRequest<ExampleTypeConfig>,
-    ) -> Result<
-        AppendEntriesResponse<ExampleNodeId>,
-        RPCError<ExampleNodeId, BasicNode, AppendEntriesError<ExampleNodeId>>,
-    > {
+    ) -> Result<AppendEntriesResponse<ExampleNodeId>, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId>>>
+    {
         self.owner.send_rpc(self.target, &self.target_node, "raft-append", req).await
     }
 
@@ -98,7 +95,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
         req: InstallSnapshotRequest<ExampleTypeConfig>,
     ) -> Result<
         InstallSnapshotResponse<ExampleNodeId>,
-        RPCError<ExampleNodeId, BasicNode, InstallSnapshotError<ExampleNodeId>>,
+        RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, InstallSnapshotError>>,
     > {
         self.owner.send_rpc(self.target, &self.target_node, "raft-snapshot", req).await
     }
@@ -106,7 +103,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_vote(
         &mut self,
         req: VoteRequest<ExampleNodeId>,
-    ) -> Result<VoteResponse<ExampleNodeId>, RPCError<ExampleNodeId, BasicNode, VoteError<ExampleNodeId>>> {
+    ) -> Result<VoteResponse<ExampleNodeId>, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId>>> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-vote", req).await
     }
 }

--- a/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
@@ -2,12 +2,11 @@ use std::any::Any;
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use openraft::error::AppendEntriesError;
 use openraft::error::InstallSnapshotError;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
+use openraft::error::RaftError;
 use openraft::error::RemoteError;
-use openraft::error::VoteError;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
 use openraft::raft::InstallSnapshotRequest;
@@ -100,10 +99,8 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_append_entries(
         &mut self,
         req: AppendEntriesRequest<ExampleTypeConfig>,
-    ) -> Result<
-        AppendEntriesResponse<ExampleNodeId>,
-        RPCError<ExampleNodeId, ExampleNode, AppendEntriesError<ExampleNodeId>>,
-    > {
+    ) -> Result<AppendEntriesResponse<ExampleNodeId>, RPCError<ExampleNodeId, ExampleNode, RaftError<ExampleNodeId>>>
+    {
         self.c().await?.raft().append(req).await.map_err(|e| to_error(e, self.target))
     }
 
@@ -112,7 +109,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
         req: InstallSnapshotRequest<ExampleTypeConfig>,
     ) -> Result<
         InstallSnapshotResponse<ExampleNodeId>,
-        RPCError<ExampleNodeId, ExampleNode, InstallSnapshotError<ExampleNodeId>>,
+        RPCError<ExampleNodeId, ExampleNode, RaftError<ExampleNodeId, InstallSnapshotError>>,
     > {
         self.c().await?.raft().snapshot(req).await.map_err(|e| to_error(e, self.target))
     }
@@ -120,7 +117,7 @@ impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
     async fn send_vote(
         &mut self,
         req: VoteRequest<ExampleNodeId>,
-    ) -> Result<VoteResponse<ExampleNodeId>, RPCError<ExampleNodeId, ExampleNode, VoteError<ExampleNodeId>>> {
+    ) -> Result<VoteResponse<ExampleNodeId>, RPCError<ExampleNodeId, ExampleNode, RaftError<ExampleNodeId>>> {
         self.c().await?.raft().vote(req).await.map_err(|e| to_error(e, self.target))
     }
 }

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -4,10 +4,9 @@ use std::sync::Arc;
 
 use tokio::sync::oneshot;
 
-use crate::error::AppendEntriesError;
+use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::error::InstallSnapshotError;
-use crate::error::VoteError;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft::AppendEntriesResponse;
@@ -132,19 +131,19 @@ where
     // ---
     /// Send vote result `res` to its caller via `tx`
     SendVoteResult {
-        send: SendResult<Result<VoteResponse<NID>, VoteError<NID>>>,
+        send: SendResult<Result<VoteResponse<NID>, Infallible>>,
     },
 
     /// Send append-entries result `res` to its caller via `tx`
     SendAppendEntriesResult {
-        send: SendResult<Result<AppendEntriesResponse<NID>, AppendEntriesError<NID>>>,
+        send: SendResult<Result<AppendEntriesResponse<NID>, Infallible>>,
     },
 
     // TODO: use it
     #[allow(dead_code)]
     /// Send install-snapshot result `res` to its caller via `tx`
     SendInstallSnapshotResult {
-        send: SendResult<Result<InstallSnapshotResponse<NID>, InstallSnapshotError<NID>>>,
+        send: SendResult<Result<InstallSnapshotResponse<NID>, InstallSnapshotError>>,
     },
 
     /// Send install-snapshot result `res` to its caller via `tx`

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -8,7 +8,6 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::entry::EntryRef;
 use crate::error::InitializeError;
-use crate::error::NotAMembershipEntry;
 use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
@@ -239,19 +238,6 @@ fn test_initialize() -> anyhow::Result<()> {
                 node_id: 0,
                 membership: m12()
             })),
-            eng.initialize(&mut entries)
-        );
-    }
-
-    tracing::info!("--- log entry is not a membership entry");
-    {
-        let mut eng = eng();
-
-        let payload = EntryPayload::<Config>::Blank;
-        let mut entries = [EntryRef::new(&payload)];
-
-        assert_eq!(
-            Err(InitializeError::NotAMembershipEntry(NotAMembershipEntry {})),
             eng.initialize(&mut entries)
         );
     }

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -10,12 +10,92 @@ use anyerror::AnyError;
 use crate::node::Node;
 use crate::raft::AppendEntriesResponse;
 use crate::raft_types::SnapshotSegmentId;
+use crate::try_as_ref::TryAsRef;
 use crate::LogId;
 use crate::Membership;
 use crate::NodeId;
 use crate::RPCTypes;
 use crate::StorageError;
 use crate::Vote;
+
+/// RaftError is returned by API methods of `Raft`.
+///
+/// It is either a Fatal error indicating that `Raft` is no longer running, such as underlying IO
+/// error, or an API error `E`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(bound = "E:serde::Serialize + for <'d> serde::Deserialize<'d>")
+)]
+pub enum RaftError<NID, E = Infallible>
+where NID: NodeId
+{
+    #[error(transparent)]
+    APIError(E),
+
+    #[error(transparent)]
+    Fatal(#[from] Fatal<NID>),
+}
+
+impl<NID, E> RaftError<NID, E>
+where
+    NID: NodeId,
+    E: Debug,
+{
+    /// Return a reference to Self::APIError.
+    pub fn api_error(&self) -> Option<&E> {
+        match self {
+            RaftError::APIError(e) => Some(e),
+            RaftError::Fatal(_) => None,
+        }
+    }
+
+    pub fn into_api_error(self) -> Option<E> {
+        match self {
+            RaftError::APIError(e) => Some(e),
+            RaftError::Fatal(_) => None,
+        }
+    }
+
+    /// Return a reference to Self::Fatal.
+    pub fn fatal(&self) -> Option<&Fatal<NID>> {
+        match self {
+            RaftError::APIError(_) => None,
+            RaftError::Fatal(f) => Some(f),
+        }
+    }
+
+    pub fn into_fatal(self) -> Option<Fatal<NID>> {
+        match self {
+            RaftError::APIError(_) => None,
+            RaftError::Fatal(f) => Some(f),
+        }
+    }
+
+    /// Return a reference to ForwardToLeader if Self::APIError contains it.
+    pub fn forward_to_leader<N>(&self) -> Option<&ForwardToLeader<NID, N>>
+    where
+        N: Node,
+        E: TryAsRef<ForwardToLeader<NID, N>>,
+    {
+        match self {
+            RaftError::APIError(api_err) => api_err.try_as_ref(),
+            RaftError::Fatal(_) => None,
+        }
+    }
+
+    pub fn into_forward_to_leader<N>(self) -> Option<ForwardToLeader<NID, N>>
+    where
+        N: Node,
+        E: TryInto<ForwardToLeader<NID, N>>,
+    {
+        match self {
+            RaftError::APIError(api_err) => api_err.try_into().ok(),
+            RaftError::Fatal(_) => None,
+        }
+    }
+}
 
 /// Fatal is unrecoverable and shuts down raft at once.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -33,40 +113,13 @@ where NID: NodeId
     Stopped,
 }
 
-// TODO: not used, remove
-#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
-#[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum AppendEntriesError<NID>
-where NID: NodeId
-{
-    #[error(transparent)]
-    Fatal(#[from] Fatal<NID>),
-}
-
-// TODO: not used, remove
-#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
-#[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum VoteError<NID>
-where NID: NodeId
-{
-    #[error(transparent)]
-    Fatal(#[from] Fatal<NID>),
-}
-
 // TODO: remove
 #[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum InstallSnapshotError<NID>
-where NID: NodeId
-{
+pub enum InstallSnapshotError {
     #[error(transparent)]
     SnapshotMismatch(#[from] SnapshotMismatch),
-
-    #[error(transparent)]
-    Fatal(#[from] Fatal<NID>),
 }
 
 /// An error related to a is_leader request.
@@ -82,9 +135,19 @@ where
 
     #[error(transparent)]
     QuorumNotEnough(#[from] QuorumNotEnough<NID>),
+}
 
-    #[error(transparent)]
-    Fatal(#[from] Fatal<NID>),
+impl<NID, N> TryAsRef<ForwardToLeader<NID, N>> for CheckIsLeaderError<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn try_as_ref(&self) -> Option<&ForwardToLeader<NID, N>> {
+        match self {
+            Self::ForwardToLeader(f) => Some(f),
+            _ => None,
+        }
+    }
 }
 
 /// An error related to a client write request.
@@ -102,9 +165,19 @@ where
     /// When writing a change-membership entry.
     #[error(transparent)]
     ChangeMembershipError(#[from] ChangeMembershipError<NID>),
+}
 
-    #[error(transparent)]
-    Fatal(#[from] Fatal<NID>),
+impl<NID, N> TryAsRef<ForwardToLeader<NID, N>> for ClientWriteError<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn try_as_ref(&self) -> Option<&ForwardToLeader<NID, N>> {
+        match self {
+            Self::ForwardToLeader(f) => Some(f),
+            _ => None,
+        }
+    }
 }
 
 /// The set of errors which may take place when requesting to propose a config change.
@@ -137,9 +210,19 @@ where
     // TODO: do we really need this error? An app may check an target node if it wants to.
     #[error(transparent)]
     NetworkError(#[from] NetworkError),
+}
 
-    #[error(transparent)]
-    Fatal(#[from] Fatal<NID>),
+impl<NID, N> TryAsRef<ForwardToLeader<NID, N>> for AddLearnerError<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn try_as_ref(&self) -> Option<&ForwardToLeader<NID, N>> {
+        match self {
+            Self::ForwardToLeader(f) => Some(f),
+            _ => None,
+        }
+    }
 }
 
 impl<NID, N> TryFrom<AddLearnerError<NID, N>> for ForwardToLeader<NID, N>
@@ -170,64 +253,6 @@ where
 
     #[error(transparent)]
     NotInMembers(#[from] NotInMembers<NID, N>),
-
-    #[error(transparent)]
-    Fatal(#[from] Fatal<NID>),
-}
-
-impl<NID> From<StorageError<NID>> for AppendEntriesError<NID>
-where NID: NodeId
-{
-    fn from(s: StorageError<NID>) -> Self {
-        let f: Fatal<NID> = s.into();
-        f.into()
-    }
-}
-impl<NID> From<StorageError<NID>> for VoteError<NID>
-where NID: NodeId
-{
-    fn from(s: StorageError<NID>) -> Self {
-        let f: Fatal<NID> = s.into();
-        f.into()
-    }
-}
-impl<NID> From<StorageError<NID>> for InstallSnapshotError<NID>
-where NID: NodeId
-{
-    fn from(s: StorageError<NID>) -> Self {
-        let f: Fatal<NID> = s.into();
-        f.into()
-    }
-}
-impl<NID, N> From<StorageError<NID>> for CheckIsLeaderError<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    fn from(s: StorageError<NID>) -> Self {
-        let f: Fatal<NID> = s.into();
-        f.into()
-    }
-}
-impl<NID, N> From<StorageError<NID>> for InitializeError<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    fn from(s: StorageError<NID>) -> Self {
-        let f: Fatal<NID> = s.into();
-        f.into()
-    }
-}
-impl<NID, N> From<StorageError<NID>> for AddLearnerError<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    fn from(s: StorageError<NID>) -> Self {
-        let f: Fatal<NID> = s.into();
-        f.into()
-    }
 }
 
 /// Error variants related to the Replication.
@@ -250,9 +275,10 @@ where
     StorageError(#[from] StorageError<NID>),
 
     #[error(transparent)]
-    RPCError(#[from] RPCError<NID, N, AppendEntriesError<NID>>),
+    RPCError(#[from] RPCError<NID, N, RaftError<NID, Infallible>>),
 }
 
+/// Error occurs when invoking a remote raft API.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(
     feature = "serde",
@@ -274,7 +300,6 @@ pub enum RPCError<NID: NodeId, N: Node, T: Error> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[error("error occur on remote peer {target}: {source}")]
 pub struct RemoteError<NID: NodeId, N: Node, T: std::error::Error> {
-    // #[serde(bound = "")]
     #[cfg_attr(feature = "serde", serde(bound = ""))]
     pub target: NID,
     #[cfg_attr(feature = "serde", serde(bound = ""))]
@@ -430,6 +455,12 @@ pub struct EmptyMembership {}
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[error("infallible")]
 pub enum Infallible {}
+
+/// A place holder to mark RaftError won't have a ForwardToLeader variant.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[error("no-forward")]
+pub enum NoForward {}
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -172,9 +172,6 @@ where
     NotInMembers(#[from] NotInMembers<NID, N>),
 
     #[error(transparent)]
-    NotAMembershipEntry(#[from] NotAMembershipEntry),
-
-    #[error(transparent)]
     Fatal(#[from] Fatal<NID>),
 }
 
@@ -423,11 +420,6 @@ where
     pub node_id: NID,
     pub membership: Membership<NID, N>,
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-#[error("initializing log entry has to be a membership config entry")]
-pub struct NotAMembershipEntry {}
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -62,6 +62,7 @@ mod runtime;
 pub mod storage;
 pub mod testing;
 pub mod timer;
+mod try_as_ref;
 pub(crate) mod validate;
 pub mod versioned;
 
@@ -71,6 +72,7 @@ pub use anyerror;
 pub use anyerror::AnyError;
 pub use async_trait;
 pub use metrics::ReplicationTargetMetrics;
+pub use try_as_ref::TryAsRef;
 
 pub use crate::change_members::ChangeMembers;
 pub use crate::config::Config;

--- a/openraft/src/network.rs
+++ b/openraft/src/network.rs
@@ -5,10 +5,9 @@ use std::fmt::Formatter;
 
 use async_trait::async_trait;
 
-use crate::error::AppendEntriesError;
 use crate::error::InstallSnapshotError;
 use crate::error::RPCError;
-use crate::error::VoteError;
+use crate::error::RaftError;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::InstallSnapshotRequest;
@@ -49,19 +48,22 @@ where C: RaftTypeConfig
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse<C::NodeId>, RPCError<C::NodeId, C::Node, AppendEntriesError<C::NodeId>>>;
+    ) -> Result<AppendEntriesResponse<C::NodeId>, RPCError<C::NodeId, C::Node, RaftError<C::NodeId>>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C::NodeId>, RPCError<C::NodeId, C::Node, InstallSnapshotError<C::NodeId>>>;
+    ) -> Result<
+        InstallSnapshotResponse<C::NodeId>,
+        RPCError<C::NodeId, C::Node, RaftError<C::NodeId, InstallSnapshotError>>,
+    >;
 
     /// Send a RequestVote RPC to the target Raft node (§5).
     async fn send_vote(
         &mut self,
         rpc: VoteRequest<C::NodeId>,
-    ) -> Result<VoteResponse<C::NodeId>, RPCError<C::NodeId, C::Node, VoteError<C::NodeId>>>;
+    ) -> Result<VoteResponse<C::NodeId>, RPCError<C::NodeId, C::Node, RaftError<C::NodeId>>>;
 }
 
 /// A trait defining the interface for a Raft network factory to create connections between cluster

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -31,13 +31,13 @@ use crate::core::VoteWiseTime;
 use crate::engine::Engine;
 use crate::engine::EngineConfig;
 use crate::error::AddLearnerError;
-use crate::error::AppendEntriesError;
 use crate::error::CheckIsLeaderError;
 use crate::error::ClientWriteError;
 use crate::error::Fatal;
+use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::error::InstallSnapshotError;
-use crate::error::VoteError;
+use crate::error::RaftError;
 use crate::membership::IntoNodes;
 use crate::metrics::RaftMetrics;
 use crate::metrics::Wait;
@@ -341,7 +341,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     pub async fn append_entries(
         &self,
         rpc: AppendEntriesRequest<C>,
-    ) -> Result<AppendEntriesResponse<C::NodeId>, AppendEntriesError<C::NodeId>> {
+    ) -> Result<AppendEntriesResponse<C::NodeId>, RaftError<C::NodeId>> {
         tracing::debug!(rpc = display(rpc.summary()), "Raft::append_entries");
 
         let (tx, rx) = oneshot::channel();
@@ -353,7 +353,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     /// These RPCs are sent by cluster peers which are in candidate state attempting to gather votes
     /// (§5.2).
     #[tracing::instrument(level = "debug", skip(self, rpc))]
-    pub async fn vote(&self, rpc: VoteRequest<C::NodeId>) -> Result<VoteResponse<C::NodeId>, VoteError<C::NodeId>> {
+    pub async fn vote(&self, rpc: VoteRequest<C::NodeId>) -> Result<VoteResponse<C::NodeId>, RaftError<C::NodeId>> {
         tracing::debug!(rpc = display(rpc.summary()), "Raft::vote()");
 
         let (tx, rx) = oneshot::channel();
@@ -368,7 +368,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     pub async fn install_snapshot(
         &self,
         rpc: InstallSnapshotRequest<C>,
-    ) -> Result<InstallSnapshotResponse<C::NodeId>, InstallSnapshotError<C::NodeId>> {
+    ) -> Result<InstallSnapshotResponse<C::NodeId>, RaftError<C::NodeId, InstallSnapshotError>> {
         tracing::debug!(rpc = display(rpc.summary()), "Raft::install_snapshot()");
 
         let (tx, rx) = oneshot::channel();
@@ -391,7 +391,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     /// The actual read operation itself is up to the application, this method just ensures that
     /// the read will not be stale.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn is_leader(&self) -> Result<(), CheckIsLeaderError<C::NodeId, C::Node>> {
+    pub async fn is_leader(&self) -> Result<(), RaftError<C::NodeId, CheckIsLeaderError<C::NodeId, C::Node>>> {
         let (tx, rx) = oneshot::channel();
         self.call_core(RaftMsg::CheckIsLeaderRequest { tx }, rx).await
     }
@@ -418,7 +418,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     pub async fn client_write(
         &self,
         app_data: C::D,
-    ) -> Result<ClientWriteResponse<C>, ClientWriteError<C::NodeId, C::Node>> {
+    ) -> Result<ClientWriteResponse<C>, RaftError<C::NodeId, ClientWriteError<C::NodeId, C::Node>>> {
         let (tx, rx) = oneshot::channel();
         self.call_core(
             RaftMsg::ClientWriteRequest {
@@ -452,8 +452,13 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
     /// More than one node performing `initialize()` with the same config is safe,
     /// with different config will result in split brain condition.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn initialize<T>(&self, members: T) -> Result<(), InitializeError<C::NodeId, C::Node>>
-    where T: IntoNodes<C::NodeId, C::Node> + Debug {
+    pub async fn initialize<T>(
+        &self,
+        members: T,
+    ) -> Result<(), RaftError<C::NodeId, InitializeError<C::NodeId, C::Node>>>
+    where
+        T: IntoNodes<C::NodeId, C::Node> + Debug,
+    {
         let (tx, rx) = oneshot::channel();
         self.call_core(
             RaftMsg::Initialize {
@@ -490,7 +495,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         id: C::NodeId,
         node: C::Node,
         blocking: bool,
-    ) -> Result<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId, C::Node>> {
+    ) -> Result<AddLearnerResponse<C::NodeId>, RaftError<C::NodeId, AddLearnerError<C::NodeId, C::Node>>> {
         let (tx, rx) = oneshot::channel();
         let resp = self.call_core(RaftMsg::AddLearner { id, node, tx }, rx).await?;
 
@@ -617,7 +622,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         members: impl Into<ChangeMembers<C::NodeId>>,
         allow_lagging: bool,
         turn_to_learner: bool,
-    ) -> Result<ClientWriteResponse<C>, ClientWriteError<C::NodeId, C::Node>> {
+    ) -> Result<ClientWriteResponse<C>, RaftError<C::NodeId, ClientWriteError<C::NodeId, C::Node>>> {
         let changes: ChangeMembers<C::NodeId> = members.into();
 
         tracing::info!(
@@ -683,8 +688,14 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
 
     /// Invoke RaftCore by sending a RaftMsg and blocks waiting for response.
     #[tracing::instrument(level = "debug", skip(self, mes, rx))]
-    pub(crate) async fn call_core<T, E>(&self, mes: RaftMsg<C, N, S>, rx: RaftRespRx<T, E>) -> Result<T, E>
-    where E: From<Fatal<C::NodeId>> + Debug {
+    pub(crate) async fn call_core<T, E>(
+        &self,
+        mes: RaftMsg<C, N, S>,
+        rx: oneshot::Receiver<Result<T, E>>,
+    ) -> Result<T, RaftError<C::NodeId, E>>
+    where
+        E: Debug,
+    {
         let sum = if tracing::enabled!(Level::DEBUG) {
             None
         } else {
@@ -695,18 +706,18 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
 
         if send_res.is_err() {
             let fatal = self.get_core_stopped_error("sending tx to RaftCore", sum).await;
-            return Err(fatal.into());
+            return Err(RaftError::Fatal(fatal));
         }
 
         let recv_res = rx.await;
         tracing::debug!("call_core receives result is error: {:?}", recv_res.is_err());
 
         match recv_res {
-            Ok(x) => x,
+            Ok(x) => x.map_err(|e| RaftError::APIError(e)),
             Err(_) => {
                 let fatal = self.get_core_stopped_error("receiving rx from RaftCore", sum).await;
                 tracing::error!(error = debug(&fatal), "core_call fatal error");
-                Err(fatal.into())
+                Err(RaftError::Fatal(fatal))
             }
         }
     }
@@ -838,7 +849,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
 }
 
 pub(crate) type RaftRespTx<T, E> = oneshot::Sender<Result<T, E>>;
-pub(crate) type RaftRespRx<T, E> = oneshot::Receiver<Result<T, E>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
@@ -854,13 +864,13 @@ pub struct AddLearnerResponse<NID: NodeId> {
 pub(crate) type RaftAddLearnerTx<NID, N> = RaftRespTx<AddLearnerResponse<NID>, AddLearnerError<NID, N>>;
 
 /// TX for Install Snapshot Response
-pub(crate) type InstallSnapshotTx<NID> = RaftRespTx<InstallSnapshotResponse<NID>, InstallSnapshotError<NID>>;
+pub(crate) type InstallSnapshotTx<NID> = RaftRespTx<InstallSnapshotResponse<NID>, InstallSnapshotError>;
 
 /// TX for Vote Response
-pub(crate) type VoteTx<NID> = RaftRespTx<VoteResponse<NID>, VoteError<NID>>;
+pub(crate) type VoteTx<NID> = RaftRespTx<VoteResponse<NID>, Infallible>;
 
 /// TX for Append Entries Response
-pub(crate) type AppendEntriesTx<NID> = RaftRespTx<AppendEntriesResponse<NID>, AppendEntriesError<NID>>;
+pub(crate) type AppendEntriesTx<NID> = RaftRespTx<AppendEntriesResponse<NID>, Infallible>;
 
 /// TX for Client Write Response
 pub(crate) type ClientWriteTx<C, NID, N> = RaftRespTx<ClientWriteResponse<C>, ClientWriteError<NID, N>>;

--- a/openraft/src/try_as_ref.rs
+++ b/openraft/src/try_as_ref.rs
@@ -1,0 +1,3 @@
+pub trait TryAsRef<T> {
+    fn try_as_ref(&self) -> Option<&T>;
+}

--- a/openraft/tests/life_cycle/t20_initialization.rs
+++ b/openraft/tests/life_cycle/t20_initialization.rs
@@ -190,7 +190,7 @@ async fn initialize_err_target_not_include_target() -> anyhow::Result<()> {
                 node_id,
                 membership: Membership::new(vec![btreeset! {9}], None)
             }),
-            err
+            err.into_api_error().unwrap()
         );
     }
 
@@ -233,7 +233,7 @@ async fn initialize_err_not_allowed() -> anyhow::Result<()> {
                 }),
                 vote: Vote::new_committed(1, 0)
             }),
-            err
+            err.into_api_error().unwrap()
         );
     }
 

--- a/openraft/tests/life_cycle/t20_shutdown.rs
+++ b/openraft/tests/life_cycle/t20_shutdown.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::error::ClientWriteError;
 use openraft::error::Fatal;
 use openraft::Config;
 use openraft::ServerState;
@@ -65,7 +64,7 @@ async fn return_error_after_panic() -> Result<()> {
     {
         let res = router.client_request(0, "foo", 2).await;
         let err = res.unwrap_err();
-        assert_eq!(ClientWriteError::<u64, ()>::Fatal(Fatal::Panicked), err);
+        assert_eq!(Fatal::Panicked, err.into_fatal().unwrap());
     }
 
     Ok(())
@@ -98,7 +97,7 @@ async fn return_error_after_shutdown() -> Result<()> {
     {
         let res = router.client_request(0, "foo", 2).await;
         let err = res.unwrap_err();
-        assert_eq!(ClientWriteError::<u64, _>::Fatal(Fatal::Stopped), err);
+        assert_eq!(Fatal::Stopped, err.into_fatal().unwrap());
     }
 
     Ok(())

--- a/openraft/tests/membership/t30_remove_leader.rs
+++ b/openraft/tests/membership/t30_remove_leader.rs
@@ -160,7 +160,7 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
         Ok(_) => {
             unreachable!("expect error");
         }
-        Err(cli_err) => match cli_err {
+        Err(cli_err) => match cli_err.api_error().unwrap() {
             ClientWriteError::ForwardToLeader(fwd) => {
                 assert!(fwd.leader_id.is_none());
                 assert!(fwd.leader_node.is_none());


### PR DESCRIPTION

## Changelog

##### Refactor: Use shorter type names for rockdb example


##### Change: add RaftError as API return error type.

Add `RaftError<E>` as error type returned by every `Raft::xxx()` API.
RaftError has two variants: Fatal error or API specific error.
This way every API error such as AppendEntriesError does not have to include
an `Fatal` in it.

Upgrade tip:

The affected types is mainly `trait RaftNetwork`, an application should
replace AppendEntriesError, VoteError, InstallSnapshotError with
`RaftError<_>`, `RaftError<_>`, and `RaftError<_, InstallSnapshotError>`.

So is for other parts, e.g., `Raft::append_entries()` now returns
`Result<AppendEntriesResponse, RaftError<_>>`, an application should
also rewrite error handling that calls these APIs.

See changes in examples/.


##### Change: remove InitializeError::NotAMembershipEntry error

Such an error can only be caused by internal calls. An application do
not need to handle it.


##### Refactor: derive Clone for Raft

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/670)
<!-- Reviewable:end -->
