### PR TITLE
Change: remove AddLearnerResponse and AddLearnerError

### DIFF
--- a/examples/raft-kv-memstore/src/client.rs
+++ b/examples/raft-kv-memstore/src/client.rs
@@ -88,7 +88,7 @@ impl ExampleClient {
     pub async fn add_learner(
         &self,
         req: (ExampleNodeId, String),
-    ) -> Result<typ::AddLearnerResponse, typ::RPCError<typ::AddLearnerError>> {
+    ) -> Result<typ::ClientWriteResponse, typ::RPCError<typ::ClientWriteError>> {
         self.send_rpc_to_leader("add-learner", Some(&req)).await
     }
 

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -45,12 +45,10 @@ pub mod typ {
         openraft::error::RPCError<ExampleNodeId, BasicNode, RaftError<E>>;
 
     pub type ClientWriteError = openraft::error::ClientWriteError<ExampleNodeId, BasicNode>;
-    pub type AddLearnerError = openraft::error::AddLearnerError<ExampleNodeId, BasicNode>;
     pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<ExampleNodeId, BasicNode>;
     pub type ForwardToLeader = openraft::error::ForwardToLeader<ExampleNodeId, BasicNode>;
     pub type InitializeError = openraft::error::InitializeError<ExampleNodeId, BasicNode>;
 
-    pub type AddLearnerResponse = openraft::raft::AddLearnerResponse<ExampleNodeId>;
     pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<ExampleTypeConfig>;
 }
 

--- a/examples/raft-kv-rocksdb/src/client.rs
+++ b/examples/raft-kv-rocksdb/src/client.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use openraft::error::AddLearnerError;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::ClientWriteError;
 use openraft::error::ForwardToLeader;
@@ -11,7 +10,6 @@ use openraft::error::NetworkError;
 use openraft::error::RPCError;
 use openraft::error::RaftError;
 use openraft::error::RemoteError;
-use openraft::raft::AddLearnerResponse;
 use openraft::raft::ClientWriteResponse;
 use openraft::RaftMetrics;
 use openraft::TryAsRef;
@@ -111,8 +109,8 @@ impl ExampleClient {
         &self,
         req: (ExampleNodeId, String, String),
     ) -> Result<
-        AddLearnerResponse<ExampleNodeId>,
-        RPCError<ExampleNodeId, ExampleNode, RaftError<ExampleNodeId, AddLearnerError<ExampleNodeId, ExampleNode>>>,
+        ClientWriteResponse<ExampleTypeConfig>,
+        RPCError<ExampleNodeId, ExampleNode, RaftError<ExampleNodeId, ClientWriteError<ExampleNodeId, ExampleNode>>>,
     > {
         self.send_rpc_to_leader("cluster/add-learner", Some(&req)).await
     }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -106,7 +106,7 @@ pub(crate) struct LeaderData<C: RaftTypeConfig, SD>
 where SD: AsyncRead + AsyncSeek + Send + Unpin + 'static
 {
     /// Channels to send result back to client when logs are committed.
-    pub(crate) client_resp_channels: BTreeMap<u64, ClientWriteTx<C, C::NodeId, C::Node>>,
+    pub(crate) client_resp_channels: BTreeMap<u64, ClientWriteTx<C>>,
 
     /// A mapping of node IDs the replication state of the target node.
     // TODO(xp): make it a field of RaftCore. it does not have to belong to leader.
@@ -375,7 +375,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         &mut self,
         target: C::NodeId,
         node: C::Node,
-        tx: ClientWriteTx<C, C::NodeId, C::Node>,
+        tx: ClientWriteTx<C>,
     ) -> Result<(), Fatal<C::NodeId>> {
         if let Some(l) = &self.leader_data {
             tracing::debug!(
@@ -529,7 +529,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     pub async fn write_entry(
         &mut self,
         payload: EntryPayload<C>,
-        resp_tx: Option<ClientWriteTx<C, C::NodeId, C::Node>>,
+        resp_tx: Option<ClientWriteTx<C>>,
     ) -> Result<LogId<C::NodeId>, Fatal<C::NodeId>> {
         tracing::debug!(payload = display(payload.summary()), "write_entry");
 
@@ -858,7 +858,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
     /// Send result of applying a log entry to its client.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(super) fn send_response(entry: &Entry<C>, resp: C::R, tx: Option<ClientWriteTx<C, C::NodeId, C::Node>>) {
+    pub(super) fn send_response(entry: &Entry<C>, resp: C::R, tx: Option<ClientWriteTx<C>>) {
         tracing::debug!(entry = display(entry.summary()), "send_response");
 
         let tx = match tx {

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -200,41 +200,6 @@ pub enum ChangeMembershipError<NID: NodeId> {
     LearnerIsLagging(#[from] LearnerIsLagging<NID>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum AddLearnerError<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    #[error(transparent)]
-    ForwardToLeader(#[from] ForwardToLeader<NID, N>),
-}
-
-impl<NID, N> TryAsRef<ForwardToLeader<NID, N>> for AddLearnerError<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    fn try_as_ref(&self) -> Option<&ForwardToLeader<NID, N>> {
-        let Self::ForwardToLeader(f) = self;
-        Some(f)
-    }
-}
-
-impl<NID, N> TryFrom<AddLearnerError<NID, N>> for ForwardToLeader<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    type Error = AddLearnerError<NID, N>;
-
-    fn try_from(value: AddLearnerError<NID, N>) -> Result<Self, Self::Error> {
-        let AddLearnerError::ForwardToLeader(e) = value;
-        Ok(e)
-    }
-}
-
 /// The set of errors which may take place when initializing a pristine Raft node.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, derive_more::TryInto)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -849,7 +849,8 @@ pub(crate) type VoteTx<NID> = RaftRespTx<VoteResponse<NID>, Infallible>;
 pub(crate) type AppendEntriesTx<NID> = RaftRespTx<AppendEntriesResponse<NID>, Infallible>;
 
 /// TX for Client Write Response
-pub(crate) type ClientWriteTx<C, NID, N> = RaftRespTx<ClientWriteResponse<C>, ClientWriteError<NID, N>>;
+pub(crate) type ClientWriteTx<C> =
+    RaftRespTx<ClientWriteResponse<C>, ClientWriteError<<C as RaftTypeConfig>::NodeId, <C as RaftTypeConfig>::Node>>;
 
 /// A message coming from the Raft API.
 pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> {
@@ -884,7 +885,7 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
 
     ClientWriteRequest {
         payload: EntryPayload<C>,
-        tx: ClientWriteTx<C, C::NodeId, C::Node>,
+        tx: ClientWriteTx<C>,
     },
 
     CheckIsLeaderRequest {
@@ -903,7 +904,7 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
         node: C::Node,
 
         /// Send the log id when the replication becomes line-rate.
-        tx: ClientWriteTx<C, C::NodeId, C::Node>,
+        tx: ClientWriteTx<C>,
     },
 
     ChangeMembership {

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -30,7 +30,6 @@ use crate::core::TickHandle;
 use crate::core::VoteWiseTime;
 use crate::engine::Engine;
 use crate::engine::EngineConfig;
-use crate::error::AddLearnerError;
 use crate::error::CheckIsLeaderError;
 use crate::error::ClientWriteError;
 use crate::error::Fatal;
@@ -495,7 +494,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         id: C::NodeId,
         node: C::Node,
         blocking: bool,
-    ) -> Result<AddLearnerResponse<C::NodeId>, RaftError<C::NodeId, AddLearnerError<C::NodeId, C::Node>>> {
+    ) -> Result<ClientWriteResponse<C>, RaftError<C::NodeId, ClientWriteError<C::NodeId, C::Node>>> {
         let (tx, rx) = oneshot::channel();
         let resp = self.call_core(RaftMsg::AddLearner { id, node, tx }, rx).await?;
 
@@ -510,19 +509,13 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         // Otherwise, blocks until the replication to the new learner becomes up to date.
 
         // The log id of the membership that contains the added learner.
-        let membership_log_id = resp.membership_log_id;
-
-        let res0 = Arc::new(std::sync::Mutex::new(resp));
-        let res = res0.clone();
+        let membership_log_id = resp.log_id;
 
         let wait_res = self
             .wait(None)
             .metrics(
-                |metrics| match self.check_replication_upto_date(metrics, id, membership_log_id) {
-                    Ok(matched) => {
-                        res.lock().unwrap().matched = matched;
-                        true
-                    }
+                |metrics| match self.check_replication_upto_date(metrics, id, Some(membership_log_id)) {
+                    Ok(_matching) => true,
                     // keep waiting
                     Err(_) => false,
                 },
@@ -532,11 +525,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
 
         tracing::info!(wait_res = debug(&wait_res), "waiting for replication to new learner");
 
-        let r = {
-            let x = res0.lock().unwrap();
-            x.clone()
-        };
-        Ok(r)
+        Ok(resp)
     }
 
     /// Returns Ok() with the latest known matched log id if it should quit waiting: leader change,
@@ -850,19 +839,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
 
 pub(crate) type RaftRespTx<T, E> = oneshot::Sender<Result<T, E>>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct AddLearnerResponse<NID: NodeId> {
-    /// The log id of the membership that contains the added learner.
-    pub membership_log_id: Option<LogId<NID>>,
-
-    /// The last log id that matches leader log.
-    pub matched: Option<LogId<NID>>,
-}
-
-/// TX for Add Learner Response
-pub(crate) type RaftAddLearnerTx<NID, N> = RaftRespTx<AddLearnerResponse<NID>, AddLearnerError<NID, N>>;
-
 /// TX for Install Snapshot Response
 pub(crate) type InstallSnapshotTx<NID> = RaftRespTx<InstallSnapshotResponse<NID>, InstallSnapshotError>;
 
@@ -927,7 +903,7 @@ pub(crate) enum RaftMsg<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStor
         node: C::Node,
 
         /// Send the log id when the replication becomes line-rate.
-        tx: RaftAddLearnerTx<C::NodeId, C::Node>,
+        tx: ClientWriteTx<C, C::NodeId, C::Node>,
     },
 
     ChangeMembership {

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -25,7 +25,6 @@ use memstore::Config as MemConfig;
 use memstore::IntoMemClientRequest;
 use memstore::MemStore;
 use openraft::async_trait::async_trait;
-use openraft::error::AddLearnerError;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::ClientWriteError;
 use openraft::error::InstallSnapshotError;
@@ -34,9 +33,9 @@ use openraft::error::RPCError;
 use openraft::error::RaftError;
 use openraft::error::RemoteError;
 use openraft::metrics::Wait;
-use openraft::raft::AddLearnerResponse;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
+use openraft::raft::ClientWriteResponse;
 use openraft::raft::InstallSnapshotRequest;
 use openraft::raft::InstallSnapshotResponse;
 use openraft::raft::VoteRequest;
@@ -556,7 +555,7 @@ where
         &self,
         leader: C::NodeId,
         target: C::NodeId,
-    ) -> Result<AddLearnerResponse<C::NodeId>, AddLearnerError<C::NodeId, C::Node>> {
+    ) -> Result<ClientWriteResponse<C>, ClientWriteError<C::NodeId, C::Node>> {
         let node = self.get_raft_handle(&leader).unwrap();
         node.add_learner(target, C::Node::default(), true).await.map_err(|e| e.into_api_error().unwrap())
     }


### PR DESCRIPTION

## Changelog

##### Refactor: RaftCore::write_entry() does not need to return log id


##### Refactor: ClientWriteTx only needs 1 generics parameter


##### Change: remove AddLearnerResponse and AddLearnerError

In openraft adds a learner is done by committing a membership config
log, which is almost the same as committing any log.

`AddLearnerResponse` contains a field `matched` to indicate the
replication state to the learner, which is not included in
`ClientWriteResponse`. This information can be retrieved via
`Raft::metrics()`.

Therefore to keep the API simple, replace `AddLearnerResponse` with
`ClientWriteResponse`.

Behavior change: adding a learner always commit a new membership config
log, no matter if it already exists in membership.
To avoid duplicated add, an application should check existence first by
examining `Raft::metrics()`

- Fix: #679

Upgrade tips:

- Replace AddLearnerResponse with ClientWriteResponse
- Replace AddLearnerError with ClientWriteError

Passes the application compilation.

See the changes in examples/.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/680)
<!-- Reviewable:end -->
