### PR TITLE
Refactor: move assign_log_ids() to RaftState, add method to build a ForwardToLeader error

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -398,6 +398,26 @@ where
     pub leader_node: Option<N>,
 }
 
+impl<NID, N> ForwardToLeader<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    pub const fn empty() -> Self {
+        Self {
+            leader_id: None,
+            leader_node: None,
+        }
+    }
+
+    pub fn new(leader_id: NID, node: N) -> Self {
+        Self {
+            leader_id: Some(leader_id),
+            leader_node: Some(node),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("snapshot segment id mismatch, expect: {expect}, got: {got}")]

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
+use maplit::btreemap;
 use maplit::btreeset;
 
 use crate::engine::LogIdList;
+use crate::error::ForwardToLeader;
 use crate::raft_state::LogStateReader;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
@@ -10,6 +12,7 @@ use crate::LogId;
 use crate::Membership;
 use crate::MembershipState;
 use crate::RaftState;
+use crate::Vote;
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
     LogId::<u64> {
@@ -200,4 +203,48 @@ fn test_raft_state_is_membership_committed() -> anyhow::Result<()> {
 
     assert!(!rs.is_membership_committed(), "rs.committed < effective.log_id");
     Ok(())
+}
+
+#[test]
+fn test_forward_to_leader_vote_not_committed() {
+    let rs = RaftState {
+        vote: Vote::new(1, 2),
+        membership_state: MembershipState::new(
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
+        ),
+        ..Default::default()
+    };
+
+    assert_eq!(ForwardToLeader::empty(), rs.forward_to_leader());
+}
+
+#[test]
+fn test_forward_to_leader_not_a_member() {
+    let rs = RaftState {
+        vote: Vote::new_committed(1, 3),
+        membership_state: MembershipState::new(
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
+        ),
+        ..Default::default()
+    };
+
+    assert_eq!(ForwardToLeader::empty(), rs.forward_to_leader());
+}
+
+#[test]
+fn test_forward_to_leader_has_leader() {
+    let m123 = || Membership::<u64, u64>::new(vec![btreeset! {1,2}], btreemap! {1=>4,2=>5,3=>6});
+
+    let rs = RaftState {
+        vote: Vote::new_committed(1, 3),
+        membership_state: MembershipState::new(
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),
+        ),
+        ..Default::default()
+    };
+
+    assert_eq!(ForwardToLeader::new(3, 6), rs.forward_to_leader());
 }


### PR DESCRIPTION

## Changelog

##### Refactor: move assign_log_ids() to RaftState, add method to build a ForwardToLeader error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/675)
<!-- Reviewable:end -->
