### PR TITLE
Refactor: allow snapshot buillding and streaming at the same time

### DIFF
--- a/openraft/src/core/building_state.rs
+++ b/openraft/src/core/building_state.rs
@@ -1,0 +1,13 @@
+use futures::future::AbortHandle;
+use tokio::task::JoinHandle;
+
+/// The Raft node is building snapshot itself.
+pub(crate) struct Building {
+    /// A handle to abort the building snapshot process early if needed.
+    #[allow(dead_code)]
+    pub(crate) abort_handle: AbortHandle,
+
+    /// A handle to join the building snapshot process.
+    #[allow(dead_code)]
+    pub(crate) join_handle: JoinHandle<()>,
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -4,18 +4,19 @@
 //! Also it receives and execute `Command` emitted by `Engine` to apply raft state to underlying
 //! storage or forward messages to other raft nodes.
 
+mod building_state;
 mod install_snapshot;
 mod raft_core;
 mod replication_state;
 mod server_state;
-mod snapshot_state;
 mod streaming_state;
 mod tick;
+
+pub(crate) mod snapshot_state;
 
 pub use raft_core::RaftCore;
 pub(crate) use replication_state::replication_lag;
 pub use server_state::ServerState;
 pub(crate) use snapshot_state::SnapshotResult;
-pub(crate) use snapshot_state::SnapshotState;
 pub(crate) use tick::Tick;
 pub(crate) use tick::TickHandle;

--- a/openraft/src/core/streaming_state.rs
+++ b/openraft/src/core/streaming_state.rs
@@ -14,18 +14,20 @@ use crate::SnapshotId;
 use crate::StorageError;
 
 /// The Raft node is streaming in a snapshot from the leader.
-pub(crate) struct StreamingState<C: RaftTypeConfig, SD> {
+pub(crate) struct Streaming<C: RaftTypeConfig, SD> {
     /// The offset of the last byte written to the snapshot.
     pub(crate) offset: u64,
+
     /// The ID of the snapshot being written.
     pub(crate) snapshot_id: SnapshotId,
+
     /// A handle to the snapshot writer.
     pub(crate) snapshot_data: Box<SD>,
 
     _p: PhantomData<C>,
 }
 
-impl<C: RaftTypeConfig, SD> StreamingState<C, SD>
+impl<C: RaftTypeConfig, SD> Streaming<C, SD>
 where SD: AsyncSeek + AsyncWrite + Unpin
 {
     pub(crate) fn new(snapshot_id: SnapshotId, snapshot_data: Box<SD>) -> Self {

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -20,9 +20,9 @@ use tracing::Level;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
 use crate::core::replication_lag;
+use crate::core::snapshot_state;
 use crate::core::RaftCore;
 use crate::core::SnapshotResult;
-use crate::core::SnapshotState;
 use crate::core::Tick;
 use crate::core::TickHandle;
 use crate::display_ext::DisplaySlice;
@@ -244,7 +244,7 @@ impl<C: RaftTypeConfig, N: RaftNetworkFactory<C>, S: RaftStorage<C>> Raft<C, N, 
             engine,
             leader_data: None,
 
-            snapshot_state: SnapshotState::None,
+            snapshot_state: snapshot_state::State::default(),
             received_snapshot: BTreeMap::new(),
 
             tx_api: tx_api.clone(),


### PR DESCRIPTION

## Changelog

##### Refactor: allow snapshot buillding and streaming at the same time

Although enabling snapshot building and streaming at the same time may
lead to inefficiencies, it enhances the clarity of the system's overall
structure. For instance, when processing a stream, there is
no need to handle any building state.

In this commit, a new `snapshot_state::State` is introduced that includes
both a building state and a streaming state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/752)
<!-- Reviewable:end -->
