### PR TITLE
Refactor: add `input_entries` to RaftCore

### DIFF
--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -35,7 +35,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         tracing::debug!(req = display(req.summary()));
 
         let res = self.engine.vote_handler().handle_message_vote(&req.vote);
-        self.run_engine_commands(&[]).await?;
+        self.run_engine_commands().await?;
         if res.is_err() {
             tracing::info!(
                 my_vote = display(self.engine.state.vote_ref()),
@@ -177,7 +177,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
         self.received_snapshot.insert(meta.snapshot_id.clone(), snapshot_data);
 
         self.engine.following_handler().install_snapshot(meta);
-        self.run_engine_commands(&[]).await?;
+        self.run_engine_commands().await?;
 
         Ok(())
     }

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -1,6 +1,7 @@
 //! Public Raft interface and data types.
 
 use std::collections::BTreeMap;
+use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::sync::atomic::Ordering;
@@ -242,6 +243,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
             storage,
 
             engine,
+            input_entries: VecDeque::with_capacity(4096),
             leader_data: None,
 
             snapshot_state: SnapshotState::None,

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -59,10 +59,6 @@ use crate::StorageError;
 pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// Run a command produced by the engine.
     ///
-    /// A command consumes zero or more input entries.
-    /// `curr` points to next non consumed entry in the `input_entries`.
-    /// It's the command's duty to decide move `curr` forward.
-    ///
     /// TODO(xp): remove this method. The API should run all commands in one shot.
     ///           E.g. `run_engine_commands(input_entries, commands)`.
     ///           But it relates to the different behaviors of server states.
@@ -71,10 +67,5 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// every command.           This can be done after moving all raft-algorithm logic into
     /// Engine.           Then a Runtime do not need to differentiate states such as LeaderState
     /// or FollowerState and all           command execution can be implemented in one method.
-    async fn run_command<'e>(
-        &mut self,
-        input_entries: &'e [C::Entry],
-        curr: &mut usize,
-        cmd: Command<C::NodeId, C::Node>,
-    ) -> Result<(), StorageError<C::NodeId>>;
+    async fn run_command<'e>(&mut self, cmd: Command<C::NodeId, C::Node>) -> Result<(), StorageError<C::NodeId>>;
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,4 +37,5 @@ tracing-subscriber = { workspace = true }
 
 [features]
 
+bt = ["openraft/bt"]
 single-term-leader = ["openraft/single-term-leader"]


### PR DESCRIPTION

## Changelog

##### Refactor: add `input_entries` to RaftCore

`RaftCore.input_entries` stores input log entries to be appended.
These entries comes from user calls to `RaftCore::client_write` for a leader, or
`RaftCore::append_entries` for a follower or learner.

`input_entries` serves as the sole storage for all log entries that are pending to be
written to `RaftStorage`. Group committing will be done on this storage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/737)
<!-- Reviewable:end -->
