### PR TITLE
Fix: when a snapshot is installed, all logs convered by snapshot should be purged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version="1.0", default-features=false, features=["sync"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.4"
 
-openraft = { path= "../openraft", version="=0.7.5" }
+openraft = { path= "../openraft", version="=0.7.6" }
 
 [dev-dependencies]
 anyhow = "1.0.63"

--- a/openraft/src/core/install_snapshot.rs
+++ b/openraft/src/core/install_snapshot.rs
@@ -276,7 +276,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
         // Applied logs are not needed. Purge them or there may be a hole in the log.
         if let Some(last) = &last_applied {
-            purge_applied_logs(self.storage.clone(), last, self.config.max_applied_log_to_keep).await?;
+            purge_applied_logs(self.storage.clone(), last, 0).await?;
         }
 
         // snapshot is installed

--- a/rocksstore/Cargo.toml
+++ b/rocksstore/Cargo.toml
@@ -16,7 +16,7 @@ repository    = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openraft = { path= "../openraft", version="=0.7.5" }
+openraft = { path= "../openraft", version="=0.7.6" }
 
 rocksdb = "0.20.1"
 byteorder = "1.4.3"


### PR DESCRIPTION

## Changelog

##### Fix: when a snapshot is installed, all logs convered by snapshot should be purged

There may be log entries that are different from the ones applied to the
snapshot. Using these logs for replication leads to data damage.


##### BumpVer: 0.7.6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/753)
<!-- Reviewable:end -->
