### PR TITLE
Refactor: let Engine track building_snapshot status

### DIFF
--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -270,8 +270,6 @@ where
             engine,
             leader_data: None,
 
-            building_snapshot: false,
-
             tx_api: tx_api.clone(),
             rx_api,
 


### PR DESCRIPTION

## Changelog

##### Refactor: let Engine track building_snapshot status

Engine needs to decide when to build a snapshot thus the present
building snapshot state should be a field of `Engine.RaftState`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/769)
<!-- Reviewable:end -->
