### PR TITLE
Change: replace EffectiveMembership with StoredMembership in RaftStorage

### DIFF
--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -126,7 +126,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     println!("=== metrics after add-learner");
     let x = client.metrics().await?;
 
-    assert_eq!(&vec![vec![1]], x.membership_config.get_joint_config());
+    assert_eq!(&vec![btreeset![1]], x.membership_config.membership().get_joint_config());
 
     let nodes_in_cluster =
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
@@ -161,7 +161,10 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     println!("=== metrics after change-member");
     let x = client.metrics().await?;
-    assert_eq!(&vec![vec![1, 2, 3]], x.membership_config.get_joint_config());
+    assert_eq!(
+        &vec![btreeset![1, 2, 3]],
+        x.membership_config.membership().get_joint_config()
+    );
 
     // --- Try to write some application data through the leader.
 
@@ -246,7 +249,7 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     println!("=== metrics after change-membership to {{3}}");
     let x = client.metrics().await?;
-    assert_eq!(&vec![vec![3]], x.membership_config.get_joint_config());
+    assert_eq!(&vec![btreeset![3]], x.membership_config.membership().get_joint_config());
 
     println!("=== write `foo=zoo` to node-3");
     let _x = client3

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -120,7 +120,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== metrics after add-learner");
     let x = leader.metrics().await?;
 
-    assert_eq!(&vec![vec![1]], x.membership_config.get_joint_config());
+    assert_eq!(&vec![btreeset![1]], x.membership_config.membership().get_joint_config());
 
     let nodes_in_cluster =
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
@@ -155,7 +155,10 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("=== metrics after change-member");
     let x = leader.metrics().await?;
-    assert_eq!(&vec![vec![1, 2, 3]], x.membership_config.get_joint_config());
+    assert_eq!(
+        &vec![btreeset![1, 2, 3]],
+        x.membership_config.membership().get_joint_config()
+    );
 
     // --- Try to write some application data through the leader.
 

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -433,7 +433,7 @@ where
         );
 
         #[allow(clippy::collapsible_if)]
-        if em.log_id.as_ref() <= self.state.committed() {
+        if em.log_id().as_ref() <= self.state.committed() {
             if !em.is_voter(&self.config.id) && self.state.is_leading(&self.config.id) {
                 tracing::debug!("leader {} is stepping down", self.config.id);
                 self.vote_handler().become_following();

--- a/openraft/src/engine/handler/replication_handler.rs
+++ b/openraft/src/engine/handler/replication_handler.rs
@@ -109,7 +109,7 @@ where
         let learner_ids = em.learner_ids().collect::<Vec<_>>();
 
         self.leader.progress =
-            old_progress.upgrade_quorum_set(em.membership.to_quorum_set(), &learner_ids, ProgressEntry::empty(end));
+            old_progress.upgrade_quorum_set(em.membership().to_quorum_set(), &learner_ids, ProgressEntry::empty(end));
     }
 
     /// Update progress when replicated data(logs or snapshot) matches on follower/learner and is

--- a/openraft/src/engine/handler/snapshot_handler.rs
+++ b/openraft/src/engine/handler/snapshot_handler.rs
@@ -52,10 +52,10 @@ mod tests {
 
     use crate::engine::Engine;
     use crate::testing::log_id;
-    use crate::EffectiveMembership;
     use crate::Membership;
     use crate::MetricsChangeFlags;
     use crate::SnapshotMeta;
+    use crate::StoredMembership;
 
     fn m12() -> Membership<u64, ()> {
         Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
@@ -71,7 +71,7 @@ mod tests {
 
         eng.state.snapshot_meta = SnapshotMeta {
             last_log_id: Some(log_id(2, 2)),
-            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+            last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
             snapshot_id: "1-2-3-4".to_string(),
         };
         eng
@@ -84,7 +84,7 @@ mod tests {
 
         let got = eng.snapshot_handler().update_snapshot(SnapshotMeta {
             last_log_id: Some(log_id(2, 2)),
-            last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m1234()),
+            last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         });
 
@@ -93,7 +93,7 @@ mod tests {
         assert_eq!(
             SnapshotMeta {
                 last_log_id: Some(log_id(2, 2)),
-                last_membership: EffectiveMembership::new(Some(log_id(1, 1)), m12()),
+                last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
                 snapshot_id: "1-2-3-4".to_string(),
             },
             eng.state.snapshot_meta
@@ -120,7 +120,7 @@ mod tests {
 
         let got = eng.snapshot_handler().update_snapshot(SnapshotMeta {
             last_log_id: Some(log_id(2, 3)),
-            last_membership: EffectiveMembership::new(Some(log_id(2, 2)), m1234()),
+            last_membership: StoredMembership::new(Some(log_id(2, 2)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         });
 
@@ -129,7 +129,7 @@ mod tests {
         assert_eq!(
             SnapshotMeta {
                 last_log_id: Some(log_id(2, 3)),
-                last_membership: EffectiveMembership::new(Some(log_id(2, 2)), m1234()),
+                last_membership: StoredMembership::new(Some(log_id(2, 2)), m1234()),
                 snapshot_id: "1-2-3-4".to_string(),
             },
             eng.state.snapshot_meta

--- a/openraft/src/engine/handler/vote_handler.rs
+++ b/openraft/src/engine/handler/vote_handler.rs
@@ -116,7 +116,7 @@ where
         let em = &self.state.membership_state.effective();
         let mut leader = Leader::new(
             *self.state.get_vote(),
-            em.membership.to_quorum_set(),
+            em.membership().to_quorum_set(),
             em.learner_ids(),
             self.state.last_log_id().index(),
         );

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -66,7 +66,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
             },
             eng.output.metrics_flags
         );
-        assert_eq!(m1(), eng.state.membership_state.effective().membership);
+        assert_eq!(&m1(), eng.state.membership_state.effective().membership());
 
         assert_eq!(
             vec![
@@ -152,7 +152,7 @@ fn test_initialize() -> anyhow::Result<()> {
             },
             eng.output.metrics_flags
         );
-        assert_eq!(m12(), eng.state.membership_state.effective().membership);
+        assert_eq!(&m12(), eng.state.membership_state.effective().membership());
 
         assert_eq!(
             vec![

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -87,6 +87,7 @@ pub use crate::entry::RaftPayload;
 pub use crate::membership::EffectiveMembership;
 pub use crate::membership::Membership;
 pub use crate::membership::MembershipState;
+pub use crate::membership::StoredMembership;
 pub use crate::metrics::RaftMetrics;
 pub use crate::network::RPCTypes;
 pub use crate::network::RaftNetwork;

--- a/openraft/src/membership/change_handler.rs
+++ b/openraft/src/membership/change_handler.rs
@@ -37,7 +37,7 @@ where
     ) -> Result<Membership<NID, N>, ChangeMembershipError<NID>> {
         self.ensure_committed()?;
 
-        let new_membership = self.state.effective().membership.clone().change(change, retain)?;
+        let new_membership = self.state.effective().membership().clone().change(change, retain)?;
         Ok(new_membership)
     }
 
@@ -49,13 +49,13 @@ where
         let effective = self.state.effective();
         let committed = self.state.committed();
 
-        if effective.log_id == committed.log_id {
+        if effective.log_id() == committed.log_id() {
             // Ok: last membership(effective) is committed
             Ok(())
         } else {
             Err(InProgress {
-                committed: committed.log_id,
-                membership_log_id: effective.log_id,
+                committed: *committed.log_id(),
+                membership_log_id: *effective.log_id(),
             })
         }
     }

--- a/openraft/src/membership/membership_state_test.rs
+++ b/openraft/src/membership/membership_state_test.rs
@@ -54,8 +54,8 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
         let mut x = new();
         let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())));
         assert!(res.is_none());
-        assert_eq!(Some(log_id(2, 2)), x.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), x.effective().log_id);
+        assert_eq!(&Some(log_id(2, 2)), x.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), x.effective().log_id());
     }
 
     // Update committed, not effective.
@@ -63,8 +63,8 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
         let mut x = new();
         let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m12())));
         assert!(res.is_none());
-        assert_eq!(Some(log_id(2, 3)), x.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), x.effective().log_id);
+        assert_eq!(&Some(log_id(2, 3)), x.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), x.effective().log_id());
     }
 
     // Update both
@@ -72,9 +72,9 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
         let mut x = new();
         let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m12())));
         assert_eq!(Some(x.effective().clone()), res);
-        assert_eq!(Some(log_id(3, 4)), x.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), x.effective().log_id);
-        assert_eq!(m12(), x.effective().membership);
+        assert_eq!(&Some(log_id(3, 4)), x.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), x.effective().log_id());
+        assert_eq!(&m12(), x.effective().membership());
     }
 
     // Update both, greater log_id.index should update the effective.
@@ -83,9 +83,9 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
         let mut x = new();
         let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(2, 5)), m12())));
         assert_eq!(Some(x.effective().clone()), res);
-        assert_eq!(Some(log_id(2, 5)), x.committed().log_id);
-        assert_eq!(Some(log_id(2, 5)), x.effective().log_id);
-        assert_eq!(m12(), x.effective().membership);
+        assert_eq!(&Some(log_id(2, 5)), x.committed().log_id());
+        assert_eq!(&Some(log_id(2, 5)), x.effective().log_id());
+        assert_eq!(&m12(), x.effective().membership());
     }
 
     Ok(())
@@ -98,9 +98,9 @@ fn test_membership_state_append() -> anyhow::Result<()> {
     let mut ms = new();
     ms.append(effmem(4, 5, m12()));
 
-    assert_eq!(Some(log_id(3, 4)), ms.committed().log_id);
-    assert_eq!(Some(log_id(4, 5)), ms.effective().log_id);
-    assert_eq!(m12(), ms.effective().membership);
+    assert_eq!(&Some(log_id(3, 4)), ms.committed().log_id());
+    assert_eq!(&Some(log_id(4, 5)), ms.effective().log_id());
+    assert_eq!(&m12(), ms.effective().membership());
 
     Ok(())
 }
@@ -113,32 +113,32 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     {
         let mut ms = new();
         ms.commit(&Some(log_id(1, 1)));
-        assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), ms.effective().log_id);
+        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
     }
 
     // Equal committed
     {
         let mut ms = new();
         ms.commit(&Some(log_id(2, 2)));
-        assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), ms.effective().log_id);
+        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
     }
 
     // Greater than committed, smaller than effective
     {
         let mut ms = new();
         ms.commit(&Some(log_id(2, 3)));
-        assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), ms.effective().log_id);
+        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
     }
 
     // Greater than committed, equal effective
     {
         let mut ms = new();
         ms.commit(&Some(log_id(3, 4)));
-        assert_eq!(Some(log_id(3, 4)), ms.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), ms.effective().log_id);
+        assert_eq!(&Some(log_id(3, 4)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
     }
 
     Ok(())
@@ -152,24 +152,24 @@ fn test_membership_state_truncate() -> anyhow::Result<()> {
         let mut ms = new();
         let res = ms.truncate(5);
         assert!(res.is_none());
-        assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
-        assert_eq!(Some(log_id(3, 4)), ms.effective().log_id);
+        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
     }
 
     {
         let mut ms = new();
         let res = ms.truncate(4);
-        assert_eq!(Some(log_id(2, 2)), res.unwrap().log_id);
-        assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
-        assert_eq!(Some(log_id(2, 2)), ms.effective().log_id);
+        assert_eq!(&Some(log_id(2, 2)), res.unwrap().log_id());
+        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(2, 2)), ms.effective().log_id());
     }
 
     {
         let mut ms = new();
         let res = ms.truncate(3);
-        assert_eq!(Some(log_id(2, 2)), res.unwrap().log_id);
-        assert_eq!(Some(log_id(2, 2)), ms.committed().log_id);
-        assert_eq!(Some(log_id(2, 2)), ms.effective().log_id);
+        assert_eq!(&Some(log_id(2, 2)), res.unwrap().log_id());
+        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(2, 2)), ms.effective().log_id());
     }
 
     Ok(())

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -3,6 +3,7 @@ mod effective_membership;
 #[allow(clippy::module_inception)] mod membership;
 mod membership_state;
 mod node_type;
+mod stored_membership;
 
 #[cfg(feature = "bench")]
 #[cfg(test)]
@@ -18,3 +19,4 @@ pub use membership::IntoNodes;
 pub use membership::Membership;
 pub use membership_state::MembershipState;
 pub(crate) use node_type::NodeRole;
+pub use stored_membership::StoredMembership;

--- a/openraft/src/membership/stored_membership.rs
+++ b/openraft/src/membership/stored_membership.rs
@@ -1,0 +1,65 @@
+use crate::LogId;
+use crate::Membership;
+use crate::MessageSummary;
+use crate::Node;
+use crate::NodeId;
+
+/// This struct represents information about a membership config that has already been stored in the
+/// raft logs.
+///
+/// It includes log id and a membership config. Such a record is used in the state machine or
+/// snapshot to track the last membership and its log id. And it is also used as a return value for
+/// functions that return membership and its log position.
+///
+/// It derives `Default` for building an uninitialized membership state, e.g., when a raft-node is
+/// just created.
+#[derive(Clone, Debug, Default)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub struct StoredMembership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    /// The id of the log that stores this membership config
+    log_id: Option<LogId<NID>>,
+
+    /// Membership config
+    membership: Membership<NID, N>,
+}
+
+impl<NID, N> StoredMembership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    pub fn new(log_id: Option<LogId<NID>>, membership: Membership<NID, N>) -> Self {
+        Self { log_id, membership }
+    }
+
+    pub fn log_id(&self) -> &Option<LogId<NID>> {
+        &self.log_id
+    }
+
+    pub fn membership(&self) -> &Membership<NID, N> {
+        &self.membership
+    }
+
+    pub fn voter_ids(&self) -> impl Iterator<Item = NID> {
+        self.membership.voter_ids()
+    }
+
+    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &N)> {
+        self.membership.nodes()
+    }
+}
+
+impl<NID, N> MessageSummary<StoredMembership<NID, N>> for StoredMembership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn summary(&self) -> String {
+        format!("{{log_id:{:?} membership:{}}}", self.log_id, self.membership.summary())
+    }
+}

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use crate::core::ServerState;
 use crate::error::Fatal;
-use crate::membership::EffectiveMembership;
 use crate::metrics::ReplicationMetrics;
 use crate::node::Node;
 use crate::summary::MessageSummary;
 use crate::versioned::Versioned;
 use crate::LogId;
 use crate::NodeId;
+use crate::StoredMembership;
 
 /// A set of metrics describing the current state of a Raft node.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -49,7 +49,7 @@ where
     pub current_leader: Option<NID>,
 
     /// The current membership config of the cluster.
-    pub membership_config: Arc<EffectiveMembership<NID, N>>,
+    pub membership_config: Arc<StoredMembership<NID, N>>,
 
     // ---
     // --- replication ---
@@ -92,7 +92,7 @@ where
             last_log_index: None,
             last_applied: None,
             current_leader: None,
-            membership_config: Arc::new(EffectiveMembership::default()),
+            membership_config: Arc::new(StoredMembership::default()),
             snapshot: None,
             replication: None,
         }

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -169,7 +169,7 @@ where
     ) -> Result<RaftMetrics<NID, N>, WaitError> {
         self.metrics(
             |x| {
-                let got = x.membership_config.nodes().map(|(nid, _)| *nid).collect::<BTreeSet<_>>();
+                let got = x.membership_config.membership().nodes().map(|(nid, _)| *nid).collect::<BTreeSet<_>>();
                 want_members == got
             },
             &format!("{} .members -> {:?}", msg.to_string(), want_members),

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -537,12 +537,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         node_id: C::NodeId,
         membership_log_id: Option<LogId<C::NodeId>>,
     ) -> Result<Option<LogId<C::NodeId>>, ()> {
-        if metrics.membership_config.log_id < membership_log_id {
+        if metrics.membership_config.log_id() < &membership_log_id {
             // Waiting for the latest metrics to report.
             return Err(());
         }
 
-        if !metrics.membership_config.membership.contains(&node_id) {
+        if !metrics.membership_config.membership().contains(&node_id) {
             // This learner has been removed.
             return Ok(None);
         }

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -12,7 +12,6 @@ use tokio::time::sleep;
 
 use crate::async_trait::async_trait;
 use crate::defensive::DefensiveCheckBase;
-use crate::membership::EffectiveMembership;
 use crate::storage::LogState;
 use crate::storage::RaftLogReader;
 use crate::storage::RaftSnapshotBuilder;
@@ -26,6 +25,7 @@ use crate::RaftStorageDebug;
 use crate::RaftTypeConfig;
 use crate::SnapshotMeta;
 use crate::StorageError;
+use crate::StoredMembership;
 use crate::Vote;
 use crate::Wrapper;
 
@@ -182,7 +182,7 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     async fn last_applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C::NodeId>>, EffectiveMembership<C::NodeId, C::Node>), StorageError<C::NodeId>> {
+    ) -> Result<(Option<LogId<C::NodeId>>, StoredMembership<C::NodeId, C::Node>), StorageError<C::NodeId>> {
         self.inner().last_applied_state().await
     }
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -27,6 +27,7 @@ use crate::RaftSnapshotBuilder;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::StorageError;
+use crate::StoredMembership;
 use crate::Violation;
 use crate::Vote;
 
@@ -160,12 +161,12 @@ where
             let mem = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
             assert_eq!(1, mem.len());
             let mem = mem[0].clone();
-            assert_eq!(Membership::new(vec![btreeset! {1, 2, 3}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {1, 2, 3}], None), mem.membership(),);
 
             let mem = StorageHelper::new(&mut store).last_membership_in_log(1).await?;
             assert_eq!(1, mem.len());
             let mem = mem[0].clone();
-            assert_eq!(Membership::new(vec![btreeset! {1, 2, 3}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {1, 2, 3}], None), mem.membership(),);
 
             let mem = StorageHelper::new(&mut store).last_membership_in_log(2).await?;
             assert!(mem.is_empty());
@@ -194,10 +195,10 @@ where
             assert_eq!(2, mems.len());
 
             let mem = mems[0].clone();
-            assert_eq!(Membership::new(vec![btreeset! {1,2,3}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {1,2,3}], None), mem.membership(),);
 
             let mem = mems[1].clone();
-            assert_eq!(Membership::new(vec![btreeset! {7,8,9}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {7,8,9}], None), mem.membership(),);
         }
 
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log but since_index is greater than the last");
@@ -219,10 +220,10 @@ where
             assert_eq!(2, mems.len());
 
             let mem = mems[0].clone();
-            assert_eq!(Membership::new(vec![btreeset! {7,8,9}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {7,8,9}], None), mem.membership(),);
 
             let mem = mems[1].clone();
-            assert_eq!(Membership::new(vec![btreeset! {10,11}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {10,11}], None), mem.membership(),);
         }
 
         Ok(())
@@ -259,10 +260,10 @@ where
             let mems = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
             assert_eq!(2, mems.len());
             let mem = mems[0].clone();
-            assert_eq!(Membership::new(vec![btreeset! {3,4,5}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {3,4,5}], None), mem.membership(),);
 
             let mem = mems[1].clone();
-            assert_eq!(Membership::new(vec![btreeset! {5,6,7}], None), mem.membership,);
+            assert_eq!(&Membership::new(vec![btreeset! {5,6,7}], None), mem.membership(),);
         }
 
         Ok(())
@@ -293,8 +294,8 @@ where
 
             assert_eq!(&EffectiveMembership::default(), mem_state.committed().as_ref());
             assert_eq!(
-                Membership::new(vec![btreeset! {1,2,3}], None),
-                mem_state.effective().membership,
+                &Membership::new(vec![btreeset! {1,2,3}], None),
+                mem_state.effective().membership(),
             );
         }
 
@@ -320,12 +321,12 @@ where
             let mem_state = StorageHelper::new(&mut store).get_membership().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4,5}], None),
-                mem_state.committed().membership,
+                &Membership::new(vec![btreeset! {3,4,5}], None),
+                mem_state.committed().membership(),
             );
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4,5}], None),
-                mem_state.effective().membership,
+                &Membership::new(vec![btreeset! {3,4,5}], None),
+                mem_state.effective().membership(),
             );
         }
 
@@ -341,12 +342,12 @@ where
             let mem_state = StorageHelper::new(&mut store).get_membership().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4,5}], None),
-                mem_state.committed().membership,
+                &Membership::new(vec![btreeset! {3,4,5}], None),
+                mem_state.committed().membership(),
             );
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4,5}], None),
-                mem_state.effective().membership,
+                &Membership::new(vec![btreeset! {3,4,5}], None),
+                mem_state.effective().membership(),
             );
         }
 
@@ -368,12 +369,12 @@ where
             let mem_state = StorageHelper::new(&mut store).get_membership().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4,5}], None),
-                mem_state.committed().membership,
+                &Membership::new(vec![btreeset! {3,4,5}], None),
+                mem_state.committed().membership(),
             );
             assert_eq!(
-                Membership::new(vec![btreeset! {7,8,9}], None),
-                mem_state.effective().membership,
+                &Membership::new(vec![btreeset! {7,8,9}], None),
+                mem_state.effective().membership(),
             );
         }
 
@@ -395,12 +396,12 @@ where
             let mem_state = StorageHelper::new(&mut store).get_membership().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {7,8,9}], None),
-                mem_state.committed().membership,
+                &Membership::new(vec![btreeset! {7,8,9}], None),
+                mem_state.committed().membership(),
             );
             assert_eq!(
-                Membership::new(vec![btreeset! {10,11}], None),
-                mem_state.effective().membership,
+                &Membership::new(vec![btreeset! {10,11}], None),
+                mem_state.effective().membership(),
             );
         }
 
@@ -475,8 +476,8 @@ where
             let initial = StorageHelper::new(&mut store).get_initial_state().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4,5}], None),
-                initial.membership_state.effective().membership,
+                &Membership::new(vec![btreeset! {3,4,5}], None),
+                initial.membership_state.effective().membership(),
             );
         }
 
@@ -492,8 +493,8 @@ where
             let initial = StorageHelper::new(&mut store).get_initial_state().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4,5}], None),
-                initial.membership_state.effective().membership,
+                &Membership::new(vec![btreeset! {3,4,5}], None),
+                initial.membership_state.effective().membership(),
             );
         }
 
@@ -509,8 +510,8 @@ where
             let initial = StorageHelper::new(&mut store).get_initial_state().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {1,2,3}], None),
-                initial.membership_state.effective().membership,
+                &Membership::new(vec![btreeset! {1,2,3}], None),
+                initial.membership_state.effective().membership(),
             );
         }
 
@@ -869,7 +870,7 @@ where
     pub async fn last_applied_state(mut store: S) -> Result<(), StorageError<C::NodeId>> {
         let (applied, membership) = store.last_applied_state().await?;
         assert_eq!(None, applied);
-        assert_eq!(EffectiveMembership::default(), membership);
+        assert_eq!(StoredMembership::default(), membership);
 
         tracing::info!("--- with last_applied and last_membership");
         {
@@ -883,7 +884,7 @@ where
             let (applied, membership) = store.last_applied_state().await?;
             assert_eq!(Some(LogId::new(CommittedLeaderId::new(1, NODE_ID.into()), 3)), applied);
             assert_eq!(
-                EffectiveMembership::new(
+                StoredMembership::new(
                     Some(LogId::new(CommittedLeaderId::new(1, NODE_ID.into()), 3)),
                     Membership::new(vec![btreeset! {1,2}], None)
                 ),
@@ -903,7 +904,7 @@ where
             let (applied, membership) = store.last_applied_state().await?;
             assert_eq!(Some(LogId::new(CommittedLeaderId::new(1, NODE_ID.into()), 5)), applied);
             assert_eq!(
-                EffectiveMembership::new(
+                StoredMembership::new(
                     Some(LogId::new(CommittedLeaderId::new(1, NODE_ID.into()), 3)),
                     Membership::new(vec![btreeset! {1,2}], None)
                 ),
@@ -1053,10 +1054,10 @@ where
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
             assert_eq!(Some(log_id(0, 0)), meta.last_log_id);
-            assert_eq!(Some(log_id(0, 0)), meta.last_membership.log_id);
+            assert_eq!(&Some(log_id(0, 0)), meta.last_membership.log_id());
             assert_eq!(
-                Membership::new(vec![btreeset! {1,2}], None),
-                meta.last_membership.membership
+                &Membership::new(vec![btreeset! {1,2}], None),
+                meta.last_membership.membership()
             );
         }
 
@@ -1077,10 +1078,10 @@ where
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
             assert_eq!(Some(log_id(2, 2)), meta.last_log_id);
-            assert_eq!(Some(log_id(2, 2)), meta.last_membership.log_id);
+            assert_eq!(&Some(log_id(2, 2)), meta.last_membership.log_id());
             assert_eq!(
-                Membership::new(vec![btreeset! {3,4}], None),
-                meta.last_membership.membership
+                &Membership::new(vec![btreeset! {3,4}], None),
+                meta.last_membership.membership()
             );
         }
 

--- a/openraft/tests/fixtures/mod.rs
+++ b/openraft/tests/fixtures/mod.rs
@@ -697,7 +697,7 @@ where
             assert_eq!(0, nodes_count, "expected empty configs, got: {:?}", nodes_count);
 
             assert!(
-                !node.membership_config.membership.is_in_joint_consensus(),
+                !node.membership_config.membership().is_in_joint_consensus(),
                 "node {} is in joint consensus, expected uniform consensus",
                 node.id
             );
@@ -784,7 +784,7 @@ where
                 node.id, members, all_nodes
             );
             assert!(
-                !node.membership_config.membership.is_in_joint_consensus(),
+                !node.membership_config.membership().is_in_joint_consensus(),
                 "node {} was not in uniform consensus state",
                 node.id
             );

--- a/openraft/tests/life_cycle/t20_initialization.rs
+++ b/openraft/tests/life_cycle/t20_initialization.rs
@@ -16,6 +16,7 @@ use openraft::Membership;
 use openraft::RaftStorage;
 use openraft::ServerState;
 use openraft::StorageHelper;
+use openraft::StoredMembership;
 use openraft::Vote;
 use tokio::sync::oneshot;
 
@@ -126,7 +127,7 @@ async fn initialization() -> anyhow::Result<()> {
 
         let sm_mem = sto.last_applied_state().await?.1;
         assert_eq!(
-            EffectiveMembership::new(
+            StoredMembership::new(
                 Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
                 Membership::new(vec![btreeset! {0,1,2}], None)
             ),

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -86,7 +86,7 @@ async fn add_learner_basic() -> Result<()> {
         router.wait(&0, timeout()).log(Some(log_index), "commit re-adding node-1 log").await?;
 
         let metrics = router.get_raft_handle(&0)?.metrics().borrow().clone();
-        let node_ids = metrics.membership_config.membership.nodes().map(|x| *x.0).collect::<Vec<_>>();
+        let node_ids = metrics.membership_config.membership().nodes().map(|x| *x.0).collect::<Vec<_>>();
         assert_eq!(vec![0, 1], node_ids);
     }
 
@@ -258,13 +258,13 @@ async fn check_learner_after_leader_transferred() -> Result<()> {
         // new membership is applied, thus get_membership() only returns one entry.
 
         assert_eq!(
-            Membership::new(vec![btreeset! {1,3,4}], Some(btreeset! {2})),
-            m.committed().membership,
+            &Membership::new(vec![btreeset! {1,3,4}], Some(btreeset! {2})),
+            m.committed().membership(),
             "membership should be overridden by the snapshot"
         );
         assert_eq!(
-            Membership::new(vec![btreeset! {1,3,4}], Some(btreeset! {2})),
-            m.effective().membership,
+            &Membership::new(vec![btreeset! {1,3,4}], Some(btreeset! {2})),
+            m.effective().membership(),
             "membership should be overridden by the snapshot"
         );
     }

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -38,8 +38,8 @@ async fn update_membership_state() -> anyhow::Result<()> {
             router.wait(&node_id, timeout()).log(Some(log_index), "change-membership log applied").await?;
             router.external_request(node_id, move |st, _, _| {
                 tracing::debug!("--- got state: {:?}", st);
-                assert_eq!(st.membership_state.committed().log_id.index(), Some(log_index));
-                assert_eq!(st.membership_state.effective().log_id.index(), Some(log_index));
+                assert_eq!(st.membership_state.committed().log_id().index(), Some(log_index));
+                assert_eq!(st.membership_state.effective().log_id().index(), Some(log_index));
             });
         }
     }

--- a/openraft/tests/membership/t30_remove_leader.rs
+++ b/openraft/tests/membership/t30_remove_leader.rs
@@ -95,15 +95,15 @@ async fn remove_leader() -> Result<()> {
     tracing::info!("--- check state of the old leader");
     {
         let metrics = router.get_metrics(&0)?;
-        let cfg = &metrics.membership_config.membership;
+        let cfg = &metrics.membership_config.membership();
 
         assert!(metrics.state != ServerState::Leader);
         assert_eq!(metrics.current_term, 1);
         assert_eq!(metrics.last_log_index, Some(8));
         assert_eq!(metrics.last_applied, Some(LogId::new(CommittedLeaderId::new(1, 0), 8)));
-        assert_eq!(metrics.membership_config.get_joint_config().clone(), vec![vec![
-            1, 2, 3
-        ]]);
+        assert_eq!(metrics.membership_config.membership().get_joint_config().clone(), vec![
+            btreeset![1, 2, 3]
+        ]);
         assert!(!cfg.is_in_joint_consensus());
     }
 

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -105,7 +105,10 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 let m = StorageHelper::new(&mut sto).get_membership().await?;
 
                 assert_eq!(&EffectiveMembership::default(), m.committed().as_ref());
-                assert_eq!(Membership::new(vec![btreeset! {2,3}], None), m.effective().membership);
+                assert_eq!(
+                    &Membership::new(vec![btreeset! {2,3}], None),
+                    m.effective().membership()
+                );
             }
         }
 
@@ -143,13 +146,13 @@ async fn snapshot_overrides_membership() -> Result<()> {
             let m = StorageHelper::new(&mut sto).get_membership().await?;
 
             assert_eq!(
-                Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),
-                m.committed().membership,
+                &Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),
+                m.committed().membership(),
                 "membership should be overridden by the snapshot"
             );
             assert_eq!(
-                Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),
-                m.effective().membership,
+                &Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),
+                m.effective().membership(),
                 "membership should be overridden by the snapshot"
             );
         }

--- a/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
@@ -78,13 +78,13 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         let m = StorageHelper::new(&mut sto0).get_membership().await?;
 
         assert_eq!(
-            Membership::new(vec![btreeset! {0,1}], None),
-            m.committed().membership,
+            &Membership::new(vec![btreeset! {0,1}], None),
+            m.committed().membership(),
             "membership "
         );
         assert_eq!(
-            Membership::new(vec![btreeset! {0,1}], None),
-            m.effective().membership,
+            &Membership::new(vec![btreeset! {0,1}], None),
+            m.effective().membership(),
             "membership "
         );
     }
@@ -114,13 +114,13 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         let m = StorageHelper::new(&mut sto0).get_membership().await?;
 
         assert_eq!(
-            Membership::new(vec![btreeset! {0,1}], None),
-            m.committed().membership,
+            &Membership::new(vec![btreeset! {0,1}], None),
+            m.committed().membership(),
             "membership "
         );
         assert_eq!(
-            Membership::new(vec![btreeset! {0,1}], None),
-            m.effective().membership,
+            &Membership::new(vec![btreeset! {0,1}], None),
+            m.effective().membership(),
             "membership "
         );
     }

--- a/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
+++ b/openraft/tests/snapshot/t43_snapshot_delete_conflict_logs.rs
@@ -124,8 +124,14 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             let m = StorageHelper::new(&mut sto1).get_membership().await?;
 
             tracing::info!("got membership of node-1: {:?}", m);
-            assert_eq!(Membership::new(vec![btreeset! {2,3}], None), m.committed().membership);
-            assert_eq!(Membership::new(vec![btreeset! {4,5}], None), m.effective().membership);
+            assert_eq!(
+                &Membership::new(vec![btreeset! {2,3}], None),
+                m.committed().membership()
+            );
+            assert_eq!(
+                &Membership::new(vec![btreeset! {4,5}], None),
+                m.effective().membership()
+            );
         }
     }
 
@@ -164,13 +170,13 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
 
         tracing::info!("got membership of node-1: {:?}", m);
         assert_eq!(
-            Membership::new(vec![btreeset! {0}], None),
-            m.committed().membership,
+            &Membership::new(vec![btreeset! {0}], None),
+            m.committed().membership(),
             "membership should be overridden by the snapshot"
         );
         assert_eq!(
-            Membership::new(vec![btreeset! {0}], None),
-            m.effective().membership,
+            &Membership::new(vec![btreeset! {0}], None),
+            m.effective().membership(),
             "conflicting effective membership does not have to be clear"
         );
 

--- a/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/openraft/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -7,12 +7,12 @@ use futures::stream::StreamExt;
 use maplit::btreeset;
 use openraft::CommittedLeaderId;
 use openraft::Config;
-use openraft::EffectiveMembership;
 use openraft::LogId;
 use openraft::LogIdOptionExt;
 use openraft::Membership;
 use openraft::RaftStorage;
 use openraft::ServerState;
+use openraft::StoredMembership;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -55,7 +55,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     for i in 0..=0 {
         let mut sto = router.get_storage_handle(&i)?;
         assert_eq!(
-            EffectiveMembership::new(
+            StoredMembership::new(
                 Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
                 Membership::new(vec![btreeset! {0}], None)
             ),
@@ -105,7 +105,7 @@ async fn state_machine_apply_membership() -> Result<()> {
         let mut sto = router.get_storage_handle(&i)?;
         let (_, last_membership) = sto.last_applied_state().await?;
         assert_eq!(
-            EffectiveMembership::new(
+            StoredMembership::new(
                 Some(LogId::new(CommittedLeaderId::new(1, 0), log_index)),
                 Membership::new(vec![btreeset! {0, 1, 2}], Some(btreeset! {3,4}))
             ),

--- a/scripts/build_change_log.py
+++ b/scripts/build_change_log.py
@@ -285,6 +285,13 @@ def load_cargo_version():
 
     t = toml.loads(cargo)
     ver = t['package']['version']
+
+    if ver == {'workspace': True}:
+        with open('./Cargo.toml',  'r') as f:
+            cargo = f.read()
+        t = toml.loads(cargo)
+        ver = t['workspace']['package']['version']
+
     print("--- openraft/Cargo.toml version is",  ver)
     return ver
 


### PR DESCRIPTION
## Changelog

##### Change: replace EffectiveMembership with StoredMembership in RaftStorage

`EffectiveMembership` is a struct used at runtime, which contains
additional information such as an optimized `QuorumSet` implementation
that has different structure from a `Membership`.

To better separate concerns, a new struct called `StoredMembership` has
been introduced specifically for storage purpose. It contains only the
information that needs to be stored in storage. Therefore,
`StoredMembership` is used instead of `EffectiveMembership` in
RaftStorage.

Upgrade tip:

Fields in `EffectiveMembership` are made private and can be accessed via
corresponding methods such as: `EffectiveMembership.log_id` and
`EffectiveMembership.membership` should be replaced with
`EffectiveMembership::log_id()` and `EffectiveMembership::membership()`.

##### Refactor: load version from workspace Cargo.toml if it is defined there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/692)
<!-- Reviewable:end -->
