### PR TITLE
Change: move `RaftStateMachine` out of `RaftStorage`

### DIFF
--- a/examples/raft-kv-memstore/src/app.rs
+++ b/examples/raft-kv-memstore/src/app.rs
@@ -1,17 +1,15 @@
 use std::sync::Arc;
 
-use openraft::Config;
-
-use crate::ExampleNodeId;
-use crate::ExampleRaft;
-use crate::ExampleStore;
+use crate::NodeId;
+use crate::Raft;
+use crate::Store;
 
 // Representation of an application state. This struct can be shared around to share
 // instances of raft, store and more.
-pub struct ExampleApp {
-    pub id: ExampleNodeId,
+pub struct App {
+    pub id: NodeId,
     pub addr: String,
-    pub raft: ExampleRaft,
-    pub store: Arc<ExampleStore>,
-    pub config: Arc<Config>,
+    pub raft: Raft,
+    pub store: Arc<Store>,
+    pub config: Arc<openraft::Config>,
 }

--- a/examples/raft-kv-memstore/src/bin/main.rs
+++ b/examples/raft-kv-memstore/src/bin/main.rs
@@ -1,12 +1,6 @@
 use clap::Parser;
-use openraft::Raft;
-use raft_kv_memstore::network::raft_network_impl::ExampleNetwork;
 use raft_kv_memstore::start_example_raft_node;
-use raft_kv_memstore::store::ExampleStore;
-use raft_kv_memstore::ExampleTypeConfig;
 use tracing_subscriber::EnvFilter;
-
-pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, ExampleStore>;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -6,54 +6,54 @@ use std::sync::Arc;
 use actix_web::middleware;
 use actix_web::middleware::Logger;
 use actix_web::web::Data;
-use actix_web::App;
 use actix_web::HttpServer;
+use openraft::storage::Adaptor;
 use openraft::BasicNode;
 use openraft::Config;
-use openraft::Raft;
 
-use crate::app::ExampleApp;
+use crate::app::App;
 use crate::network::api;
 use crate::network::management;
 use crate::network::raft;
-use crate::network::raft_network_impl::ExampleNetwork;
-use crate::store::ExampleRequest;
-use crate::store::ExampleResponse;
-use crate::store::ExampleStore;
+use crate::network::Network;
+use crate::store::Request;
+use crate::store::Response;
+use crate::store::Store;
 
 pub mod app;
 pub mod client;
 pub mod network;
 pub mod store;
 
-pub type ExampleNodeId = u64;
+pub type NodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
-    pub ExampleTypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId, Node = BasicNode, Entry = openraft::Entry<ExampleTypeConfig>
+    pub TypeConfig: D = Request, R = Response, NodeId = NodeId, Node = BasicNode, Entry = openraft::Entry<TypeConfig>
 );
 
-pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, Arc<ExampleStore>>;
+pub type LogStore = Adaptor<TypeConfig, Arc<Store>>;
+pub type StateMachineStore = Adaptor<TypeConfig, Arc<Store>>;
+pub type Raft = openraft::Raft<TypeConfig, Network, LogStore, StateMachineStore>;
 
 pub mod typ {
     use openraft::BasicNode;
 
-    use crate::ExampleNodeId;
-    use crate::ExampleTypeConfig;
+    use crate::NodeId;
+    use crate::TypeConfig;
 
-    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<ExampleNodeId, E>;
-    pub type RPCError<E = openraft::error::Infallible> =
-        openraft::error::RPCError<ExampleNodeId, BasicNode, RaftError<E>>;
+    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<NodeId, E>;
+    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
 
-    pub type ClientWriteError = openraft::error::ClientWriteError<ExampleNodeId, BasicNode>;
-    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<ExampleNodeId, BasicNode>;
-    pub type ForwardToLeader = openraft::error::ForwardToLeader<ExampleNodeId, BasicNode>;
-    pub type InitializeError = openraft::error::InitializeError<ExampleNodeId, BasicNode>;
+    pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
+    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;
+    pub type ForwardToLeader = openraft::error::ForwardToLeader<NodeId, BasicNode>;
+    pub type InitializeError = openraft::error::InitializeError<NodeId, BasicNode>;
 
-    pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<ExampleTypeConfig>;
+    pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 }
 
-pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) -> std::io::Result<()> {
+pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std::io::Result<()> {
     // Create a configuration for the raft instance.
     let config = Config {
         heartbeat_interval: 500,
@@ -65,18 +65,20 @@ pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) 
     let config = Arc::new(config.validate().unwrap());
 
     // Create a instance of where the Raft data will be stored.
-    let store = Arc::new(ExampleStore::default());
+    let store = Arc::new(Store::default());
+
+    let (log_store, state_machine) = Adaptor::new(store.clone());
 
     // Create the network layer that will connect and communicate the raft instances and
     // will be used in conjunction with the store created above.
-    let network = ExampleNetwork {};
+    let network = Network {};
 
     // Create a local raft instance.
-    let raft = Raft::new(node_id, config.clone(), network, store.clone()).await.unwrap();
+    let raft = openraft::Raft::new(node_id, config.clone(), network, log_store, state_machine).await.unwrap();
 
     // Create an application that will store all the instances created above, this will
     // be later used on the actix-web services.
-    let app = Data::new(ExampleApp {
+    let app_data = Data::new(App {
         id: node_id,
         addr: http_addr.clone(),
         raft,
@@ -86,11 +88,11 @@ pub async fn start_example_raft_node(node_id: ExampleNodeId, http_addr: String) 
 
     // Start the actix-web server.
     let server = HttpServer::new(move || {
-        App::new()
+        actix_web::App::new()
             .wrap(Logger::default())
             .wrap(Logger::new("%a %{User-Agent}i"))
             .wrap(middleware::Compress::default())
-            .app_data(app.clone())
+            .app_data(app_data.clone())
             // raft internal RPC
             .service(raft::append)
             .service(raft::snapshot)

--- a/examples/raft-kv-memstore/src/network/management.rs
+++ b/examples/raft-kv-memstore/src/network/management.rs
@@ -3,16 +3,15 @@ use std::collections::BTreeSet;
 
 use actix_web::get;
 use actix_web::post;
-use actix_web::web;
 use actix_web::web::Data;
+use actix_web::web::Json;
 use actix_web::Responder;
 use openraft::error::Infallible;
 use openraft::BasicNode;
 use openraft::RaftMetrics;
-use web::Json;
 
-use crate::app::ExampleApp;
-use crate::ExampleNodeId;
+use crate::app::App;
+use crate::NodeId;
 
 // --- Cluster management
 
@@ -22,10 +21,7 @@ use crate::ExampleNodeId;
 /// This should be done before adding a node as a member into the cluster
 /// (by calling `change-membership`)
 #[post("/add-learner")]
-pub async fn add_learner(
-    app: Data<ExampleApp>,
-    req: Json<(ExampleNodeId, String)>,
-) -> actix_web::Result<impl Responder> {
+pub async fn add_learner(app: Data<App>, req: Json<(NodeId, String)>) -> actix_web::Result<impl Responder> {
     let node_id = req.0 .0;
     let node = BasicNode { addr: req.0 .1.clone() };
     let res = app.raft.add_learner(node_id, node, true).await;
@@ -34,17 +30,14 @@ pub async fn add_learner(
 
 /// Changes specified learners to members, or remove members.
 #[post("/change-membership")]
-pub async fn change_membership(
-    app: Data<ExampleApp>,
-    req: Json<BTreeSet<ExampleNodeId>>,
-) -> actix_web::Result<impl Responder> {
+pub async fn change_membership(app: Data<App>, req: Json<BTreeSet<NodeId>>) -> actix_web::Result<impl Responder> {
     let res = app.raft.change_membership(req.0, false).await;
     Ok(Json(res))
 }
 
 /// Initialize a single-node cluster.
 #[post("/init")]
-pub async fn init(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
+pub async fn init(app: Data<App>) -> actix_web::Result<impl Responder> {
     let mut nodes = BTreeMap::new();
     nodes.insert(app.id, BasicNode { addr: app.addr.clone() });
     let res = app.raft.initialize(nodes).await;
@@ -53,9 +46,9 @@ pub async fn init(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
 
 /// Get the latest metrics of the cluster
 #[get("/metrics")]
-pub async fn metrics(app: Data<ExampleApp>) -> actix_web::Result<impl Responder> {
+pub async fn metrics(app: Data<App>) -> actix_web::Result<impl Responder> {
     let metrics = app.raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<ExampleNodeId, BasicNode>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<NodeId, BasicNode>, Infallible> = Ok(metrics);
     Ok(Json(res))
 }

--- a/examples/raft-kv-memstore/src/network/mod.rs
+++ b/examples/raft-kv-memstore/src/network/mod.rs
@@ -1,4 +1,7 @@
 pub mod api;
 pub mod management;
 pub mod raft;
-pub mod raft_network_impl;
+mod raft_network_impl;
+
+pub use raft_network_impl::Network;
+pub use raft_network_impl::NetworkConnection;

--- a/examples/raft-kv-memstore/src/network/raft.rs
+++ b/examples/raft-kv-memstore/src/network/raft.rs
@@ -1,37 +1,33 @@
 use actix_web::post;
-use actix_web::web;
 use actix_web::web::Data;
+use actix_web::web::Json;
 use actix_web::Responder;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::InstallSnapshotRequest;
 use openraft::raft::VoteRequest;
-use web::Json;
 
-use crate::app::ExampleApp;
-use crate::ExampleNodeId;
-use crate::ExampleTypeConfig;
+use crate::app::App;
+use crate::NodeId;
+use crate::TypeConfig;
 
 // --- Raft communication
 
 #[post("/raft-vote")]
-pub async fn vote(app: Data<ExampleApp>, req: Json<VoteRequest<ExampleNodeId>>) -> actix_web::Result<impl Responder> {
+pub async fn vote(app: Data<App>, req: Json<VoteRequest<NodeId>>) -> actix_web::Result<impl Responder> {
     let res = app.raft.vote(req.0).await;
     Ok(Json(res))
 }
 
 #[post("/raft-append")]
-pub async fn append(
-    app: Data<ExampleApp>,
-    req: Json<AppendEntriesRequest<ExampleTypeConfig>>,
-) -> actix_web::Result<impl Responder> {
+pub async fn append(app: Data<App>, req: Json<AppendEntriesRequest<TypeConfig>>) -> actix_web::Result<impl Responder> {
     let res = app.raft.append_entries(req.0).await;
     Ok(Json(res))
 }
 
 #[post("/raft-snapshot")]
 pub async fn snapshot(
-    app: Data<ExampleApp>,
-    req: Json<InstallSnapshotRequest<ExampleTypeConfig>>,
+    app: Data<App>,
+    req: Json<InstallSnapshotRequest<TypeConfig>>,
 ) -> actix_web::Result<impl Responder> {
     let res = app.raft.install_snapshot(req.0).await;
     Ok(Json(res))

--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 use openraft::error::InstallSnapshotError;
 use openraft::error::NetworkError;
-use openraft::error::RPCError;
-use openraft::error::RaftError;
 use openraft::error::RemoteError;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
@@ -16,19 +14,20 @@ use openraft::RaftNetworkFactory;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::ExampleNodeId;
-use crate::ExampleTypeConfig;
+use crate::typ;
+use crate::NodeId;
+use crate::TypeConfig;
 
-pub struct ExampleNetwork {}
+pub struct Network {}
 
-impl ExampleNetwork {
+impl Network {
     pub async fn send_rpc<Req, Resp, Err>(
         &self,
-        target: ExampleNodeId,
+        target: NodeId,
         target_node: &BasicNode,
         uri: &str,
         req: Req,
-    ) -> Result<Resp, RPCError<ExampleNodeId, BasicNode, Err>>
+    ) -> Result<Resp, openraft::error::RPCError<NodeId, BasicNode, Err>>
     where
         Req: Serialize,
         Err: std::error::Error + DeserializeOwned,
@@ -37,68 +36,65 @@ impl ExampleNetwork {
         let addr = &target_node.addr;
 
         let url = format!("http://{}/{}", addr, uri);
-
         tracing::debug!("send_rpc to url: {}", url);
 
         let client = reqwest::Client::new();
-
         tracing::debug!("client is created for: {}", url);
 
-        let resp = client.post(url).json(&req).send().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        let resp = client
+            .post(url)
+            .json(&req)
+            .send()
+            .await
+            .map_err(|e| openraft::error::RPCError::Network(NetworkError::new(&e)))?;
 
         tracing::debug!("client.post() is sent");
 
-        let res: Result<Resp, Err> = resp.json().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        let res: Result<Resp, Err> =
+            resp.json().await.map_err(|e| openraft::error::RPCError::Network(NetworkError::new(&e)))?;
 
-        res.map_err(|e| RPCError::RemoteError(RemoteError::new(target, e)))
+        res.map_err(|e| openraft::error::RPCError::RemoteError(RemoteError::new(target, e)))
     }
 }
 
 // NOTE: This could be implemented also on `Arc<ExampleNetwork>`, but since it's empty, implemented
 // directly.
 #[async_trait]
-impl RaftNetworkFactory<ExampleTypeConfig> for ExampleNetwork {
-    type Network = ExampleNetworkConnection;
+impl RaftNetworkFactory<TypeConfig> for Network {
+    type Network = NetworkConnection;
 
-    async fn new_client(&mut self, target: ExampleNodeId, node: &BasicNode) -> Self::Network {
-        ExampleNetworkConnection {
-            owner: ExampleNetwork {},
+    async fn new_client(&mut self, target: NodeId, node: &BasicNode) -> Self::Network {
+        NetworkConnection {
+            owner: Network {},
             target,
             target_node: node.clone(),
         }
     }
 }
 
-pub struct ExampleNetworkConnection {
-    owner: ExampleNetwork,
-    target: ExampleNodeId,
+pub struct NetworkConnection {
+    owner: Network,
+    target: NodeId,
     target_node: BasicNode,
 }
 
 #[async_trait]
-impl RaftNetwork<ExampleTypeConfig> for ExampleNetworkConnection {
+impl RaftNetwork<TypeConfig> for NetworkConnection {
     async fn send_append_entries(
         &mut self,
-        req: AppendEntriesRequest<ExampleTypeConfig>,
-    ) -> Result<AppendEntriesResponse<ExampleNodeId>, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId>>>
-    {
+        req: AppendEntriesRequest<TypeConfig>,
+    ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-append", req).await
     }
 
     async fn send_install_snapshot(
         &mut self,
-        req: InstallSnapshotRequest<ExampleTypeConfig>,
-    ) -> Result<
-        InstallSnapshotResponse<ExampleNodeId>,
-        RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId, InstallSnapshotError>>,
-    > {
+        req: InstallSnapshotRequest<TypeConfig>,
+    ) -> Result<InstallSnapshotResponse<NodeId>, typ::RPCError<InstallSnapshotError>> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-snapshot", req).await
     }
 
-    async fn send_vote(
-        &mut self,
-        req: VoteRequest<ExampleNodeId>,
-    ) -> Result<VoteResponse<ExampleNodeId>, RPCError<ExampleNodeId, BasicNode, RaftError<ExampleNodeId>>> {
+    async fn send_vote(&mut self, req: VoteRequest<NodeId>) -> Result<VoteResponse<NodeId>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-vote", req).await
     }
 }

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -9,7 +9,7 @@ use maplit::btreeset;
 use openraft::BasicNode;
 use raft_kv_memstore::client::ExampleClient;
 use raft_kv_memstore::start_example_raft_node;
-use raft_kv_memstore::store::ExampleRequest;
+use raft_kv_memstore::store::Request;
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
 
@@ -170,7 +170,7 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     println!("=== write `foo=bar`");
     let _x = client
-        .write(&ExampleRequest::Set {
+        .write(&Request::Set {
             key: "foo".to_string(),
             value: "bar".to_string(),
         })
@@ -200,7 +200,7 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     println!("=== read `foo` on node 2");
     let _x = client2
-        .write(&ExampleRequest::Set {
+        .write(&Request::Set {
             key: "foo".to_string(),
             value: "wow".to_string(),
         })
@@ -253,7 +253,7 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     println!("=== write `foo=zoo` to node-3");
     let _x = client3
-        .write(&ExampleRequest::Set {
+        .write(&Request::Set {
             key: "foo".to_string(),
             value: "zoo".to_string(),
         })

--- a/examples/raft-kv-rocksdb/src/app.rs
+++ b/examples/raft-kv-rocksdb/src/app.rs
@@ -2,17 +2,17 @@ use std::sync::Arc;
 
 use openraft::Config;
 
-use crate::ExampleNodeId;
 use crate::ExampleRaft;
-use crate::ExampleStore;
+use crate::NodeId;
+use crate::Store;
 
 // Representation of an application state. This struct can be shared around to share
 // instances of raft, store and more.
-pub struct ExampleApp {
-    pub id: ExampleNodeId,
+pub struct App {
+    pub id: NodeId,
     pub api_addr: String,
     pub rcp_addr: String,
     pub raft: ExampleRaft,
-    pub store: Arc<ExampleStore>,
+    pub store: Arc<Store>,
     pub config: Arc<Config>,
 }

--- a/examples/raft-kv-rocksdb/src/bin/main.rs
+++ b/examples/raft-kv-rocksdb/src/bin/main.rs
@@ -1,12 +1,6 @@
 use clap::Parser;
-use openraft::Raft;
-use raft_kv_rocksdb::network::raft_network_impl::ExampleNetwork;
 use raft_kv_rocksdb::start_example_raft_node;
-use raft_kv_rocksdb::store::ExampleStore;
-use raft_kv_rocksdb::ExampleTypeConfig;
 use tracing_subscriber::EnvFilter;
-
-pub type ExampleRaft = Raft<ExampleTypeConfig, ExampleNetwork, ExampleStore>;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/examples/raft-kv-rocksdb/src/network.rs
+++ b/examples/raft-kv-rocksdb/src/network.rs
@@ -1,4 +1,7 @@
 pub mod api;
 pub mod management;
 pub mod raft;
-pub mod raft_network_impl;
+mod raft_network_impl;
+
+pub use raft_network_impl::Network;
+pub use raft_network_impl::NetworkConnection;

--- a/examples/raft-kv-rocksdb/src/network/management.rs
+++ b/examples/raft-kv-rocksdb/src/network/management.rs
@@ -9,9 +9,9 @@ use tide::Request;
 use tide::Response;
 use tide::StatusCode;
 
-use crate::app::ExampleApp;
-use crate::ExampleNode;
-use crate::ExampleNodeId;
+use crate::app::App;
+use crate::Node;
+use crate::NodeId;
 use crate::Server;
 
 // --- Cluster management
@@ -29,24 +29,24 @@ pub fn rest(app: &mut Server) {
 /// A Learner receives log replication from the leader but does not vote.
 /// This should be done before adding a node as a member into the cluster
 /// (by calling `change-membership`)
-async fn add_learner(mut req: Request<Arc<ExampleApp>>) -> tide::Result {
-    let (node_id, api_addr, rpc_addr): (ExampleNodeId, String, String) = req.body_json().await?;
-    let node = ExampleNode { rpc_addr, api_addr };
+async fn add_learner(mut req: Request<Arc<App>>) -> tide::Result {
+    let (node_id, api_addr, rpc_addr): (NodeId, String, String) = req.body_json().await?;
+    let node = Node { rpc_addr, api_addr };
     let res = req.state().raft.add_learner(node_id, node, true).await;
     Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
 }
 
 /// Changes specified learners to members, or remove members.
-async fn change_membership(mut req: Request<Arc<ExampleApp>>) -> tide::Result {
-    let body: BTreeSet<ExampleNodeId> = req.body_json().await?;
+async fn change_membership(mut req: Request<Arc<App>>) -> tide::Result {
+    let body: BTreeSet<NodeId> = req.body_json().await?;
     let res = req.state().raft.change_membership(body, false).await;
     Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
 }
 
 /// Initialize a single-node cluster.
-async fn init(req: Request<Arc<ExampleApp>>) -> tide::Result {
+async fn init(req: Request<Arc<App>>) -> tide::Result {
     let mut nodes = BTreeMap::new();
-    let node = ExampleNode {
+    let node = Node {
         api_addr: req.state().api_addr.clone(),
         rpc_addr: req.state().rcp_addr.clone(),
     };
@@ -57,9 +57,9 @@ async fn init(req: Request<Arc<ExampleApp>>) -> tide::Result {
 }
 
 /// Get the latest metrics of the cluster
-async fn metrics(req: Request<Arc<ExampleApp>>) -> tide::Result {
+async fn metrics(req: Request<Arc<App>>) -> tide::Result {
     let metrics = req.state().raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<ExampleNodeId, ExampleNode>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<NodeId, Node>, Infallible> = Ok(metrics);
     Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
 }

--- a/examples/raft-kv-rocksdb/src/network/raft.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft.rs
@@ -8,36 +8,38 @@ use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
 use toy_rpc::macros::export_impl;
 
-use crate::app::ExampleApp;
-use crate::ExampleTypeConfig;
+use crate::app::App;
+use crate::TypeConfig;
 
-// --- Raft communication
-
+/// Raft protocol service.
 pub struct Raft {
-    app: Arc<ExampleApp>,
+    app: Arc<App>,
 }
 
 #[export_impl]
 impl Raft {
-    pub fn new(app: Arc<ExampleApp>) -> Self {
+    pub fn new(app: Arc<App>) -> Self {
         Self { app }
     }
+
     #[export_method]
     pub async fn vote(&self, vote: VoteRequest<u64>) -> Result<VoteResponse<u64>, toy_rpc::Error> {
         self.app.raft.vote(vote).await.map_err(|e| toy_rpc::Error::Internal(Box::new(e)))
     }
+
     #[export_method]
     pub async fn append(
         &self,
-        req: AppendEntriesRequest<ExampleTypeConfig>,
+        req: AppendEntriesRequest<TypeConfig>,
     ) -> Result<AppendEntriesResponse<u64>, toy_rpc::Error> {
         tracing::debug!("handle append");
         self.app.raft.append_entries(req).await.map_err(|e| toy_rpc::Error::Internal(Box::new(e)))
     }
+
     #[export_method]
     pub async fn snapshot(
         &self,
-        req: InstallSnapshotRequest<ExampleTypeConfig>,
+        req: InstallSnapshotRequest<TypeConfig>,
     ) -> Result<InstallSnapshotResponse<u64>, toy_rpc::Error> {
         self.app.raft.install_snapshot(req).await.map_err(|e| toy_rpc::Error::Internal(Box::new(e)))
     }

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -9,8 +9,8 @@ use maplit::btreemap;
 use maplit::btreeset;
 use raft_kv_rocksdb::client::ExampleClient;
 use raft_kv_rocksdb::start_example_raft_node;
-use raft_kv_rocksdb::store::ExampleRequest;
-use raft_kv_rocksdb::ExampleNode;
+use raft_kv_rocksdb::store::Request;
+use raft_kv_rocksdb::Node;
 use tracing_subscriber::EnvFilter;
 
 pub fn log_panic(panic: &PanicInfo) {
@@ -126,9 +126,9 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
     assert_eq!(
         btreemap! {
-            1 => ExampleNode{rpc_addr: get_rpc_addr(1), api_addr: get_addr(1)},
-            2 => ExampleNode{rpc_addr: get_rpc_addr(2), api_addr: get_addr(2)},
-            3 => ExampleNode{rpc_addr: get_rpc_addr(3), api_addr: get_addr(3)},
+            1 => Node{rpc_addr: get_rpc_addr(1), api_addr: get_addr(1)},
+            2 => Node{rpc_addr: get_rpc_addr(2), api_addr: get_addr(2)},
+            3 => Node{rpc_addr: get_rpc_addr(3), api_addr: get_addr(3)},
         },
         nodes_in_cluster
     );
@@ -164,7 +164,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("=== write `foo=bar`");
     let _x = leader
-        .write(&ExampleRequest::Set {
+        .write(&Request::Set {
             key: "foo".to_string(),
             value: "bar".to_string(),
         })
@@ -194,7 +194,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("=== read `foo` on node 2");
     let _x = client2
-        .write(&ExampleRequest::Set {
+        .write(&Request::Set {
             key: "foo".to_string(),
             value: "wow".to_string(),
         })
@@ -227,7 +227,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     match x {
         Err(e) => {
             let s = e.to_string();
-            let expect_err:String = "error occur on remote peer 2: has to forward request to: Some(1), Some(ExampleNode { rpc_addr: \"127.0.0.1:22001\", api_addr: \"127.0.0.1:21001\" })".to_string();
+            let expect_err:String = "error occur on remote peer 2: has to forward request to: Some(1), Some(Node { rpc_addr: \"127.0.0.1:22001\", api_addr: \"127.0.0.1:21001\" })".to_string();
 
             assert_eq!(s, expect_err);
         }

--- a/memstore/src/test.rs
+++ b/memstore/src/test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use openraft::storage::Adaptor;
 use openraft::testing::StoreBuilder;
 use openraft::testing::Suite;
 use openraft::StorageError;
@@ -11,10 +12,13 @@ use crate::MemStore;
 
 struct MemBuilder {}
 #[async_trait]
-impl StoreBuilder<Config, Arc<MemStore>> for MemBuilder {
-    async fn build(&self) -> Result<((), Arc<MemStore>), StorageError<MemNodeId>> {
+impl StoreBuilder<Config, Adaptor<Config, Arc<MemStore>>, Adaptor<Config, Arc<MemStore>>> for MemBuilder {
+    async fn build(
+        &self,
+    ) -> Result<((), Adaptor<Config, Arc<MemStore>>, Adaptor<Config, Arc<MemStore>>), StorageError<MemNodeId>> {
         let store = MemStore::new_async().await;
-        Ok(((), store))
+        let (log_store, sm) = Adaptor::new(store);
+        Ok(((), log_store, sm))
     }
 }
 

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -14,20 +14,20 @@ use tracing::Level;
 use tracing::Span;
 
 use crate::raft::RaftMsg;
+use crate::storage::RaftLogStorage;
 use crate::RaftNetworkFactory;
-use crate::RaftStorage;
 use crate::RaftTypeConfig;
 
 /// Emit RaftMsg::Tick event at regular `interval`.
-pub(crate) struct Tick<C, N, S>
+pub(crate) struct Tick<C, N, LS>
 where
     C: RaftTypeConfig,
     N: RaftNetworkFactory<C>,
-    S: RaftStorage<C>,
+    LS: RaftLogStorage<C>,
 {
     interval: Duration,
 
-    tx: mpsc::UnboundedSender<RaftMsg<C, N, S>>,
+    tx: mpsc::UnboundedSender<RaftMsg<C, N, LS>>,
 
     /// Emit event or not
     enabled: Arc<AtomicBool>,
@@ -38,13 +38,13 @@ pub(crate) struct TickHandle {
     join_handle: JoinHandle<()>,
 }
 
-impl<C, N, S> Tick<C, N, S>
+impl<C, N, LS> Tick<C, N, LS>
 where
     C: RaftTypeConfig,
     N: RaftNetworkFactory<C>,
-    S: RaftStorage<C>,
+    LS: RaftLogStorage<C>,
 {
-    pub(crate) fn spawn(interval: Duration, tx: mpsc::UnboundedSender<RaftMsg<C, N, S>>, enabled: bool) -> TickHandle {
+    pub(crate) fn spawn(interval: Duration, tx: mpsc::UnboundedSender<RaftMsg<C, N, LS>>, enabled: bool) -> TickHandle {
         let enabled = Arc::new(AtomicBool::from(enabled));
         let this = Self {
             interval,

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -1,9 +1,8 @@
 use crate::log_id::RaftLogId;
-use crate::storage::StorageHelper;
+use crate::storage::RaftLogReaderExt;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::NodeId;
-use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 
@@ -43,14 +42,14 @@ where NID: NodeId
     /// A-------B-------C : find(A,B); find(B,C)   // both find `B`, need to de-dup
     /// A-------C-------C : find(A,C)
     /// ```
-    pub(crate) async fn load_log_ids<C, Sto>(
+    pub(crate) async fn load_log_ids<C, LRX>(
         last_purged_log_id: Option<LogId<NID>>,
         last_log_id: Option<LogId<NID>>,
-        sto: &mut StorageHelper<'_, C, Sto>,
+        sto: &mut LRX,
     ) -> Result<LogIdList<NID>, StorageError<NID>>
     where
         C: RaftTypeConfig<NodeId = NID>,
-        Sto: RaftStorage<C>,
+        LRX: RaftLogReaderExt<C>,
     {
         let mut res = vec![];
 

--- a/openraft/src/storage/adapter.rs
+++ b/openraft/src/storage/adapter.rs
@@ -1,0 +1,207 @@
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::ops::DerefMut;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use tokio::sync::RwLockReadGuard;
+use tokio::sync::RwLockWriteGuard;
+
+use crate::storage::v2::sealed::Sealed;
+use crate::storage::LogFlushed;
+use crate::storage::RaftLogStorage;
+use crate::storage::RaftStateMachine;
+use crate::LogId;
+use crate::LogState;
+use crate::RaftLogReader;
+use crate::RaftStorage;
+use crate::RaftTypeConfig;
+use crate::Snapshot;
+use crate::SnapshotMeta;
+use crate::StorageError;
+use crate::StoredMembership;
+use crate::Vote;
+
+/// An adapter that allows an implementation of [`RaftStorage`] to be used in the latest framework.
+///
+/// It hide an implementation of [`RaftStorage`] behind a RWLock.
+/// Therefore, it provides full functionalities but without any parallelism.
+///
+/// `Adaptor` implements both [`RaftLogStorage`] and [`RaftStateMachine`],
+/// and just pass the calls to the underlying [`RaftStorage`].
+///
+/// To use the old [`RaftStorage`] implementation in the latest framework:
+/// ```ignore
+/// # use std::sync::Arc;
+/// # use openraft::{Config, Raft};
+/// # use openraft::storage::Adaptor;
+///
+/// let store = MyRaftStorage::new();
+/// let (log_store, state_machine) = Adaptor::new(store);
+/// Raft::new(1, Arc::new(Config::default()), MyNetwork::default(), log_store, state_machine);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Adaptor<C, S>
+where
+    C: RaftTypeConfig,
+    S: RaftStorage<C>,
+{
+    storage: Arc<RwLock<S>>,
+    _phantom: PhantomData<C>,
+}
+
+impl<C, S> Default for Adaptor<C, S>
+where
+    C: RaftTypeConfig,
+    S: RaftStorage<C> + Default,
+{
+    fn default() -> Self {
+        Self::create(Arc::new(RwLock::new(S::default())))
+    }
+}
+
+impl<C, S> Adaptor<C, S>
+where
+    C: RaftTypeConfig,
+    S: RaftStorage<C>,
+{
+    /// Create a [`RaftLogStorage`] and a [`RaftStateMachine`] upon an implementation of
+    /// [`RaftStorage`].
+    pub fn new(store: S) -> (Self, Self) {
+        let s = Arc::new(RwLock::new(store));
+
+        let log_store = Adaptor::create(s.clone());
+        let state_machine = Adaptor::create(s);
+
+        (log_store, state_machine)
+    }
+
+    fn create(storage: Arc<RwLock<S>>) -> Self {
+        Self {
+            storage,
+            _phantom: PhantomData::default(),
+        }
+    }
+
+    // TODO(1): make it private because only tests need it.
+    //          rewrite memstore with separated log-store and state machine.
+    /// Get a write lock of the underlying storage.
+    pub async fn storage_mut(&self) -> RwLockWriteGuard<S> {
+        self.storage.write().await
+    }
+
+    /// Get a read lock of the underlying storage.
+    pub async fn storage(&self) -> RwLockReadGuard<S> {
+        self.storage.read().await
+    }
+}
+
+#[async_trait]
+impl<C, S> RaftLogReader<C> for Adaptor<C, S>
+where
+    C: RaftTypeConfig,
+    S: RaftStorage<C>,
+{
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>> {
+        S::get_log_state(self.storage_mut().await.deref_mut()).await
+    }
+
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+        S::try_get_log_entries(self.storage_mut().await.deref_mut(), range).await
+    }
+}
+
+impl<C, S> Sealed for Adaptor<C, S>
+where
+    C: RaftTypeConfig,
+    S: RaftStorage<C>,
+{
+}
+
+#[async_trait]
+impl<C, S> RaftLogStorage<C> for Adaptor<C, S>
+where
+    C: RaftTypeConfig,
+    S: RaftStorage<C>,
+{
+    type LogReader = S::LogReader;
+
+    async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+        S::save_vote(self.storage_mut().await.deref_mut(), vote).await
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>> {
+        S::read_vote(self.storage_mut().await.deref_mut()).await
+    }
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        S::get_log_reader(self.storage_mut().await.deref_mut()).await
+    }
+
+    async fn append<I>(&mut self, entries: I, callback: LogFlushed<C::NodeId>) -> Result<(), StorageError<C::NodeId>>
+    where I: IntoIterator<Item = C::Entry> + Send {
+        // Default implementation that calls the flush-before-return `append_to_log`.
+
+        S::append_to_log(self.storage_mut().await.deref_mut(), entries).await?;
+        callback.log_io_completed(Ok(()));
+
+        Ok(())
+    }
+
+    async fn truncate(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+        S::delete_conflict_logs_since(self.storage_mut().await.deref_mut(), log_id).await
+    }
+
+    async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+        S::purge_logs_upto(self.storage_mut().await.deref_mut(), log_id).await
+    }
+}
+
+#[async_trait]
+impl<C, S> RaftStateMachine<C> for Adaptor<C, S>
+where
+    C: RaftTypeConfig,
+    S: RaftStorage<C>,
+{
+    type SnapshotData = S::SnapshotData;
+    type SnapshotBuilder = S::SnapshotBuilder;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<(Option<LogId<C::NodeId>>, StoredMembership<C::NodeId, C::Node>), StorageError<C::NodeId>> {
+        S::last_applied_state(self.storage_mut().await.deref_mut()).await
+    }
+
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<C::R>, StorageError<C::NodeId>>
+    where I: IntoIterator<Item = C::Entry> + Send {
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        S::apply_to_state_machine(self.storage_mut().await.deref_mut(), &entries).await
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        S::get_snapshot_builder(self.storage_mut().await.deref_mut()).await
+    }
+
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError<C::NodeId>> {
+        S::begin_receiving_snapshot(self.storage_mut().await.deref_mut()).await
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapshotMeta<C::NodeId, C::Node>,
+        snapshot: Box<Self::SnapshotData>,
+    ) -> Result<(), StorageError<C::NodeId>> {
+        S::install_snapshot(self.storage_mut().await.deref_mut(), meta, snapshot).await
+    }
+
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<C::NodeId, C::Node, Self::SnapshotData>>, StorageError<C::NodeId>> {
+        S::get_current_snapshot(self.storage_mut().await.deref_mut()).await
+    }
+}

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -1,0 +1,92 @@
+//! Callbacks used by Storage API
+
+use std::io;
+
+use tokio::sync::oneshot;
+
+use crate::display_ext::DisplayOption;
+use crate::LogId;
+use crate::NodeId;
+use crate::RaftTypeConfig;
+use crate::StorageIOError;
+
+/// A oneshot callback for completion of log io operation.
+pub struct LogFlushed<NID>
+where NID: NodeId
+{
+    last_log_id: Option<LogId<NID>>,
+    tx: oneshot::Sender<Result<Option<LogId<NID>>, io::Error>>,
+}
+
+impl<NID> LogFlushed<NID>
+where NID: NodeId
+{
+    pub(crate) fn new(
+        last_log_id: Option<LogId<NID>>,
+        tx: oneshot::Sender<Result<Option<LogId<NID>>, io::Error>>,
+    ) -> Self {
+        Self { last_log_id, tx }
+    }
+
+    /// Report log io completion event.
+    ///
+    /// It will be called when the log is successfully appended to the storage or an error occurs.
+    pub fn log_io_completed(self, result: Result<(), io::Error>) {
+        let res = if let Err(e) = result {
+            tracing::error!(
+                "LogFlush error: {}, while flushing upto {}",
+                e,
+                DisplayOption(&self.last_log_id)
+            );
+            self.tx.send(Err(e))
+        } else {
+            self.tx.send(Ok(self.last_log_id))
+        };
+
+        if let Err(e) = res {
+            tracing::error!("failed to send log io completion event: {:?}", e);
+        }
+    }
+}
+
+/// A oneshot callback for completion of applying logs to state machine.
+pub struct LogApplied<C>
+where C: RaftTypeConfig
+{
+    last_log_id: LogId<C::NodeId>,
+    tx: oneshot::Sender<Result<(LogId<C::NodeId>, Vec<C::R>), StorageIOError<C::NodeId>>>,
+}
+
+impl<C> LogApplied<C>
+where C: RaftTypeConfig
+{
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        last_log_id: LogId<C::NodeId>,
+        tx: oneshot::Sender<Result<(LogId<C::NodeId>, Vec<C::R>), StorageIOError<C::NodeId>>>,
+    ) -> Self {
+        Self { last_log_id, tx }
+    }
+
+    /// Report apply io completion event.
+    ///
+    /// It will be called when the log is successfully applied to the state machine or an error
+    /// occurs.
+    pub fn completed(self, result: Result<Vec<C::R>, StorageIOError<C::NodeId>>) {
+        let res = match result {
+            Ok(x) => {
+                tracing::debug!("LogApplied upto {}", self.last_log_id);
+                let resp = (self.last_log_id, x);
+                self.tx.send(Ok(resp))
+            }
+            Err(e) => {
+                tracing::error!("LogApplied error: {}, while applying upto {}", e, self.last_log_id);
+                self.tx.send(Err(e))
+            }
+        };
+
+        if let Err(_e) = res {
+            tracing::error!("failed to send apply complete event, last_log_id: {}", self.last_log_id);
+        }
+    }
+}

--- a/openraft/src/storage/log_store_ext.rs
+++ b/openraft/src/storage/log_store_ext.rs
@@ -1,0 +1,60 @@
+use std::fmt::Debug;
+use std::ops::RangeBounds;
+
+use async_trait::async_trait;
+
+use crate::defensive::check_range_matches_entries;
+use crate::LogId;
+use crate::LogIdOptionExt;
+use crate::RaftLogId;
+use crate::RaftLogReader;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+
+#[async_trait]
+pub trait RaftLogReaderExt<C>: RaftLogReader<C>
+where C: RaftTypeConfig
+{
+    /// Try to get an log entry.
+    ///
+    /// It does not return an error if the log entry at `log_index` is not found.
+    async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<C::Entry>, StorageError<C::NodeId>> {
+        let mut res = self.try_get_log_entries(log_index..(log_index + 1)).await?;
+        Ok(res.pop())
+    }
+
+    /// Get a series of log entries from storage.
+    ///
+    /// Similar to `try_get_log_entries` except an error will be returned if there is an entry not
+    /// found in the specified range.
+    async fn get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+        let res = self.try_get_log_entries(range.clone()).await?;
+
+        check_range_matches_entries::<C, _>(range, &res)?;
+
+        Ok(res)
+    }
+
+    /// Get the log id of the entry at `index`.
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C::NodeId>> {
+        let st = self.get_log_state().await?;
+
+        if Some(log_index) == st.last_purged_log_id.index() {
+            return Ok(st.last_purged_log_id.unwrap());
+        }
+
+        let entries = self.get_log_entries(log_index..=log_index).await?;
+
+        Ok(*entries[0].get_log_id())
+    }
+}
+
+impl<C, LR> RaftLogReaderExt<C> for LR
+where
+    C: RaftTypeConfig,
+    LR: RaftLogReader<C>,
+{
+}

--- a/openraft/src/storage/v2.rs
+++ b/openraft/src/storage/v2.rs
@@ -1,0 +1,123 @@
+//! Defines [`RaftLogStorage`] and [`RaftStateMachine`] trait to replace the previous
+//! [`RaftStorage`](`crate::storage::RaftStorage`). [`RaftLogStorage`] is responsible for storing
+//! logs, and [`RaftStateMachine`] is responsible for storing state machine and snapshot.
+
+use async_trait::async_trait;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncSeek;
+use tokio::io::AsyncWrite;
+
+use crate::storage::callback::LogFlushed;
+use crate::storage::v2::sealed::Sealed;
+use crate::LogId;
+use crate::RaftLogReader;
+use crate::RaftSnapshotBuilder;
+use crate::RaftTypeConfig;
+use crate::Snapshot;
+use crate::SnapshotMeta;
+use crate::StorageError;
+use crate::StoredMembership;
+use crate::Vote;
+
+pub(crate) mod sealed {
+    /// Seal [`RaftLogStorage`] and [`RaftStateMachine`]. This is to prevent users from implementing
+    /// them before being stable.
+    pub trait Sealed {}
+}
+
+#[async_trait]
+pub trait RaftLogStorage<C>: Sealed + RaftLogReader<C> + Send + Sync + 'static
+where C: RaftTypeConfig
+{
+    type LogReader: RaftLogReader<C>;
+
+    async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C::NodeId>>;
+
+    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>>;
+
+    async fn get_log_reader(&mut self) -> Self::LogReader;
+
+    /// Append log entries and call the `callback` once logs are persisted on disk.
+    ///
+    /// It should returns immediately after saving the input log entries in memory, and calls the
+    /// `callback` when the entries are persisted on disk, i.e., avoid blocking.
+    ///
+    /// This method is still async because preparing preparing the IO is usually async.
+    ///
+    /// To ensure correctness:
+    ///
+    /// - When this method returns, the entries must be readable, i.e., a `LogReader` can read these
+    ///   entries.
+    ///
+    /// - When the `callback` is called, the entries must be persisted on disk.
+    ///
+    ///   NOTE that: the `callback` can be called either before or after this method returns.
+    ///
+    /// - There must not be a **hole** in logs. Because Raft only examine the last log id to ensure
+    ///   correctness.
+    async fn append<I>(&mut self, entries: I, callback: LogFlushed<C::NodeId>) -> Result<(), StorageError<C::NodeId>>
+    where I: IntoIterator<Item = C::Entry> + Send;
+
+    /// Truncate logs since `log_id`, inclusive
+    async fn truncate(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>>;
+
+    /// Purge logs upto `log_id`, inclusive
+    async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>>;
+}
+
+#[async_trait]
+pub trait RaftStateMachine<C>: Sealed + Send + Sync + 'static
+where C: RaftTypeConfig
+{
+    type SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + Send + Sync + Unpin + 'static;
+
+    type SnapshotBuilder: RaftSnapshotBuilder<C, Self::SnapshotData>;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<(Option<LogId<C::NodeId>>, StoredMembership<C::NodeId, C::Node>), StorageError<C::NodeId>>;
+
+    /// Apply the given payload of entries to the state machine.
+    ///
+    /// The Raft protocol guarantees that only logs which have been _committed_, that is, logs which
+    /// have been replicated to a quorum of the cluster, will be applied to the state machine.
+    ///
+    /// This is where the business logic of interacting with your application's state machine
+    /// should live. This is 100% application specific. Perhaps this is where an application
+    /// specific transaction is being started, or perhaps committed. This may be where a key/value
+    /// is being stored.
+    ///
+    /// For every entry to apply, an implementation should:
+    /// - Store the log id as last applied log id.
+    /// - Deal with the business logic log.
+    /// - Store membership config if `RaftEntry::get_membership()` returns `Some`.
+    ///
+    /// Note that for a membership log, the implementation need to do nothing about it, except
+    /// storing it.
+    ///
+    /// An implementation may choose to persist either the state machine or the snapshot:
+    ///
+    /// - An implementation with persistent state machine: persists the state on disk before
+    ///   returning from `apply_to_state_machine()`. So that a snapshot does not need to be
+    ///   persistent.
+    ///
+    /// - An implementation with persistent snapshot: `apply_to_state_machine()` does not have to
+    ///   persist state on disk. But every snapshot has to be persistent. And when starting up the
+    ///   application, the state machine should be rebuilt from the last snapshot.
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<C::R>, StorageError<C::NodeId>>
+    where I: IntoIterator<Item = C::Entry> + Send;
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder;
+
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError<C::NodeId>>;
+
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapshotMeta<C::NodeId, C::Node>,
+        snapshot: Box<Self::SnapshotData>,
+    ) -> Result<(), StorageError<C::NodeId>>;
+
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<C::NodeId, C::Node, Self::SnapshotData>>, StorageError<C::NodeId>>;
+}

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -1,12 +1,20 @@
 mod store_builder;
 mod suite;
 
+use anyerror::AnyError;
 pub use store_builder::StoreBuilder;
 pub use suite::Suite;
+use tokio::sync::oneshot;
 
+use crate::log_id::RaftLogId;
+use crate::storage::LogFlushed;
+use crate::storage::RaftLogStorage;
 use crate::BasicNode;
 use crate::CommittedLeaderId;
 use crate::LogId;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+use crate::StorageIOError;
 
 crate::declare_raft_types!(
     /// Dummy Raft types for the purpose of testing internal structures requiring
@@ -20,4 +28,23 @@ pub fn log_id(term: u64, index: u64) -> LogId<u64> {
         leader_id: CommittedLeaderId::new(term, 1),
         index,
     }
+}
+
+/// Append to log and wait for the log to be flushed.
+pub async fn blocking_append<C: RaftTypeConfig, LS: RaftLogStorage<C>, I>(
+    log_store: &mut LS,
+    entries: I,
+) -> Result<(), StorageError<C::NodeId>>
+where
+    I: IntoIterator<Item = C::Entry>,
+{
+    let entries = entries.into_iter().collect::<Vec<_>>();
+    let last_log_id = entries.last().map(|e| *e.get_log_id()).unwrap();
+
+    let (tx, rx) = oneshot::channel();
+    let cb = LogFlushed::new(Some(last_log_id), tx);
+    log_store.append(entries, cb).await?;
+    rx.await.unwrap().map_err(|e| StorageIOError::write_logs(AnyError::error(e)))?;
+
+    Ok(())
 }

--- a/openraft/src/testing/store_builder.rs
+++ b/openraft/src/testing/store_builder.rs
@@ -1,23 +1,27 @@
 use async_trait::async_trait;
 
-use crate::RaftStorage;
+use crate::storage::RaftLogStorage;
+use crate::storage::RaftStateMachine;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 
-/// The trait to build a [`RaftStorage`] implementation.
+/// The trait to build a [`RaftLogStorage`] and [`RaftStateMachine`] implementation.
 ///
-/// The generic parameter `C` is type config for a `RaftStorage` implementation,
-/// `S` is the type that implements `RaftStorage`,
+/// The generic parameter `C` is type config for a `RaftLogStorage` and `RaftStateMachine`
+/// implementation,
+/// `LS` is the type that implements `RaftLogStorage`,
+/// `SM` is the type that implements `RaftStateMachine`,
 /// and `G` is a guard type that cleanup resource when being dropped.
 ///
 /// By default `G` is a trivial guard `()`. To test a store that is backed by a folder on disk, `G`
 /// could be the dropper of the temp-dir that stores data.
 #[async_trait]
-pub trait StoreBuilder<C, S, G = ()>: Send + Sync
+pub trait StoreBuilder<C, LS, SM, G = ()>: Send + Sync
 where
     C: RaftTypeConfig,
-    S: RaftStorage<C>,
+    LS: RaftLogStorage<C>,
+    SM: RaftStateMachine<C>,
 {
-    /// Build a [`RaftStorage`] implementation
-    async fn build(&self) -> Result<(G, S), StorageError<C::NodeId>>;
+    /// Build a [`RaftLogStorage`] implementation
+    async fn build(&self) -> Result<(G, LS, SM), StorageError<C::NodeId>>;
 }

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -4,14 +4,20 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::option::Option::None;
 
+use anyerror::AnyError;
 use maplit::btreeset;
+use tokio::sync::oneshot;
 
 use crate::entry::RaftEntry;
 use crate::log_id::RaftLogId;
 use crate::membership::EffectiveMembership;
 use crate::raft_state::LogStateReader;
 use crate::raft_state::RaftState;
+use crate::storage::LogFlushed;
 use crate::storage::LogState;
+use crate::storage::RaftLogReaderExt;
+use crate::storage::RaftLogStorage;
+use crate::storage::RaftStateMachine;
 use crate::storage::StorageHelper;
 use crate::testing::StoreBuilder;
 use crate::vote::CommittedLeaderId;
@@ -21,9 +27,9 @@ use crate::LogId;
 use crate::Membership;
 use crate::NodeId;
 use crate::RaftSnapshotBuilder;
-use crate::RaftStorage;
 use crate::RaftTypeConfig;
 use crate::StorageError;
+use crate::StorageIOError;
 use crate::StoredMembership;
 use crate::Vote;
 
@@ -40,31 +46,29 @@ macro_rules! btreeset {
 }
 
 /// Test suite to ensure a `RaftStore` impl works as expected.
-///
-/// Usage:
-pub struct Suite<C, S, B, G>
+pub struct Suite<C, LS, SM, B, G>
 where
     C: RaftTypeConfig,
     C::D: AppData + Debug,
     C::R: AppDataResponse + Debug,
-    S: RaftStorage<C>,
-    B: StoreBuilder<C, S, G>,
+    LS: RaftLogStorage<C>,
+    SM: RaftStateMachine<C>,
+    B: StoreBuilder<C, LS, SM, G>,
     G: Send + Sync,
 {
-    c: PhantomData<C>,
-    p: PhantomData<S>,
-    f: PhantomData<B>,
-    g: PhantomData<G>,
+    _p: PhantomData<(C, LS, SM, B, G)>,
 }
 
-impl<C, S, B, G> Suite<C, S, B, G>
+#[allow(unused)]
+impl<C, LS, SM, B, G> Suite<C, LS, SM, B, G>
 where
     C: RaftTypeConfig,
     C::D: AppData + Debug,
     C::R: AppDataResponse + Debug,
     C::NodeId: From<u64>,
-    S: RaftStorage<C>,
-    B: StoreBuilder<C, S, G>,
+    LS: RaftLogStorage<C>,
+    SM: RaftStateMachine<C>,
+    B: StoreBuilder<C, LS, SM, G>,
     G: Send + Sync,
 {
     pub fn test_all(builder: B) -> Result<(), StorageError<C::NodeId>> {
@@ -110,55 +114,56 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log_initial(mut store: S) -> Result<(), StorageError<C::NodeId>> {
-        let membership = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
+    pub async fn last_membership_in_log_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+        let membership = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
 
         assert!(membership.is_empty());
 
         Ok(())
     }
 
-    pub async fn last_membership_in_log(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- no log, do not read membership from state machine");
         {
-            store
-                .apply_to_state_machine(&[blank_ent::<C>(1, 1), membership_ent::<C>(1, 1, btreeset! {3,4,5})])
-                .await?;
+            apply(&mut sm, [
+                blank_ent::<C>(1, 1),
+                membership_ent::<C>(1, 1, btreeset! {3,4,5}),
+            ])
+            .await?;
 
-            let mem = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
+            let mem = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
 
             assert!(mem.is_empty());
         }
 
         tracing::info!("--- membership presents in log, smaller than last_applied, read from log");
         {
-            store.append_to_log([membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
-            let mem = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
+            let mem = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
             assert_eq!(1, mem.len());
             let mem = mem[0].clone();
             assert_eq!(&Membership::new(vec![btreeset! {1, 2, 3}], None), mem.membership(),);
 
-            let mem = StorageHelper::new(&mut store).last_membership_in_log(1).await?;
+            let mem = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(1).await?;
             assert_eq!(1, mem.len());
             let mem = mem[0].clone();
             assert_eq!(&Membership::new(vec![btreeset! {1, 2, 3}], None), mem.membership(),);
 
-            let mem = StorageHelper::new(&mut store).last_membership_in_log(2).await?;
+            let mem = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(2).await?;
             assert!(mem.is_empty());
         }
 
         tracing::info!("--- membership presents in log and > sm.last_applied, read 2 membership entries from log");
         {
-            store
-                .append_to_log([
-                    blank_ent::<C>(1, 2),
-                    membership_ent::<C>(1, 3, btreeset! {7,8,9}),
-                    blank_ent::<C>(1, 4),
-                ])
-                .await?;
+            append(&mut store, [
+                blank_ent::<C>(1, 2),
+                membership_ent::<C>(1, 3, btreeset! {7,8,9}),
+                blank_ent::<C>(1, 4),
+            ])
+            .await?;
 
-            let mems = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
+            let mems = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
             assert_eq!(2, mems.len());
 
             let mem = mems[0].clone();
@@ -170,15 +175,15 @@ where
 
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log but since_index is greater than the last");
         {
-            let mem = StorageHelper::new(&mut store).last_membership_in_log(4).await?;
+            let mem = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(4).await?;
             assert!(mem.is_empty());
         }
 
         tracing::info!("--- 3 memberships in log, only return the last 2 of them");
         {
-            store.append_to_log([membership_ent::<C>(1, 5, btreeset! {10,11})]).await?;
+            append(&mut store, [membership_ent::<C>(1, 5, btreeset! {10,11})]).await?;
 
-            let mems = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
+            let mems = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
             assert_eq!(2, mems.len());
 
             let mem = mems[0].clone();
@@ -191,24 +196,23 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log_multi_step(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log_multi_step(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- find membership log entry backwards, multiple steps");
         {
-            store
-                .append_to_log([
-                    //
-                    membership_ent::<C>(1, 1, btreeset! {1,2,3}),
-                    membership_ent::<C>(1, 2, btreeset! {3,4,5}),
-                ])
-                .await?;
+            append(&mut store, [
+                //
+                membership_ent::<C>(1, 1, btreeset! {1,2,3}),
+                membership_ent::<C>(1, 2, btreeset! {3,4,5}),
+            ])
+            .await?;
 
             for i in 3..100 {
-                store.append_to_log([blank_ent::<C>(1, i)]).await?;
+                append(&mut store, [blank_ent::<C>(1, i)]).await?;
             }
 
-            store.append_to_log([membership_ent::<C>(1, 100, btreeset! {5,6,7})]).await?;
+            append(&mut store, [membership_ent::<C>(1, 100, btreeset! {5,6,7})]).await?;
 
-            let mems = StorageHelper::new(&mut store).last_membership_in_log(0).await?;
+            let mems = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
             assert_eq!(2, mems.len());
             let mem = mems[0].clone();
             assert_eq!(&Membership::new(vec![btreeset! {3,4,5}], None), mem.membership(),);
@@ -220,8 +224,8 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_initial(mut store: S) -> Result<(), StorageError<C::NodeId>> {
-        let mem_state = StorageHelper::new(&mut store).get_membership().await?;
+    pub async fn get_membership_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+        let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
         assert_eq!(&EffectiveMembership::default(), mem_state.committed().as_ref());
         assert_eq!(&EffectiveMembership::default(), mem_state.effective().as_ref());
@@ -229,14 +233,17 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_log_and_empty_sm(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_log_and_empty_sm(
+        mut store: LS,
+        mut sm: SM,
+    ) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- no log, read membership from state machine");
         {
             // There is an empty membership config in an empty state machine.
 
-            store.append_to_log([membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
-            let mem_state = StorageHelper::new(&mut store).get_membership().await?;
+            let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
             assert_eq!(&EffectiveMembership::default(), mem_state.committed().as_ref());
             assert_eq!(
@@ -248,14 +255,16 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_log_and_sm(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_log_and_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- no log, read membership from state machine");
         {
-            store
-                .apply_to_state_machine(&[blank_ent::<C>(1, 1), membership_ent::<C>(1, 2, btreeset! {3,4,5})])
-                .await?;
+            apply(&mut sm, [
+                blank_ent::<C>(1, 1),
+                membership_ent::<C>(1, 2, btreeset! {3,4,5}),
+            ])
+            .await?;
 
-            let mem_state = StorageHelper::new(&mut store).get_membership().await?;
+            let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {3,4,5}], None),
@@ -269,9 +278,9 @@ where
 
         tracing::info!("--- membership presents in log, but smaller than last_applied, read from state machine");
         {
-            store.append_to_log([membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
-            let mem_state = StorageHelper::new(&mut store).get_membership().await?;
+            let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {3,4,5}], None),
@@ -285,9 +294,13 @@ where
 
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
         {
-            store.append_to_log([blank_ent::<C>(1, 2), membership_ent::<C>(1, 3, btreeset! {7,8,9})]).await?;
+            append(&mut store, [
+                blank_ent::<C>(1, 2),
+                membership_ent::<C>(1, 3, btreeset! {7,8,9}),
+            ])
+            .await?;
 
-            let mem_state = StorageHelper::new(&mut store).get_membership().await?;
+            let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {3,4,5}], None),
@@ -301,9 +314,13 @@ where
 
         tracing::info!("--- two membership present in log and > sm.last_applied, read 2 from log");
         {
-            store.append_to_log([blank_ent::<C>(1, 4), membership_ent::<C>(1, 5, btreeset! {10,11})]).await?;
+            append(&mut store, [
+                blank_ent::<C>(1, 4),
+                membership_ent::<C>(1, 5, btreeset! {10,11}),
+            ])
+            .await?;
 
-            let mem_state = StorageHelper::new(&mut store).get_membership().await?;
+            let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {7,8,9}], None),
@@ -318,8 +335,8 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_without_init(mut store: S) -> Result<(), StorageError<C::NodeId>> {
-        let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+    pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+        let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
         let mut want = RaftState::default();
         want.vote.update(initial.vote.utime().unwrap(), Vote::default());
 
@@ -327,14 +344,19 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_with_state(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_with_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::default_vote(&mut store).await?;
 
-        store.append_to_log([blank_ent::<C>(0, 0), blank_ent::<C>(1, 1), blank_ent::<C>(3, 2)]).await?;
+        append(&mut store, [
+            blank_ent::<C>(0, 0),
+            blank_ent::<C>(1, 1),
+            blank_ent::<C>(3, 2),
+        ])
+        .await?;
 
-        store.apply_to_state_machine(&[blank_ent::<C>(3, 1)]).await?;
+        apply(&mut sm, [blank_ent::<C>(3, 1)]).await?;
 
-        let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+        let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
         assert_eq!(
             Some(&log_id(3, 2)),
@@ -354,7 +376,10 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_membership_from_log_and_sm(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_membership_from_log_and_sm(
+        mut store: LS,
+        mut sm: SM,
+    ) -> Result<(), StorageError<C::NodeId>> {
         // It should never return membership from logs that are included in state machine present.
 
         Self::default_vote(&mut store).await?;
@@ -363,11 +388,13 @@ where
 
         tracing::info!("--- no log, read membership from state machine");
         {
-            store
-                .apply_to_state_machine(&[blank_ent::<C>(1, 1), membership_ent::<C>(1, 2, btreeset! {3,4,5})])
-                .await?;
+            apply(&mut sm, [
+                blank_ent::<C>(1, 1),
+                membership_ent::<C>(1, 2, btreeset! {3,4,5}),
+            ])
+            .await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {3,4,5}], None),
@@ -377,9 +404,9 @@ where
 
         tracing::info!("--- membership presents in log, but smaller than last_applied, read from state machine");
         {
-            store.append_to_log([membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {3,4,5}], None),
@@ -389,9 +416,9 @@ where
 
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
         {
-            store.append_to_log([membership_ent::<C>(1, 3, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent::<C>(1, 3, btreeset! {1,2,3})]).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {1,2,3}], None),
@@ -402,14 +429,14 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_gt_sm(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_last_log_gt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::default_vote(&mut store).await?;
 
-        store.append_to_log([blank_ent::<C>(0, 0), blank_ent::<C>(2, 1)]).await?;
+        append(&mut store, [blank_ent::<C>(0, 0), blank_ent::<C>(2, 1)]).await?;
 
-        store.apply_to_state_machine(&[blank_ent::<C>(1, 1), blank_ent::<C>(1, 2)]).await?;
+        apply(&mut sm, [blank_ent::<C>(1, 1), blank_ent::<C>(1, 2)]).await?;
 
-        let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+        let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
         assert_eq!(
             Some(&log_id(2, 1)),
@@ -419,14 +446,14 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_lt_sm(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_last_log_lt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::default_vote(&mut store).await?;
 
-        store.append_to_log([blank_ent::<C>(1, 2)]).await?;
+        append(&mut store, [blank_ent::<C>(1, 2)]).await?;
 
-        store.apply_to_state_machine(&[blank_ent::<C>(3, 1)]).await?;
+        apply(&mut sm, [blank_ent::<C>(3, 1)]).await?;
 
-        let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+        let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
         assert_eq!(
             Some(&log_id(3, 1)),
@@ -441,7 +468,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_log_ids(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_log_ids(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         let log_id = |t, n: u64, i| LogId::<C::NodeId> {
             leader_id: CommittedLeaderId::new(t, n.into()),
             index: i,
@@ -449,23 +476,28 @@ where
 
         tracing::info!("--- empty store, expect []");
         {
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(Vec::<LogId<C::NodeId>>::new(), initial.log_ids.key_log_ids());
         }
 
         tracing::info!("--- log terms: [0], last_purged_log_id is None, expect [(0,0)]");
         {
-            store.append_to_log([blank_ent::<C>(0, 0)]).await?;
+            append(&mut store, [blank_ent::<C>(0, 0)]).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(vec![log_id(0, 0, 0)], initial.log_ids.key_log_ids());
         }
 
         tracing::info!("--- log terms: [0,1,1,2], last_purged_log_id is None, expect [(0,0),(1,1),(2,3)]");
         {
-            store.append_to_log([blank_ent::<C>(1, 1), blank_ent::<C>(1, 2), blank_ent::<C>(2, 3)]).await?;
+            append(&mut store, [
+                blank_ent::<C>(1, 1),
+                blank_ent::<C>(1, 2),
+                blank_ent::<C>(2, 3),
+            ])
+            .await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(
                 vec![log_id(0, 0, 0), log_id(1, 0, 1), log_id(2, 0, 3)],
                 initial.log_ids.key_log_ids()
@@ -476,9 +508,14 @@ where
             "--- log terms: [0,1,1,2,2,3,3], last_purged_log_id is None, expect [(0,0),(1,1),(2,3),(3,5),(3,6)]"
         );
         {
-            store.append_to_log([blank_ent::<C>(2, 4), blank_ent::<C>(3, 5), blank_ent::<C>(3, 6)]).await?;
+            append(&mut store, [
+                blank_ent::<C>(2, 4),
+                blank_ent::<C>(3, 5),
+                blank_ent::<C>(3, 6),
+            ])
+            .await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(
                 vec![
                     log_id(0, 0, 0),
@@ -495,9 +532,9 @@ where
             "--- log terms: [x,1,1,2,2,3,3], last_purged_log_id: (0,0), expect [(0,0),(1,1),(2,3),(3,5),(3,6)]"
         );
         {
-            store.purge_logs_upto(log_id(0, 0, 0)).await?;
+            store.purge(log_id(0, 0, 0)).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(
                 vec![
                     log_id(0, 0, 0),
@@ -512,9 +549,9 @@ where
 
         tracing::info!("--- log terms: [x,x,1,2,2,3,3], last_purged_log_id: (1,1), expect [(1,1),(2,3),(3,5),(3,6)]");
         {
-            store.purge_logs_upto(log_id(1, 0, 1)).await?;
+            store.purge(log_id(1, 0, 1)).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(
                 vec![log_id(1, 0, 1), log_id(2, 0, 3), log_id(3, 0, 5), log_id(3, 0, 6)],
                 initial.log_ids.key_log_ids()
@@ -523,9 +560,9 @@ where
 
         tracing::info!("--- log terms: [x,x,x,2,2,3,3], last_purged_log_id: (1,2), expect [(1,2),(2,3),(3,5),(3,6)]");
         {
-            store.purge_logs_upto(log_id(1, 0, 2)).await?;
+            store.purge(log_id(1, 0, 2)).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(
                 vec![log_id(1, 0, 2), log_id(2, 0, 3), log_id(3, 0, 5), log_id(3, 0, 6)],
                 initial.log_ids.key_log_ids()
@@ -534,9 +571,9 @@ where
 
         tracing::info!("--- log terms: [x,x,x,x,2,3,3], last_purged_log_id: (2,3), expect [(2,3),(3,5),(3,6)]");
         {
-            store.purge_logs_upto(log_id(2, 0, 3)).await?;
+            store.purge(log_id(2, 0, 3)).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(
                 vec![log_id(2, 0, 3), log_id(3, 0, 5), log_id(3, 0, 6)],
                 initial.log_ids.key_log_ids()
@@ -545,16 +582,16 @@ where
 
         tracing::info!("--- log terms: [x,x,x,x,x,x,x], last_purged_log_id: (3,6), e.g., all purged expect [(3,6)]");
         {
-            store.purge_logs_upto(log_id(3, 0, 6)).await?;
+            store.purge(log_id(3, 0, 6)).await?;
 
-            let initial = StorageHelper::new(&mut store).get_initial_state().await?;
+            let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(vec![log_id(3, 0, 6)], initial.log_ids.key_log_ids());
         }
 
         Ok(())
     }
 
-    pub async fn save_vote(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn save_vote(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         store.save_vote(&Vote::new(100, NODE_ID.into())).await?;
 
         let got = store.read_vote().await?;
@@ -563,18 +600,18 @@ where
         Ok(())
     }
 
-    pub async fn get_log_entries(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         tracing::info!("--- get start == stop");
         {
-            let logs = StorageHelper::new(&mut store).get_log_entries(3..3).await?;
+            let logs = store.get_log_entries(3..3).await?;
             assert_eq!(logs.len(), 0, "expected no logs to be returned");
         }
 
         tracing::info!("--- get start < stop");
         {
-            let logs = StorageHelper::new(&mut store).get_log_entries(5..7).await?;
+            let logs = store.get_log_entries(5..7).await?;
 
             assert_eq!(logs.len(), 2);
             assert_eq!(*logs[0].get_log_id(), log_id(1, 5));
@@ -584,34 +621,31 @@ where
         Ok(())
     }
 
-    pub async fn try_get_log_entry(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn try_get_log_entry(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge_logs_upto(LogId::new(CommittedLeaderId::new(0, C::NodeId::default()), 0)).await?;
+        store.purge(LogId::new(CommittedLeaderId::new(0, C::NodeId::default()), 0)).await?;
 
-        let mut sh = StorageHelper::new(&mut store);
-
-        let ent = sh.try_get_log_entry(3).await?;
+        let ent = store.try_get_log_entry(3).await?;
         assert_eq!(Some(log_id(1, 3)), ent.map(|x| *x.get_log_id()));
 
-        let ent = sh.try_get_log_entry(0).await?;
+        let ent = store.try_get_log_entry(0).await?;
         assert_eq!(None, ent.map(|x| *x.get_log_id()));
 
-        let ent = sh.try_get_log_entry(11).await?;
+        let ent = store.try_get_log_entry(11).await?;
         assert_eq!(None, ent.map(|x| *x.get_log_id()));
 
         Ok(())
     }
 
-    pub async fn initial_logs(mut store: S) -> Result<(), StorageError<C::NodeId>> {
-        let mut sh = StorageHelper::new(&mut store);
-        let ent = sh.try_get_log_entry(0).await?;
+    pub async fn initial_logs(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+        let ent = store.try_get_log_entry(0).await?;
         assert!(ent.is_none(), "store initialized");
 
         Ok(())
     }
 
-    pub async fn get_log_state(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         let st = store.get_log_state().await?;
 
         assert_eq!(None, st.last_purged_log_id);
@@ -619,7 +653,12 @@ where
 
         tracing::info!("--- only logs");
         {
-            store.append_to_log([blank_ent::<C>(0, 0), blank_ent::<C>(1, 1), blank_ent::<C>(1, 2)]).await?;
+            append(&mut store, [
+                blank_ent::<C>(0, 0),
+                blank_ent::<C>(1, 1),
+                blank_ent::<C>(1, 2),
+            ])
+            .await?;
 
             let st = store.get_log_state().await?;
             assert_eq!(None, st.last_purged_log_id);
@@ -628,7 +667,7 @@ where
 
         tracing::info!("--- delete log 0-0");
         {
-            store.purge_logs_upto(log_id(0, 0)).await?;
+            store.purge(log_id(0, 0)).await?;
 
             let st = store.get_log_state().await?;
             assert_eq!(
@@ -640,7 +679,7 @@ where
 
         tracing::info!("--- delete all log");
         {
-            store.purge_logs_upto(log_id(1, 2)).await?;
+            store.purge(log_id(1, 2)).await?;
 
             let st = store.get_log_state().await?;
             assert_eq!(Some(log_id(1, 2)), st.last_purged_log_id);
@@ -649,7 +688,7 @@ where
 
         tracing::info!("--- delete advance last present logs");
         {
-            store.purge_logs_upto(log_id(2, 3)).await?;
+            store.purge(log_id(2, 3)).await?;
 
             let st = store.get_log_state().await?;
             assert_eq!(Some(log_id(2, 3)), st.last_purged_log_id);
@@ -659,33 +698,38 @@ where
         Ok(())
     }
 
-    pub async fn get_log_id(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_id(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge_logs_upto(log_id(1, 3)).await?;
+        store.purge(log_id(1, 3)).await?;
 
-        let res = StorageHelper::new(&mut store).get_log_id(0).await;
+        let res = store.get_log_id(0).await;
         assert!(res.is_err());
 
-        let res = StorageHelper::new(&mut store).get_log_id(11).await;
+        let res = store.get_log_id(11).await;
         assert!(res.is_err());
 
-        let res = StorageHelper::new(&mut store).get_log_id(3).await?;
+        let res = store.get_log_id(3).await?;
         assert_eq!(log_id(1, 3), res);
 
-        let res = StorageHelper::new(&mut store).get_log_id(4).await?;
+        let res = store.get_log_id(4).await?;
         assert_eq!(log_id(1, 4), res);
 
         Ok(())
     }
 
-    pub async fn last_id_in_log(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_id_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         let last_log_id = store.get_log_state().await?.last_log_id;
         assert_eq!(None, last_log_id);
 
         tracing::info!("--- only logs");
         {
-            store.append_to_log([blank_ent::<C>(0, 0), blank_ent::<C>(1, 1), blank_ent::<C>(1, 2)]).await?;
+            append(&mut store, [
+                blank_ent::<C>(0, 0),
+                blank_ent::<C>(1, 1),
+                blank_ent::<C>(1, 2),
+            ])
+            .await?;
 
             let last_log_id = store.get_log_state().await?.last_log_id;
             assert_eq!(Some(log_id(1, 2)), last_log_id);
@@ -693,14 +737,14 @@ where
 
         tracing::info!("--- last id in logs < last applied id in sm, only return the id in logs");
         {
-            store.apply_to_state_machine(&[blank_ent::<C>(1, 3)]).await?;
+            apply(&mut sm, [blank_ent::<C>(1, 3)]).await?;
             let last_log_id = store.get_log_state().await?.last_log_id;
             assert_eq!(Some(log_id(1, 2)), last_log_id);
         }
 
         tracing::info!("--- no logs, return default");
         {
-            store.purge_logs_upto(log_id(1, 2)).await?;
+            store.purge(log_id(1, 2)).await?;
 
             let last_log_id = store.get_log_state().await?.last_log_id;
             assert_eq!(Some(log_id(1, 2)), last_log_id);
@@ -709,16 +753,16 @@ where
         Ok(())
     }
 
-    pub async fn last_applied_state(mut store: S) -> Result<(), StorageError<C::NodeId>> {
-        let (applied, mem) = store.last_applied_state().await?;
+    pub async fn last_applied_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+        let (applied, mem) = sm.applied_state().await?;
         assert_eq!(None, applied);
         assert_eq!(StoredMembership::default(), mem);
 
         tracing::info!("--- with last_applied and last_membership");
         {
-            store.apply_to_state_machine(&[membership_ent::<C>(1, 3, btreeset! {1,2})]).await?;
+            apply(&mut sm, [membership_ent::<C>(1, 3, btreeset! {1,2})]).await?;
 
-            let (applied, mem) = store.last_applied_state().await?;
+            let (applied, mem) = sm.applied_state().await?;
             assert_eq!(Some(log_id(1, 3)), applied);
             assert_eq!(
                 StoredMembership::new(Some(log_id(1, 3)), Membership::new(vec![btreeset! {1,2}], None)),
@@ -728,9 +772,9 @@ where
 
         tracing::info!("--- no logs, return default");
         {
-            store.apply_to_state_machine(&[blank_ent::<C>(1, 5)]).await?;
+            apply(&mut sm, [blank_ent::<C>(1, 5)]).await?;
 
-            let (applied, mem) = store.last_applied_state().await?;
+            let (applied, mem) = sm.applied_state().await?;
             assert_eq!(Some(log_id(1, 5)), applied);
             assert_eq!(
                 StoredMembership::new(Some(log_id(1, 3)), Membership::new(vec![btreeset! {1,2}], None)),
@@ -741,12 +785,12 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_0(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- delete (-oo, 0]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge_logs_upto(log_id(0, 0)).await?;
+        store.purge(log_id(0, 0)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 10);
@@ -762,12 +806,12 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_5(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_5(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- delete (-oo, 5]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge_logs_upto(log_id(1, 5)).await?;
+        store.purge(log_id(1, 5)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 5);
@@ -783,12 +827,12 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_20(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_20(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- delete (-oo, 20]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge_logs_upto(log_id(1, 20)).await?;
+        store.purge(log_id(1, 20)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 0);
@@ -803,12 +847,12 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_11(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn delete_logs_since_11(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- delete [11, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.delete_conflict_logs_since(log_id(1, 11)).await?;
+        store.truncate(log_id(1, 11)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 11);
@@ -823,12 +867,12 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_0(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn delete_logs_since_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- delete [0, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.delete_conflict_logs_since(log_id(0, 0)).await?;
+        store.truncate(log_id(0, 0)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 0);
@@ -844,12 +888,12 @@ where
         Ok(())
     }
 
-    pub async fn append_to_log(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn append_to_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge_logs_upto(log_id(0, 0)).await?;
+        store.purge(log_id(0, 0)).await?;
 
-        store.append_to_log([blank_ent::<C>(2, 10)]).await?;
+        append(&mut store, [blank_ent::<C>(2, 10)]).await?;
 
         let l = store.try_get_log_entries(0..).await?.len();
         let last = store.try_get_log_entries(0..).await?.into_iter().last().unwrap();
@@ -859,12 +903,12 @@ where
         Ok(())
     }
 
-    pub async fn snapshot_meta(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn snapshot_meta(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- just initialized");
         {
-            store.apply_to_state_machine(&[membership_ent::<C>(0, 0, btreeset! {1,2})]).await?;
+            apply(&mut sm, [membership_ent::<C>(0, 0, btreeset! {1,2})]).await?;
 
-            let mut b = store.get_snapshot_builder().await;
+            let mut b = sm.get_snapshot_builder().await;
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
             assert_eq!(Some(log_id(0, 0)), meta.last_log_id);
@@ -877,11 +921,13 @@ where
 
         tracing::info!("--- one app log, one membership log");
         {
-            store
-                .apply_to_state_machine(&[blank_ent::<C>(1, 1), membership_ent::<C>(2, 2, btreeset! {3,4})])
-                .await?;
+            apply(&mut sm, [
+                blank_ent::<C>(1, 1),
+                membership_ent::<C>(2, 2, btreeset! {3,4}),
+            ])
+            .await?;
 
-            let mut b = store.get_snapshot_builder().await;
+            let mut b = sm.get_snapshot_builder().await;
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
             assert_eq!(Some(log_id(2, 2)), meta.last_log_id);
@@ -895,7 +941,7 @@ where
         Ok(())
     }
 
-    // pub async fn apply_single(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    // pub async fn apply_single(mut store: S, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
 
     //
     //     let entry = Entry {
@@ -908,7 +954,7 @@ where
     //         }),
     //     };
     //
-    //     store.apply_to_state_machine(&[&entry]).await?;
+    //     apply(&mut sm, &[&entry]).await?;
     //     let (last_applied, _) = store.last_applied_state().await?;
     //
     //     assert_eq!(
@@ -933,7 +979,7 @@ where
     //     Ok(())
     // }
     //
-    // pub async fn apply_multi(mut store: S) -> Result<(), StorageError<C::NodeId>> {
+    // pub async fn apply_multi(mut store: S, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
 
     //
     //     let req0 = ClientRequest {
@@ -964,7 +1010,7 @@ where
     //     })
     //     .collect::<Vec<_>>();
     //
-    //     store.apply_to_state_machine(&entries.iter().collect::<Vec<_>>()).await?;
+    //     apply(&mut sm, &entries.iter().collect::<Vec<_>>()).await?;
     //
     //     let (last_applied, _) = store.last_applied_state().await?;
     //
@@ -1011,11 +1057,11 @@ where
     //     Ok(())
     // }
 
-    pub async fn feed_10_logs_vote_self(sto: &mut S) -> Result<(), StorageError<C::NodeId>> {
-        sto.append_to_log([blank_ent::<C>(0, 0)]).await?;
+    pub async fn feed_10_logs_vote_self(sto: &mut LS) -> Result<(), StorageError<C::NodeId>> {
+        append(sto, [blank_ent::<C>(0, 0)]).await?;
 
         for i in 1..=10 {
-            sto.append_to_log([blank_ent::<C>(1, i)]).await?;
+            append(sto, [blank_ent::<C>(1, i)]).await?;
         }
 
         Self::default_vote(sto).await?;
@@ -1023,7 +1069,7 @@ where
         Ok(())
     }
 
-    pub async fn default_vote(sto: &mut S) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn default_vote(sto: &mut LS) -> Result<(), StorageError<C::NodeId>> {
         sto.save_vote(&Vote::new(1, NODE_ID.into())).await?;
 
         Ok(())
@@ -1063,14 +1109,48 @@ where
 }
 
 /// Build a `RaftStorage` implementation and run a test on it.
-async fn run_test<C, S, G, B, TestFn, Ret, Fu>(builder: &B, test_fn: TestFn) -> Result<Ret, StorageError<C::NodeId>>
+async fn run_test<C, LS, SM, G, B, TestFn, Ret, Fu>(
+    builder: &B,
+    test_fn: TestFn,
+) -> Result<Ret, StorageError<C::NodeId>>
 where
     C: RaftTypeConfig,
-    S: RaftStorage<C>,
-    B: StoreBuilder<C, S, G>,
+    LS: RaftLogStorage<C>,
+    SM: RaftStateMachine<C>,
+    B: StoreBuilder<C, LS, SM, G>,
     Fu: Future<Output = Result<Ret, StorageError<C::NodeId>>> + Send,
-    TestFn: Fn(S) -> Fu + Sync + Send,
+    TestFn: Fn(LS, SM) -> Fu + Sync + Send,
 {
-    let (_g, store) = builder.build().await?;
-    test_fn(store).await
+    let (_g, store, sm) = builder.build().await?;
+    test_fn(store, sm).await
+}
+
+/// A wrapper for calling nonblocking `RaftStorage::apply_to_state_machine()`
+async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<(), StorageError<C::NodeId>>
+where
+    C: RaftTypeConfig,
+    SM: RaftStateMachine<C>,
+    I: IntoIterator<Item = C::Entry> + Send,
+{
+    sm.apply(entries).await?;
+    Ok(())
+}
+
+/// A wrapper for calling nonblocking `RaftStorage::append_to_log()`
+async fn append<C, LS, I>(store: &mut LS, entries: I) -> Result<(), StorageError<C::NodeId>>
+where
+    C: RaftTypeConfig,
+    LS: RaftLogStorage<C>,
+    I: IntoIterator<Item = C::Entry>,
+{
+    let entries = entries.into_iter().collect::<Vec<_>>();
+    let last_log_id = *entries.last().unwrap().get_log_id();
+
+    let (tx, rx) = oneshot::channel();
+
+    let cb = LogFlushed::new(Some(last_log_id), tx);
+
+    store.append(entries, cb).await?;
+    rx.await.unwrap().map_err(|e| StorageIOError::write_logs(AnyError::error(e)))?;
+    Ok(())
 }

--- a/rocksstore-compat07/src/test.rs
+++ b/rocksstore-compat07/src/test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use openraft::storage::Adaptor;
 use openraft::testing::StoreBuilder;
 use openraft::testing::Suite;
 use openraft::StorageError;
@@ -10,13 +11,17 @@ use crate::Config;
 use crate::RocksNodeId;
 use crate::RocksStore;
 
+type LogStore = Adaptor<Config, Arc<RocksStore>>;
+type StateMachine = Adaptor<Config, Arc<RocksStore>>;
+
 struct RocksBuilder {}
 #[async_trait]
-impl StoreBuilder<Config, Arc<RocksStore>, TempDir> for RocksBuilder {
-    async fn build(&self) -> Result<(TempDir, Arc<RocksStore>), StorageError<RocksNodeId>> {
+impl StoreBuilder<Config, LogStore, StateMachine, TempDir> for RocksBuilder {
+    async fn build(&self) -> Result<(TempDir, LogStore, StateMachine), StorageError<RocksNodeId>> {
         let td = tempfile::TempDir::new().expect("couldn't create temp dir");
         let store = RocksStore::new(td.path()).await;
-        Ok((td, store))
+        let (log_store, sm) = Adaptor::new(store);
+        Ok((td, log_store, sm))
     }
 }
 

--- a/sledstore/src/test.rs
+++ b/sledstore/src/test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use openraft::storage::Adaptor;
 use openraft::testing::StoreBuilder;
 use openraft::testing::Suite;
 use openraft::StorageError;
@@ -17,15 +18,19 @@ pub fn test_sled_store() -> Result<(), StorageError<ExampleNodeId>> {
     Suite::test_all(SledBuilder {})
 }
 
+type LogStore = Adaptor<ExampleTypeConfig, Arc<SledStore>>;
+type StateMachine = Adaptor<ExampleTypeConfig, Arc<SledStore>>;
+
 #[async_trait]
-impl StoreBuilder<ExampleTypeConfig, Arc<SledStore>, TempDir> for SledBuilder {
-    async fn build(&self) -> Result<(TempDir, Arc<SledStore>), StorageError<ExampleNodeId>> {
-        let td = tempfile::TempDir::new().expect("couldn't create temp dir");
+impl StoreBuilder<ExampleTypeConfig, LogStore, StateMachine, TempDir> for SledBuilder {
+    async fn build(&self) -> Result<(TempDir, LogStore, StateMachine), StorageError<ExampleNodeId>> {
+        let td = TempDir::new().expect("couldn't create temp dir");
 
         let db: sled::Db = sled::open(td.path()).unwrap();
 
         let store = SledStore::new(Arc::new(db)).await;
+        let (log_store, sm) = Adaptor::new(store);
 
-        Ok((td, store))
+        Ok((td, log_store, sm))
     }
 }

--- a/tests/tests/append_entries/t40_append_updates_membership.rs
+++ b/tests/tests/append_entries/t40_append_updates_membership.rs
@@ -40,7 +40,7 @@ async fn append_updates_membership() -> Result<()> {
     router.wait_for_log(&btreeset![0], None, None, "empty").await?;
     router.wait_for_state(&btreeset![0], ServerState::Learner, None, "empty").await?;
 
-    let (r0, _sto0) = router.remove_node(0).unwrap();
+    let (r0, _sto0, _sm0) = router.remove_node(0).unwrap();
 
     tracing::info!("--- append-entries update membership");
     {

--- a/tests/tests/append_entries/t50_append_entries_with_bigger_term.rs
+++ b/tests/tests/append_entries/t50_append_entries_with_bigger_term.rs
@@ -55,11 +55,12 @@ async fn append_entries_with_bigger_term() -> Result<()> {
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1
-    let mut store = router.get_storage_handle(&0)?;
+    let (mut store, mut sm) = router.get_storage_handle(&0)?;
 
     router
         .assert_storage_state_with_sto(
             &mut store,
+            &mut sm,
             &0,
             2,
             log_index,

--- a/tests/tests/life_cycle/t20_shutdown.rs
+++ b/tests/tests/life_cycle/t20_shutdown.rs
@@ -26,7 +26,7 @@ async fn shutdown() -> Result<()> {
     tracing::info!("--- performing node shutdowns");
     {
         for i in [0, 1, 2] {
-            let (node, _) = router.remove_node(i).unwrap();
+            let (node, _, _) = router.remove_node(i).unwrap();
             node.shutdown().await?;
             let m = node.metrics();
             assert_eq!(ServerState::Shutdown, m.borrow().state, "shutdown node-{}", i);

--- a/tests/tests/life_cycle/t30_follower_restart_does_not_interrupt.rs
+++ b/tests/tests/life_cycle/t30_follower_restart_does_not_interrupt.rs
@@ -33,19 +33,19 @@ async fn follower_restart_does_not_interrupt() -> anyhow::Result<()> {
         let m = router.get_metrics(&0)?;
         let term = m.current_term;
 
-        let (n2, sto2) = router.remove_node(2).unwrap();
+        let (n2, sto2, sm2) = router.remove_node(2).unwrap();
         n2.shutdown().await?;
 
-        let (n1, sto1) = router.remove_node(1).unwrap();
+        let (n1, sto1, sm1) = router.remove_node(1).unwrap();
         n1.shutdown().await?;
 
-        let (n0, _sto0) = router.remove_node(0).unwrap();
+        let (n0, _sto0, _sm0) = router.remove_node(0).unwrap();
         n0.shutdown().await?;
 
         tracing::info!("--- restart node 1,2");
 
-        router.new_raft_node_with_sto(1, sto1).await;
-        router.new_raft_node_with_sto(2, sto2).await;
+        router.new_raft_node_with_sto(1, sto1, sm1).await;
+        router.new_raft_node_with_sto(2, sto2, sm2).await;
         let res = router
             .wait(&1, Some(Duration::from_millis(1_000)))
             .metrics(|x| x.current_term > term, "node increase term to start election")

--- a/tests/tests/life_cycle/t90_issue_607_single_restart.rs
+++ b/tests/tests/life_cycle/t90_issue_607_single_restart.rs
@@ -35,12 +35,12 @@ async fn single_restart() -> anyhow::Result<()> {
 
     tracing::info!("--- stop and restart node 0");
     {
-        let (node, sto) = router.remove_node(0).unwrap();
+        let (node, sto, sm) = router.remove_node(0).unwrap();
         node.shutdown().await?;
 
         tracing::info!("--- restart node 0");
 
-        router.new_raft_node_with_sto(0, sto).await;
+        router.new_raft_node_with_sto(0, sto, sm).await;
     }
 
     tracing::info!("--- write to 1 log after restart");

--- a/tests/tests/membership/t00_learner_restart.rs
+++ b/tests/tests/membership/t00_learner_restart.rs
@@ -41,14 +41,14 @@ async fn learner_restart() -> Result<()> {
 
     router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "write one log").await?;
 
-    let (node0, _sto0) = router.remove_node(0).unwrap();
+    let (node0, _sto0, _sm0) = router.remove_node(0).unwrap();
     node0.shutdown().await?;
 
-    let (node1, sto1) = router.remove_node(1).unwrap();
+    let (node1, sto1, sm1) = router.remove_node(1).unwrap();
     node1.shutdown().await?;
 
     // restart node-1, assert the state as expected.
-    let restarted = Raft::new(1, config.clone(), router.clone(), sto1).await?;
+    let restarted = Raft::new(1, config.clone(), router.clone(), sto1, sm1).await?;
     restarted.wait(timeout()).log(Some(log_index), "log after restart").await?;
     restarted.wait(timeout()).state(ServerState::Learner, "server state after restart").await?;
 

--- a/tests/tests/membership/t20_change_membership.rs
+++ b/tests/tests/membership/t20_change_membership.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use maplit::btreeset;
 use openraft::error::ChangeMembershipError;
 use openraft::error::ClientWriteError;
+use openraft::storage::RaftLogReaderExt;
 use openraft::Config;
 use openraft::LogIdOptionExt;
 use openraft::ServerState;
-use openraft::StorageHelper;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -86,8 +86,8 @@ async fn change_with_new_learner_blocking() -> anyhow::Result<()> {
         tracing::info!("--- change_membership blocks until success: {:?}", res);
 
         for node_id in 0..2 {
-            let mut sto = router.get_storage_handle(&node_id)?;
-            let logs = StorageHelper::new(&mut sto).get_log_entries(..).await?;
+            let (mut sto, _sm) = router.get_storage_handle(&node_id)?;
+            let logs = sto.get_log_entries(..).await?;
             assert_eq!(log_index, logs[logs.len() - 1].log_id.index, "node: {}", node_id);
             // 0-th log
             assert_eq!(log_index + 1, logs.len() as u64, "node: {}", node_id);

--- a/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -56,8 +56,8 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     log_index += 1;
     for node_id in 0..2 {
         router.wait_for_log(&btreeset![node_id], Some(log_index), None, "write one log").await?;
-        let sto = router.get_storage_handle(&node_id)?;
-        assert!(sto.get_state_machine().await.client_status.get("foo").is_some());
+        let (sto, _sm) = router.get_storage_handle(&node_id)?;
+        assert!(sto.storage().await.get_state_machine().await.client_status.get("foo").is_some());
     }
 
     Ok(())

--- a/tests/tests/snapshot/t23_snapshot_chunk_size.rs
+++ b/tests/tests/snapshot/t23_snapshot_chunk_size.rs
@@ -110,10 +110,11 @@ async fn snapshot_chunk_size() -> Result<()> {
 
         // after add_learner, log_index + 1,
         // leader has only log_index log in snapshot, cause it has compacted before add_learner
-        let mut store = router.get_storage_handle(&0)?;
+        let (mut store, mut sm) = router.get_storage_handle(&0)?;
         router
             .assert_storage_state_with_sto(
                 &mut store,
+                &mut sm,
                 &0,
                 1,
                 log_index,
@@ -125,10 +126,11 @@ async fn snapshot_chunk_size() -> Result<()> {
 
         // learner has log_index + 1 log in snapshot, cause it do compact after add_learner,
         // so learner's snapshot include add_learner log
-        let mut store = router.get_storage_handle(&1)?;
+        let (mut store, mut sm) = router.get_storage_handle(&1)?;
         router
             .assert_storage_state_with_sto(
                 &mut store,
+                &mut sm,
                 &1,
                 1,
                 log_index,

--- a/tests/tests/snapshot/t40_purge_in_snapshot_logs.rs
+++ b/tests/tests/snapshot/t40_purge_in_snapshot_logs.rs
@@ -35,7 +35,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
     let leader = router.get_raft_handle(&0)?;
     let learner = router.get_raft_handle(&1)?;
 
-    let mut sto0 = router.get_storage_handle(&0)?;
+    let (mut sto0, mut _sm0) = router.get_storage_handle(&0)?;
 
     tracing::info!("--- build snapshot on leader, check purged log");
     {
@@ -48,7 +48,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
                 "building 1st snapshot",
             )
             .await?;
-        let mut sto0 = router.get_storage_handle(&0)?;
+        let (mut sto0, mut _sm0) = router.get_storage_handle(&0)?;
 
         // Wait for purge to complete.
         sleep(Duration::from_millis(500)).await;
@@ -92,7 +92,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
             )
             .await?;
 
-        let mut sto1 = router.get_storage_handle(&1)?;
+        let (mut sto1, mut _sm) = router.get_storage_handle(&1)?;
         let logs = sto1.try_get_log_entries(..).await?;
         assert_eq!(0, logs.len());
     }

--- a/tests/tests/snapshot/t41_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot/t41_snapshot_overrides_membership.rs
@@ -85,7 +85,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
     {
         tracing::info!("--- create learner");
         router.new_raft_node(1).await;
-        let mut sto = router.get_storage_handle(&1)?;
+        let (mut sto, mut sm) = router.get_storage_handle(&1)?;
 
         tracing::info!("--- add a membership config log to the learner");
         {
@@ -102,7 +102,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
 
             tracing::info!("--- check that learner membership is affected");
             {
-                let m = StorageHelper::new(&mut sto).get_membership().await?;
+                let m = StorageHelper::new(&mut sto, &mut sm).get_membership().await?;
 
                 assert_eq!(&EffectiveMembership::default(), m.committed().as_ref());
                 assert_eq!(
@@ -143,7 +143,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 )
                 .await?;
 
-            let m = StorageHelper::new(&mut sto).get_membership().await?;
+            let m = StorageHelper::new(&mut sto, &mut sm).get_membership().await?;
 
             assert_eq!(
                 &Membership::new(vec![btreeset! {0}], Some(btreeset! {1})),

--- a/tests/tests/snapshot/t44_replication_does_not_block_purge.rs
+++ b/tests/tests/snapshot/t44_replication_does_not_block_purge.rs
@@ -54,7 +54,7 @@ async fn replication_does_not_block_purge() -> Result<()> {
 
         sleep(Duration::from_millis(500)).await;
 
-        let mut sto0 = router.get_storage_handle(&0)?;
+        let (mut sto0, mut _sm0) = router.get_storage_handle(&0)?;
         let logs = sto0.try_get_log_entries(..).await?;
         assert_eq!(max_keep as usize, logs.len(), "leader's local logs are purged");
     }

--- a/tests/tests/state_machine/t10_total_order_apply.rs
+++ b/tests/tests/state_machine/t10_total_order_apply.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::storage::RaftStateMachine;
 use openraft::Config;
 use openraft::LogIdOptionExt;
-use openraft::RaftStorage;
 use openraft::ServerState;
 use tokio::sync::watch;
 
@@ -42,7 +42,7 @@ async fn total_order_apply() -> Result<()> {
 
     let (tx, rx) = watch::channel(false);
 
-    let mut sto1 = router.get_storage_handle(&1)?;
+    let (_sto1, mut sm1) = router.get_storage_handle(&1)?;
 
     let mut prev = None;
     let h = tokio::spawn(async move {
@@ -51,7 +51,7 @@ async fn total_order_apply() -> Result<()> {
                 break;
             }
 
-            let (last, _) = sto1.last_applied_state().await.unwrap();
+            let (last, _) = sm1.applied_state().await.unwrap();
 
             if last.index() < prev {
                 panic!("out of order apply");


### PR DESCRIPTION

## Changelog

##### Change: move `RaftStateMachine` out of `RaftStorage`

In Raft, the state machine is an independent storage component that
operates separately from the log store. As a result, accessing the log
store and accessing the state machine can be naturally parallelized.

This commit replaces the type parameter `RaftStorage` in `Raft<.., S: RaftStorage>` with two type parameters: `RaftLogStorage` and
`RaftStateMachine`.

### Upgrade tip

Re-implement `RaftLogStorage` and `RaftStateMachine` for the application storage, or use an adapter to wrap `RaftStorage`:
```rust

// Before:
let store = MyRaftStorage::new();
Raft::new(..., store);

// After:
let store = MyRaftStorage::new();
let (log_store, sm) = Adaptoer::new_pair(store);
Raft::new(..., log_store, sm);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/762)
<!-- Reviewable:end -->
