### PR TITLE
Refactor: run engine commands after handling a message

### DIFF
--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -162,9 +162,11 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
 
         let mut snapshot_data = streaming.snapshot_data;
 
-        snapshot_data.as_mut().shutdown().await.map_err(|e| StorageError::IO {
-            source: StorageIOError::write_snapshot(meta.signature(), &e),
-        })?;
+        snapshot_data
+            .as_mut()
+            .shutdown()
+            .await
+            .map_err(|e| StorageIOError::write_snapshot(meta.signature(), &e))?;
 
         // Buffer the snapshot data, let Engine decide to install it or to cancel it.
         self.received_snapshot.insert(meta.snapshot_id.clone(), snapshot_data);

--- a/tests/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/tests/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -13,15 +13,18 @@ use openraft::Vote;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
-/// append-entries should update hard state when adding new logs with bigger term
+/// append-entries should update the vote when adding new logs with greater vote.
 ///
-/// - bring up a learner and send to it append_entries request. Check the hard state updated.
+/// - Bring up a learner and send to it append_entries request.
+///
+/// Check the vote updated.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn append_entries_with_bigger_term() -> Result<()> {
     // Setup test dependencies.
     let config = Arc::new(
         Config {
             enable_heartbeat: false,
+            enable_elect: false,
             ..Default::default()
         }
         .validate()?,


### PR DESCRIPTION

## Changelog

##### Refactor: run engine commands after handling a message

It is not necessary for every message handler to run engine output
commands. Instead, the `runtime_loop()` can run these commands
immediately after processing a message.

- [ ] some message can not be handled in one-shot, i.e., it needs to
  access Engine more than once, such as snapshot handler.
  They will be refactored in the upcoming commits

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/743)
<!-- Reviewable:end -->
