### PR TITLE
Change: move default implemented method from trait `RaftLogReader` to `StorageHelper`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -89,6 +89,7 @@ use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::SnapshotId;
 use crate::StorageError;
+use crate::StorageHelper;
 use crate::Update;
 use crate::Vote;
 
@@ -705,7 +706,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
             return Ok(());
         }
 
-        let entries = self.storage.get_log_entries(since..end).await?;
+        let entries = StorageHelper::new(&mut self.storage).get_log_entries(since..end).await?;
         tracing::debug!(entries=%entries.as_slice().summary(), "about to apply");
 
         let entry_refs = entries.iter().collect::<Vec<_>>();

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -233,7 +233,16 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Replication
         let logs = if start == end {
             vec![]
         } else {
-            self.log_reader.get_log_entries(start..end).await?
+            let logs = self.log_reader.try_get_log_entries(start..end).await?;
+            debug_assert_eq!(
+                logs.len(),
+                (end - start) as usize,
+                "expect logs {}..{} but got only {} entries",
+                start,
+                end,
+                logs.len()
+            );
+            logs
         };
 
         // Build the heartbeat frame to be sent to the follower.

--- a/openraft/tests/append_entries/t20_append_conflicts.rs
+++ b/openraft/tests/append_entries/t20_append_conflicts.rs
@@ -12,6 +12,7 @@ use openraft::MessageSummary;
 use openraft::RaftStorage;
 use openraft::RaftTypeConfig;
 use openraft::ServerState;
+use openraft::StorageHelper;
 use openraft::Vote;
 
 use crate::fixtures::blank;
@@ -222,7 +223,7 @@ where
     C: RaftTypeConfig,
     Sto: RaftStorage<C>,
 {
-    let logs = sto.get_log_entries(..).await?;
+    let logs = StorageHelper::new(sto).get_log_entries(..).await?;
     let skip = 0;
     let want: Vec<Entry<memstore::Config>> = terms
         .iter()

--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -8,9 +8,9 @@ use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
-use openraft::RaftLogReader;
 use openraft::RaftStorage;
 use openraft::ServerState;
+use openraft::StorageHelper;
 use openraft::Vote;
 
 use crate::fixtures::init_default_ut_tracing;
@@ -119,7 +119,7 @@ async fn append_inconsistent_log() -> Result<()> {
         .log_at_least(Some(log_index), "sync log to node 0")
         .await?;
 
-    let logs = sto0.get_log_entries(60..=60).await?;
+    let logs = StorageHelper::new(&mut sto0).get_log_entries(60..=60).await?;
     assert_eq!(
         3,
         logs.first().unwrap().log_id.leader_id.term,

--- a/openraft/tests/life_cycle/t20_initialization.rs
+++ b/openraft/tests/life_cycle/t20_initialization.rs
@@ -13,9 +13,9 @@ use openraft::EffectiveMembership;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::Membership;
-use openraft::RaftLogReader;
 use openraft::RaftStorage;
 use openraft::ServerState;
+use openraft::StorageHelper;
 use openraft::Vote;
 use tokio::sync::oneshot;
 
@@ -113,7 +113,7 @@ async fn initialization() -> anyhow::Result<()> {
 
     for i in [0, 1, 2] {
         let mut sto = router.get_storage_handle(&1)?;
-        let first = sto.get_log_entries(0..2).await?.first().cloned();
+        let first = StorageHelper::new(&mut sto).get_log_entries(0..2).await?.first().cloned();
 
         tracing::info!("--- check membership is replicated: id: {}, first log: {:?}", i, first);
         let mem = match first.unwrap().payload {

--- a/openraft/tests/log_compaction/t10_compaction.rs
+++ b/openraft/tests/log_compaction/t10_compaction.rs
@@ -11,12 +11,12 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::Membership;
-use openraft::RaftLogReader;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
 use openraft::RaftStorage;
 use openraft::ServerState;
 use openraft::SnapshotPolicy;
+use openraft::StorageHelper;
 use openraft::Vote;
 
 use crate::fixtures::blank;
@@ -115,7 +115,7 @@ async fn compaction() -> Result<()> {
     tracing::info!("--- logs should be deleted after installing snapshot; left only the last one");
     {
         let mut sto = router.get_storage_handle(&1)?;
-        let logs = sto.get_log_entries(..).await?;
+        let logs = StorageHelper::new(&mut sto).get_log_entries(..).await?;
         assert_eq!(2, logs.len());
         assert_eq!(LogId::new(CommittedLeaderId::new(1, 0), log_index - 1), logs[0].log_id)
     }

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -10,7 +10,6 @@ use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::LogId;
 use openraft::Membership;
-use openraft::RaftLogReader;
 use openraft::StorageHelper;
 use tokio::time::sleep;
 
@@ -68,7 +67,7 @@ async fn add_learner_basic() -> Result<()> {
         {
             let mut sto1 = router.get_storage_handle(&1)?;
 
-            let logs = sto1.get_log_entries(..).await?;
+            let logs = StorageHelper::new(&mut sto1).get_log_entries(..).await?;
 
             assert_eq!(log_index, logs[logs.len() - 1].log_id.index);
             // 0-th log

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -6,8 +6,8 @@ use openraft::error::ChangeMembershipError;
 use openraft::error::ClientWriteError;
 use openraft::Config;
 use openraft::LogIdOptionExt;
-use openraft::RaftLogReader;
 use openraft::ServerState;
+use openraft::StorageHelper;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -87,7 +87,7 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
 
         for node_id in 0..2 {
             let mut sto = router.get_storage_handle(&node_id)?;
-            let logs = sto.get_log_entries(..).await?;
+            let logs = StorageHelper::new(&mut sto).get_log_entries(..).await?;
             assert_eq!(log_index, logs[logs.len() - 1].log_id.index, "node: {}", node_id);
             // 0-th log
             assert_eq!(log_index + 1, logs.len() as u64, "node: {}", node_id);

--- a/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -70,7 +70,7 @@ async fn new_leader_auto_commit_uniform_config() -> Result<()> {
     //     )
     //     .await?;
     //
-    // let final_log = sto.get_log_entries(want..=want).await?[0].clone();
+    // let final_log = StorageHelper::new(&mut sto).get_log_entries(want..=want).await?[0].clone();
     //
     // let m = match final_log.payload {
     //     EntryPayload::Membership(ref m) => m.membership.clone(),

--- a/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
@@ -8,7 +8,6 @@ use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::LogId;
 use openraft::Membership;
-use openraft::RaftLogReader;
 use openraft::SnapshotPolicy;
 use openraft::StorageHelper;
 
@@ -73,7 +72,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             .await?;
 
         {
-            let logs = sto0.get_log_entries(..).await?;
+            let logs = StorageHelper::new(&mut sto0).get_log_entries(..).await?;
             assert_eq!(3, logs.len(), "only one applied log is kept");
         }
         let m = StorageHelper::new(&mut sto0).get_membership().await?;
@@ -109,7 +108,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
     tracing::info!("--- check membership");
     {
         {
-            let logs = sto0.get_log_entries(..).await?;
+            let logs = StorageHelper::new(&mut sto0).get_log_entries(..).await?;
             assert_eq!(3, logs.len(), "only one applied log");
         }
         let m = StorageHelper::new(&mut sto0).get_membership().await?;


### PR DESCRIPTION

## Changelog

##### Change: move default implemented method from trait `RaftLogReader` to `StorageHelper`

Function `get_log_entries()` and `try_get_log_entry()` are provided by
trait `RaftLogReader` with default implementations. However, they do not
need to be part of this trait and an application does not have to
implement them.

Therefore in this patch they are moved to `StorageHelper` struct, which
provides additional storage access methods that are built based on the
`RaftStorage` trait.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/686)
<!-- Reviewable:end -->
