### PR TITLE
Improve: follower stores the accepted log id

### DIFF
--- a/openraft/src/engine/handle_append_entries_req_test.rs
+++ b/openraft/src/engine/handle_append_entries_req_test.rs
@@ -278,7 +278,7 @@ fn test_handle_append_entries_req_prev_log_id_not_exists() -> anyhow::Result<()>
     let resp = eng.handle_append_entries_req(
         &Vote::new_committed(2, 1),
         Some(log_id(2, 4)),
-        vec![blank(1, 1), blank(2, 2)],
+        vec![blank(2, 5), blank(2, 6)],
         Some(log_id(1, 1)),
     );
 

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use maplit::btreeset;
+
+use crate::engine::testing::UTCfg;
+use crate::engine::Engine;
+use crate::raft_state::LogStateReader;
+use crate::testing::log_id;
+use crate::EffectiveMembership;
+use crate::Entry;
+use crate::EntryPayload;
+use crate::Membership;
+use crate::MembershipState;
+use crate::RaftTypeConfig;
+use crate::Vote;
+
+fn blank(term: u64, index: u64) -> Entry<UTCfg> {
+    Entry {
+        log_id: log_id(term, index),
+        payload: EntryPayload::<UTCfg>::Blank,
+    }
+}
+
+fn m01() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {0,1}], None)
+}
+
+fn m23() -> Membership<u64, ()> {
+    Membership::new(vec![btreeset! {2,3}], None)
+}
+
+fn eng() -> Engine<u64, (), <UTCfg as RaftTypeConfig>::Entry> {
+    let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+
+    eng.config.id = 2;
+    eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
+    eng.state.log_ids.append(log_id(1, 1));
+    eng.state.log_ids.append(log_id(2, 3));
+    eng.state.membership_state = MembershipState::new(
+        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+    );
+    eng.state.server_state = eng.calc_server_state();
+    eng
+}
+
+#[test]
+fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.following_handler().append_entries(
+        Some(log_id(2, 3)),
+        vec![
+            //
+            blank(3, 4),
+            blank(3, 5),
+        ],
+        None,
+    );
+
+    assert_eq!(
+        &[
+            log_id(1, 1), //
+            log_id(2, 3),
+            log_id(3, 4),
+            log_id(3, 5),
+        ],
+        eng.state.log_ids.key_log_ids()
+    );
+    assert_eq!(Some(&log_id(3, 5)), eng.state.accepted());
+
+    // Update again, accept should not decrease.
+
+    eng.following_handler().append_entries(
+        Some(log_id(2, 3)),
+        vec![
+            //
+            blank(3, 4),
+        ],
+        None,
+    );
+
+    assert_eq!(Some(&log_id(3, 5)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id(3, 5)), eng.state.accepted());
+
+    Ok(())
+}

--- a/openraft/src/raft_state/accepted.rs
+++ b/openraft/src/raft_state/accepted.rs
@@ -1,0 +1,45 @@
+use crate::LeaderId;
+use crate::LogId;
+use crate::NodeId;
+
+/// A range of log entries that is accepted by a follower.
+///
+/// It is similar to the `accepted` value in paxos.
+/// But it is not persisted and is not considered when election.
+///
+/// It is only used when determining the last committable log id.
+///
+/// The accepted log id must be present. When the follower truncates its log, `accepted` should be
+/// reset.
+#[derive(Debug, Clone)]
+#[derive(Default)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct Accepted<NID: NodeId> {
+    /// From which leader this range of log is accepted.
+    leader_id: LeaderId<NID>,
+
+    /// The last log id that is accepted.
+    log_id: Option<LogId<NID>>,
+}
+
+impl<NID: NodeId> Accepted<NID> {
+    /// Create a new `Accepted` with the given leader id and log id.
+    pub(crate) fn new(leader_id: LeaderId<NID>, log_id: Option<LogId<NID>>) -> Self {
+        Self { leader_id, log_id }
+    }
+
+    pub(crate) fn leader_id(&self) -> &LeaderId<NID> {
+        &self.leader_id
+    }
+
+    /// Get the last accepted log id from the given leader.
+    ///
+    /// If the given leader is not the leader of this `Accepted`, return `None`.
+    pub(crate) fn last_accepted_log_id(&self, leader_id: &LeaderId<NID>) -> Option<&LogId<NID>> {
+        if leader_id == &self.leader_id {
+            self.log_id.as_ref()
+        } else {
+            None
+        }
+    }
+}

--- a/openraft/src/raft_state/tests/accepted_test.rs
+++ b/openraft/src/raft_state/tests/accepted_test.rs
@@ -1,0 +1,17 @@
+use crate::raft_state::accepted::Accepted;
+use crate::CommittedLeaderId;
+use crate::LeaderId;
+use crate::LogId;
+
+#[test]
+fn test_accepted() -> anyhow::Result<()> {
+    let a = Accepted::new(LeaderId::new(5, 10), Some(LogId::new(CommittedLeaderId::new(6, 2), 3)));
+    assert_eq!(
+        Some(&LogId::new(CommittedLeaderId::new(6, 2), 3)),
+        a.last_accepted_log_id(&LeaderId::new(5, 10)),
+    );
+    assert_eq!(None, a.last_accepted_log_id(&LeaderId::new(6, 10)));
+    assert_eq!(None, a.last_accepted_log_id(&LeaderId::new(4, 10)));
+
+    Ok(())
+}

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -85,6 +85,7 @@ where
 
             // -- volatile fields: they are not persisted.
             server_state: Default::default(),
+            accepted: Default::default(),
             purge_upto: last_purged_log_id,
         })
     }


### PR DESCRIPTION

## Changelog

##### Improve: follower stores the accepted log id

A follower stores the ID of the latest log that has been synchronized by
the leader, represented as `(LeaderId, Option<LogId>)`.
This information is only kept in memory and is not taken into account
when processing vote requests or determining the commit condition.

The reason for storing this information is to allow followers to commit
only those logs that have been replicated by their current leader.

- Fix: #747

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/748)
<!-- Reviewable:end -->
