### PR TITLE
Refactor: RaftMsg::ClientWriteRequest does not require an `EntryPayload`, and can instead be simplified to only include an `AppData`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,11 +154,9 @@ jobs:
           args: --all -- --check
 
 
-      - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings
+      - name: clippy
+        shell: bash
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 
       - name: Build-doc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,9 @@ jobs:
 
       - name: clippy
         shell: bash
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: |
+          cargo clippy --workspace --all-targets                -- -D warnings
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 
       - name: Build-doc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,7 +242,6 @@ jobs:
 
 
       - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml --all-targets -- -D warnings
+        shell: bash
+        run: |
+          cargo clippy --manifest-path examples/${{ matrix.example }}/Cargo.toml --all-targets -- -D warnings

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1033,8 +1033,8 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
                     self.reject_with_forward_to_leader(tx);
                 }
             }
-            RaftMsg::ClientWriteRequest { payload, tx } => {
-                self.write_entry(payload, Some(tx)).await?;
+            RaftMsg::ClientWriteRequest { app_data, tx } => {
+                self.write_entry(EntryPayload::Normal(app_data), Some(tx)).await?;
             }
             RaftMsg::Initialize { members, tx } => {
                 self.handle_initialize(members, tx).await?;

--- a/openraft/src/validate/bench/valid_deref.rs
+++ b/openraft/src/validate/bench/valid_deref.rs
@@ -1,13 +1,10 @@
 extern crate test;
 use std::error::Error;
 
-use maplit::btreeset;
 use test::black_box;
 use test::Bencher;
 
 use crate::less_equal;
-use crate::quorum::AsJoint;
-use crate::quorum::QuorumSet;
 use crate::validate::Valid;
 use crate::validate::Validate;
 


### PR DESCRIPTION

## Changelog

##### Refactor: RaftMsg::ClientWriteRequest does not require an `EntryPayload`, and can instead be simplified to only include an `AppData`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/718)
<!-- Reviewable:end -->
