### PR TITLE
Change: remove `Clone` from trait `AppData`

### DIFF
--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -16,7 +16,6 @@ pub use traits::RaftEntry;
 pub use traits::RaftPayload;
 
 /// A Raft log entry.
-#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct Entry<C>
 where C: RaftTypeConfig
@@ -25,6 +24,19 @@ where C: RaftTypeConfig
 
     /// This entry's payload.
     pub payload: EntryPayload<C>,
+}
+
+impl<C> Clone for Entry<C>
+where
+    C: RaftTypeConfig,
+    C::D: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            log_id: self.log_id,
+            payload: self.payload.clone(),
+        }
+    }
 }
 
 impl<C> Debug for Entry<C>

--- a/openraft/src/entry/payload.rs
+++ b/openraft/src/entry/payload.rs
@@ -7,7 +7,7 @@ use crate::MessageSummary;
 use crate::RaftTypeConfig;
 
 /// Log entry payload variants.
-#[derive(Clone, PartialEq)]
+#[derive(PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum EntryPayload<C: RaftTypeConfig> {
     /// An empty payload committed by a new cluster leader.
@@ -17,6 +17,20 @@ pub enum EntryPayload<C: RaftTypeConfig> {
 
     /// A change-membership log entry.
     Membership(Membership<C::NodeId, C::Node>),
+}
+
+impl<C> Clone for EntryPayload<C>
+where
+    C: RaftTypeConfig,
+    C::D: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            EntryPayload::Blank => EntryPayload::Blank,
+            EntryPayload::Normal(n) => EntryPayload::Normal(n.clone()),
+            EntryPayload::Membership(m) => EntryPayload::Membership(m.clone()),
+        }
+    }
 }
 
 impl<C: RaftTypeConfig> fmt::Debug for EntryPayload<C> {

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -164,9 +164,9 @@ impl<T> OptionalSerde for T {}
 /// ## Note
 ///
 /// The trait is automatically implemented for all types which satisfy its supertraits.
-pub trait AppData: Clone + Send + Sync + 'static + OptionalSerde {}
+pub trait AppData: Send + Sync + 'static + OptionalSerde {}
 
-impl<T> AppData for T where T: Clone + Send + Sync + 'static + OptionalSerde {}
+impl<T> AppData for T where T: Send + Sync + 'static + OptionalSerde {}
 
 /// A trait defining application specific response data.
 ///

--- a/tests/tests/append_entries/t20_append_conflicts.rs
+++ b/tests/tests/append_entries/t20_append_conflicts.rs
@@ -51,7 +51,7 @@ async fn append_conflicts() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
-    let resp = r0.append_entries(req.clone()).await?;
+    let resp = r0.append_entries(req).await?;
 
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
@@ -65,7 +65,7 @@ async fn append_conflicts() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
-    let resp = r0.append_entries(req.clone()).await?;
+    let resp = r0.append_entries(req).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -78,7 +78,7 @@ async fn append_conflicts() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
-    let resp = r0.append_entries(req.clone()).await?;
+    let resp = r0.append_entries(req).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -86,7 +86,7 @@ async fn append_conflicts() -> Result<()> {
 
     tracing::info!("--- case 0: prev_log_id.index == 0, ");
 
-    let req = AppendEntriesRequest {
+    let req = || AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
         entries: vec![blank(1, 1), blank(1, 2), blank(1, 3), blank(1, 4)],
@@ -94,7 +94,7 @@ async fn append_conflicts() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
-    let resp = r0.append_entries(req.clone()).await?;
+    let resp = r0.append_entries(req()).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -102,7 +102,7 @@ async fn append_conflicts() -> Result<()> {
 
     tracing::info!("--- case 0: prev_log_id.index == 0, last_log_id mismatch");
 
-    let resp = r0.append_entries(req.clone()).await?;
+    let resp = r0.append_entries(req()).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 

--- a/tests/tests/append_entries/t40_append_updates_membership.rs
+++ b/tests/tests/append_entries/t40_append_updates_membership.rs
@@ -64,7 +64,7 @@ async fn append_updates_membership() -> Result<()> {
             leader_commit: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
         };
 
-        let resp = r0.append_entries(req.clone()).await?;
+        let resp = r0.append_entries(req).await?;
         assert!(resp.is_success());
         assert!(!resp.is_conflict());
 
@@ -80,7 +80,7 @@ async fn append_updates_membership() -> Result<()> {
             leader_commit: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
         };
 
-        let resp = r0.append_entries(req.clone()).await?;
+        let resp = r0.append_entries(req).await?;
         assert!(resp.is_success());
         assert!(!resp.is_conflict());
 

--- a/tests/tests/life_cycle/t20_initialization.rs
+++ b/tests/tests/life_cycle/t20_initialization.rs
@@ -114,7 +114,7 @@ async fn initialization() -> anyhow::Result<()> {
 
     for i in [0, 1, 2] {
         let mut sto = router.get_storage_handle(&1)?;
-        let first = StorageHelper::new(&mut sto).get_log_entries(0..2).await?.first().cloned();
+        let first = StorageHelper::new(&mut sto).get_log_entries(0..2).await?.into_iter().next();
 
         tracing::info!("--- check membership is replicated: id: {}, first log: {:?}", i, first);
         let mem = match first.unwrap().payload {


### PR DESCRIPTION

## Changelog

##### Change: remove `Clone` from trait `AppData`

Application data `AppData` does not have to be `Clone`.

Upgrade tip:

Nothing needs to be done.
The default `RaftEntry` implementation `Entry` provided by openraft is
still `Clone`, if the AppData in it is `Clone`.


##### Refactor: memstore stores serialized entry

So that Entry does not need to be `Clone`. Therefore `Clone` can be
removed from `AppData`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/740)
<!-- Reviewable:end -->
