### PR TITLE
Refactor: Adds a new method `ensure_last_membership_committed()` to the `MembershipState`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -391,7 +391,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         turn_to_learner: bool,
         tx: RaftRespTx<ClientWriteResponse<C>, ClientWriteError<C::NodeId, C::Node>>,
     ) -> Result<(), Fatal<C::NodeId>> {
-        let res = self.engine.state.membership_state.next_membership(changes, turn_to_learner);
+        let res = self.engine.state.membership_state.create_updated_membership(changes, turn_to_learner);
         let new_membership = match res {
             Ok(x) => x,
             Err(e) => {

--- a/openraft/src/membership/membership_state_test.rs
+++ b/openraft/src/membership/membership_state_test.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
+use maplit::btreemap;
 use maplit::btreeset;
 
+use crate::error::ChangeMembershipError;
+use crate::error::EmptyMembership;
+use crate::error::InProgress;
+use crate::error::LearnerNotFound;
 use crate::testing::log_id;
+use crate::ChangeMembers;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -171,6 +177,69 @@ fn test_membership_state_truncate() -> anyhow::Result<()> {
         assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
         assert_eq!(Some(log_id(2, 2)), ms.effective().log_id);
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_state_next_membership_not_committed() -> anyhow::Result<()> {
+    let new = || MembershipState::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
+    let res = new().create_updated_membership(ChangeMembers::Add(btreeset! {1}), false);
+
+    assert_eq!(
+        Err(ChangeMembershipError::InProgress(InProgress {
+            committed: Some(log_id(2, 2)),
+            membership_log_id: Some(log_id(3, 4))
+        })),
+        res
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_state_create_updated_membership_empty_voters() -> anyhow::Result<()> {
+    let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
+    let res = new().create_updated_membership(ChangeMembers::Remove(btreeset! {1}), false);
+
+    assert_eq!(Err(ChangeMembershipError::EmptyMembership(EmptyMembership {})), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_state_create_updated_membership_learner_not_found() -> anyhow::Result<()> {
+    let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
+    let res = new().create_updated_membership(ChangeMembers::Add(btreeset! {2}), false);
+
+    assert_eq!(
+        Err(ChangeMembershipError::LearnerNotFound(LearnerNotFound { node_id: 2 })),
+        res
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_state_create_updated_membership_removed_to_learner() -> anyhow::Result<()> {
+    let new = || MembershipState::new(effmem(3, 4, m12()), effmem(3, 4, m123_345()));
+
+    // Do not leave removed voters as learner
+    let res = new().create_updated_membership(ChangeMembers::Remove(btreeset! {1,2}), false);
+    assert_eq!(
+        Ok(Membership::new(vec![btreeset! {3,4,5}], btreemap! {3=>(),4=>(),5=>()})),
+        res
+    );
+
+    // Leave removed voters as learner
+    let res = new().create_updated_membership(ChangeMembers::Remove(btreeset! {1,2}), true);
+    assert_eq!(
+        Ok(Membership::new(
+            vec![btreeset! {3,4,5}],
+            btreemap! {1=>(),2=>(),3=>(),4=>(),5=>()}
+        )),
+        res
+    );
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### Refactor: Adds a new method `ensure_last_membership_committed()` to the `MembershipState`

The function checks if the current effective membership configuration is
committed to the Raft log or not.

If it is committed, the function returns `Ok()`, otherwise, it returns an
error `Err(InProgress)`.

`create_updated_membership()` has been modified to use the new
`ensure_last_membership_committed()` to validate the committed and effective
configurations of the membership before building a new membership
configuration.
If the committed and effective membership configurations are not the
same, the `create_updated_membership()` function now returns a
`ChangeMembershipError::InProgress` error.

The patch also adds new tests to test the new
`ensure_last_membership_committed()` and modified `create_updated_membership()`
functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/684)
<!-- Reviewable:end -->
