### PR TITLE
Improve: add trait OptionalSerde as a global containing trait of optional serde traits

### DIFF
--- a/openraft/src/feature_serde_test.rs
+++ b/openraft/src/feature_serde_test.rs
@@ -1,0 +1,90 @@
+#[cfg(feature = "serde")]
+mod serde_enabled {
+    use crate::AppData;
+    use crate::AppDataResponse;
+    use crate::OptionalSerde;
+
+    #[derive(Clone)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct SerdeEnabled {
+        i: u32,
+    }
+
+    #[test]
+    fn test_optional_serde_enabled() {
+        /// A value that implements OptionalSerde implements serde::Serialize
+        fn serde_it(v: impl OptionalSerde) {
+            let s = serde_json::to_string(&v).unwrap();
+            assert_eq!(r#"{"i":3}"#, s);
+        }
+
+        serde_it(SerdeEnabled { i: 3 })
+    }
+
+    #[test]
+    fn test_app_data_serde_enabled() {
+        /// A value that implements OptionalSerde implements serde::Serialize
+        fn serde_it(v: impl AppData) {
+            let s = serde_json::to_string(&v).unwrap();
+            assert_eq!(r#"{"i":3}"#, s);
+        }
+
+        serde_it(SerdeEnabled { i: 3 })
+    }
+
+    #[test]
+    fn test_app_data_response_serde_enabled() {
+        /// A value that implements OptionalSerde implements serde::Serialize
+        fn serde_it(v: impl AppDataResponse) {
+            let s = serde_json::to_string(&v).unwrap();
+            assert_eq!(r#"{"i":3}"#, s);
+        }
+
+        serde_it(SerdeEnabled { i: 3 })
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+mod serde_disabled {
+
+    use crate::AppData;
+    use crate::AppDataResponse;
+    use crate::OptionalSerde;
+
+    #[derive(Clone)]
+    struct SerdeDisabled {
+        #[allow(dead_code)]
+        i: u32,
+    }
+
+    #[test]
+    fn test_optional_serde_disabled() {
+        /// Any value implements
+        fn accept_any_value(v: impl OptionalSerde) {
+            let _ = v;
+        }
+
+        accept_any_value(SerdeDisabled { i: 3 });
+        accept_any_value(1u32);
+    }
+
+    #[test]
+    fn test_app_data_serde_disabled() {
+        fn accept_any_value(v: impl AppData) {
+            let _ = v;
+        }
+
+        accept_any_value(SerdeDisabled { i: 3 });
+        accept_any_value(1u32);
+    }
+
+    #[test]
+    fn test_app_data_response_serde_disabled() {
+        fn accept_any_value(v: impl AppDataResponse) {
+            let _ = v;
+        }
+
+        accept_any_value(SerdeDisabled { i: 3 });
+        accept_any_value(1u32);
+    }
+}

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -72,6 +72,8 @@ mod raft_state;
 mod runtime;
 mod try_as_ref;
 
+#[cfg(test)] mod feature_serde_test;
+
 pub use anyerror;
 pub use anyerror::AnyError;
 pub use async_trait;
@@ -132,6 +134,20 @@ pub use crate::vote::CommittedLeaderId;
 pub use crate::vote::LeaderId;
 pub use crate::vote::Vote;
 
+#[cfg(feature = "serde")]
+#[doc(hidden)]
+pub trait OptionalSerde: serde::Serialize + for<'a> serde::Deserialize<'a> {}
+
+#[cfg(feature = "serde")]
+impl<T> OptionalSerde for T where T: serde::Serialize + for<'a> serde::Deserialize<'a> {}
+
+#[cfg(not(feature = "serde"))]
+#[doc(hidden)]
+pub trait OptionalSerde {}
+
+#[cfg(not(feature = "serde"))]
+impl<T> OptionalSerde for T {}
+
 /// A trait defining application specific data.
 ///
 /// The intention of this trait is that applications which are using this crate will be able to
@@ -144,16 +160,9 @@ pub use crate::vote::Vote;
 /// ## Note
 ///
 /// The trait is automatically implemented for all types which satisfy its supertraits.
-#[cfg(feature = "serde")]
-pub trait AppData: Clone + Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
-#[cfg(feature = "serde")]
-impl<T> AppData for T where T: Clone + Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
+pub trait AppData: Clone + Send + Sync + 'static + OptionalSerde {}
 
-#[cfg(not(feature = "serde"))]
-pub trait AppData: Clone + Send + Sync + 'static {}
-
-#[cfg(not(feature = "serde"))]
-impl<T> AppData for T where T: Clone + Send + Sync + 'static {}
+impl<T> AppData for T where T: Clone + Send + Sync + 'static + OptionalSerde {}
 
 /// A trait defining application specific response data.
 ///
@@ -172,14 +181,6 @@ impl<T> AppData for T where T: Clone + Send + Sync + 'static {}
 /// ## Note
 ///
 /// The trait is automatically implemented for all types which satisfy its supertraits.
-#[cfg(feature = "serde")]
-pub trait AppDataResponse: Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
+pub trait AppDataResponse: Send + Sync + 'static + OptionalSerde {}
 
-#[cfg(feature = "serde")]
-impl<T> AppDataResponse for T where T: Send + Sync + serde::Serialize + serde::de::DeserializeOwned + 'static {}
-
-#[cfg(not(feature = "serde"))]
-pub trait AppDataResponse: Send + Sync + 'static {}
-
-#[cfg(not(feature = "serde"))]
-impl<T> AppDataResponse for T where T: Send + Sync + 'static {}
+impl<T> AppDataResponse for T where T: Send + Sync + 'static + OptionalSerde {}

--- a/openraft/src/vote/leader_id/leader_id_adv.rs
+++ b/openraft/src/vote/leader_id/leader_id_adv.rs
@@ -69,12 +69,13 @@ pub type CommittedLeaderId<NID> = LeaderId<NID>;
 
 #[cfg(test)]
 mod tests {
-    use crate::CommittedLeaderId;
     use crate::LeaderId;
 
     #[cfg(feature = "serde")]
     #[test]
     fn test_committed_leader_id_serde() -> anyhow::Result<()> {
+        use crate::CommittedLeaderId;
+
         let c = CommittedLeaderId::<u32>::new(5, 10);
         let s = serde_json::to_string(&c)?;
         assert_eq!(r#"{"term":5,"node_id":10}"#, s);


### PR DESCRIPTION

## Changelog

##### Improve: add trait OptionalSerde as a global containing trait of optional serde traits

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/722)
<!-- Reviewable:end -->
