### PR TITLE
Refactor: embed log entries in Command

### DIFF
--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -1,6 +1,7 @@
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::entry::RaftEntry;
 use crate::raft_state::LogStateReader;
 use crate::summary::MessageSummary;
 use crate::LogId;
@@ -13,20 +14,22 @@ use crate::RaftState;
 #[cfg(test)] mod purge_log_test;
 
 /// Handle raft vote related operations
-pub(crate) struct LogHandler<'x, NID, N>
+pub(crate) struct LogHandler<'x, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     pub(crate) config: &'x mut EngineConfig<NID>,
     pub(crate) state: &'x mut RaftState<NID, N>,
-    pub(crate) output: &'x mut EngineOutput<NID, N>,
+    pub(crate) output: &'x mut EngineOutput<NID, N, Ent>,
 }
 
-impl<'x, NID, N> LogHandler<'x, NID, N>
+impl<'x, NID, N, Ent> LogHandler<'x, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     /// Purge log entries upto `RaftState.purge_upto()`, inclusive.
     #[tracing::instrument(level = "debug", skip_all)]

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -1,6 +1,7 @@
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::entry::RaftEntry;
 use crate::Node;
 use crate::NodeId;
 use crate::RaftState;
@@ -9,20 +10,22 @@ use crate::ServerState;
 #[cfg(test)] mod update_server_state_test;
 
 /// Handle raft server-state related operations
-pub(crate) struct ServerStateHandler<'st, NID, N>
+pub(crate) struct ServerStateHandler<'st, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     pub(crate) config: &'st EngineConfig<NID>,
     pub(crate) state: &'st mut RaftState<NID, N>,
-    pub(crate) output: &'st mut EngineOutput<NID, N>,
+    pub(crate) output: &'st mut EngineOutput<NID, N, Ent>,
 }
 
-impl<'st, NID, N> ServerStateHandler<'st, NID, N>
+impl<'st, NID, N, Ent> ServerStateHandler<'st, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     /// Re-calculate the server-state, if it changed, update the `server_state` field and dispatch
     /// commands to inform a runtime.

--- a/openraft/src/engine/handler/snapshot_handler/mod.rs
+++ b/openraft/src/engine/handler/snapshot_handler/mod.rs
@@ -1,4 +1,5 @@
 use crate::engine::EngineOutput;
+use crate::entry::RaftEntry;
 use crate::raft_state::LogStateReader;
 use crate::summary::MessageSummary;
 use crate::Node;
@@ -9,19 +10,21 @@ use crate::SnapshotMeta;
 #[cfg(test)] mod update_snapshot_test;
 
 /// Handle raft vote related operations
-pub(crate) struct SnapshotHandler<'st, 'out, NID, N>
+pub(crate) struct SnapshotHandler<'st, 'out, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     pub(crate) state: &'st mut RaftState<NID, N>,
-    pub(crate) output: &'out mut EngineOutput<NID, N>,
+    pub(crate) output: &'out mut EngineOutput<NID, N, Ent>,
 }
 
-impl<'st, 'out, NID, N> SnapshotHandler<'st, 'out, NID, N>
+impl<'st, 'out, NID, N, Ent> SnapshotHandler<'st, 'out, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     /// Update engine state when a new snapshot is built or installed.
     ///

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -3,6 +3,7 @@ use crate::engine::time_state::TimeState;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::entry::RaftEntry;
 use crate::error::RejectVoteRequest;
 use crate::internal_server_state::InternalServerState;
 use crate::leader::Leader;
@@ -20,22 +21,24 @@ use crate::Vote;
 ///
 /// A `vote` defines the state of a openraft node.
 /// See [`RaftState::calc_server_state`] .
-pub(crate) struct VoteHandler<'st, NID, N>
+pub(crate) struct VoteHandler<'st, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     pub(crate) config: &'st EngineConfig<NID>,
     pub(crate) state: &'st mut RaftState<NID, N>,
     pub(crate) timer: &'st mut TimeState,
-    pub(crate) output: &'st mut EngineOutput<NID, N>,
+    pub(crate) output: &'st mut EngineOutput<NID, N, Ent>,
     pub(crate) internal_server_state: &'st mut InternalServerState<NID>,
 }
 
-impl<'st, NID, N> VoteHandler<'st, NID, N>
+impl<'st, NID, N, Ent> VoteHandler<'st, NID, N, Ent>
 where
     NID: NodeId,
     N: Node,
+    Ent: RaftEntry<NID, N>,
 {
     /// Mark the vote as committed, i.e., being granted and saved by a quorum.
     ///
@@ -161,7 +164,7 @@ where
         self.server_state_handler().update_server_state_if_changed();
     }
 
-    pub(crate) fn server_state_handler(&mut self) -> ServerStateHandler<NID, N> {
+    pub(crate) fn server_state_handler(&mut self) -> ServerStateHandler<NID, N, Ent> {
         ServerStateHandler {
             config: self.config,
             state: self.state,

--- a/openraft/src/engine/initialize_test.rs
+++ b/openraft/src/engine/initialize_test.rs
@@ -42,7 +42,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
     };
 
     let m1 = || Membership::<u64, ()>::new(vec![btreeset! {1}], None);
-    let mut entries = [Entry::<Config>::new_membership(LogId::default(), m1())];
+    let entry = Entry::<Config>::new_membership(LogId::default(), m1());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");
     tracing::info!("--- expect OK result, check output commands and state changes");
@@ -50,7 +50,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
         let mut eng = eng();
         eng.config.id = 1;
 
-        eng.initialize(&mut entries)?;
+        eng.initialize(entry)?;
 
         assert_eq!(Some(log_id0), eng.state.get_log_id(0));
         assert_eq!(Some(log_id(1, 1)), eng.state.get_log_id(1));
@@ -71,7 +71,9 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 
         assert_eq!(
             vec![
-                Command::AppendInputEntries { range: 0..1 },
+                Command::AppendEntry {
+                    entry: Entry::<Config>::new_membership(LogId::default(), m1())
+                },
                 Command::UpdateMembership {
                     membership: eng.state.membership_state.effective().clone()
                 },
@@ -128,7 +130,7 @@ fn test_initialize() -> anyhow::Result<()> {
     };
 
     let m12 = || Membership::<u64, ()>::new(vec![btreeset! {1,2}], None);
-    let mut entries = [Entry::<Config>::new_membership(LogId::default(), m12())];
+    let entry = || Entry::<Config>::new_membership(LogId::default(), m12());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");
     tracing::info!("--- expect OK result, check output commands and state changes");
@@ -136,7 +138,7 @@ fn test_initialize() -> anyhow::Result<()> {
         let mut eng = eng();
         eng.config.id = 1;
 
-        eng.initialize(&mut entries)?;
+        eng.initialize(entry())?;
 
         assert_eq!(Some(log_id0), eng.state.get_log_id(0));
         assert_eq!(None, eng.state.get_log_id(1));
@@ -155,7 +157,9 @@ fn test_initialize() -> anyhow::Result<()> {
 
         assert_eq!(
             vec![
-                Command::AppendInputEntries { range: 0..1 },
+                Command::AppendEntry {
+                    entry: Entry::new_membership(LogId::default(), m12())
+                },
                 Command::UpdateMembership {
                     membership: eng.state.membership_state.effective().clone()
                 },
@@ -187,7 +191,7 @@ fn test_initialize() -> anyhow::Result<()> {
                 last_log_id: Some(log_id0),
                 vote: Vote::default(),
             })),
-            eng.initialize(&mut entries)
+            eng.initialize(entry())
         );
     }
 
@@ -201,7 +205,7 @@ fn test_initialize() -> anyhow::Result<()> {
                 last_log_id: None,
                 vote: Vote::new(0, 1),
             })),
-            eng.initialize(&mut entries)
+            eng.initialize(entry())
         );
     }
 
@@ -214,7 +218,7 @@ fn test_initialize() -> anyhow::Result<()> {
                 node_id: 0,
                 membership: m12()
             })),
-            eng.initialize(&mut entries)
+            eng.initialize(entry())
         );
     }
 

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -2,11 +2,13 @@ use crate::RaftTypeConfig;
 
 /// Req for test
 #[derive(Clone)]
+#[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct Req {}
 
 /// Resp for test
 #[derive(Clone)]
+#[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct Resp {}
 

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -1,7 +1,6 @@
 //! Public Raft interface and data types.
 
 use std::collections::BTreeMap;
-use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::sync::atomic::Ordering;
@@ -243,7 +242,6 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
             storage,
 
             engine,
-            input_entries: VecDeque::with_capacity(4096),
             leader_data: None,
 
             snapshot_state: SnapshotState::None,

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -260,7 +260,7 @@ where
 
     pub(crate) fn assign_log_ids<'a, Ent: RaftEntry<NID, N> + 'a>(
         &mut self,
-        entries: impl Iterator<Item = &'a mut Ent>,
+        entries: impl IntoIterator<Item = &'a mut Ent>,
     ) {
         let mut log_id = LogId::new(
             self.vote_ref().committed_leader_id().unwrap(),

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -67,5 +67,8 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// every command.           This can be done after moving all raft-algorithm logic into
     /// Engine.           Then a Runtime do not need to differentiate states such as LeaderState
     /// or FollowerState and all           command execution can be implemented in one method.
-    async fn run_command<'e>(&mut self, cmd: Command<C::NodeId, C::Node>) -> Result<(), StorageError<C::NodeId>>;
+    async fn run_command<'e>(
+        &mut self,
+        cmd: Command<C::NodeId, C::Node, C::Entry>,
+    ) -> Result<(), StorageError<C::NodeId>>;
 }


### PR DESCRIPTION

## Changelog

##### Refactor: embed log entries in Command

Previously the `input_entries` buffer is used to store the input log
entries for writing on a leader or replicating on a follower.
A Command that is generated by Engine only contains an index range to
indicate which log entries it uses.

This method is prone to error as the index and the entries need to be
carefully maintained to ensure consitency.

In this commit log entries are stored directly in a Command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/746)
<!-- Reviewable:end -->
