### PR TITLE
Fix: trait RaftLogId should be public

### DIFF
--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -53,6 +53,7 @@ mod vote;
 
 pub mod entry;
 pub mod error;
+pub mod log_id;
 pub mod metrics;
 pub mod network;
 pub mod raft;
@@ -61,7 +62,6 @@ pub mod testing;
 pub mod timer;
 pub mod versioned;
 
-pub(crate) mod log_id;
 pub(crate) mod log_id_range;
 pub(crate) mod utime;
 pub(crate) mod validate;
@@ -92,6 +92,7 @@ pub use crate::entry::EntryPayload;
 pub use crate::log_id::LogId;
 pub use crate::log_id::LogIdOptionExt;
 pub use crate::log_id::LogIndexOptionExt;
+pub use crate::log_id::RaftLogId;
 pub use crate::membership::EffectiveMembership;
 pub use crate::membership::Membership;
 pub use crate::membership::StoredMembership;

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -1,3 +1,6 @@
+//! This mod defines the identity of a raft log and provides supporting utilities to work with log
+//! id related types.
+
 mod log_id_option_ext;
 mod log_index_option_ext;
 mod raft_log_id;


### PR DESCRIPTION

## Changelog

##### Fix: trait RaftLogId should be public

- Fix: #725

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/726)
<!-- Reviewable:end -->
