### PR TITLE
Improve: send AppendEntries response before committing entries

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -948,11 +948,11 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> RaftCore<C,
     ) {
         tracing::debug!(req = display(req.summary()), func = func_name!());
 
-        let resp = self.engine.handle_append_entries_req(&req.vote, req.prev_log_id, req.entries, req.leader_commit);
+        let is_ok = self.engine.handle_append_entries(&req.vote, req.prev_log_id, req.entries, Some(tx));
 
-        self.engine.output.push_command(Command::SendAppendEntriesResult {
-            send: SendResult::new(Ok(resp), tx),
-        });
+        if is_ok {
+            self.engine.handle_commit_entries(req.leader_commit);
+        }
     }
 
     // TODO: Make this method non-async. It does not need to run any async command in it.

--- a/openraft/src/display_ext.rs
+++ b/openraft/src/display_ext.rs
@@ -1,4 +1,4 @@
-//! Implement [`std::fmt::Display`] for types such as `Option<T>` and slice `&[T]`.
+//! Implement [`fmt::Display`] for types such as `Option<T>` and slice `&[T]`.
 
 use std::fmt;
 
@@ -9,7 +9,7 @@ use std::fmt;
 pub(crate) struct DisplayOption<'a, T: fmt::Display>(pub &'a Option<T>);
 
 impl<'a, T: fmt::Display> fmt::Display for DisplayOption<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             None => {
                 write!(f, "None")
@@ -26,7 +26,7 @@ impl<'a, T: fmt::Display> fmt::Display for DisplayOption<'a, T> {
 pub(crate) struct DisplaySlice<'a, T: fmt::Display, const MAX: usize = 5>(pub &'a [T]);
 
 impl<'a, T: fmt::Display, const MAX: usize> fmt::Display for DisplaySlice<'a, T, MAX> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let slice = self.0;
         let len = slice.len();
 

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -41,15 +41,11 @@ fn eng() -> Engine<u64, (), <UTCfg as RaftTypeConfig>::Entry> {
 fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    eng.following_handler().append_entries(
-        Some(log_id(2, 3)),
-        vec![
-            //
-            blank_ent(3, 4),
-            blank_ent(3, 5),
-        ],
-        None,
-    );
+    eng.following_handler().append_entries(Some(log_id(2, 3)), vec![
+        //
+        blank_ent(3, 4),
+        blank_ent(3, 5),
+    ]);
 
     assert_eq!(
         &[
@@ -64,14 +60,10 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
 
     // Update again, accept should not decrease.
 
-    eng.following_handler().append_entries(
-        Some(log_id(2, 3)),
-        vec![
-            //
-            blank_ent(3, 4),
-        ],
-        None,
-    );
+    eng.following_handler().append_entries(Some(log_id(2, 3)), vec![
+        //
+        blank_ent(3, 4),
+    ]);
 
     assert_eq!(Some(&log_id(3, 5)), eng.state.last_log_id());
     assert_eq!(Some(&log_id(3, 5)), eng.state.accepted());

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -97,10 +97,11 @@ fn test_following_handler_commit_entries_le_accepted() -> anyhow::Result<()> {
     );
     assert_eq!(
         vec![
+            //
             Command::FollowerCommit {
                 already_committed: Some(log_id(1, 1)),
                 upto: log_id(2, 3)
-            }, //
+            },
         ],
         eng.output.take_commands()
     );

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -38,9 +38,9 @@ pub(crate) mod time_state;
 
 #[cfg(test)]
 mod tests {
+    mod append_entries_test;
     mod command_test;
     mod elect_test;
-    mod handle_append_entries_req_test;
     mod handle_vote_req_test;
     mod handle_vote_resp_test;
     mod initialize_test;


### PR DESCRIPTION

## Changelog

##### Improve: send AppendEntries response before committing entries

When a follower receives an append-entries request that includes a
series of log entries to append and the log id that the leader
has committed, it responds with an append-entries response after
committing and applying the entries.

However, this is not strictly necessary. The follower could simply send
the response as soon as the log entries have been appended and flushed
to disk, without waiting for them to be committed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/751)
<!-- Reviewable:end -->
