### PR TITLE
CI: add change type "DataChange:" for commit that introduces on-disk data type changes that may require manual updrade

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -21,12 +21,13 @@ jobs:
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^(Change:|Feature:|Improve:|Dep:|Doc:|Test:|CI:|Refactor:|Fix:|Fixdoc:|Fixup:|Merge|BumpVer:|Build\(deps\):) .+$'
+          pattern: '^(DataChange:|Change:|Feature:|Improve:|Dep:|Doc:|Test:|CI:|Refactor:|Fix:|Fixdoc:|Fixup:|Merge|BumpVer:|Build\(deps\):) .+$'
           flags: 'gm'
           error: |
             Subject line has to contain a commit type, e.g.: "Change: blabla" or a merge commit e.g.: "Merge xxx".
             Valid types are:
-              Change        - breaking change
+              DataChange    - Persistent data change
+              Change        - API breaking change
               Feature       - API compatible new feature
               Improve       - Become better without functional changes
               Dep           - dependency update

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 - **Openraft API is not stable yet**. Before `1.0.0`, an upgrade may contain incompatible changes.
   Check our [change-log](https://github.com/datafuselabs/openraft/blob/main/change-log.md). A commit message starts with a keyword to indicate the modification type of the commit:
 
-  - `Change:` if it introduces incompatible changes.
+  - `DataChange:` on-disk data types changes, which may require manual upgrade.
+  - `Change:` if it introduces incompatible changes. 
   - `Feature:` if it introduces compatible non-breaking new features.
   - `Fix:` if it just fixes a bug.
 

--- a/scripts/build_change_log.py
+++ b/scripts/build_change_log.py
@@ -17,6 +17,11 @@ typs = {x:x for x in typs}
 
 # categories has another mapping to fix typo in commit message
 categories = {
+        'data-change:':  typs['data-change'],
+        'data-changes:': typs['data-change'],
+        'DataChange:':   typs['data-change'],
+        'DataChanges:':  typs['data-change'],
+
         'api-change:':   typs['api-change'],
         'new-feature:':  typs['new-feature'],
         'improve:':      typs['improve'],
@@ -62,6 +67,7 @@ categories = {
 }
 
 category_display = {
+    "data-change": "DataChanged",
     "api-change": "Changed",
     "new-feature": "Added",
     "dep": "Dependency",

--- a/scripts/change-types.yaml
+++ b/scripts/change-types.yaml
@@ -1,3 +1,4 @@
+- data-change
 - api-change
 - new-feature
 - improve


### PR DESCRIPTION

## Changelog

##### CI: add change type "DataChange:" for commit that introduces on-disk data type changes that may require manual updrade

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/714)
<!-- Reviewable:end -->
