### PR TITLE
Fix: when adding a learner, ensure the last membership is committed

### DIFF
--- a/openraft/src/change_members.rs
+++ b/openraft/src/change_members.rs
@@ -1,35 +1,30 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
+use crate::Node;
 use crate::NodeId;
 
 #[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum ChangeMembers<NID: NodeId> {
-    Add(BTreeSet<NID>),
-    Remove(BTreeSet<NID>),
-    Replace(BTreeSet<NID>),
+pub enum ChangeMembers<NID: NodeId, N: Node> {
+    AddVoter(BTreeSet<NID>),
+    RemoveVoter(BTreeSet<NID>),
+    ReplaceAllVoters(BTreeSet<NID>),
+    AddNodes(BTreeMap<NID, N>),
+    RemoveNodes(BTreeSet<NID>),
+    ReplaceAllNodes(BTreeMap<NID, N>),
 }
 
 /// Convert a series of ids to a `Replace` operation.
-impl<NID, I> From<I> for ChangeMembers<NID>
+impl<NID, N, I> From<I> for ChangeMembers<NID, N>
 where
     NID: NodeId,
+    N: Node,
     I: IntoIterator<Item = NID>,
 {
     fn from(r: I) -> Self {
         let ids = r.into_iter().collect::<BTreeSet<NID>>();
-        ChangeMembers::Replace(ids)
-    }
-}
-
-impl<NID: NodeId> ChangeMembers<NID> {
-    /// Apply the `ChangeMembers` to `old` node set, return new node set
-    pub fn apply_to(self, old: &BTreeSet<NID>) -> BTreeSet<NID> {
-        match self {
-            ChangeMembers::Replace(c) => c,
-            ChangeMembers::Add(add_members) => old.union(&add_members).cloned().collect::<BTreeSet<_>>(),
-            ChangeMembers::Remove(remove_members) => old.difference(&remove_members).cloned().collect::<BTreeSet<_>>(),
-        }
+        ChangeMembers::ReplaceAllVoters(ids)
     }
 }

--- a/openraft/src/membership/change_handler.rs
+++ b/openraft/src/membership/change_handler.rs
@@ -1,0 +1,161 @@
+use crate::error::ChangeMembershipError;
+use crate::error::InProgress;
+use crate::ChangeMembers;
+use crate::Membership;
+use crate::MembershipState;
+use crate::Node;
+use crate::NodeId;
+
+pub(crate) struct ChangeHandler<'m, NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    pub(crate) state: &'m MembershipState<NID, N>,
+}
+
+impl<'m, NID, N> ChangeHandler<'m, NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    /// Builds a new membership configuration by applying changes to the current configuration.
+    ///
+    /// * `changes`: The changes to apply to the current membership configuration.
+    /// * `retain` specifies whether to retain the removed voters as a learners, i.e., nodes that
+    ///   continue to receive log replication from the leader.
+    ///
+    /// A Result containing the new membership configuration if the operation succeeds, or a
+    /// `ChangeMembershipError` if an error occurs.
+    ///
+    /// This function ensures that the cluster will have at least one voter in the new membership
+    /// configuration.
+    pub(crate) fn apply(
+        &self,
+        change: ChangeMembers<NID, N>,
+        retain: bool,
+    ) -> Result<Membership<NID, N>, ChangeMembershipError<NID>> {
+        self.ensure_committed()?;
+
+        let new_membership = self.state.effective().membership.clone().change(change, retain)?;
+        Ok(new_membership)
+    }
+
+    /// Ensures that the latest membership has been committed.
+    ///
+    /// Returns Ok if the last membership is committed, or an InProgress error
+    /// otherwise, to indicate a change-membership request should be rejected.
+    pub(crate) fn ensure_committed(&self) -> Result<(), InProgress<NID>> {
+        let effective = self.state.effective();
+        let committed = self.state.committed();
+
+        if effective.log_id == committed.log_id {
+            // Ok: last membership(effective) is committed
+            Ok(())
+        } else {
+            Err(InProgress {
+                committed: committed.log_id,
+                membership_log_id: effective.log_id,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use maplit::btreemap;
+    use maplit::btreeset;
+
+    use crate::error::ChangeMembershipError;
+    use crate::error::EmptyMembership;
+    use crate::error::InProgress;
+    use crate::error::LearnerNotFound;
+    use crate::testing::log_id;
+    use crate::ChangeMembers;
+    use crate::EffectiveMembership;
+    use crate::Membership;
+    use crate::MembershipState;
+
+    /// Create an Arc<EffectiveMembership>
+    fn effmem(term: u64, index: u64, m: Membership<u64, ()>) -> Arc<EffectiveMembership<u64, ()>> {
+        let lid = Some(log_id(term, index));
+        Arc::new(EffectiveMembership::new(lid, m))
+    }
+
+    fn m1() -> Membership<u64, ()> {
+        Membership::new(vec![btreeset! {1}], None)
+    }
+
+    fn m12() -> Membership<u64, ()> {
+        Membership::new(vec![btreeset! {1,2}], None)
+    }
+
+    fn m123_345() -> Membership<u64, ()> {
+        Membership::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None)
+    }
+
+    #[test]
+    fn test_apply_not_committed() -> anyhow::Result<()> {
+        let new = || MembershipState::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
+        let res = new().change_handler().apply(ChangeMembers::AddVoter(btreeset! {1}), false);
+
+        assert_eq!(
+            Err(ChangeMembershipError::InProgress(InProgress {
+                committed: Some(log_id(2, 2)),
+                membership_log_id: Some(log_id(3, 4))
+            })),
+            res
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_empty_voters() -> anyhow::Result<()> {
+        let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
+        let res = new().change_handler().apply(ChangeMembers::RemoveVoter(btreeset! {1}), false);
+
+        assert_eq!(Err(ChangeMembershipError::EmptyMembership(EmptyMembership {})), res);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_learner_not_found() -> anyhow::Result<()> {
+        let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
+        let res = new().change_handler().apply(ChangeMembers::AddVoter(btreeset! {2}), false);
+
+        assert_eq!(
+            Err(ChangeMembershipError::LearnerNotFound(LearnerNotFound { node_id: 2 })),
+            res
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_retain_learner() -> anyhow::Result<()> {
+        let new = || MembershipState::new(effmem(3, 4, m12()), effmem(3, 4, m123_345()));
+
+        // Do not leave removed voters as learner
+        let res = new().change_handler().apply(ChangeMembers::RemoveVoter(btreeset! {1,2}), false);
+        assert_eq!(
+            Ok(Membership::new(vec![btreeset! {3,4,5}], btreemap! {3=>(),4=>(),5=>()})),
+            res
+        );
+
+        // Leave removed voters as learner
+        let res = new().change_handler().apply(ChangeMembers::RemoveVoter(btreeset! {1,2}), true);
+        assert_eq!(
+            Ok(Membership::new(
+                vec![btreeset! {3,4,5}],
+                btreemap! {1=>(),2=>(),3=>(),4=>(),5=>()}
+            )),
+            res
+        );
+
+        Ok(())
+    }
+}

--- a/openraft/src/membership/membership_state.rs
+++ b/openraft/src/membership/membership_state.rs
@@ -1,17 +1,13 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use crate::error::ChangeMembershipError;
-use crate::error::EmptyMembership;
-use crate::error::InProgress;
 use crate::less_equal;
+use crate::membership::ChangeHandler;
 use crate::node::Node;
 use crate::validate::Validate;
-use crate::ChangeMembers;
 use crate::EffectiveMembership;
 use crate::LogId;
 use crate::LogIdOptionExt;
-use crate::Membership;
 use crate::MessageSummary;
 use crate::NodeId;
 
@@ -78,59 +74,6 @@ where
 
     pub(crate) fn is_voter(&self, id: &NID) -> bool {
         self.effective.membership.is_voter(id)
-    }
-
-    /// Builds a new membership configuration by applying changes to the current configuration.
-    ///
-    /// * `changes`: The changes to apply to the current membership configuration.
-    /// * `convert_removed_to_learner`: Indicates whether the removed voter should be left in the
-    ///   membership configuration as a learner.
-    ///
-    /// A Result containing the new membership configuration if the operation succeeds, or a
-    /// `ChangeMembershipError` if an error occurs.
-    ///
-    /// This function ensures that the cluster will have at least one voter in the new membership
-    /// configuration.
-    pub(crate) fn create_updated_membership(
-        &self,
-        changes: ChangeMembers<NID>,
-        convert_removed_to_learner: bool,
-    ) -> Result<Membership<NID, N>, ChangeMembershipError<NID>> {
-        let effective = self.effective();
-
-        self.ensure_last_membership_committed()?;
-
-        let last = effective.membership.get_joint_config().last().unwrap();
-        let new_voter_ids = changes.apply_to(last);
-
-        // Ensure cluster will have at least one voter.
-        if new_voter_ids.is_empty() {
-            return Err(EmptyMembership {}.into());
-        }
-
-        let new_membership = effective.membership.next_safe(new_voter_ids, convert_removed_to_learner)?;
-
-        tracing::debug!(?new_membership, "new membership config");
-        Ok(new_membership)
-    }
-
-    /// Ensures that the latest membership configuration has been committed.
-    ///
-    /// Returns Ok if the last membership configuration is committed, or an InProgress error
-    /// otherwise.
-    pub(crate) fn ensure_last_membership_committed(&self) -> Result<(), InProgress<NID>> {
-        let effective = self.effective();
-        let committed = self.committed();
-
-        if self.committed().log_id == self.effective().log_id {
-            // Ok: last membership(effective) is committed
-            Ok(())
-        } else {
-            Err(InProgress {
-                committed: committed.log_id,
-                membership_log_id: effective.log_id,
-            })
-        }
     }
 
     /// Update membership state if the specified committed_log_id is greater than `self.effective`
@@ -255,6 +198,10 @@ where
 
     pub fn effective(&self) -> &Arc<EffectiveMembership<NID, N>> {
         &self.effective
+    }
+
+    pub(crate) fn change_handler(&self) -> ChangeHandler<NID, N> {
+        ChangeHandler { state: self }
     }
 }
 

--- a/openraft/src/membership/membership_state_test.rs
+++ b/openraft/src/membership/membership_state_test.rs
@@ -1,14 +1,8 @@
 use std::sync::Arc;
 
-use maplit::btreemap;
 use maplit::btreeset;
 
-use crate::error::ChangeMembershipError;
-use crate::error::EmptyMembership;
-use crate::error::InProgress;
-use crate::error::LearnerNotFound;
 use crate::testing::log_id;
-use crate::ChangeMembers;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -177,69 +171,6 @@ fn test_membership_state_truncate() -> anyhow::Result<()> {
         assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
         assert_eq!(Some(log_id(2, 2)), ms.effective().log_id);
     }
-
-    Ok(())
-}
-
-#[test]
-fn test_membership_state_next_membership_not_committed() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
-    let res = new().create_updated_membership(ChangeMembers::Add(btreeset! {1}), false);
-
-    assert_eq!(
-        Err(ChangeMembershipError::InProgress(InProgress {
-            committed: Some(log_id(2, 2)),
-            membership_log_id: Some(log_id(3, 4))
-        })),
-        res
-    );
-
-    Ok(())
-}
-
-#[test]
-fn test_membership_state_create_updated_membership_empty_voters() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
-    let res = new().create_updated_membership(ChangeMembers::Remove(btreeset! {1}), false);
-
-    assert_eq!(Err(ChangeMembershipError::EmptyMembership(EmptyMembership {})), res);
-
-    Ok(())
-}
-
-#[test]
-fn test_membership_state_create_updated_membership_learner_not_found() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
-    let res = new().create_updated_membership(ChangeMembers::Add(btreeset! {2}), false);
-
-    assert_eq!(
-        Err(ChangeMembershipError::LearnerNotFound(LearnerNotFound { node_id: 2 })),
-        res
-    );
-
-    Ok(())
-}
-
-#[test]
-fn test_membership_state_create_updated_membership_removed_to_learner() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(3, 4, m12()), effmem(3, 4, m123_345()));
-
-    // Do not leave removed voters as learner
-    let res = new().create_updated_membership(ChangeMembers::Remove(btreeset! {1,2}), false);
-    assert_eq!(
-        Ok(Membership::new(vec![btreeset! {3,4,5}], btreemap! {3=>(),4=>(),5=>()})),
-        res
-    );
-
-    // Leave removed voters as learner
-    let res = new().create_updated_membership(ChangeMembers::Remove(btreeset! {1,2}), true);
-    assert_eq!(
-        Ok(Membership::new(
-            vec![btreeset! {3,4,5}],
-            btreemap! {1=>(),2=>(),3=>(),4=>(),5=>()}
-        )),
-        res
-    );
 
     Ok(())
 }

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -1,3 +1,4 @@
+mod change_handler;
 mod effective_membership;
 #[allow(clippy::module_inception)] mod membership;
 mod membership_state;
@@ -11,6 +12,7 @@ mod bench;
 #[cfg(test)] mod membership_state_test;
 #[cfg(test)] mod membership_test;
 
+pub(crate) use change_handler::ChangeHandler;
 pub use effective_membership::EffectiveMembership;
 pub use membership::IntoNodes;
 pub use membership::Membership;

--- a/openraft/src/quorum/coherent.rs
+++ b/openraft/src/quorum/coherent.rs
@@ -1,7 +1,8 @@
 use crate::quorum::QuorumSet;
 
 /// **Coherent** quorum set A and B is defined as: `∀ qᵢ ∈ A, ∀ qⱼ ∈ B: qᵢ ∩ qⱼ != ø`, i.e., `A ~
-/// B`. A distributed consensus protocol such as openraft is only allowed to switch membership
+/// B`.
+/// A distributed consensus protocol such as openraft is only allowed to switch membership
 /// between two **coherent** quorum sets. Being coherent is one of the two restrictions. The other
 /// restriction is to disable other smaller candidate to elect.
 pub(crate) trait Coherent<ID, Other>
@@ -10,8 +11,8 @@ where
     Self: QuorumSet<ID>,
     Other: QuorumSet<ID>,
 {
-    /// Returns if two QuorumSet are coherent.
-    fn is_coherent(&self, other: &Other) -> bool;
+    /// Returns `true` if this QuorumSet is coherent with the other quorum set.
+    fn is_coherent_with(&self, other: &Other) -> bool;
 }
 
 pub(crate) trait FindCoherent<ID, Other>

--- a/openraft/src/quorum/coherent_impl.rs
+++ b/openraft/src/quorum/coherent_impl.rs
@@ -12,7 +12,7 @@ where
     ///
     /// Read more about:
     /// [safe-membership-change](https://datafuselabs.github.io/openraft/dynamic-membership.html#the-safe-to-relation)
-    fn is_coherent(&self, other: &Joint<ID, QS, Vec<QS>>) -> bool {
+    fn is_coherent_with(&self, other: &Joint<ID, QS, Vec<QS>>) -> bool {
         for a in self.children() {
             for b in other.children() {
                 if a == b {
@@ -30,7 +30,7 @@ where
     ID: PartialOrd + Ord + 'static,
     QS: QuorumSet<ID> + PartialEq,
 {
-    fn is_coherent(&self, other: &Joint<ID, QS, &[QS]>) -> bool {
+    fn is_coherent_with(&self, other: &Joint<ID, QS, &[QS]>) -> bool {
         for a in self.children().iter() {
             for b in other.children().iter() {
                 if a == b {
@@ -48,7 +48,7 @@ where
     ID: PartialOrd + Ord + 'static,
     QS: QuorumSet<ID> + PartialEq,
 {
-    fn is_coherent(&self, other: &QS) -> bool {
+    fn is_coherent_with(&self, other: &QS) -> bool {
         for a in self.children().iter() {
             if a == other {
                 return true;
@@ -66,7 +66,7 @@ where
     QS: QuorumSet<ID> + PartialEq + Clone,
 {
     fn find_coherent(&self, other: QS) -> Self {
-        if self.is_coherent(&other) {
+        if self.is_coherent_with(&other) {
             Joint::from(vec![other])
         } else {
             Joint::from(vec![self.children().last().unwrap().clone(), other])

--- a/openraft/src/quorum/coherent_test.rs
+++ b/openraft/src/quorum/coherent_test.rs
@@ -16,25 +16,25 @@ fn test_is_coherent_vec() -> anyhow::Result<()> {
     let j123_345 = Joint::from(vec![s123(), s345()]);
     let j345_789 = Joint::from(vec![s345(), s789()]);
 
-    assert!(j123.is_coherent(&j123));
-    assert!(!j123.is_coherent(&j345));
-    assert!(j123.is_coherent(&j123_345));
-    assert!(!j123.is_coherent(&j345_789));
+    assert!(j123.is_coherent_with(&j123));
+    assert!(!j123.is_coherent_with(&j345));
+    assert!(j123.is_coherent_with(&j123_345));
+    assert!(!j123.is_coherent_with(&j345_789));
 
-    assert!(!j345.is_coherent(&j123));
-    assert!(j345.is_coherent(&j345));
-    assert!(j345.is_coherent(&j123_345));
-    assert!(j345.is_coherent(&j345_789));
+    assert!(!j345.is_coherent_with(&j123));
+    assert!(j345.is_coherent_with(&j345));
+    assert!(j345.is_coherent_with(&j123_345));
+    assert!(j345.is_coherent_with(&j345_789));
 
-    assert!(j123_345.is_coherent(&j123));
-    assert!(j123_345.is_coherent(&j345));
-    assert!(j123_345.is_coherent(&j123_345));
-    assert!(j123_345.is_coherent(&j345_789));
+    assert!(j123_345.is_coherent_with(&j123));
+    assert!(j123_345.is_coherent_with(&j345));
+    assert!(j123_345.is_coherent_with(&j123_345));
+    assert!(j123_345.is_coherent_with(&j345_789));
 
-    assert!(!j345_789.is_coherent(&j123));
-    assert!(j345_789.is_coherent(&j345));
-    assert!(j345_789.is_coherent(&j123_345));
-    assert!(j345_789.is_coherent(&j345_789));
+    assert!(!j345_789.is_coherent_with(&j123));
+    assert!(j345_789.is_coherent_with(&j345));
+    assert!(j345_789.is_coherent_with(&j123_345));
+    assert!(j345_789.is_coherent_with(&j345_789));
 
     Ok(())
 }
@@ -55,25 +55,25 @@ fn test_is_coherent_slice() -> anyhow::Result<()> {
     let j123_345 = v123_345.as_joint();
     let j345_789 = v345_789.as_joint();
 
-    assert!(j123.is_coherent(&j123));
-    assert!(!j123.is_coherent(&j345));
-    assert!(j123.is_coherent(&j123_345));
-    assert!(!j123.is_coherent(&j345_789));
+    assert!(j123.is_coherent_with(&j123));
+    assert!(!j123.is_coherent_with(&j345));
+    assert!(j123.is_coherent_with(&j123_345));
+    assert!(!j123.is_coherent_with(&j345_789));
 
-    assert!(!j345.is_coherent(&j123));
-    assert!(j345.is_coherent(&j345));
-    assert!(j345.is_coherent(&j123_345));
-    assert!(j345.is_coherent(&j345_789));
+    assert!(!j345.is_coherent_with(&j123));
+    assert!(j345.is_coherent_with(&j345));
+    assert!(j345.is_coherent_with(&j123_345));
+    assert!(j345.is_coherent_with(&j345_789));
 
-    assert!(j123_345.is_coherent(&j123));
-    assert!(j123_345.is_coherent(&j345));
-    assert!(j123_345.is_coherent(&j123_345));
-    assert!(j123_345.is_coherent(&j345_789));
+    assert!(j123_345.is_coherent_with(&j123));
+    assert!(j123_345.is_coherent_with(&j345));
+    assert!(j123_345.is_coherent_with(&j123_345));
+    assert!(j123_345.is_coherent_with(&j345_789));
 
-    assert!(!j345_789.is_coherent(&j123));
-    assert!(j345_789.is_coherent(&j345));
-    assert!(j345_789.is_coherent(&j123_345));
-    assert!(j345_789.is_coherent(&j345_789));
+    assert!(!j345_789.is_coherent_with(&j123));
+    assert!(j345_789.is_coherent_with(&j345));
+    assert!(j345_789.is_coherent_with(&j123_345));
+    assert!(j345_789.is_coherent_with(&j345_789));
 
     Ok(())
 }

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -112,6 +112,8 @@ async fn change_without_adding_learner() -> anyhow::Result<()> {
     {
         let res = leader.change_membership(btreeset! {0,1}, false).await;
         let raft_err = res.unwrap_err();
+        tracing::debug!("raft_err: {:?}", raft_err);
+
         match raft_err.api_error().unwrap() {
             ClientWriteError::ChangeMembershipError(ChangeMembershipError::LearnerNotFound(err)) => {
                 assert_eq!(1, err.node_id);


### PR DESCRIPTION

## Changelog

##### Fix: when adding a learner, ensure the last membership is committed

Previously, when adding a learner to a Raft cluster, the last membership was not
always marked as committed, which could cause issues when a follower tried to
truncate logs by reverting to the last committed membership. To prevent this
issue, we have updated the code to ensure the last membership is committed when
adding a learner.

In addition to this fix, we have also made several refactoring changes,
including refining method names for trait `Coherent`, renaming
`Membership::next_safe()` to `next_coherent()` for consistency, and updating
enum `ChangeMembers` to include more variants for adding and removing learners.
We have also removed `RaftCore::add_learner()` in favor of using
`change_membership()` for all membership operations, and added a `ChangeHandler`
to build new membership configurations for change-membership requests.

Finally, we have updated the `Membership` API with a new method `new_with_nodes()`
for building a new membership configuration, and moved the validation check
out into a separate function, `ensure_valid()`. Validation is now done only
when needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/685)
<!-- Reviewable:end -->
