### PR TITLE
Refactor: enable `serde_json` for toy-rpc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,8 +179,7 @@ jobs:
           - "nightly"
         example:
           - "raft-kv-memstore"
-          # 2023-02-17: this test blocks forever
-          # - "raft-kv-rocksdb"
+          - "raft-kv-rocksdb"
 
     steps:
       - uses: actions/checkout@v2

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -175,7 +175,7 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     // --- Wait for a while to let the replication get done.
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    tokio::time::sleep(Duration::from_millis(1_000)).await;
 
     // --- Read it on every node.
 
@@ -203,7 +203,7 @@ async fn test_cluster() -> anyhow::Result<()> {
         })
         .await?;
 
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(1_000)).await;
 
     // --- Read it on every node.
 

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -32,7 +32,9 @@ rocksdb = "0.20.1"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"
 tide = { version = "0.16" }
-toy-rpc = { version = "0.8.6", features = [ "ws_async_std", "server", "client", "async_std_runtime", ] }
+# for toy-rpc, use `serde_json` instead of the default `serde_bincode`:
+# bincode which enabled by default by toy-rpc, does not support `#[serde(flatten)]`: https://docs.rs/bincode/2.0.0-alpha.1/bincode/serde/index.html#known-issues
+toy-rpc = { version = "0.8.6", default-features = false, features = [ "serde_json", "ws_async_std", "server", "client", "async_std_runtime", ] }
 tracing = "0.1.29"
 tracing-futures = "0.2.4"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }


### PR DESCRIPTION

## Changelog

##### Refactor: enable `serde_json` for toy-rpc

For toy-rpc, use `serde_json` instead of the default `serde_bincode`:
`bincode` which enabled by default by toy-rpc, does not support
`#[serde(flatten)]`:

See: https://docs.rs/bincode/2.0.0-alpha.1/bincode/serde/index.html#known-issues

- Fix: #677

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/681)
<!-- Reviewable:end -->
