### PR TITLE
Change: StoreBuilder does not need to run a test, it only needs to build a store

### DIFF
--- a/memstore/src/test.rs
+++ b/memstore/src/test.rs
@@ -1,4 +1,3 @@
-use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -13,13 +12,9 @@ use crate::MemStore;
 struct MemBuilder {}
 #[async_trait]
 impl StoreBuilder<Config, Arc<MemStore>> for MemBuilder {
-    async fn run_test<Fun, Ret, Res>(&self, t: Fun) -> Result<Ret, StorageError<MemNodeId>>
-    where
-        Res: Future<Output = Result<Ret, StorageError<MemNodeId>>> + Send,
-        Fun: Fn(Arc<MemStore>) -> Res + Sync + Send,
-    {
+    async fn build(&self) -> Result<((), Arc<MemStore>), StorageError<MemNodeId>> {
         let store = MemStore::new_async().await;
-        t(store).await
+        Ok(((), store))
     }
 }
 

--- a/openraft/src/testing/store_builder.rs
+++ b/openraft/src/testing/store_builder.rs
@@ -1,11 +1,7 @@
-use std::fmt::Debug;
-use std::future::Future;
 use std::marker::PhantomData;
 
 use async_trait::async_trait;
 
-use crate::AppData;
-use crate::AppDataResponse;
 use crate::DefensiveCheckBase;
 use crate::RaftStorage;
 use crate::RaftTypeConfig;
@@ -13,54 +9,50 @@ use crate::StorageError;
 use crate::StoreExt;
 
 /// The trait to build a [`RaftStorage`] implementation.
+///
+/// The generic parameter `C` is type config for a `RaftStorage` implementation,
+/// `S` is the type that implements `RaftStorage`,
+/// and `G` is a guard type that cleanup resource when being dropped.
+///
+/// By default `G` is a trivial guard `()`. To test a store that is backed by a folder on disk, `G`
+/// could be the dropper of the temp-dir that stores data.
 #[async_trait]
-pub trait StoreBuilder<C, S>: Send + Sync
+pub trait StoreBuilder<C, S, G = ()>: Send + Sync
 where
     C: RaftTypeConfig,
     S: RaftStorage<C>,
 {
-    async fn run_test<Fun, Ret, Res>(&self, t: Fun) -> Result<Ret, StorageError<C::NodeId>>
-    where
-        Res: Future<Output = Result<Ret, StorageError<C::NodeId>>> + Send,
-        Fun: Fn(S) -> Res + Sync + Send;
+    /// Build a [`RaftStorage`] implementation
+    async fn build(&self) -> Result<(G, S), StorageError<C::NodeId>>;
 }
 
 /// A builder for testing [`StoreExt`].
-pub struct DefensiveStoreBuilder<C, BaseStore, BaseBuilder>
+pub struct DefensiveStoreBuilder<C, BaseStore, BaseBuilder, G>
 where
     C: RaftTypeConfig,
-    C::D: AppData + Debug,
-    C::R: AppDataResponse + Debug,
     BaseStore: RaftStorage<C>,
-    BaseBuilder: StoreBuilder<C, BaseStore>,
+    BaseBuilder: StoreBuilder<C, BaseStore, G>,
 {
     pub base_builder: BaseBuilder,
 
-    pub s: PhantomData<(C, BaseStore)>,
+    pub s: PhantomData<(C, BaseStore, G)>,
 }
 
 #[async_trait]
-impl<C, BaseStore, BaseBuilder> StoreBuilder<C, StoreExt<C, BaseStore>>
-    for DefensiveStoreBuilder<C, BaseStore, BaseBuilder>
+impl<C, G, BaseStore, BaseBuilder> StoreBuilder<C, StoreExt<C, BaseStore>, G>
+    for DefensiveStoreBuilder<C, BaseStore, BaseBuilder, G>
 where
     C: RaftTypeConfig,
-    C::D: AppData + Debug,
-    C::R: AppDataResponse + Debug,
     BaseStore: RaftStorage<C>,
-    BaseBuilder: StoreBuilder<C, BaseStore>,
+    BaseBuilder: StoreBuilder<C, BaseStore, G>,
+    G: Send + Sync,
 {
-    async fn run_test<Fun, Ret, Res>(&self, t: Fun) -> Result<Ret, StorageError<C::NodeId>>
-    where
-        Res: Future<Output = Result<Ret, StorageError<C::NodeId>>> + Send,
-        Fun: Fn(StoreExt<C, BaseStore>) -> Res + Sync + Send,
-    {
-        self.base_builder
-            .run_test(|base_store| async {
-                let sto_ext = StoreExt::new(base_store);
-                sto_ext.set_defensive(true);
-                assert!(sto_ext.is_defensive(), "must impl defensive check");
-                t(sto_ext).await
-            })
-            .await
+    async fn build(&self) -> Result<(G, StoreExt<C, BaseStore>), StorageError<C::NodeId>> {
+        let (g, store) = self.base_builder.build().await?;
+        let sto_ext = StoreExt::new(store);
+        sto_ext.set_defensive(true);
+        assert!(sto_ext.is_defensive(), "must impl defensive check");
+
+        Ok((g, sto_ext))
     }
 }

--- a/rocksstore-compat07/src/test.rs
+++ b/rocksstore-compat07/src/test.rs
@@ -1,10 +1,10 @@
-use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use openraft::testing::StoreBuilder;
 use openraft::testing::Suite;
 use openraft::StorageError;
+use tempfile::TempDir;
 
 use crate::Config;
 use crate::RocksNodeId;
@@ -12,19 +12,11 @@ use crate::RocksStore;
 
 struct RocksBuilder {}
 #[async_trait]
-impl StoreBuilder<Config, Arc<RocksStore>> for RocksBuilder {
-    async fn run_test<Fun, Ret, Res>(&self, t: Fun) -> Result<Ret, StorageError<RocksNodeId>>
-    where
-        Res: Future<Output = Result<Ret, StorageError<RocksNodeId>>> + Send,
-        Fun: Fn(Arc<RocksStore>) -> Res + Sync + Send,
-    {
+impl StoreBuilder<Config, Arc<RocksStore>, TempDir> for RocksBuilder {
+    async fn build(&self) -> Result<(TempDir, Arc<RocksStore>), StorageError<RocksNodeId>> {
         let td = tempfile::TempDir::new().expect("couldn't create temp dir");
-        let r = {
-            let store = RocksStore::new(td.path()).await;
-            t(store).await
-        };
-        td.close().expect("could not close temp directory");
-        r
+        let store = RocksStore::new(td.path()).await;
+        Ok((td, store))
     }
 }
 

--- a/sledstore/src/test.rs
+++ b/sledstore/src/test.rs
@@ -1,18 +1,14 @@
-use std::future::Future;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use openraft::testing::StoreBuilder;
 use openraft::testing::Suite;
 use openraft::StorageError;
+use tempfile::TempDir;
 
 use crate::ExampleNodeId;
 use crate::ExampleTypeConfig;
 use crate::SledStore;
-
-static GLOBAL_TEST_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 struct SledBuilder {}
 
@@ -22,34 +18,14 @@ pub fn test_sled_store() -> Result<(), StorageError<ExampleNodeId>> {
 }
 
 #[async_trait]
-impl StoreBuilder<ExampleTypeConfig, Arc<SledStore>> for SledBuilder {
-    async fn run_test<Fun, Ret, Res>(&self, t: Fun) -> Result<Ret, StorageError<ExampleNodeId>>
-    where
-        Res: Future<Output = Result<Ret, StorageError<ExampleNodeId>>> + Send,
-        Fun: Fn(Arc<SledStore>) -> Res + Sync + Send,
-    {
-        let pid = std::process::id();
+impl StoreBuilder<ExampleTypeConfig, Arc<SledStore>, TempDir> for SledBuilder {
+    async fn build(&self) -> Result<(TempDir, Arc<SledStore>), StorageError<ExampleNodeId>> {
         let td = tempfile::TempDir::new().expect("couldn't create temp dir");
-        let temp_dir_path = td.path().to_str().expect("Could not convert temp dir");
-        let r = {
-            let old_count = GLOBAL_TEST_COUNT.fetch_add(1, Ordering::SeqCst);
-            let db_dir_str = format!("{}pid{}/num{}/", &temp_dir_path, pid, old_count);
 
-            let db_dir = std::path::Path::new(&db_dir_str);
-            if !db_dir.exists() {
-                std::fs::create_dir_all(db_dir).unwrap_or_else(|_| panic!("could not create: {:?}", db_dir.to_str()));
-            }
+        let db: sled::Db = sled::open(td.path()).unwrap();
 
-            let db: sled::Db = sled::open(db_dir).unwrap_or_else(|_| panic!("could not open: {:?}", db_dir.to_str()));
+        let store = SledStore::new(Arc::new(db)).await;
 
-            let store = SledStore::new(Arc::new(db)).await;
-            let test_res = t(store).await;
-
-            if db_dir.exists() {
-                std::fs::remove_dir_all(db_dir).expect("Could not clean up test directory");
-            }
-            test_res
-        };
-        r
+        Ok((td, store))
     }
 }


### PR DESCRIPTION

## Changelog

##### Change: StoreBuilder does not need to run a test, it only needs to build a store

`StoreBuilder::run_test()` is removed, and a new method `build()` is
added. To test a `RaftStorage` implementation, just implementing
`StoreBuilder::build()` is enough now. It returns a store instance and a
**guard**, for disk backed store to clean up the data when the guard is
dropped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/730)
<!-- Reviewable:end -->
