### PR TITLE
Fix: Wait::members() should not count learners as members

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,12 @@ jobs:
           RUSTDOCFLAGS: "-D warnings"
 
 
+      - name: Audit dependencies
+        shell: bash
+        # if: "!contains(github.event.head_commit.message, 'skip audit')"
+        run: cargo audit --db ./target/advisory-db
+
+
   test-examples:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pretty_assertions = "1.0.0"
 rand = "0.8"
 serde = { version="1.0.114", features=["derive", "rc"]}
 serde_json = "1.0.57"
-tempdir = "0.3.7"
+tempfile = { version = "3.4.0" }
 thiserror = "1.0.33"
 tokio = { version="1.8", default-features=false, features=["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.29"

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -41,7 +41,8 @@ tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 
 [dev-dependencies]
 maplit = "1.0.2"
-tempdir = "0.3.0"
+tempfile = { version = "3.4.0" }
+
 
 [features]
 docinclude = [] # Used only for activating `doc(include="...")` on nightly.

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -73,9 +73,9 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // --- Start 3 raft node in 3 threads.
-    let d1 = tempfile::TempDir::new("test_cluster")?;
-    let d2 = tempfile::TempDir::new("test_cluster")?;
-    let d3 = tempfile::TempDir::new("test_cluster")?;
+    let d1 = tempfile::TempDir::new()?;
+    let d2 = tempfile::TempDir::new()?;
+    let d3 = tempfile::TempDir::new()?;
 
     let _h1 = thread::spawn(|| {
         let x = block_on(async move { start_example_raft_node(1, d1.path(), get_addr(1), get_rpc_addr(1)).await });

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -73,9 +73,9 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // --- Start 3 raft node in 3 threads.
-    let d1 = tempdir::TempDir::new("test_cluster")?;
-    let d2 = tempdir::TempDir::new("test_cluster")?;
-    let d3 = tempdir::TempDir::new("test_cluster")?;
+    let d1 = tempfile::TempDir::new("test_cluster")?;
+    let d2 = tempfile::TempDir::new("test_cluster")?;
+    let d3 = tempfile::TempDir::new("test_cluster")?;
 
     let _h1 = thread::spawn(|| {
         let x = block_on(async move { start_example_raft_node(1, d1.path(), get_addr(1), get_rpc_addr(1)).await });

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -26,7 +26,7 @@ rand            = { workspace = true }
 serde           = { workspace = true, optional = true }
 serde_json      = { workspace = true, optional = true }
 clap            = { workspace = true }
-tempdir         = { workspace = true, optional = true }
+tempfile        = { workspace = true, optional = true }
 thiserror       = { workspace = true }
 tokio           = { workspace = true }
 tracing         = { workspace = true }
@@ -82,7 +82,7 @@ compat = []
 
 # Turn on to let openraft provide addtional data types to build v0.7 compatible RaftStorage.
 compat-07 = ["compat", "serde", "dep:or07", "compat-07-testing"]
-compat-07-testing = ["dep:tempdir", "anyhow", "dep:serde_json"]
+compat-07-testing = ["dep:tempfile", "anyhow", "dep:serde_json"]
 
 # default = ["single-term-leader"]
 

--- a/openraft/src/compat/compat07.rs
+++ b/openraft/src/compat/compat07.rs
@@ -571,8 +571,8 @@ pub mod testing {
         }
     }
 
-    fn tmp_dir() -> tempdir::TempDir {
-        tempdir::TempDir::new("RocksCompatibility").expect("couldn't create temp dir")
+    fn tmp_dir() -> tempfile::TempDir {
+        tempfile::TempDir::new().expect("couldn't create temp dir")
     }
 }
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1367,7 +1367,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
                                 let _ = node.tx_repl.send(Replicate::Heartbeat);
                             }
                             Inflight::Logs { id, log_id_range } => {
-                                let _ = node.tx_repl.send(Replicate::Logs { id, log_id_range });
+                                let _ = node.tx_repl.send(Replicate::logs(id, log_id_range));
                             }
                             Inflight::Snapshot { id, last_log_id } => {
                                 let snapshot = self.storage.get_current_snapshot().await?;
@@ -1375,7 +1375,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftRuntime
 
                                 if let Some(snapshot) = snapshot {
                                     debug_assert_eq!(last_log_id, snapshot.meta.last_log_id);
-                                    let _ = node.tx_repl.send(Replicate::Snapshot { id, snapshot });
+                                    let _ = node.tx_repl.send(Replicate::snapshot(id, snapshot));
                                 } else {
                                     unreachable!("No snapshot");
                                 }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1102,6 +1102,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
                 let current_vote = self.engine.state.get_vote();
 
+                tracing::debug!(
+                    "next_election_time: {:?}, current_vote: {:?}",
+                    self.next_election_time,
+                    current_vote
+                );
+
                 // Follower/Candidate timer: next election
                 if let Some(t) = self.next_election_time.get_time(current_vote) {
                     #[allow(clippy::collapsible_else_if)]

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -169,7 +169,7 @@ where
 
         self.state.server_state = server_state;
 
-        tracing::debug!(
+        tracing::info!(
             "startup: id={} target_state: {:?}",
             self.config.id,
             self.state.server_state

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -143,6 +143,13 @@ where
     pub(crate) fn startup(&mut self) {
         // Allows starting up as a leader.
 
+        tracing::info!("startup: state: {:?}", self.state);
+        tracing::info!("startup: is_leader: {}", self.state.is_leader(&self.config.id));
+        tracing::info!(
+            "startup: is_voter: {}",
+            self.state.membership_state.effective().is_voter(&self.config.id)
+        );
+
         // Previously it is a leader. restore it as leader at once
         if self.state.is_leader(&self.config.id) {
             self.vote_handler().update_internal_server_state();

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -169,7 +169,7 @@ where
     ) -> Result<RaftMetrics<NID, N>, WaitError> {
         self.metrics(
             |x| {
-                let got = x.membership_config.membership().nodes().map(|(nid, _)| *nid).collect::<BTreeSet<_>>();
+                let got = x.membership_config.membership().voter_ids().collect::<BTreeSet<_>>();
                 want_members == got
             },
             &format!("{} .members -> {:?}", msg.to_string(), want_members),

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use maplit::btreemap;
 use maplit::btreeset;
 use tokio::sync::watch;
 use tokio::time::sleep;
@@ -90,7 +91,7 @@ async fn test_wait() -> anyhow::Result<()> {
             let mut update = init.clone();
             update.membership_config = Arc::new(StoredMembership::new(
                 None,
-                Membership::new(vec![btreeset! {1,2}], None),
+                Membership::new(vec![btreeset! {1,2}], btreemap! {3=>()}),
             ));
             let rst = tx.send(update);
             assert!(rst.is_ok());

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -78,17 +78,17 @@ where
 
 /// The data associated with the current snapshot.
 #[derive(Debug)]
-pub struct Snapshot<NID, N, S>
+pub struct Snapshot<NID, N, SD>
 where
     NID: NodeId,
     N: Node,
-    S: AsyncRead + AsyncSeek + Send + Unpin + 'static,
+    SD: AsyncRead + AsyncSeek + Send + Unpin + 'static,
 {
     /// metadata of a snapshot
     pub meta: SnapshotMeta<NID, N>,
 
     /// A read handle to the associated snapshot.
-    pub snapshot: Box<S>,
+    pub snapshot: Box<SD>,
 }
 
 /// The state about logs.

--- a/openraft/tests/append_entries/t10_see_higher_vote.rs
+++ b/openraft/tests/append_entries/t10_see_higher_vote.rs
@@ -33,7 +33,7 @@ async fn append_sees_higher_vote() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    let _log_index = router.new_nodes_from_single(btreeset! {0,1}, btreeset! {}).await?;
+    let _log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
 
     tracing::info!("--- upgrade vote on node-1");
     {

--- a/openraft/tests/append_entries/t30_append_inconsistent_log.rs
+++ b/openraft/tests/append_entries/t30_append_inconsistent_log.rs
@@ -46,7 +46,7 @@ async fn append_inconsistent_log() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0).await;
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- remove all nodes and fake the logs");
 

--- a/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/openraft/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -27,7 +27,7 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    let log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     // before append entries, check hard state in term 1 and vote for node 0
     router

--- a/openraft/tests/append_entries/t50_replication_1_voter_to_isolated_learner.rs
+++ b/openraft/tests/append_entries/t50_replication_1_voter_to_isolated_learner.rs
@@ -26,7 +26,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     tracing::info!("--- stop replication to node 1");
     {

--- a/openraft/tests/append_entries/t60_enable_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_enable_heartbeat.rs
@@ -23,7 +23,7 @@ async fn enable_heartbeat() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3}).await?;
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
     let _ = log_index;
 
     let node0 = router.get_raft_handle(&0)?;

--- a/openraft/tests/append_entries/t60_heartbeat_reject_vote.rs
+++ b/openraft/tests/append_entries/t60_heartbeat_reject_vote.rs
@@ -28,7 +28,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3}).await?;
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
 
     let leader_expire_at = Arc::new(Mutex::new(Instant::now()));
     tracing::info!("--- leader lease is set by heartbeat");

--- a/openraft/tests/append_entries/t60_large_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_large_heartbeat.rs
@@ -25,7 +25,7 @@ async fn large_heartbeat() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     router.client_request_many(0, "foo", 10).await?;
     log_index += 10;

--- a/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
+++ b/openraft/tests/append_entries/t90_issue_216_stale_last_log_id.rs
@@ -34,7 +34,7 @@ async fn stale_last_log_id() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
     router.network_send_delay(5);
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3,4}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3,4}).await?;
 
     let n_threads = 4;
     let n_ops = 500;

--- a/openraft/tests/benchmark/bench_cluster.rs
+++ b/openraft/tests/benchmark/bench_cluster.rs
@@ -87,7 +87,7 @@ async fn do_bench(bench_config: &BenchConfig) -> anyhow::Result<()> {
         .validate()?,
     );
     let mut router = RaftRouter::new(config.clone());
-    let _log_index = router.new_nodes_from_single(bench_config.members.clone(), btreeset! {}).await?;
+    let _log_index = router.new_cluster(bench_config.members.clone(), btreeset! {}).await?;
 
     let n = bench_config.n_operations;
 

--- a/openraft/tests/client_api/t10_client_writes.rs
+++ b/openraft/tests/client_api/t10_client_writes.rs
@@ -35,7 +35,7 @@ async fn client_writes() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
     // Write a bunch of data and assert that the cluster stayes stable.
     let leader = router.leader().expect("leader not found");

--- a/openraft/tests/life_cycle/t20_shutdown.rs
+++ b/openraft/tests/life_cycle/t20_shutdown.rs
@@ -21,7 +21,7 @@ async fn shutdown() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    let _log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
+    let _log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- performing node shutdowns");
     {
@@ -50,7 +50,7 @@ async fn return_error_after_panic() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");
-    let log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
     let _ = log_index; // unused;
 
     tracing::info!("--- panic the RaftCore");
@@ -84,7 +84,7 @@ async fn return_error_after_shutdown() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");
-    let log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
     let _ = log_index; // unused;
 
     tracing::info!("--- shutdown the raft");

--- a/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
+++ b/openraft/tests/life_cycle/t90_issue_607_single_restart.rs
@@ -25,7 +25,7 @@ async fn single_restart() -> anyhow::Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- bring up cluster of 1 node");
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!("--- write to 1 log");
     {

--- a/openraft/tests/membership/t00_learner_restart.rs
+++ b/openraft/tests/membership/t00_learner_restart.rs
@@ -34,7 +34,7 @@ async fn learner_restart() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing");
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     router.client_request(0, "foo", 1).await?;
     log_index += 1;

--- a/openraft/tests/membership/t10_add_learner.rs
+++ b/openraft/tests/membership/t10_add_learner.rs
@@ -35,7 +35,7 @@ async fn add_learner_basic() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!("--- re-adding leader commits a new log but does nothing");
     {
@@ -110,7 +110,7 @@ async fn add_learner_non_blocking() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!("--- add new node node-1, in non blocking mode");
     {
@@ -155,7 +155,7 @@ async fn add_learner_when_previous_membership_not_committed() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     tracing::info!("--- block replication to prevent committing any log");
     {
@@ -209,7 +209,7 @@ async fn check_learner_after_leader_transferred() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster members: 0,1; learners: 2");
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1}, btreeset! {2}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {2}).await?;
 
     // Submit a config change which adds two new nodes and removes the current leader.
     let orig_leader_id = router.leader().expect("expected the cluster to have a leader");

--- a/openraft/tests/membership/t15_add_remove_follower.rs
+++ b/openraft/tests/membership/t15_add_remove_follower.rs
@@ -30,7 +30,7 @@ async fn add_remove_voter() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(c01234.clone(), btreeset! {}).await?;
+    let mut log_index = router.new_cluster(c01234.clone(), btreeset! {}).await?;
 
     tracing::info!("--- write 100 logs");
     {

--- a/openraft/tests/membership/t16_change_membership_cases.rs
+++ b/openraft/tests/membership/t16_change_membership_cases.rs
@@ -116,7 +116,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(old.clone(), btreeset! {}).await?;
+    let mut log_index = router.new_cluster(old.clone(), btreeset! {}).await?;
 
     tracing::info!("--- write 10 logs");
     {
@@ -260,7 +260,7 @@ async fn change_by_add(old: BTreeSet<MemNodeId>, add: &[MemNodeId]) -> anyhow::R
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(old.clone(), btreeset! {}).await?;
+    let mut log_index = router.new_cluster(old.clone(), btreeset! {}).await?;
 
     tracing::info!("--- write 10 logs");
     {
@@ -329,7 +329,7 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(old.clone(), btreeset! {}).await?;
+    let mut log_index = router.new_cluster(old.clone(), btreeset! {}).await?;
 
     tracing::info!("--- write 10 logs");
     {

--- a/openraft/tests/membership/t20_change_membership.rs
+++ b/openraft/tests/membership/t20_change_membership.rs
@@ -24,7 +24,7 @@ async fn update_membership_state() -> anyhow::Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {3,4}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3,4}).await?;
 
     tracing::info!("--- change membership from 012 to 01234");
     {
@@ -63,7 +63,7 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!("--- write up to 100 logs");
     {
@@ -102,7 +102,7 @@ async fn change_without_adding_learner() -> anyhow::Result<()> {
     let config = Arc::new(Config { ..Default::default() }.validate()?);
     let mut router = RaftRouter::new(config.clone());
 
-    let log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
     router.wait(&0, timeout()).log(Some(log_index), "received 100 logs").await?;
 
     router.new_raft_node(1).await;
@@ -154,7 +154,7 @@ async fn change_with_turn_removed_voter_to_learner() -> anyhow::Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
     let timeout = Some(Duration::from_millis(1000));
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- write up to 1 logs");
     {

--- a/openraft/tests/membership/t25_elect_with_new_config.rs
+++ b/openraft/tests/membership/t25_elect_with_new_config.rs
@@ -34,7 +34,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
     // Isolate old leader and assert that a new leader takes over.
     tracing::info!("--- isolating leader node 0");

--- a/openraft/tests/membership/t30_commit_joint_config.rs
+++ b/openraft/tests/membership/t30_commit_joint_config.rs
@@ -104,7 +104,7 @@ async fn commit_joint_config_during_012_to_234() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0).await;
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
     tracing::info!("--- isolate 3,4");
 

--- a/openraft/tests/membership/t30_remove_leader.rs
+++ b/openraft/tests/membership/t30_remove_leader.rs
@@ -34,7 +34,7 @@ async fn remove_leader() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1}, btreeset! {2,3}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {2,3}).await?;
 
     // Submit a config change which adds two new nodes and removes the current leader.
     let orig_leader = router.leader().expect("expected the cluster to have a leader");
@@ -126,7 +126,7 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
     let orig_leader = 0;
 

--- a/openraft/tests/membership/t40_removed_follower.rs
+++ b/openraft/tests/membership/t40_removed_follower.rs
@@ -22,7 +22,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0).await;
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
     tracing::info!("--- add node 3,4");
 

--- a/openraft/tests/membership/t45_remove_unreachable_follower.rs
+++ b/openraft/tests/membership/t45_remove_unreachable_follower.rs
@@ -23,7 +23,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
     let mut router = RaftRouter::new(config.clone());
     router.new_raft_node(0).await;
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
     tracing::info!("--- isolate node 4");
     {

--- a/openraft/tests/membership/t99_issue_471_adding_learner_uses_uninit_leader_id.rs
+++ b/openraft/tests/membership/t99_issue_471_adding_learner_uses_uninit_leader_id.rs
@@ -27,7 +27,7 @@ async fn adding_learner_do_not_use_matched_leader_id() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!("--- feed 2 log to make replication busy");
     {

--- a/openraft/tests/membership/t99_issue_584_replication_state_reverted.rs
+++ b/openraft/tests/membership/t99_issue_584_replication_state_reverted.rs
@@ -26,7 +26,7 @@ async fn t99_issue_584_replication_state_reverted() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     let n = 500u64;
     tracing::info!("--- write up to {} logs", n);

--- a/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/openraft/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -34,7 +34,7 @@ async fn new_leader_auto_commit_uniform_config() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     let mut sto = router.get_storage_handle(&0)?;
     router.remove_node(0);

--- a/openraft/tests/metrics/t10_current_leader.rs
+++ b/openraft/tests/metrics/t10_current_leader.rs
@@ -25,7 +25,7 @@ async fn current_leader() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    let _log_index = router.new_nodes_from_single(btreeset! {0,1,2}, btreeset! {}).await?;
+    let _log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
     // Get the ID of the leader, and assert that current_leader succeeds.
     let leader = router.leader().expect("leader not found");

--- a/openraft/tests/snapshot/t20_trigger_snapshot.rs
+++ b/openraft/tests/snapshot/t20_trigger_snapshot.rs
@@ -23,7 +23,7 @@ async fn trigger_snapshot() -> anyhow::Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     tracing::info!("--- initializing cluster");
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
 
     tracing::info!("--- trigger snapshot for node-1");
     {

--- a/openraft/tests/snapshot/t24_snapshot_when_lacking_log.rs
+++ b/openraft/tests/snapshot/t24_snapshot_when_lacking_log.rs
@@ -32,7 +32,7 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!("--- send just enough logs to trigger snapshot");
     {

--- a/openraft/tests/snapshot/t25_snapshot_line_rate_to_snapshot.rs
+++ b/openraft/tests/snapshot/t25_snapshot_line_rate_to_snapshot.rs
@@ -36,7 +36,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     tracing::info!("--- send more than half threshold logs");
     {

--- a/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
+++ b/openraft/tests/snapshot/t40_after_snapshot_add_learner_and_request_a_log.rs
@@ -29,7 +29,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
     let snapshot_index;
 
     tracing::info!("--- send just enough logs to trigger snapshot");

--- a/openraft/tests/snapshot/t40_purge_in_snapshot_logs.rs
+++ b/openraft/tests/snapshot/t40_purge_in_snapshot_logs.rs
@@ -30,7 +30,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     let leader = router.get_raft_handle(&0)?;
     let learner = router.get_raft_handle(&1)?;

--- a/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/openraft/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -45,7 +45,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!("--- send just enough logs to trigger snapshot");
     {

--- a/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
+++ b/openraft/tests/snapshot/t42_snapshot_uses_prev_snap_membership.rs
@@ -45,7 +45,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = router.new_nodes_from_single(btreeset! {0,1}, btreeset! {}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
 
     let mut sto0 = router.get_storage_handle(&0)?;
 

--- a/openraft/tests/snapshot/t44_replication_does_not_block_purge.rs
+++ b/openraft/tests/snapshot/t44_replication_does_not_block_purge.rs
@@ -35,7 +35,7 @@ async fn replication_does_not_block_purge() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    let mut log_index = router.new_nodes_from_single(btreeset! {0}, btreeset! {1,2}).await?;
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1,2}).await?;
 
     let leader = router.get_raft_handle(&0)?;
 

--- a/rocksstore-compat07/Cargo.toml
+++ b/rocksstore-compat07/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.29"
 [dev-dependencies]
 anyhow = { workspace = true }
 async-trait = { version = "0.1.36" }
-tempdir = { version = "0.3.7" }
+tempfile = { version = "3.4.0" }
 tokio = { version = "1.25.0" }
 
 rocksstore07 = { package = "openraft-rocksstore", version = "0.7.4" }

--- a/rocksstore-compat07/src/test.rs
+++ b/rocksstore-compat07/src/test.rs
@@ -18,7 +18,7 @@ impl StoreBuilder<Config, Arc<RocksStore>> for RocksBuilder {
         Res: Future<Output = Result<Ret, StorageError<RocksNodeId>>> + Send,
         Fun: Fn(Arc<RocksStore>) -> Res + Sync + Send,
     {
-        let td = tempdir::TempDir::new("RocksBuilder").expect("couldn't create temp dir");
+        let td = tempfile::TempDir::new().expect("couldn't create temp dir");
         let r = {
             let store = RocksStore::new(td.path()).await;
             t(store).await

--- a/rocksstore/Cargo.toml
+++ b/rocksstore/Cargo.toml
@@ -27,4 +27,5 @@ tracing = "0.1.29"
 
 [dev-dependencies]
 async-trait = { version = "0.1.36" }
-tempdir = { version = "0.3.7" }
+tempfile = { version = "3.4.0" }
+

--- a/rocksstore/src/test.rs
+++ b/rocksstore/src/test.rs
@@ -18,7 +18,7 @@ impl StoreBuilder<Config, Arc<RocksStore>> for RocksBuilder {
         Res: Future<Output = Result<Ret, StorageError<RocksNodeId>>> + Send,
         Fun: Fn(Arc<RocksStore>) -> Res + Sync + Send,
     {
-        let td = tempdir::TempDir::new("RocksBuilder").expect("couldn't create temp dir");
+        let td = tempfile::TempDir::new().expect("couldn't create temp dir");
         let r = {
             let store = RocksStore::new(td.path()).await;
             t(store).await

--- a/sledstore/Cargo.toml
+++ b/sledstore/Cargo.toml
@@ -24,5 +24,5 @@ async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 tracing = "0.1.29"
 
 [dev-dependencies]
-tempdir = { version = "0.3.7" }
+tempfile = { version = "3.4.0" }
 async-trait = { version = "0.1.36" }

--- a/sledstore/src/test.rs
+++ b/sledstore/src/test.rs
@@ -29,7 +29,7 @@ impl StoreBuilder<ExampleTypeConfig, Arc<SledStore>> for SledBuilder {
         Fun: Fn(Arc<SledStore>) -> Res + Sync + Send,
     {
         let pid = std::process::id();
-        let td = tempdir::TempDir::new("SledBuilder").expect("couldn't create temp dir");
+        let td = tempfile::TempDir::new().expect("couldn't create temp dir");
         let temp_dir_path = td.path().to_str().expect("Could not convert temp dir");
         let r = {
             let old_count = GLOBAL_TEST_COUNT.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION

## Changelog

##### Refactor: add logging to tick handler


##### Refactor: add log for startup()


##### Dep: replace tempdir with tempfile

`tempdir` is an archived inactive crate.

Add audit check to CI


##### Fix: Wait::members() should not count learners as members

`Wait::members()` waits until membership becomes the expected value.
It should not check against all nodes.
Instead, it should only check voters, excluding learners.


##### Refactor: remove unneeded error handling, since RaftNetworkFactory::new_client() does not return an error


##### Refactor: refactor data types for Replication-RaftCore communication


##### Refactor: rename methods in testing fixtures

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/699)
<!-- Reviewable:end -->
