### PR TITLE
Change: RaftState: make vote private. Accesses vote via 2 new public methods: `vote_ref()` and `vote_last_modified()`.

### DIFF
--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -82,19 +82,19 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     let _h1 = thread::spawn(|| {
         let rt = Runtime::new().unwrap();
-        let x = rt.block_on(async move { start_example_raft_node(1, "127.0.0.1:21001".to_string()).await });
+        let x = rt.block_on(start_example_raft_node(1, "127.0.0.1:21001".to_string()));
         println!("x: {:?}", x);
     });
 
     let _h2 = thread::spawn(|| {
         let rt = Runtime::new().unwrap();
-        let x = rt.block_on(async move { start_example_raft_node(2, "127.0.0.1:21002".to_string()).await });
+        let x = rt.block_on(start_example_raft_node(2, "127.0.0.1:21002".to_string()));
         println!("x: {:?}", x);
     });
 
     let _h3 = thread::spawn(|| {
         let rt = Runtime::new().unwrap();
-        let x = rt.block_on(async move { start_example_raft_node(3, "127.0.0.1:21003".to_string()).await });
+        let x = rt.block_on(start_example_raft_node(3, "127.0.0.1:21003".to_string()));
         println!("x: {:?}", x);
     });
 

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -77,18 +77,18 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     let d2 = tempfile::TempDir::new()?;
     let d3 = tempfile::TempDir::new()?;
 
-    let _h1 = thread::spawn(|| {
-        let x = block_on(async move { start_example_raft_node(1, d1.path(), get_addr(1), get_rpc_addr(1)).await });
+    let _h1 = thread::spawn(move || {
+        let x = block_on(start_example_raft_node(1, d1.path(), get_addr(1), get_rpc_addr(1)));
         println!("x: {:?}", x);
     });
 
-    let _h2 = thread::spawn(|| {
-        let x = block_on(async move { start_example_raft_node(2, d2.path(), get_addr(2), get_rpc_addr(2)).await });
+    let _h2 = thread::spawn(move || {
+        let x = block_on(start_example_raft_node(2, d2.path(), get_addr(2), get_rpc_addr(2)));
         println!("x: {:?}", x);
     });
 
-    let _h3 = thread::spawn(|| {
-        let x = block_on(async move { start_example_raft_node(3, d3.path(), get_addr(3), get_rpc_addr(3)).await });
+    let _h3 = thread::spawn(move || {
+        let x = block_on(start_example_raft_node(3, d3.path(), get_addr(3), get_rpc_addr(3)));
         println!("x: {:?}", x);
     });
 

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -19,4 +19,3 @@ pub(crate) use snapshot_state::SnapshotResult;
 pub(crate) use snapshot_state::SnapshotState;
 pub(crate) use tick::Tick;
 pub(crate) use tick::TickHandle;
-pub(crate) use tick::VoteWiseTime;

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -14,38 +14,9 @@ use tracing::Level;
 use tracing::Span;
 
 use crate::raft::RaftMsg;
-use crate::NodeId;
 use crate::RaftNetworkFactory;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
-use crate::Vote;
-
-/// An instant time point bound to a vote.
-///
-/// If the vote on a node changes, the timeout belonging to a previous vote becomes invalid.
-/// See: https://datafuselabs.github.io/openraft/vote.html
-#[derive(Debug)]
-pub(crate) struct VoteWiseTime<NID: NodeId> {
-    pub(crate) vote: Vote<NID>,
-    pub(crate) time: Instant,
-}
-
-impl<NID: NodeId> VoteWiseTime<NID> {
-    pub(crate) fn new(vote: Vote<NID>, time: Instant) -> Self {
-        Self { vote, time }
-    }
-
-    /// Return the time if vote does not change since it is set.
-    pub(crate) fn get_time(&self, current_vote: &Vote<NID>) -> Option<Instant> {
-        debug_assert!(&self.vote <= current_vote);
-
-        if &self.vote == current_vote {
-            Some(self.time)
-        } else {
-            None
-        }
-    }
-}
 
 /// Emit RaftMsg::Tick event at regular `interval`.
 pub(crate) struct Tick<C, N, S>

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -102,16 +102,6 @@ where
     /// Send vote to all other members
     SendVote { vote_req: VoteRequest<NID> },
 
-    /// Install a timer to trigger an election, e.g., calling `Engine::elect()` after some
-    /// `timeout` which is decided by the runtime. An already installed timer should be
-    /// cleared.
-    InstallElectionTimer {
-        /// When a candidate fails to elect, it falls back to follower.
-        /// If many enough greater last-log-ids are seen, then this node can never become a leader.
-        /// Thus give it a longer sleep time before next election.
-        can_be_leader: bool,
-    },
-
     /// Purge log from the beginning to `upto`, inclusive.
     PurgeLog { upto: LogId<NID> },
 
@@ -181,7 +171,6 @@ where
             Command::MoveInputCursorBy { .. } => {}
             Command::SaveVote { .. } => flags.set_data_changed(),
             Command::SendVote { .. } => {}
-            Command::InstallElectionTimer { .. } => {}
             Command::PurgeLog { .. } => flags.set_data_changed(),
             Command::DeleteConflictLog { .. } => flags.set_data_changed(),
             Command::InstallSnapshot { .. } => flags.set_data_changed(),

--- a/openraft/src/engine/handler/leader_handler.rs
+++ b/openraft/src/engine/handler/leader_handler.rs
@@ -135,11 +135,13 @@ mod tests {
         #[allow(unused_imports)] use pretty_assertions::assert_eq;
         #[allow(unused_imports)] use pretty_assertions::assert_ne;
         #[allow(unused_imports)] use pretty_assertions::assert_str_eq;
+        use tokio::time::Instant;
 
         use crate::engine::Command;
         use crate::engine::Engine;
         use crate::progress::Inflight;
         use crate::progress::Progress;
+        use crate::utime::UTime;
         use crate::EffectiveMembership;
         use crate::Membership;
         use crate::MembershipState;
@@ -165,7 +167,7 @@ mod tests {
 
             eng.config.id = 1;
             eng.state.committed = Some(log_id(0, 0));
-            eng.state.vote = Vote::new_committed(3, 1);
+            eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(3, 1));
             eng.state.log_ids.append(log_id(1, 1));
             eng.state.log_ids.append(log_id(2, 3));
             eng.state.membership_state = MembershipState::new(
@@ -240,12 +242,14 @@ mod tests {
         #[allow(unused_imports)] use pretty_assertions::assert_eq;
         #[allow(unused_imports)] use pretty_assertions::assert_ne;
         #[allow(unused_imports)] use pretty_assertions::assert_str_eq;
+        use tokio::time::Instant;
 
         use crate::engine::Command;
         use crate::engine::Engine;
         use crate::progress::entry::ProgressEntry;
         use crate::progress::Inflight;
         use crate::raft_state::LogStateReader;
+        use crate::utime::UTime;
         use crate::vote::CommittedLeaderId;
         use crate::EffectiveMembership;
         use crate::Entry;
@@ -301,7 +305,7 @@ mod tests {
 
             eng.config.id = 1;
             eng.state.committed = Some(log_id(0, 0));
-            eng.state.vote = Vote::new_committed(3, 1);
+            eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(3, 1));
             eng.state.log_ids.append(log_id(1, 1));
             eng.state.log_ids.append(log_id(2, 3));
             eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/replication_handler.rs
+++ b/openraft/src/engine/handler/replication_handler.rs
@@ -415,6 +415,7 @@ mod tests {
 
         use maplit::btreeset;
         use pretty_assertions::assert_eq;
+        use tokio::time::Instant;
 
         use crate::engine::Command;
         use crate::engine::Engine;
@@ -422,6 +423,7 @@ mod tests {
         use crate::progress::Progress;
         use crate::raft_state::LogStateReader;
         use crate::testing::log_id;
+        use crate::utime::UTime;
         use crate::EffectiveMembership;
         use crate::Membership;
         use crate::MembershipState;
@@ -440,7 +442,7 @@ mod tests {
             eng.state.enable_validate = false; // Disable validation for incomplete state
 
             eng.config.id = 2;
-            eng.state.vote = Vote::new_committed(2, 1);
+            eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 1));
             eng.state.membership_state = MembershipState::new(
                 Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
                 Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m123())),
@@ -563,6 +565,7 @@ mod tests {
         use std::sync::Arc;
 
         use maplit::btreeset;
+        use tokio::time::Instant;
 
         use crate::core::ServerState;
         use crate::engine::Command;
@@ -571,6 +574,7 @@ mod tests {
         use crate::progress::entry::ProgressEntry;
         use crate::progress::Inflight;
         use crate::progress::Progress;
+        use crate::utime::UTime;
         use crate::CommittedLeaderId;
         use crate::EffectiveMembership;
         use crate::LogId;
@@ -612,7 +616,7 @@ mod tests {
                 Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
                 Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
             );
-            eng.state.vote = Vote::new_committed(2, 2);
+            eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
             eng.state.server_state = eng.calc_server_state();
             eng
         }
@@ -622,7 +626,7 @@ mod tests {
             let mut eng = eng();
             eng.state.server_state = ServerState::Leader;
             // Make it a real leader: voted for itself and vote is committed.
-            eng.state.vote = Vote::new_committed(2, 2);
+            eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
             eng.vote_handler().become_leading();
 
             eng.replication_handler().append_membership(&log_id(3, 4), &m34());
@@ -683,7 +687,7 @@ mod tests {
 
             eng.state.server_state = ServerState::Leader;
             // Make it a real leader: voted for itself and vote is committed.
-            eng.state.vote = Vote::new_committed(2, 2);
+            eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
             eng.state
                 .membership_state
                 .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23_45())));

--- a/openraft/src/engine/handler/server_state_handler.rs
+++ b/openraft/src/engine/handler/server_state_handler.rs
@@ -59,10 +59,12 @@ mod tests {
 
     use maplit::btreeset;
     use pretty_assertions::assert_eq;
+    use tokio::time::Instant;
 
     use crate::engine::Command;
     use crate::engine::Engine;
     use crate::testing::log_id;
+    use crate::utime::UTime;
     use crate::EffectiveMembership;
     use crate::Membership;
     use crate::MembershipState;
@@ -82,7 +84,7 @@ mod tests {
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.config.id = 2;
-        eng.state.vote = Vote::new_committed(2, 2);
+        eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
         eng.state.membership_state = MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
             Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m123())),
@@ -102,7 +104,7 @@ mod tests {
             assert_eq!(ServerState::Leader, ssh.state.server_state);
 
             ssh.output.commands = vec![];
-            ssh.state.vote = Vote::new(2, 100);
+            ssh.state.vote = UTime::new(Instant::now(), Vote::new(2, 100));
             ssh.update_server_state_if_changed();
 
             assert_eq!(ServerState::Follower, ssh.state.server_state);

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -1,5 +1,6 @@
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
+use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::Config;
@@ -12,6 +13,7 @@ use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
 use crate::raft_state::LogStateReader;
+use crate::utime::UTime;
 use crate::vote::CommittedLeaderId;
 use crate::EntryPayload;
 use crate::LogId;
@@ -174,7 +176,6 @@ fn test_initialize() -> anyhow::Result<()> {
                         },),
                     },
                 },
-                Command::InstallElectionTimer { can_be_leader: true },
             ],
             eng.output.commands
         );
@@ -197,7 +198,7 @@ fn test_initialize() -> anyhow::Result<()> {
     tracing::info!("--- not allowed because of vote");
     {
         let mut eng = eng();
-        eng.state.vote = Vote::new(0, 1);
+        eng.state.vote = UTime::new(Instant::now(), Vote::new(0, 1));
 
         assert_eq!(
             Err(InitializeError::NotAllowed(NotAllowed {

--- a/openraft/src/engine/startup_test.rs
+++ b/openraft/src/engine/startup_test.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
 use maplit::btreeset;
+use tokio::time::Instant;
 
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::testing::log_id;
+use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MetricsChangeFlags;
@@ -37,7 +39,7 @@ fn test_startup_as_leader() -> anyhow::Result<()> {
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())));
     // Committed vote makes it a leader at startup.
-    eng.state.vote = Vote::new_committed(1, 2);
+    eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(1, 2));
 
     eng.startup();
 
@@ -79,7 +81,7 @@ fn test_startup_candidate_becomes_follower() -> anyhow::Result<()> {
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())));
     // Non-committed vote makes it a candidate at startup.
-    eng.state.vote = Vote::new(1, 2);
+    eng.state.vote = UTime::new(Instant::now(), Vote::new(1, 2));
 
     eng.startup();
 

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -29,6 +29,12 @@ pub(crate) struct Leader<NID: NodeId, QS: QuorumSet<NID>> {
     /// The vote this leader works in.
     pub(crate) vote: Vote<NID>,
 
+    /// Whether a greater log id is seen during election.
+    ///
+    /// If it is true, then this node **may** not become a leader therefore the election timeout
+    /// should be greater.
+    seen_greater_log: bool,
+
     /// Which nodes have granted the the vote of this node.
     pub(crate) vote_granted_by: BTreeSet<NID>,
 
@@ -49,6 +55,7 @@ where
     ) -> Self {
         Self {
             vote,
+            seen_greater_log: false,
             vote_granted_by: BTreeSet::new(),
             progress: VecProgress::new(
                 quorum_set,
@@ -56,6 +63,22 @@ where
                 ProgressEntry::empty(last_log_index.next_index()),
             ),
         }
+    }
+
+    pub(crate) fn is_there_greater_log(&self) -> bool {
+        self.seen_greater_log
+    }
+
+    /// Set that there is greater last log id found.
+    ///
+    /// In such a case, this node should not try to elect aggressively.
+    pub(crate) fn set_greater_log(&mut self) {
+        self.seen_greater_log = true;
+    }
+
+    /// Clear the flag of that there is greater last log id.
+    pub(crate) fn reset_greater_log(&mut self) {
+        self.seen_greater_log = false;
     }
 
     /// Update that a node has granted the vote.

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -61,6 +61,7 @@ pub mod timer;
 pub mod versioned;
 
 pub(crate) mod log_id_range;
+pub(crate) mod utime;
 pub(crate) mod validate;
 
 mod engine;

--- a/openraft/src/raft_state/time_state.rs
+++ b/openraft/src/raft_state/time_state.rs
@@ -1,0 +1,58 @@
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct Config {
+    /// The time interval after which the next election will be initiated once the current lease has
+    /// expired.
+    pub(crate) election_timeout: Duration,
+
+    /// The duration of an active leader's lease.
+    ///
+    /// When a follower or learner perceives an active leader, such as by receiving an AppendEntries
+    /// message, it should not grant another candidate to become the leader during this period.
+    pub(crate) leader_lease: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            election_timeout: Duration::from_millis(150),
+            leader_lease: Duration::from_millis(150),
+        }
+    }
+}
+
+/// Wall clock time related state that track current wall clock time, leader lease, timeout etc.
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct TimeState {
+    /// Cached current time.
+    now: Instant,
+}
+
+impl Default for TimeState {
+    fn default() -> Self {
+        let now = Instant::now();
+        Self { now }
+    }
+}
+
+impl TimeState {
+    pub(crate) fn new(now: Instant) -> Self {
+        Self { now }
+    }
+
+    pub(crate) fn now(&self) -> &Instant {
+        &self.now
+    }
+
+    pub(crate) fn update_now(&mut self, now: Instant) {
+        tracing::debug!("update_now: {:?}", now);
+        debug_assert!(now >= self.now, "monotonic time expects {:?} >= {:?}", now, self.now);
+
+        self.now = now;
+    }
+}

--- a/openraft/src/raft_state_test.rs
+++ b/openraft/src/raft_state_test.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use maplit::btreemap;
 use maplit::btreeset;
+use tokio::time::Instant;
 
 use crate::engine::LogIdList;
 use crate::error::ForwardToLeader;
 use crate::raft_state::LogStateReader;
+use crate::utime::UTime;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
 use crate::LogId;
@@ -164,7 +166,7 @@ fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
 #[test]
 fn test_forward_to_leader_vote_not_committed() {
     let rs = RaftState {
-        vote: Vote::new(1, 2),
+        vote: UTime::new(Instant::now(), Vote::new(1, 2)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -178,7 +180,7 @@ fn test_forward_to_leader_vote_not_committed() {
 #[test]
 fn test_forward_to_leader_not_a_member() {
     let rs = RaftState {
-        vote: Vote::new_committed(1, 3),
+        vote: UTime::new(Instant::now(), Vote::new_committed(1, 3)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -194,7 +196,7 @@ fn test_forward_to_leader_has_leader() {
     let m123 = || Membership::<u64, u64>::new(vec![btreeset! {1,2}], btreemap! {1=>4,2=>5,3=>6});
 
     let rs = RaftState {
-        vote: Vote::new_committed(1, 3),
+        vote: UTime::new(Instant::now(), Vote::new_committed(1, 3)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -409,10 +409,10 @@ where
     }
 
     pub async fn get_initial_state_without_init(mut store: S) -> Result<(), StorageError<C::NodeId>> {
-        let mut initial = StorageHelper::new(&mut store).get_initial_state().await?;
-        let want = RaftState::default();
-        initial.leader_expire_at = want.leader_expire_at;
-        initial.now = want.now;
+        let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+        let mut want = RaftState::default();
+        want.vote.update(initial.vote.utime().unwrap(), Vote::default());
+
         assert_eq!(want, initial, "uninitialized state");
         Ok(())
     }

--- a/openraft/src/utime.rs
+++ b/openraft/src/utime.rs
@@ -1,0 +1,65 @@
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use tokio::time::Instant;
+
+/// Record the last update time for an object
+#[derive(Debug, Default)]
+pub(crate) struct UTime<T> {
+    data: T,
+    utime: Option<Instant>,
+}
+
+impl<T: Clone> Clone for UTime<T> {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            utime: self.utime,
+        }
+    }
+}
+
+impl<T: PartialEq> PartialEq for UTime<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data && self.utime == other.utime
+    }
+}
+
+impl<T: PartialEq + Eq> Eq for UTime<T> {}
+
+impl<T> Deref for UTime<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for UTime<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+impl<T> UTime<T> {
+    /// Creates a new object that keeps track of the time when it was last updated.
+    pub(crate) fn new(now: Instant, data: T) -> Self {
+        Self { data, utime: Some(now) }
+    }
+
+    /// Return the last updated time of this object.
+    pub(crate) fn utime(&self) -> Option<Instant> {
+        self.utime
+    }
+
+    /// Update the content of the object and the last updated time.
+    pub(crate) fn update(&mut self, now: Instant, data: T) {
+        self.data = data;
+        self.utime = Some(now);
+    }
+
+    /// Update the last updated time.
+    pub(crate) fn touch(&mut self, now: Instant) {
+        self.utime = Some(now);
+    }
+}

--- a/openraft/tests/append_entries/t10_see_higher_vote.rs
+++ b/openraft/tests/append_entries/t10_see_higher_vote.rs
@@ -73,7 +73,7 @@ async fn append_sees_higher_vote() -> Result<()> {
             .await?;
 
         router.external_request(0, |st, _, _| {
-            assert_eq!(Vote::new(10, 1), st.vote, "higher vote is stored");
+            assert_eq!(&Vote::new(10, 1), st.vote_ref(), "higher vote is stored");
         });
     }
 

--- a/openraft/tests/append_entries/t60_enable_heartbeat.rs
+++ b/openraft/tests/append_entries/t60_enable_heartbeat.rs
@@ -30,6 +30,7 @@ async fn enable_heartbeat() -> Result<()> {
     node0.enable_heartbeat(true);
 
     for _i in 0..3 {
+        let now = Instant::now();
         sleep(Duration::from_millis(500)).await;
 
         for node_id in [1, 2, 3] {
@@ -41,7 +42,7 @@ async fn enable_heartbeat() -> Result<()> {
 
             // leader lease is extended.
             router.external_request(node_id, move |state, _store, _net| {
-                assert!(state.leader_expire_at() > Instant::now());
+                assert!(state.vote_last_modified() > Some(now));
             });
         }
     }

--- a/openraft/tests/life_cycle/main.rs
+++ b/openraft/tests/life_cycle/main.rs
@@ -10,4 +10,6 @@ mod fixtures;
 
 mod t20_initialization;
 mod t20_shutdown;
+mod t30_follower_restart_does_not_interrupt;
+mod t30_single_follower_restart;
 mod t90_issue_607_single_restart;

--- a/openraft/tests/life_cycle/t30_follower_restart_does_not_interrupt.rs
+++ b/openraft/tests/life_cycle/t30_follower_restart_does_not_interrupt.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// A follower that restarted should not interrupt a stable cluster by a too quick election.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn follower_restart_does_not_interrupt() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            election_timeout_min: 3_000,
+            election_timeout_max: 4_000,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up cluster of 3 nodes");
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+    let _ = log_index;
+
+    tracing::info!("--- stop and restart follower nodes 1,2");
+    {
+        // Stop followers first or the follower may start re-electing.
+
+        let m = router.get_metrics(&0)?;
+        let term = m.current_term;
+
+        let (n2, sto2) = router.remove_node(2).unwrap();
+        n2.shutdown().await?;
+
+        let (n1, sto1) = router.remove_node(1).unwrap();
+        n1.shutdown().await?;
+
+        let (n0, _sto0) = router.remove_node(0).unwrap();
+        n0.shutdown().await?;
+
+        tracing::info!("--- restart node 1,2");
+
+        router.new_raft_node_with_sto(1, sto1).await;
+        router.new_raft_node_with_sto(2, sto2).await;
+        let res = router
+            .wait(&1, Some(Duration::from_millis(1_000)))
+            .metrics(|x| x.current_term > term, "node increase term to start election")
+            .await;
+
+        assert!(res.is_err(), "term should not increase");
+
+        router
+            .wait(&1, Some(Duration::from_millis(7_000)))
+            .metrics(
+                |x| x.current_term > term,
+                concat!(
+                    "node increase term to start election after a election timeout.",
+                    "When it starts up, it set the last-update time of the vote to `now`, ",
+                    "which make it as if a just renewed vote(has a full leader lease)."
+                ),
+            )
+            .await?;
+    }
+
+    Ok(())
+}

--- a/openraft/tests/life_cycle/t30_single_follower_restart.rs
+++ b/openraft/tests/life_cycle/t30_single_follower_restart.rs
@@ -44,7 +44,7 @@ async fn single_follower_restart() -> anyhow::Result<()> {
         let v = sto.read_vote().await?.unwrap_or_default();
 
         // Set a non-committed vote so that the node restarts as a follower.
-        sto.save_vote(&Vote::new(v.leader_id.get_term(), v.leader_id.voted_for().unwrap())).await?;
+        sto.save_vote(&Vote::new(v.leader_id.get_term() + 1, v.leader_id.voted_for().unwrap())).await?;
 
         tracing::info!("--- restart node 0");
 


### PR DESCRIPTION

## Changelog

##### Change: RaftState: make vote private. Accesses vote via 2 new public methods: `vote_ref()` and `vote_last_modified()`.

There are several timer-related states that support heartbeat, election,
and other functionalities. These states must be updated correctly in
several places when the raft state changes. For example, when the vote
or the membership changes. However, achieving consistency in all updates becomes difficult.

To address this issue, this patch reduces the number of states that need
to be maintained. Only the last-updated time is recorded every time the
`vote` changes. Other states, such as leader lease and election timeout,
are calculated only when needed.

- Refactor: remove `VoteWiseTime`, remove `Command::InstallElectionTimer`.

- Refactor: remove `next_election_time` from `RaftCore`

- Refactor: update the last-modified time every time `vote` changes.
  Calculate leader lease and election timeout only when used. This way
  it reduces the number of state to maintain.

- Refactor: Engine: move now from RaftState `timer` to track time,

- Refactor: add UTime to track last-updated time for an object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/708)
<!-- Reviewable:end -->
