### PR TITLE
Refactor: rename RaftState.get_vote() to vote_ref()

### DIFF
--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -8,7 +8,6 @@ use crate::error::SnapshotMismatch;
 use crate::raft::InstallSnapshotRequest;
 use crate::raft::InstallSnapshotResponse;
 use crate::raft::InstallSnapshotTx;
-use crate::raft_state::VoteStateReader;
 use crate::Entry;
 use crate::ErrorSubject;
 use crate::ErrorVerb;
@@ -40,12 +39,12 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         self.run_engine_commands::<Entry<C>>(&[]).await?;
         if res.is_err() {
             tracing::info!(
-                my_vote = display(self.engine.state.get_vote()),
+                my_vote = display(self.engine.state.vote_ref()),
                 req_vote = display(&req.vote),
                 "InstallSnapshot RPC term is less than current term, ignoring it."
             );
             let _ = tx.send(Ok(InstallSnapshotResponse {
-                vote: *self.engine.state.get_vote(),
+                vote: *self.engine.state.vote_ref(),
             }));
             return Ok(());
         }
@@ -108,7 +107,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         }
 
         let _ = tx.send(Ok(InstallSnapshotResponse {
-            vote: *self.engine.state.get_vote(),
+            vote: *self.engine.state.vote_ref(),
         }));
 
         Ok(())

--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -9,7 +9,6 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
-use crate::raft_state::VoteStateReader;
 use crate::testing::log_id;
 use crate::utime::UTime;
 use crate::CommittedLeaderId;
@@ -46,7 +45,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         eng.elect();
 
-        assert_eq!(Vote::new_committed(1, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new_committed(1, 1), *eng.state.vote_ref());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -109,7 +108,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         eng.elect();
 
-        assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -168,7 +167,7 @@ fn test_elect() -> anyhow::Result<()> {
 
         eng.elect();
 
-        assert_eq!(Vote::new(1, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(1, 1), *eng.state.vote_ref());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -9,7 +9,6 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft::AppendEntriesResponse;
 use crate::raft_state::LogStateReader;
-use crate::raft_state::VoteStateReader;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Entry;
@@ -75,7 +74,7 @@ fn test_handle_append_entries_req_vote_is_rejected() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
     assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -123,7 +122,7 @@ fn test_handle_append_entries_req_prev_log_id_is_applied() -> anyhow::Result<()>
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
     assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -172,7 +171,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
     assert_eq!(Some(&log_id(1, 1)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -228,7 +227,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
     assert_eq!(Some(&log_id(2, 2)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(1, 1)), eng.state.committed());
     assert_eq!(
@@ -292,7 +291,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
     assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(0, 0)), eng.state.committed());
     assert_eq!(
@@ -350,7 +349,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
     assert_eq!(Some(&log_id(3, 3)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(3, 3)), eng.state.committed());
     assert_eq!(

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -10,7 +10,6 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
-use crate::raft_state::VoteStateReader;
 use crate::testing::log_id;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
@@ -58,7 +57,7 @@ fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
         resp
     );
 
-    assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
     assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -94,7 +93,7 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
         resp
     );
 
-    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
     assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -131,7 +130,7 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
         resp
     );
 
-    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
     assert!(eng.internal_server_state.is_leading());
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -173,7 +172,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         resp
     );
 
-    assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
     assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -216,7 +215,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
         resp
     );
 
-    assert_eq!(Vote::new(3, 1), *eng.state.get_vote());
+    assert_eq!(Vote::new(3, 1), *eng.state.vote_ref());
     assert!(eng.internal_server_state.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -11,7 +11,6 @@ use crate::engine::LogIdList;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft::VoteResponse;
-use crate::raft_state::VoteStateReader;
 use crate::testing::log_id;
 use crate::utime::UTime;
 use crate::CommittedLeaderId;
@@ -54,7 +53,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
         assert!(eng.internal_server_state.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -88,7 +87,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -126,7 +125,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(3, 2), *eng.state.get_vote());
+        assert_eq!(Vote::new(3, 2), *eng.state.vote_ref());
         assert!(eng.internal_server_state.is_leading());
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
@@ -160,7 +159,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
         assert_eq!(
             Some(btreeset! {1},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -197,7 +196,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
         assert_eq!(
             Some(btreeset! {1,2},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())
@@ -234,7 +233,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             last_log_id: Some(log_id(2, 2)),
         });
 
-        assert_eq!(Vote::new_committed(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
         assert_eq!(
             Some(btreeset! {1,2},),
             eng.internal_server_state.leading().map(|x| x.vote_granted_by.clone())

--- a/openraft/src/engine/handler/replication_handler.rs
+++ b/openraft/src/engine/handler/replication_handler.rs
@@ -10,7 +10,6 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
 use crate::raft_state::LogStateReader;
-use crate::raft_state::VoteStateReader;
 use crate::replication::ReplicationResult;
 use crate::EffectiveMembership;
 use crate::LogId;
@@ -62,7 +61,7 @@ where
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn append_blank_log(&mut self) {
         let log_id = LogId::new(
-            self.state.get_vote().committed_leader_id().unwrap(),
+            self.state.vote_ref().committed_leader_id().unwrap(),
             self.state.last_log_id().next_index(),
         );
         self.state.log_ids.append(log_id);
@@ -176,7 +175,7 @@ where
     pub(crate) fn try_commit_granted(&mut self, granted: Option<LogId<NID>>) {
         // Only when the log id is proposed by current leader, it is committed.
         if let Some(c) = granted {
-            if !self.state.get_vote().is_same_leader(c.committed_leader_id()) {
+            if !self.state.vote_ref().is_same_leader(c.committed_leader_id()) {
                 return;
             }
         }

--- a/openraft/src/engine/handler/vote_handler.rs
+++ b/openraft/src/engine/handler/vote_handler.rs
@@ -8,7 +8,6 @@ use crate::leader::Leader;
 use crate::progress::Progress;
 use crate::raft_state::time_state::TimeState;
 use crate::raft_state::LogStateReader;
-use crate::raft_state::VoteStateReader;
 use crate::LogIdOptionExt;
 use crate::Node;
 use crate::NodeId;
@@ -43,14 +42,14 @@ where
     /// - Voting is not in the hot path, thus no performance penalty.
     /// - Leadership won't be lost if a leader restarted quick enough.
     pub(crate) fn commit_vote(&mut self) {
-        debug_assert!(!self.state.get_vote().is_committed());
+        debug_assert!(!self.state.vote_ref().is_committed());
         debug_assert_eq!(
-            self.state.get_vote().leader_id().voted_for(),
+            self.state.vote_ref().leader_id().voted_for(),
             Some(self.config.id),
             "it can only commit its own vote"
         );
 
-        let mut v = *self.state.get_vote();
+        let mut v = *self.state.vote_ref();
         v.commit();
 
         let _res = self.handle_message_vote(&v);
@@ -69,16 +68,16 @@ where
         // Partial ord compare:
         // Vote does not has to be total ord.
         // `!(a >= b)` does not imply `a < b`.
-        if vote >= self.state.get_vote() {
+        if vote >= self.state.vote_ref() {
             // Ok
         } else {
-            return Err(RejectVoteRequest::ByVote(*self.state.get_vote()));
+            return Err(RejectVoteRequest::ByVote(*self.state.vote_ref()));
         }
         tracing::debug!(%vote, "vote is changing to" );
 
         // Grant the vote
 
-        if vote > self.state.get_vote() {
+        if vote > self.state.vote_ref() {
             self.state.vote.update(*self.timer.now(), *vote);
             self.output.push_command(Command::SaveVote { vote: *vote });
         } else {
@@ -96,7 +95,7 @@ where
 
     /// Enter leading or following state by checking `vote`.
     pub(crate) fn update_internal_server_state(&mut self) {
-        if self.state.get_vote().leader_id().voted_for() == Some(self.config.id) {
+        if self.state.vote_ref().leader_id().voted_for() == Some(self.config.id) {
             self.become_leading();
         } else {
             self.become_following();
@@ -110,9 +109,9 @@ where
     /// and phase-2. Leader and Candidate shares the same state.
     pub(crate) fn become_leading(&mut self) {
         if let Some(l) = self.internal_server_state.leading_mut() {
-            if l.vote.leader_id() == self.state.get_vote().leader_id() {
+            if l.vote.leader_id() == self.state.vote_ref().leader_id() {
                 // Vote still belongs to the same leader. Just updating vote is enough.
-                l.vote = *self.state.get_vote();
+                l.vote = *self.state.vote_ref();
                 self.server_state_handler().update_server_state_if_changed();
                 return;
             }
@@ -123,7 +122,7 @@ where
 
         let em = &self.state.membership_state.effective();
         let mut leader = Leader::new(
-            *self.state.get_vote(),
+            *self.state.vote_ref(),
             em.membership().to_quorum_set(),
             em.learner_ids(),
             self.state.last_log_id().index(),
@@ -146,7 +145,7 @@ where
         // timeout.
 
         debug_assert!(
-            self.state.get_vote().leader_id().voted_for() != Some(self.config.id)
+            self.state.vote_ref().leader_id().voted_for() != Some(self.config.id)
                 || !self.state.membership_state.effective().contains(&self.config.id),
             "It must hold: vote is not mine, or I am not a voter(leader just left the cluster)"
         );
@@ -183,7 +182,6 @@ mod tests {
     use crate::engine::Engine;
     use crate::engine::LogIdList;
     use crate::error::RejectVoteRequest;
-    use crate::raft_state::VoteStateReader;
     use crate::testing::log_id;
     use crate::utime::UTime;
     use crate::EffectiveMembership;
@@ -218,7 +216,7 @@ mod tests {
 
         assert_eq!(Err(RejectVoteRequest::ByVote(Vote::new(2, 1))), resp);
 
-        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
         assert!(eng.internal_server_state.is_leading());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -248,7 +246,7 @@ mod tests {
 
         assert_eq!(Ok(()), resp);
 
-        assert_eq!(Vote::new_committed(3, 2), *eng.state.get_vote());
+        assert_eq!(Vote::new_committed(3, 2), *eng.state.vote_ref());
         assert!(eng.internal_server_state.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -285,7 +283,7 @@ mod tests {
 
         assert_eq!(Ok(()), resp);
 
-        assert_eq!(Vote::new(2, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
         assert!(eng.internal_server_state.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -314,7 +312,7 @@ mod tests {
 
         assert_eq!(Ok(()), resp);
 
-        assert_eq!(Vote::new(3, 1), *eng.state.get_vote());
+        assert_eq!(Vote::new(3, 1), *eng.state.vote_ref());
         assert!(eng.internal_server_state.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -38,7 +38,6 @@ use crate::membership::IntoNodes;
 use crate::metrics::RaftMetrics;
 use crate::metrics::Wait;
 use crate::node::Node;
-use crate::raft_state::VoteStateReader;
 use crate::replication::ReplicationResult;
 use crate::replication::ReplicationSessionId;
 use crate::AppData;
@@ -227,7 +226,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
         };
 
         // TODO(xp): this is not necessary.
-        storage.save_vote(state.get_vote()).await?;
+        storage.save_vote(state.vote_ref()).await?;
 
         let engine = Engine::new(state, eng_config);
 

--- a/openraft/src/raft_state.rs
+++ b/openraft/src/raft_state.rs
@@ -89,8 +89,8 @@ pub(crate) trait LogStateReader<NID: NodeId> {
 
 /// APIs to get vote.
 pub(crate) trait VoteStateReader<NID: NodeId> {
-    /// Get the current vote.
-    fn get_vote(&self) -> &Vote<NID>;
+    /// Get a reference to the current vote.
+    fn vote_ref(&self) -> &Vote<NID>;
 }
 
 /// A struct used to represent the raft state which a Raft node needs.
@@ -174,7 +174,7 @@ where
     NID: NodeId,
     N: Node,
 {
-    fn get_vote(&self) -> &Vote<NID> {
+    fn vote_ref(&self) -> &Vote<NID> {
         self.vote.deref()
     }
 }
@@ -214,6 +214,7 @@ where
     NID: NodeId,
     N: Node,
 {
+    /// Get a reference to the current vote.
     pub fn vote_ref(&self) -> &Vote<NID> {
         self.vote.deref()
     }
@@ -320,7 +321,7 @@ where
         entries: impl Iterator<Item = &'a mut Ent>,
     ) {
         let mut log_id = LogId::new(
-            self.get_vote().committed_leader_id().unwrap(),
+            self.vote_ref().committed_leader_id().unwrap(),
             self.last_log_id().next_index(),
         );
         for entry in entries {
@@ -332,7 +333,7 @@ where
 
     /// Build a ForwardToLeader error that contains the leader id and node it knows.
     pub(crate) fn forward_to_leader(&self) -> ForwardToLeader<NID, N> {
-        let vote = self.get_vote();
+        let vote = self.vote_ref();
 
         if vote.is_committed() {
             // Safe unwrap(): vote that is committed has to already have voted for some node.

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -8,7 +8,6 @@ use maplit::btreeset;
 use crate::membership::EffectiveMembership;
 use crate::raft_state::LogStateReader;
 use crate::raft_state::RaftState;
-use crate::raft_state::VoteStateReader;
 use crate::storage::LogState;
 use crate::storage::StorageHelper;
 use crate::testing::DefensiveStoreBuilder;
@@ -448,7 +447,7 @@ where
         );
         assert_eq!(
             Vote::new(1, NODE_ID.into()),
-            *initial.get_vote(),
+            *initial.vote_ref(),
             "unexpected value for default hard state"
         );
         Ok(())


### PR DESCRIPTION

## Changelog

##### Refactor: rename RaftState.get_vote() to vote_ref()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/709)
<!-- Reviewable:end -->
