### PR TITLE
Refactor: let Engine submit a building-snapshot command

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -33,8 +33,7 @@ impl SnapshotPolicy {
     where NID: NodeId {
         match self {
             SnapshotPolicy::LogsSinceLast(threshold) => {
-                // NOTE: io_applied() is delayed and may be smaller than the expected state `snapshot_meta`.
-                state.io_applied().next_index() >= state.snapshot_last_log_id().next_index() + threshold
+                state.committed().next_index() >= state.snapshot_last_log_id().next_index() + threshold
             }
         }
     }

--- a/openraft/src/engine/engine_config.rs
+++ b/openraft/src/engine/engine_config.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use crate::engine::time_state;
 use crate::Config;
 use crate::NodeId;
+use crate::SnapshotPolicy;
 
 /// Config for Engine
 #[derive(Clone, Debug)]
@@ -10,6 +11,9 @@ use crate::NodeId;
 pub(crate) struct EngineConfig<NID: NodeId> {
     /// The id of this node.
     pub(crate) id: NID,
+
+    /// The snapshot policy to use for a Raft node.
+    pub(crate) snapshot_policy: SnapshotPolicy,
 
     /// The maximum number of applied logs to keep before purging.
     pub(crate) max_in_snapshot_log_to_keep: u64,
@@ -27,6 +31,7 @@ impl<NID: NodeId> Default for EngineConfig<NID> {
     fn default() -> Self {
         Self {
             id: NID::default(),
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(5000),
             max_in_snapshot_log_to_keep: 1000,
             purge_batch_size: 256,
             max_payload_entries: 300,
@@ -40,6 +45,7 @@ impl<NID: NodeId> EngineConfig<NID> {
         let election_timeout = Duration::from_millis(config.new_rand_election_timeout());
         Self {
             id,
+            snapshot_policy: config.snapshot_policy.clone(),
             max_in_snapshot_log_to_keep: config.max_in_snapshot_log_to_keep,
             purge_batch_size: config.purge_batch_size,
             max_payload_entries: config.max_payload_entries,

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -11,6 +11,7 @@ use crate::engine::handler::log_handler::LogHandler;
 use crate::engine::handler::replication_handler::ReplicationHandler;
 use crate::engine::handler::replication_handler::SendNone;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
+use crate::engine::handler::sm_handler::StateMachineHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::handler::vote_handler::VoteHandler;
 use crate::engine::time_state;
@@ -469,6 +470,8 @@ where
     pub(crate) fn finish_building_snapshot(&mut self, meta: SnapshotMeta<NID, N>) {
         tracing::info!("finish_building_snapshot: {:?}", meta);
 
+        self.state.io_state_mut().set_building_snapshot(false);
+
         let mut h = self.snapshot_handler();
 
         let updated = h.update_snapshot(meta);
@@ -640,6 +643,13 @@ where
 
         FollowingHandler {
             config: &mut self.config,
+            state: &mut self.state,
+            output: &mut self.output,
+        }
+    }
+
+    pub(crate) fn sm_handler(&mut self) -> StateMachineHandler<NID, N, Ent> {
+        StateMachineHandler {
             state: &mut self.state,
             output: &mut self.output,
         }

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -4,6 +4,7 @@ use crate::display_ext::DisplayOption;
 use crate::display_ext::DisplaySlice;
 use crate::engine::handler::log_handler::LogHandler;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
+use crate::engine::handler::sm_handler::StateMachineHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
@@ -163,6 +164,10 @@ where
                 already_committed: prev_committed,
                 upto: committed.unwrap(),
             });
+
+            if self.config.snapshot_policy.should_snapshot(&self.state) {
+                self.sm_handler().build_snapshot();
+            }
         }
     }
 
@@ -375,6 +380,13 @@ where
 
     fn snapshot_handler(&mut self) -> SnapshotHandler<NID, N, Ent> {
         SnapshotHandler {
+            state: self.state,
+            output: self.output,
+        }
+    }
+
+    pub(crate) fn sm_handler(&mut self) -> StateMachineHandler<NID, N, Ent> {
+        StateMachineHandler {
             state: self.state,
             output: self.output,
         }

--- a/openraft/src/engine/handler/mod.rs
+++ b/openraft/src/engine/handler/mod.rs
@@ -3,5 +3,6 @@ pub(crate) mod leader_handler;
 pub(crate) mod log_handler;
 pub(crate) mod replication_handler;
 pub(crate) mod server_state_handler;
+pub(crate) mod sm_handler;
 pub(crate) mod snapshot_handler;
 pub(crate) mod vote_handler;

--- a/openraft/src/engine/handler/sm_handler/mod.rs
+++ b/openraft/src/engine/handler/sm_handler/mod.rs
@@ -1,0 +1,45 @@
+//! This mod handles state machine operations
+use crate::engine::Command;
+use crate::engine::EngineOutput;
+use crate::entry::RaftEntry;
+use crate::Node;
+use crate::NodeId;
+use crate::RaftState;
+
+// TODO: add test
+// #[cfg(test)] mod build_snapshot_test;
+
+/// Handle raft vote related operations
+pub(crate) struct StateMachineHandler<'st, 'out, NID, N, Ent>
+where
+    NID: NodeId,
+    N: Node,
+    Ent: RaftEntry<NID, N>,
+{
+    pub(crate) state: &'st mut RaftState<NID, N>,
+    pub(crate) output: &'out mut EngineOutput<NID, N, Ent>,
+}
+
+impl<'st, 'out, NID, N, Ent> StateMachineHandler<'st, 'out, NID, N, Ent>
+where
+    NID: NodeId,
+    N: Node,
+    Ent: RaftEntry<NID, N>,
+{
+    /// Trigger building snapshot if there is no pending building job.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) fn build_snapshot(&mut self) -> bool {
+        tracing::info!("{}", func_name!());
+
+        if self.state.io_state_mut().building_snapshot() {
+            tracing::debug!("snapshot building is in progress, do not trigger snapshot");
+            return false;
+        }
+
+        tracing::info!("push snapshot building command");
+
+        self.state.io_state.set_building_snapshot(true);
+        self.output.push_command(Command::BuildSnapshot {});
+        true
+    }
+}


### PR DESCRIPTION

## Changelog

##### Refactor: let Engine submit a building-snapshot command

Transfer the control of building-snapshot from `RaftCore` to `Engine`.
`RaftCore` functions as a passive runtime that only responds to
commands, while `Engine` is responsible for managing control flow
and making decisions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/771)
<!-- Reviewable:end -->
