### PR TITLE
Refactor: refine Membership API doc

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -21,7 +21,6 @@ use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::internal_server_state::InternalServerState;
 use crate::membership::EffectiveMembership;
-use crate::membership::NodeRole;
 use crate::node::Node;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::RaftRespTx;
@@ -419,10 +418,7 @@ where
 
         // vote is rejected:
 
-        debug_assert_eq!(
-            Some(NodeRole::Voter),
-            self.state.membership_state.effective().get_node_role(&self.config.id)
-        );
+        debug_assert!(self.state.membership_state.effective().is_voter(&self.config.id));
 
         // If peer's vote is greater than current vote, revert to follower state.
         if &resp.vote > self.state.vote_ref() {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -148,7 +148,7 @@ where
 
         debug_assert!(
             self.state.vote_ref().leader_id().voted_for() != Some(self.config.id)
-                || !self.state.membership_state.effective().contains(&self.config.id),
+                || !self.state.membership_state.effective().membership().is_voter(&self.config.id),
             "It must hold: vote is not mine, or I am not a voter(leader just left the cluster)"
         );
 

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::entry::RaftEntry;
-use crate::membership::NodeRole;
 use crate::node::Node;
 use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
@@ -133,17 +132,6 @@ where
     N: Node,
     NID: NodeId,
 {
-    /// Return if a node is a voter or learner, or not in this membership config at all.
-    pub(crate) fn get_node_role(&self, nid: &NID) -> Option<NodeRole> {
-        if self.voter_ids.contains(nid) {
-            Some(NodeRole::Voter)
-        } else if self.contains(nid) {
-            Some(NodeRole::Learner)
-        } else {
-            None
-        }
-    }
-
     #[allow(dead_code)]
     pub(crate) fn is_voter(&self, nid: &NID) -> bool {
         self.membership().is_voter(nid)
@@ -158,11 +146,6 @@ where
     #[allow(dead_code)]
     pub(crate) fn learner_ids(&self) -> impl Iterator<Item = NID> + '_ {
         self.membership().learner_ids()
-    }
-
-    /// Returns if a voter or learner exists in this membership.
-    pub(crate) fn contains(&self, id: &NID) -> bool {
-        self.membership().contains(id)
     }
 
     /// Get a the node(either voter or learner) by node id.

--- a/openraft/src/membership/into_nodes.rs
+++ b/openraft/src/membership/into_nodes.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use maplit::btreemap;
+
+use crate::Node;
+use crate::NodeId;
+
+/// Convert into a map of `Node`.
+///
+/// This is used as a user input acceptor when building a Membership, to convert various input types
+/// into a map of `Node`.
+pub trait IntoNodes<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn has_nodes(&self) -> bool;
+    fn node_ids(&self) -> Vec<NID>;
+    fn into_nodes(self) -> BTreeMap<NID, N>;
+}
+
+impl<NID, N> IntoNodes<NID, N> for ()
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn has_nodes(&self) -> bool {
+        false
+    }
+
+    fn node_ids(&self) -> Vec<NID> {
+        vec![]
+    }
+
+    fn into_nodes(self) -> BTreeMap<NID, N> {
+        btreemap! {}
+    }
+}
+
+impl<NID, N> IntoNodes<NID, N> for BTreeSet<NID>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn has_nodes(&self) -> bool {
+        false
+    }
+
+    fn node_ids(&self) -> Vec<NID> {
+        self.iter().copied().collect()
+    }
+
+    fn into_nodes(self) -> BTreeMap<NID, N> {
+        self.into_iter().map(|node_id| (node_id, N::default())).collect()
+    }
+}
+
+impl<NID, N> IntoNodes<NID, N> for Option<BTreeSet<NID>>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn has_nodes(&self) -> bool {
+        true
+    }
+
+    fn node_ids(&self) -> Vec<NID> {
+        match self {
+            None => {
+                vec![]
+            }
+            Some(bs) => bs.iter().copied().collect(),
+        }
+    }
+
+    fn into_nodes(self) -> BTreeMap<NID, N> {
+        match self {
+            None => BTreeMap::new(),
+            Some(s) => s.into_iter().map(|node_id| (node_id, N::default())).collect(),
+        }
+    }
+}
+
+impl<NID, N> IntoNodes<NID, N> for BTreeMap<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn has_nodes(&self) -> bool {
+        true
+    }
+
+    fn node_ids(&self) -> Vec<NID> {
+        self.keys().copied().collect()
+    }
+
+    fn into_nodes(self) -> BTreeMap<NID, N> {
+        self
+    }
+}

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -7,7 +7,6 @@ use maplit::btreemap;
 use crate::error::ChangeMembershipError;
 use crate::error::EmptyMembership;
 use crate::error::LearnerNotFound;
-use crate::membership::NodeRole;
 use crate::node::Node;
 use crate::quorum::AsJoint;
 use crate::quorum::FindCoherent;
@@ -17,7 +16,10 @@ use crate::ChangeMembers;
 use crate::MessageSummary;
 use crate::NodeId;
 
-/// Convert types into a map of `Node`.
+/// Convert into a map of `Node`.
+///
+/// This is used as a user input acceptor when building a Membership, to convert various input types
+/// into a map of `Node`.
 pub trait IntoNodes<NID, N>
 where
     N: Node,
@@ -309,18 +311,6 @@ where
         self.nodes.get(node_id)
     }
 
-    /// Return if a node is a voter or learner, or not in this membership config at all.
-    #[allow(dead_code)]
-    pub(crate) fn get_node_role(&self, nid: &NID) -> Option<NodeRole> {
-        if self.is_voter(nid) {
-            Some(NodeRole::Voter)
-        } else if self.contains(nid) {
-            Some(NodeRole::Learner)
-        } else {
-            None
-        }
-    }
-
     /// Check if the given `NodeId` exists and is a voter.
     pub(crate) fn is_voter(&self, node_id: &NID) -> bool {
         for c in self.configs.iter() {
@@ -329,11 +319,6 @@ where
             }
         }
         false
-    }
-
-    /// Returns if a voter or learner exists in this membership.
-    pub(crate) fn contains(&self, node_id: &NID) -> bool {
-        self.nodes.contains_key(node_id)
     }
 
     /// Returns reference to the joint config.

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -2,11 +2,10 @@ use core::fmt;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-use maplit::btreemap;
-
 use crate::error::ChangeMembershipError;
 use crate::error::EmptyMembership;
 use crate::error::LearnerNotFound;
+use crate::membership::IntoNodes;
 use crate::node::Node;
 use crate::quorum::AsJoint;
 use crate::quorum::FindCoherent;
@@ -15,100 +14,6 @@ use crate::quorum::QuorumSet;
 use crate::ChangeMembers;
 use crate::MessageSummary;
 use crate::NodeId;
-
-/// Convert into a map of `Node`.
-///
-/// This is used as a user input acceptor when building a Membership, to convert various input types
-/// into a map of `Node`.
-pub trait IntoNodes<NID, N>
-where
-    N: Node,
-    NID: NodeId,
-{
-    fn has_nodes(&self) -> bool;
-    fn node_ids(&self) -> Vec<NID>;
-    fn into_nodes(self) -> BTreeMap<NID, N>;
-}
-
-impl<NID, N> IntoNodes<NID, N> for ()
-where
-    N: Node,
-    NID: NodeId,
-{
-    fn has_nodes(&self) -> bool {
-        false
-    }
-
-    fn node_ids(&self) -> Vec<NID> {
-        vec![]
-    }
-
-    fn into_nodes(self) -> BTreeMap<NID, N> {
-        btreemap! {}
-    }
-}
-
-impl<NID, N> IntoNodes<NID, N> for BTreeSet<NID>
-where
-    N: Node,
-    NID: NodeId,
-{
-    fn has_nodes(&self) -> bool {
-        false
-    }
-
-    fn node_ids(&self) -> Vec<NID> {
-        self.iter().copied().collect()
-    }
-
-    fn into_nodes(self) -> BTreeMap<NID, N> {
-        self.into_iter().map(|node_id| (node_id, N::default())).collect()
-    }
-}
-
-impl<NID, N> IntoNodes<NID, N> for Option<BTreeSet<NID>>
-where
-    N: Node,
-    NID: NodeId,
-{
-    fn has_nodes(&self) -> bool {
-        true
-    }
-
-    fn node_ids(&self) -> Vec<NID> {
-        match self {
-            None => {
-                vec![]
-            }
-            Some(bs) => bs.iter().copied().collect(),
-        }
-    }
-
-    fn into_nodes(self) -> BTreeMap<NID, N> {
-        match self {
-            None => BTreeMap::new(),
-            Some(s) => s.into_iter().map(|node_id| (node_id, N::default())).collect(),
-        }
-    }
-}
-
-impl<NID, N> IntoNodes<NID, N> for BTreeMap<NID, N>
-where
-    N: Node,
-    NID: NodeId,
-{
-    fn has_nodes(&self) -> bool {
-        true
-    }
-
-    fn node_ids(&self) -> Vec<NID> {
-        self.keys().copied().collect()
-    }
-
-    fn into_nodes(self) -> BTreeMap<NID, N> {
-        self
-    }
-}
 
 /// The membership configuration of the cluster.
 ///

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -44,7 +44,7 @@ where
 {
     fn from(b: BTreeMap<NID, N>) -> Self {
         let member_ids = b.keys().cloned().collect::<BTreeSet<NID>>();
-        Membership::new_with_nodes(vec![member_ids], b)
+        Membership::new_unchecked(vec![member_ids], b)
     }
 }
 
@@ -108,27 +108,29 @@ where
     N: Node,
     NID: NodeId,
 {
-    /// Create a new Membership of multiple configs(joint) and optionally a set of learner node ids.
+    /// Create a new Membership from a joint config of voter-ids and a collection of all
+    /// `Node`(voter nodes and learner nodes).
     ///
-    /// A node id that is in `nodes` but is not in `configs` is a **learner**.
+    /// A node id that is in `nodes` but is not in `config` is a **learner**.
     ///
-    /// An node id present in `configs` but not in `nodes` is filled with default value.
-    pub fn new<T>(configs: Vec<BTreeSet<NID>>, nodes: T) -> Self
-    where T: IntoNodes<NID, N> {
-        let voter_ids = configs.as_joint().ids().collect::<BTreeSet<_>>();
-        let nodes = Self::extend_nodes(nodes.into_nodes(), &voter_ids.into_nodes());
-
-        Membership { configs, nodes }
-    }
-
-    /// Create a new Membership of multiple configs and optional node infos.
+    /// A node presents in `config` but not in `nodes` is filled with default value.
     ///
-    /// The node infos `nodes` can be:
-    /// - a simple `()`, if there are no non-voter(learner) nodes,
+    /// The `nodes` can be:
+    /// - a simple `()`, if there are no learner nodes,
     /// - `BTreeSet<NodeId>` provides learner node ids whose `Node` data are `Node::default()`,
     /// - `BTreeMap<NodeId, Node>` provides nodes for every node id. Node ids that are not in
     ///   `configs` are learners.
-    pub(crate) fn new_with_nodes<T>(configs: Vec<BTreeSet<NID>>, nodes: T) -> Self
+    pub fn new<T>(config: Vec<BTreeSet<NID>>, nodes: T) -> Self
+    where T: IntoNodes<NID, N> {
+        let voter_ids = config.as_joint().ids().collect::<BTreeSet<_>>();
+        let nodes = Self::extend_nodes(nodes.into_nodes(), &voter_ids.into_nodes());
+
+        Membership { configs: config, nodes }
+    }
+
+    /// Create a new Membership the same as [`new()`], but does not add default value
+    /// `Node::default()` if a voter id is not in `nodes`. Thus it may create an invalid instance.
+    pub(crate) fn new_unchecked<T>(configs: Vec<BTreeSet<NID>>, nodes: T) -> Self
     where T: IntoNodes<NID, N> {
         let nodes = nodes.into_nodes();
         Membership { configs, nodes }
@@ -276,7 +278,7 @@ where
             }
         };
 
-        Membership::new_with_nodes(config, nodes)
+        Membership::new_unchecked(config, nodes)
     }
 
     /// Apply a change-membership request and return a new instance.

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -42,7 +42,7 @@ fn test_membership_summary() -> anyhow::Result<()> {
     let m = Membership::<u64, ()>::new(vec![btreeset! {1,2}, btreeset! {3}], Some(btreeset! {4}));
     assert_eq!("members:[{1:{()},2:{()}},{3:{()}}],learners:[4:{()}]", m.summary());
 
-    let m = Membership::<u64, TestNode>::new_with_nodes(vec![btreeset! {1,2}, btreeset! {3}], btreemap! {
+    let m = Membership::<u64, TestNode>::new_unchecked(vec![btreeset! {1,2}, btreeset! {3}], btreemap! {
         1=>node("127.0.0.1", "k1"),
         2=>node("127.0.0.2", "k2"),
         3=>node("127.0.0.3", "k3"),
@@ -130,7 +130,7 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
         data: Default::default(),
     };
 
-    let m_1_2 = Membership::<u64, TestNode>::new_with_nodes(
+    let m_1_2 = Membership::<u64, TestNode>::new_unchecked(
         vec![btreeset! {1}, btreeset! {2}],
         btreemap! {1=>node("1"), 2=>node("2")},
     );
@@ -144,7 +144,7 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
 
     let m_1_2_3 = m_1_2.change(ChangeMembers::AddNodes(btreemap! {3=>node("3")}), true)?;
     assert_eq!(
-        Membership::<u64, TestNode>::new_with_nodes(
+        Membership::<u64, TestNode>::new_unchecked(
             vec![btreeset! {1}, btreeset! {2}],
             btreemap! {1=>node("1"), 2=>node("2"), 3=>node("3")}
         ),
@@ -181,7 +181,7 @@ fn test_membership_extend_nodes() -> anyhow::Result<()> {
 #[test]
 fn test_membership_with_nodes() -> anyhow::Result<()> {
     let node = TestNode::default;
-    let with_nodes = |nodes| Membership::<u64, TestNode>::new_with_nodes(vec![btreeset! {1}, btreeset! {2}], nodes);
+    let with_nodes = |nodes| Membership::<u64, TestNode>::new_unchecked(vec![btreeset! {1}, btreeset! {2}], nodes);
 
     let res = with_nodes(btreemap! {1=>node(), 2=>node()});
     assert_eq!(
@@ -247,7 +247,7 @@ fn test_membership_next_coherent_with_nodes() -> anyhow::Result<()> {
     let c1 = || btreeset! {1};
     let c2 = || btreeset! {2};
 
-    let initial = Membership::<u64, TestNode>::new_with_nodes(vec![c1(), c2()], btreemap! {1=>node("1"), 2=>node("2")});
+    let initial = Membership::<u64, TestNode>::new_unchecked(vec![c1(), c2()], btreemap! {1=>node("1"), 2=>node("2")});
 
     // joint [{2}, {1,2}]
 

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -1,5 +1,6 @@
 mod change_handler;
 mod effective_membership;
+mod into_nodes;
 #[allow(clippy::module_inception)] mod membership;
 mod membership_state;
 mod stored_membership;
@@ -14,7 +15,7 @@ mod bench;
 
 pub(crate) use change_handler::ChangeHandler;
 pub use effective_membership::EffectiveMembership;
-pub use membership::IntoNodes;
+pub use into_nodes::IntoNodes;
 pub use membership::Membership;
 pub use membership_state::MembershipState;
 pub use stored_membership::StoredMembership;

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -2,7 +2,6 @@ mod change_handler;
 mod effective_membership;
 #[allow(clippy::module_inception)] mod membership;
 mod membership_state;
-mod node_type;
 mod stored_membership;
 
 #[cfg(feature = "bench")]
@@ -18,5 +17,4 @@ pub use effective_membership::EffectiveMembership;
 pub use membership::IntoNodes;
 pub use membership::Membership;
 pub use membership_state::MembershipState;
-pub(crate) use node_type::NodeRole;
 pub use stored_membership::StoredMembership;

--- a/openraft/src/membership/node_type.rs
+++ b/openraft/src/membership/node_type.rs
@@ -1,6 +1,0 @@
-#[derive(Debug)]
-#[derive(PartialEq, Eq)]
-pub(crate) enum NodeRole {
-    Voter,
-    Learner,
-}

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -531,7 +531,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
             return Err(());
         }
 
-        if !metrics.membership_config.membership().contains(&node_id) {
+        if metrics.membership_config.membership().get_node(&node_id).is_none() {
             // This learner has been removed.
             return Ok(None);
         }


### PR DESCRIPTION

## Changelog

##### Refactor: refine Membership API doc


##### Refactor: move IntoNodes into separate file


##### Refactor: remove unused private methods from Membership

`Membership::contains()` is unclear about whether a voter or learner it
is queried for. It is removed and an application uses `is_voter()`,
`is_learner()`, `get_node().is_some()` instead.

`NodeRole` is removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/713)
<!-- Reviewable:end -->
