### PR TITLE
Refactor: replace Vec with VecDeque for Engine output commands type

### DIFF
--- a/openraft/src/engine/elect_test.rs
+++ b/openraft/src/engine/elect_test.rs
@@ -91,7 +91,7 @@ fn test_elect() -> anyhow::Result<()> {
                     },
                 },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
 
@@ -154,7 +154,7 @@ fn test_elect() -> anyhow::Result<()> {
                     },
                 },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
 
@@ -189,7 +189,7 @@ fn test_elect() -> anyhow::Result<()> {
             vec![Command::SaveVote { vote: Vote::new(1, 1) }, Command::SendVote {
                 vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1)))
             },],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
     Ok(())

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::time::Duration;
 
@@ -100,7 +101,7 @@ where
     pub(crate) metrics_flags: MetricsChangeFlags,
 
     /// Command queue that need to be executed by `RaftRuntime`.
-    pub(crate) commands: Vec<Command<NID, N>>,
+    pub(crate) commands: VecDeque<Command<NID, N>>,
 }
 
 impl<NID, N> EngineOutput<NID, N>
@@ -108,9 +109,39 @@ where
     NID: NodeId,
     N: Node,
 {
+    pub(crate) fn new(command_buffer_size: usize) -> Self {
+        Self {
+            metrics_flags: MetricsChangeFlags::default(),
+            commands: VecDeque::with_capacity(command_buffer_size),
+        }
+    }
+
+    /// Push a command to the queue.
     pub(crate) fn push_command(&mut self, cmd: Command<NID, N>) {
         cmd.update_metrics_flags(&mut self.metrics_flags);
-        self.commands.push(cmd)
+        self.commands.push_back(cmd)
+    }
+
+    /// Pop the first command to run from the queue.
+    pub(crate) fn pop_command(&mut self) -> Option<Command<NID, N>> {
+        self.commands.pop_front()
+    }
+
+    /// Iterate all queued commands.
+    pub(crate) fn iter_commands(&self) -> impl Iterator<Item = &Command<NID, N>> {
+        self.commands.iter()
+    }
+
+    /// Take all queued commands and clear the queue.
+    #[cfg(test)]
+    pub(crate) fn take_commands(&mut self) -> Vec<Command<NID, N>> {
+        self.commands.drain(..).collect()
+    }
+
+    /// Clear all queued commands.
+    #[cfg(test)]
+    pub(crate) fn clear_commands(&mut self) {
+        self.commands.clear()
     }
 }
 
@@ -168,7 +199,7 @@ where
             seen_greater_log: false,
             timer: time_state::TimeState::new(now),
             internal_server_state: InternalServerState::default(),
-            output: EngineOutput::default(),
+            output: EngineOutput::new(4096),
             _p: PhantomData::default(),
         }
     }

--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -92,7 +92,7 @@ fn test_handle_append_entries_req_vote_is_rejected() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -144,7 +144,7 @@ fn test_handle_append_entries_req_prev_log_id_is_applied() -> anyhow::Result<()>
         vec![Command::SaveVote {
             vote: Vote::new_committed(2, 1)
         },],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -199,7 +199,7 @@ fn test_handle_append_entries_req_prev_log_id_conflict() -> anyhow::Result<()> {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -260,7 +260,7 @@ fn test_handle_append_entries_req_prev_log_id_is_committed() -> anyhow::Result<(
                 upto: log_id(1, 1)
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -312,7 +312,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
         vec![Command::SaveVote {
             vote: Vote::new_committed(2, 1)
         },],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -384,7 +384,7 @@ fn test_handle_append_entries_req_entries_conflict() -> anyhow::Result<()> {
                 upto: log_id(3, 3)
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())

--- a/openraft/src/engine/handle_vote_req_test.rs
+++ b/openraft/src/engine/handle_vote_req_test.rs
@@ -72,7 +72,7 @@ fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -108,7 +108,7 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -145,7 +145,7 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
     Ok(())
 }
 
@@ -158,7 +158,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     eng.vote_handler().update_internal_server_state();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    eng.output.commands = vec![];
+    eng.output.clear_commands();
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(2, 1),
@@ -187,7 +187,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         eng.output.metrics_flags
     );
 
-    assert!(eng.output.commands.is_empty());
+    assert!(eng.output.take_commands().is_empty());
     Ok(())
 }
 
@@ -200,7 +200,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     eng.vote_handler().update_internal_server_state();
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
 
-    eng.output.commands = vec![];
+    eng.output.clear_commands();
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 1),
@@ -230,7 +230,10 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(vec![Command::SaveVote { vote: Vote::new(3, 1) },], eng.output.commands);
+    assert_eq!(
+        vec![Command::SaveVote { vote: Vote::new(3, 1) },],
+        eng.output.take_commands()
+    );
     Ok(())
 }
 
@@ -246,7 +249,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         eng.config.id = 100; // make it a non-voter
         eng.vote_handler().become_following();
         eng.state.server_state = st;
-        eng.output.commands = vec![];
+        eng.output.clear_commands();
 
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
@@ -259,7 +262,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
                 //
                 Command::SaveVote { vote: Vote::new(3, 1) },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
     // Follower
@@ -270,7 +273,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         eng.config.id = 0; // make it a voter
         eng.vote_handler().become_following();
         eng.state.server_state = st;
-        eng.output.commands = vec![];
+        eng.output.clear_commands();
 
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
@@ -283,7 +286,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
                 //
                 Command::SaveVote { vote: Vote::new(3, 1) },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
     Ok(())

--- a/openraft/src/engine/handle_vote_resp_test.rs
+++ b/openraft/src/engine/handle_vote_resp_test.rs
@@ -68,7 +68,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             eng.output.metrics_flags
         );
 
-        assert_eq!(0, eng.output.commands.len());
+        assert_eq!(0, eng.output.take_commands().len());
     }
 
     tracing::info!("--- recv a smaller vote. vote_granted==false always; keep trying in candidate state");
@@ -105,7 +105,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             eng.output.metrics_flags
         );
 
-        assert!(eng.output.commands.is_empty());
+        assert!(eng.output.take_commands().is_empty());
     }
 
     // TODO: when seeing a higher vote, keep trying until a majority of higher votes are seen.
@@ -141,7 +141,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             eng.output.metrics_flags
         );
 
-        assert_eq!(vec![Command::SaveVote { vote: Vote::new(3, 2) },], eng.output.commands);
+        assert_eq!(
+            vec![Command::SaveVote { vote: Vote::new(3, 2) },],
+            eng.output.take_commands()
+        );
     }
 
     tracing::info!("--- equal vote, rejected by higher last_log_id. keep trying in candidate state");
@@ -178,7 +181,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             eng.output.metrics_flags
         );
 
-        assert!(eng.output.commands.is_empty());
+        assert!(eng.output.take_commands().is_empty());
     }
 
     tracing::info!("--- equal vote, granted, but not constitute a quorum. nothing to do");
@@ -215,7 +218,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             eng.output.metrics_flags
         );
 
-        assert_eq!(0, eng.output.commands.len());
+        assert_eq!(0, eng.output.take_commands().len());
     }
 
     tracing::info!("--- equal vote, granted, constitute a quorum. become leader");
@@ -272,7 +275,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                     req: Inflight::logs(None, Some(log_id(2, 1))).with_id(1),
                 },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
 

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -63,7 +63,7 @@ fn test_follower_commit_entries_empty() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -92,7 +92,7 @@ fn test_follower_commit_entries_no_update() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -128,7 +128,7 @@ fn test_follower_commit_entries_lt_last_entry() -> anyhow::Result<()> {
                 upto: log_id(2, 3)
             }, //
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -165,7 +165,7 @@ fn test_follower_commit_entries_gt_last_entry() -> anyhow::Result<()> {
                 upto: log_id(2, 3)
             }, //
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -92,7 +92,7 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
             //
             Command::AppendInputEntries { range: 1..1 },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -140,7 +140,7 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
     assert_eq!(
         vec![Command::AppendInputEntries { range: 1..2 }, //
             ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -208,7 +208,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 5)), m34())),
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -287,7 +287,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(4, 7)), m45())),
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -84,7 +84,7 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
                 snapshot_id: "1-2-3-4".to_string(),
             }
         }],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -130,7 +130,7 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
                 snapshot_id: "1-2-3-4".to_string(),
             }
         }],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -186,7 +186,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
             },
             Command::PurgeLog { upto: log_id(4, 6) },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -266,7 +266,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
             },
             Command::PurgeLog { upto: log_id(5, 6) },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -326,7 +326,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
             },
             Command::PurgeLog { upto: log_id(100, 100) },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -80,7 +80,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01()))
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -113,7 +113,7 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![Command::DeleteConflictLog { since: log_id(4, 4) }],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -138,7 +138,7 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![Command::DeleteConflictLog { since: log_id(4, 5) }],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -166,7 +166,7 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![Command::DeleteConflictLog { since: log_id(4, 6) }],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -192,7 +192,7 @@ fn test_truncate_logs_since_7() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert!(eng.output.commands.is_empty());
+    assert!(eng.output.take_commands().is_empty());
 
     Ok(())
 }
@@ -217,7 +217,7 @@ fn test_truncate_logs_since_8() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert!(eng.output.commands.is_empty());
+    assert!(eng.output.take_commands().is_empty());
 
     Ok(())
 }
@@ -252,7 +252,7 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
                 membership: Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m01()))
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -67,7 +67,7 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
         vec![Command::UpdateMembership {
             membership: Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
         },],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -108,7 +108,7 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -167,7 +167,7 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
                 req: Inflight::logs(None, Some(log_id(3, 6))).with_id(1),
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -181,7 +181,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m1())));
     eng.vote_handler().become_leading();
 
-    eng.output.commands = vec![];
+    eng.output.clear_commands();
     eng.output.metrics_flags.reset();
 
     // log id will be assigned by eng.
@@ -227,7 +227,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     assert_eq!(
@@ -327,7 +327,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
                 req: Inflight::logs(None, Some(log_id(3, 6))).with_id(1),
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -343,7 +343,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
     eng.vote_handler().become_leading();
     eng.state.server_state = eng.calc_server_state();
 
-    eng.output.commands = vec![];
+    eng.output.clear_commands();
     eng.output.metrics_flags.reset();
 
     // log id will be assigned by eng.
@@ -423,7 +423,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -441,7 +441,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
     eng.vote_handler().become_leading();
     eng.state.server_state = eng.calc_server_state();
 
-    eng.output.commands = vec![];
+    eng.output.clear_commands();
     eng.output.metrics_flags.reset();
 
     // log id will be assigned by eng.
@@ -504,7 +504,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     assert_eq!(

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -64,15 +64,15 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
                     req: Inflight::logs(None, Some(log_id(2, 3))).with_id(1),
                 },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
 
     // No RPC will be sent if there are inflight RPC
     {
-        eng.output.commands = vec![];
+        eng.output.clear_commands();
         eng.leader_handler()?.send_heartbeat();
-        assert!(eng.output.commands.is_empty());
+        assert!(eng.output.take_commands().is_empty());
     }
 
     // No data to send, sending a heartbeat is to send empty RPC:
@@ -81,7 +81,7 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
         let _ = l.leader.progress.update_with(&2, |ent| ent.update_matching(Some(log_id(2, 3))));
         let _ = l.leader.progress.update_with(&3, |ent| ent.update_matching(Some(log_id(2, 3))));
     }
-    eng.output.commands = vec![];
+    eng.output.clear_commands();
     eng.leader_handler()?.send_heartbeat();
     assert_eq!(
         vec![
@@ -94,7 +94,7 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
                 req: Inflight::logs(Some(log_id(2, 3)), Some(log_id(2, 3))).with_id(1),
             },
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -27,7 +27,7 @@ fn test_purge_log_already_purged() -> anyhow::Result<()> {
     assert_eq!(log_id(2, 2), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
 
-    assert_eq!(0, lh.output.commands.len());
+    assert_eq!(0, lh.output.take_commands().len());
 
     Ok(())
 }
@@ -44,7 +44,7 @@ fn test_purge_log_equal_prev_last_purged() -> anyhow::Result<()> {
     assert_eq!(log_id(2, 2), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
 
-    assert_eq!(0, lh.output.commands.len());
+    assert_eq!(0, lh.output.take_commands().len());
 
     Ok(())
 }
@@ -60,7 +60,10 @@ fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
     assert_eq!(log_id(2, 3), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(2, 3) }], lh.output.commands);
+    assert_eq!(
+        vec![Command::PurgeLog { upto: log_id(2, 3) }],
+        lh.output.take_commands()
+    );
 
     Ok(())
 }
@@ -77,7 +80,10 @@ fn test_purge_log_to_last_key_log() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 4), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 4) }], lh.output.commands);
+    assert_eq!(
+        vec![Command::PurgeLog { upto: log_id(4, 4) }],
+        lh.output.take_commands()
+    );
 
     Ok(())
 }
@@ -94,7 +100,10 @@ fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 5), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 5) }], lh.output.commands);
+    assert_eq!(
+        vec![Command::PurgeLog { upto: log_id(4, 5) }],
+        lh.output.take_commands()
+    );
 
     Ok(())
 }
@@ -111,7 +120,10 @@ fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 6), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 6) }], lh.output.commands);
+    assert_eq!(
+        vec![Command::PurgeLog { upto: log_id(4, 6) }],
+        lh.output.take_commands()
+    );
 
     Ok(())
 }
@@ -128,7 +140,10 @@ fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
     assert_eq!(log_id(4, 7), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(4, 7)), lh.state.last_log_id());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(4, 7) }], lh.output.commands);
+    assert_eq!(
+        vec![Command::PurgeLog { upto: log_id(4, 7) }],
+        lh.output.take_commands()
+    );
 
     Ok(())
 }
@@ -145,7 +160,10 @@ fn test_purge_log_to_higher_leader_lgo() -> anyhow::Result<()> {
     assert_eq!(log_id(5, 7), lh.state.log_ids.key_log_ids()[0],);
     assert_eq!(Some(&log_id(5, 7)), lh.state.last_log_id());
 
-    assert_eq!(vec![Command::PurgeLog { upto: log_id(5, 7) }], lh.output.commands);
+    assert_eq!(
+        vec![Command::PurgeLog { upto: log_id(5, 7) }],
+        lh.output.take_commands()
+    );
 
     Ok(())
 }

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -97,7 +97,7 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
                                                                                             * won't be removed */
             }
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     assert!(

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -88,21 +88,21 @@ fn test_update_matching() -> anyhow::Result<()> {
                     matching: log_id(1, 2),
                 },
             ],
-            rh.output.commands
+            rh.output.take_commands()
         );
     }
 
     // progress: None, (2,1), (1,2); quorum-ed: (1,2), not at leader vote, not committed
     {
-        rh.output.commands = vec![];
+        rh.output.clear_commands();
         rh.update_matching(2, inflight_id_2, Some(log_id(2, 1)));
         assert_eq!(None, rh.state.committed());
-        assert_eq!(0, rh.output.commands.len());
+        assert_eq!(0, rh.output.take_commands().len());
     }
 
     // progress: None, (2,1), (2,3); committed: (2,1)
     {
-        rh.output.commands = vec![];
+        rh.output.clear_commands();
         rh.update_matching(3, inflight_id_3, Some(log_id(2, 3)));
         assert_eq!(Some(&log_id(2, 1)), rh.state.committed());
         assert_eq!(
@@ -119,13 +119,13 @@ fn test_update_matching() -> anyhow::Result<()> {
                     upto: log_id(2, 1)
                 }
             ],
-            rh.output.commands
+            rh.output.take_commands()
         );
     }
 
     // progress: (2,4), (2,1), (2,3); committed: (1,3)
     {
-        rh.output.commands = vec![];
+        rh.output.clear_commands();
         rh.update_matching(1, inflight_id_1, Some(log_id(2, 4)));
         assert_eq!(Some(&log_id(2, 3)), rh.state.committed());
         assert_eq!(
@@ -142,7 +142,7 @@ fn test_update_matching() -> anyhow::Result<()> {
                     upto: log_id(2, 3)
                 }
             ],
-            rh.output.commands
+            rh.output.take_commands()
         );
     }
 

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -48,7 +48,7 @@ fn test_update_server_state_if_changed() -> anyhow::Result<()> {
     {
         assert_eq!(ServerState::Leader, ssh.state.server_state);
 
-        ssh.output.commands = vec![];
+        ssh.output.clear_commands();
         ssh.state.vote = UTime::new(Instant::now(), Vote::new(2, 100));
         ssh.update_server_state_if_changed();
 
@@ -58,7 +58,7 @@ fn test_update_server_state_if_changed() -> anyhow::Result<()> {
                 //
                 Command::QuitLeader,
             ],
-            ssh.output.commands
+            ssh.output.take_commands()
         );
     }
 

--- a/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
@@ -61,7 +61,7 @@ fn test_update_snapshot_no_update() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -97,7 +97,7 @@ fn test_update_snapshot_updated() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -106,7 +106,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                     },
                 },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
     Ok(())
@@ -173,7 +173,7 @@ fn test_initialize() -> anyhow::Result<()> {
                     },
                 },
             ],
-            eng.output.commands
+            eng.output.take_commands()
         );
     }
 

--- a/openraft/src/engine/startup_test.rs
+++ b/openraft/src/engine/startup_test.rs
@@ -69,7 +69,7 @@ fn test_startup_as_leader() -> anyhow::Result<()> {
                 })]
             }
         ],
-        eng.output.commands
+        eng.output.take_commands()
     );
 
     Ok(())
@@ -98,7 +98,7 @@ fn test_startup_candidate_becomes_follower() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -123,7 +123,7 @@ fn test_startup_as_follower() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }
@@ -149,7 +149,7 @@ fn test_startup_as_learner() -> anyhow::Result<()> {
         eng.output.metrics_flags
     );
 
-    assert_eq!(0, eng.output.commands.len());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### Refactor: replace Vec with VecDeque for Engine output commands type

Using a `VecDeque` for output commands buffer so that it does not need
to allocate a new `Vec` every time running the commands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/736)
<!-- Reviewable:end -->
