### PR TITLE
Improve: AppDataResponse does not need a Clone trait bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ lint:
 
 typos:
 	# cargo install typos-cli
-	typos
+	typos --write-changes openraft/ memstore/ rocksstore rocksstore-compat07/ examples/raft-kv-memstore/ examples/raft-kv-rocksdb/
+	# typos
 
 clean:
 	cargo clean

--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -14,7 +14,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path= "../openraft", version = "0.8.2", features=["serde"] }
+openraft = { path= "../openraft", version = "0.8.3", features=["serde"] }
 
 serde           = { workspace = true }
 serde_json      = { workspace = true }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -199,8 +199,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         // To ensure that restarted nodes don't disrupt a stable cluster.
         if self.engine.state.server_state == ServerState::Follower {
             // If there is only one voter, elect at once.
-            let voter_ids = self.engine.state.membership_state.effective().voter_ids().collect::<Vec<_>>();
-            if voter_ids.len() == 1 {
+            let voter_count = self.engine.state.membership_state.effective().voter_ids().count();
+            if voter_count == 1 {
                 let now = Instant::now();
                 self.next_election_time = VoteWiseTime::new(*self.engine.state.get_vote(), now);
             } else {

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -172,13 +172,13 @@ impl<T> AppData for T where T: Clone + Send + Sync + 'static {}
 ///
 /// The trait is automatically implemented for all types which satisfy its supertraits.
 #[cfg(feature = "serde")]
-pub trait AppDataResponse: Clone + Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
+pub trait AppDataResponse: Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
 
 #[cfg(feature = "serde")]
-impl<T> AppDataResponse for T where T: Clone + Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
+impl<T> AppDataResponse for T where T: Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
 
 #[cfg(not(feature = "serde"))]
-pub trait AppDataResponse: Clone + Send + Sync + 'static {}
+pub trait AppDataResponse: Send + Sync + 'static {}
 
 #[cfg(not(feature = "serde"))]
-impl<T> AppDataResponse for T where T: Clone + Send + Sync + 'static {}
+impl<T> AppDataResponse for T where T: Send + Sync + 'static {}

--- a/rocksstore-compat07/Cargo.toml
+++ b/rocksstore-compat07/Cargo.toml
@@ -15,7 +15,7 @@ repository    = { workspace = true }
 
 
 [dependencies]
-openraft = { path = "../openraft", package = "openraft", version = "0.8.2", features = ["compat-07"] }
+openraft = { path = "../openraft", package = "openraft", version = "0.8.3", features = ["compat-07"] }
 
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 byteorder = "1.4.3"

--- a/rocksstore/Cargo.toml
+++ b/rocksstore/Cargo.toml
@@ -16,7 +16,7 @@ repository    = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openraft = { path= "../openraft", version = "0.8.2", features=["serde"] }
+openraft = { path= "../openraft", version = "0.8.3", features=["serde"] }
 
 rocksdb = "0.20.1"
 byteorder = "1.4.3"

--- a/sledstore/Cargo.toml
+++ b/sledstore/Cargo.toml
@@ -14,7 +14,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path= "../openraft", version = "0.8.2", features=["serde"] }
+openraft = { path= "../openraft", version = "0.8.3", features=["serde"] }
 
 sled = "0.34.7"
 byteorder = "1.4.3"


### PR DESCRIPTION

## Changelog

##### Improve: AppDataResponse does not need a Clone trait bound

- Fix: #703


##### Refactor: rename RaftCore.nodes to replications


##### BumpVer: 0.8.3


##### Refactor: when starting up, if there is only one voter, elect at once

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/704)
<!-- Reviewable:end -->
