### PR TITLE
Change: remove unused trait RaftStorageDebug

### DIFF
--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -21,7 +21,6 @@ use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::RaftLogId;
 use openraft::RaftStorage;
-use openraft::RaftStorageDebug;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
@@ -136,19 +135,16 @@ impl MemStore {
     pub async fn new_async() -> Arc<Self> {
         Arc::new(Self::new())
     }
+
+    /// Get a handle to the state machine for testing purposes.
+    pub async fn get_state_machine(&self) -> MemStoreStateMachine {
+        self.sm.write().await.clone()
+    }
 }
 
 impl Default for MemStore {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-#[async_trait]
-impl RaftStorageDebug<MemStoreStateMachine> for Arc<MemStore> {
-    /// Get a handle to the state machine for testing purposes.
-    async fn get_state_machine(&mut self) -> MemStoreStateMachine {
-        self.sm.write().await.clone()
     }
 }
 

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -119,7 +119,6 @@ pub use crate::storage::LogState;
 pub use crate::storage::RaftLogReader;
 pub use crate::storage::RaftSnapshotBuilder;
 pub use crate::storage::RaftStorage;
-pub use crate::storage::RaftStorageDebug;
 pub use crate::storage::Snapshot;
 pub use crate::storage::SnapshotMeta;
 pub use crate::storage::StorageHelper;

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -340,10 +340,3 @@ where C: RaftTypeConfig
         &mut self,
     ) -> Result<Option<Snapshot<C::NodeId, C::Node, Self::SnapshotData>>, StorageError<C::NodeId>>;
 }
-
-/// APIs for debugging a store.
-#[async_trait]
-pub trait RaftStorageDebug<SM> {
-    /// Get a handle to the state machine for testing purposes.
-    async fn get_state_machine(&mut self) -> SM;
-}

--- a/openraft/src/store_ext.rs
+++ b/openraft/src/store_ext.rs
@@ -20,7 +20,6 @@ use crate::storage::Snapshot;
 use crate::DefensiveCheck;
 use crate::LogId;
 use crate::RaftStorage;
-use crate::RaftStorageDebug;
 use crate::RaftTypeConfig;
 use crate::SnapshotMeta;
 use crate::StorageError;
@@ -142,17 +141,6 @@ where
     C: RaftTypeConfig,
     T: RaftStorage<C>,
 {
-}
-
-#[async_trait]
-impl<C, T, SM> RaftStorageDebug<SM> for StoreExt<C, T>
-where
-    T: RaftStorage<C> + RaftStorageDebug<SM>,
-    C: RaftTypeConfig,
-{
-    async fn get_state_machine(&mut self) -> SM {
-        self.inner().get_state_machine().await
-    }
 }
 
 #[async_trait]

--- a/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
-use openraft::RaftStorageDebug;
 use openraft::ServerState;
 
 use crate::fixtures::init_default_ut_tracing;
@@ -57,7 +56,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     log_index += 1;
     for node_id in 0..2 {
         router.wait_for_log(&btreeset![node_id], Some(log_index), None, "write one log").await?;
-        let mut sto = router.get_storage_handle(&node_id)?;
+        let sto = router.get_storage_handle(&node_id)?;
         assert!(sto.get_state_machine().await.client_status.get("foo").is_some());
     }
 


### PR DESCRIPTION

## Changelog

##### Change: remove unused trait RaftStorageDebug

`RaftStorageDebug` has only one method `get_state_machine()`,
and state machine is entirely a user defined struct. Obtaining a state
machine does not imply anything about the struct or behavior of it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/759)
<!-- Reviewable:end -->
