### PR TITLE
Refactor: Remove Command::MoveInputCursorBy

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -246,8 +246,6 @@ where
 
         self.server_state_handler().update_server_state_if_changed();
 
-        self.output.push_command(Command::MoveInputCursorBy { n: l });
-
         // With the new config, start to elect to become leader
         self.elect();
 

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -259,7 +259,6 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
                 already_committed: Some(log_id(0, 0)),
                 upto: log_id(1, 1)
             },
-            Command::MoveInputCursorBy { n: 2 },
         ],
         eng.output.commands
     );
@@ -384,7 +383,6 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
                 already_committed: Some(log_id(0, 0)),
                 upto: log_id(3, 3)
             },
-            Command::MoveInputCursorBy { n: 2 },
         ],
         eng.output.commands
     );

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -58,7 +58,6 @@ fn eng() -> Engine<u64, (), <UTCfg as RaftTypeConfig>::Entry> {
 fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    // Neither of these two will update anything.
     eng.following_handler().do_append_entries(&Vec::<Entry<UTCfg>>::new(), 0);
     eng.following_handler().do_append_entries(&[blank(3, 4)], 1);
 
@@ -88,7 +87,13 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(
+        vec![
+            //
+            Command::AppendInputEntries { range: 1..1 },
+        ],
+        eng.output.commands
+    );
 
     Ok(())
 }

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -166,7 +166,6 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
                 target: 3,
                 req: Inflight::logs(None, Some(log_id(3, 6))).with_id(1),
             },
-            Command::MoveInputCursorBy { n: 3 },
         ],
         eng.output.commands
     );
@@ -227,7 +226,6 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
                 already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
-            Command::MoveInputCursorBy { n: 3 },
         ],
         eng.output.commands
     );
@@ -328,7 +326,6 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
                 target: 4,
                 req: Inflight::logs(None, Some(log_id(3, 6))).with_id(1),
             },
-            Command::MoveInputCursorBy { n: 3 },
         ],
         eng.output.commands
     );
@@ -425,7 +422,6 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                 already_committed: Some(LogId::new(CommittedLeaderId::new(3, 1), 4)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
-            Command::MoveInputCursorBy { n: 3 },
         ],
         eng.output.commands
     );
@@ -507,7 +503,6 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                 already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
-            Command::MoveInputCursorBy { n: 3 },
         ],
         eng.output.commands
     );

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -113,8 +113,6 @@ where
 
         rh.update_local_progress(last_log_id);
         rh.initiate_replication(SendNone::False);
-
-        self.output.push_command(Command::MoveInputCursorBy { n: l });
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -78,7 +78,6 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output
                 // command.
-                Command::MoveInputCursorBy { n: 1 },
                 Command::SaveVote { vote: Vote::new(1, 1) },
                 // TODO: duplicated SaveVote: one is emitted by elect(), the second is emitted when
                 // the node becomes       leader.
@@ -163,7 +162,6 @@ fn test_initialize() -> anyhow::Result<()> {
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output
                 // command.
-                Command::MoveInputCursorBy { n: 1 },
                 Command::SaveVote { vote: Vote::new(1, 1) },
                 Command::SendVote {
                     vote_req: VoteRequest {


### PR DESCRIPTION

## Changelog

##### Refactor: Remove Command::MoveInputCursorBy

The input entries buffer can not be shared by RaftCore and IO-worker,
thus `Command::AppendInputEntries` implies consuming the input.

The `AppendInputEntries` command moves entries from the input buffer to
IO-worker which makes them consumed and invalid for further use.
Therefore, there is no longer a need to manage the input buffer's cursor
using `MoveInputCursorBy`, when `AppendInputEntries` is executed.

- Fix: #733

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/734)
<!-- Reviewable:end -->
