### PR TITLE
Refactor: replace Engine and Command type parameter (NID, N, Entry) with C

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -191,7 +191,7 @@ where
     /// A controlling handle to the [`RaftStateMachine`] worker.
     pub(crate) sm_handle: sm::Handle<C, SM>,
 
-    pub(crate) engine: Engine<C::NodeId, C::Node, C::Entry>,
+    pub(crate) engine: Engine<C>,
 
     pub(crate) leader_data: Option<LeaderData<C, SM::SnapshotData>>,
 
@@ -1379,10 +1379,7 @@ where
     LS: RaftLogStorage<C>,
     SM: RaftStateMachine<C>,
 {
-    async fn run_command<'e>(
-        &mut self,
-        cmd: Command<C::NodeId, C::Node, C::Entry>,
-    ) -> Result<Option<Command<C::NodeId, C::Node, C::Entry>>, StorageError<C::NodeId>> {
+    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C::NodeId>> {
         if let Some(condition) = cmd.condition() {
             match condition {
                 Condition::LogFlushed { .. } => {

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -10,7 +10,6 @@ use crate::testing::log_id;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
-use crate::RaftTypeConfig;
 use crate::Vote;
 
 fn m01() -> Membership<u64, ()> {
@@ -21,7 +20,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<u64, (), <UTCfg as RaftTypeConfig>::Entry> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft_state::Accepted;
@@ -21,7 +20,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -15,7 +15,6 @@ use crate::Entry;
 use crate::EntryPayload;
 use crate::Membership;
 use crate::MembershipState;
-use crate::RaftTypeConfig;
 
 fn m01() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {0,1}], None)
@@ -33,7 +32,7 @@ fn m45() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {4,5}], None)
 }
 
-fn eng() -> Engine<u64, (), <UTCfg as RaftTypeConfig>::Entry> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -4,7 +4,6 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -24,7 +23,7 @@ fn m1234() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
@@ -165,7 +164,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     // Snapshot will be installed, all non-committed log will be deleted.
     // And there should be no conflicting logs left.
     let mut eng = {
-        let mut eng = CEngine::<UTCfg>::default();
+        let mut eng = Engine::<UTCfg>::default();
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -26,7 +25,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -4,7 +4,6 @@ use maplit::btreeset;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Engine;
 use crate::testing::log_id;
 use crate::EffectiveMembership;
@@ -23,7 +22,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -8,7 +8,6 @@ use tokio::time::Instant;
 
 use crate::engine::testing::blank_ent;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
@@ -51,7 +50,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -7,7 +7,6 @@ use maplit::btreeset;
 use tokio::time::Instant;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Inflight;
@@ -27,7 +26,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
+++ b/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
@@ -1,5 +1,4 @@
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::CommittedLeaderId;
@@ -12,7 +11,7 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -1,12 +1,11 @@
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -5,7 +5,6 @@ use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -41,7 +40,7 @@ fn m4_356() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -5,7 +5,6 @@ use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Inflight;
@@ -26,7 +25,7 @@ fn m123() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -1,31 +1,23 @@
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
-use crate::entry::RaftEntry;
-use crate::Node;
-use crate::NodeId;
 use crate::RaftState;
+use crate::RaftTypeConfig;
 use crate::ServerState;
 
 #[cfg(test)] mod update_server_state_test;
 
 /// Handle raft server-state related operations
-pub(crate) struct ServerStateHandler<'st, NID, N, Ent>
-where
-    NID: NodeId,
-    N: Node,
-    Ent: RaftEntry<NID, N>,
+pub(crate) struct ServerStateHandler<'st, C>
+where C: RaftTypeConfig
 {
-    pub(crate) config: &'st EngineConfig<NID>,
-    pub(crate) state: &'st mut RaftState<NID, N>,
-    pub(crate) output: &'st mut EngineOutput<NID, N, Ent>,
+    pub(crate) config: &'st EngineConfig<C::NodeId>,
+    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node>,
+    pub(crate) output: &'st mut EngineOutput<C>,
 }
 
-impl<'st, NID, N, Ent> ServerStateHandler<'st, NID, N, Ent>
-where
-    NID: NodeId,
-    N: Node,
-    Ent: RaftEntry<NID, N>,
+impl<'st, C> ServerStateHandler<'st, C>
+where C: RaftTypeConfig
 {
     /// Re-calculate the server-state, if it changed, update the `server_state` field and dispatch
     /// commands to inform a runtime.

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -5,7 +5,6 @@ use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::testing::log_id;
@@ -24,7 +23,7 @@ fn m123() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/snapshot_handler/trigger_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/trigger_snapshot_test.rs
@@ -1,11 +1,10 @@
 use pretty_assertions::assert_eq;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
@@ -2,7 +2,6 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Engine;
 use crate::testing::log_id;
 use crate::Membership;
@@ -17,7 +16,7 @@ fn m1234() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -7,7 +7,6 @@ use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::Respond;
@@ -32,7 +31,7 @@ fn mk_res() -> Result<VoteResponse<u64>, Infallible> {
     })
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -6,7 +6,6 @@ use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -21,7 +20,7 @@ fn m01() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -59,11 +59,3 @@ pub(crate) use engine_config::EngineConfig;
 pub(crate) use engine_impl::Engine;
 pub(crate) use engine_output::EngineOutput;
 pub use log_id_list::LogIdList;
-
-use crate::RaftTypeConfig;
-
-/// A type alias that use `C: RaftTypeConfig` as generic parameter and is used internally with a
-/// shorter name for convenience.
-#[allow(dead_code)]
-pub(crate) type CEngine<C> =
-    Engine<<C as RaftTypeConfig>::NodeId, <C as RaftTypeConfig>::Node, <C as RaftTypeConfig>::Entry>;

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -7,7 +7,6 @@ use tokio::time::Instant;
 use crate::core::ServerState;
 use crate::engine::testing::blank_ent;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
@@ -33,7 +32,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/tests/command_test.rs
+++ b/openraft/src/engine/tests/command_test.rs
@@ -7,7 +7,6 @@ use crate::progress::Inflight;
 use crate::raft::VoteRequest;
 use crate::raft_types::MetricsChangeFlags;
 use crate::testing::log_id;
-use crate::Entry;
 use crate::Membership;
 use crate::SnapshotMeta;
 use crate::StoredMembership;
@@ -17,7 +16,7 @@ use crate::Vote;
 #[rustfmt::skip]
 fn test_command_update_metrics_flags() -> anyhow::Result<()> {
     //
-    fn t(c: Command<u64, (), Entry<UTCfg>>, repl: bool, data: bool, cluster: bool) {
+    fn t(c: Command<UTCfg>, repl: bool, data: bool, cluster: bool) {
         let mut flags = MetricsChangeFlags::default();
 
         c.update_metrics_flags(&mut flags);

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -6,7 +6,6 @@ use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -28,7 +27,7 @@ fn m12() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.log_ids = LogIdList::new([LogId::new(CommittedLeaderId::new(0, 0), 0)]);
     eng.state.enable_validate = false; // Disable validation for incomplete state

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -6,7 +6,6 @@ use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -22,7 +21,7 @@ fn m01() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -6,7 +6,6 @@ use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -30,7 +29,7 @@ fn m1234() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -24,7 +24,7 @@ use crate::Vote;
 #[test]
 fn test_initialize_single_node() -> anyhow::Result<()> {
     let eng = || {
-        let mut eng = Engine::default();
+        let mut eng = Engine::<Config>::default();
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.server_state = eng.calc_server_state();
@@ -114,7 +114,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 #[test]
 fn test_initialize() -> anyhow::Result<()> {
     let eng = || {
-        let mut eng = Engine::default();
+        let mut eng = Engine::<Config>::default();
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.server_state = eng.calc_server_state();

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -4,7 +4,6 @@ use maplit::btreeset;
 use tokio::time::Instant;
 
 use crate::engine::testing::UTCfg;
-use crate::engine::CEngine;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::entry::ProgressEntry;
@@ -24,7 +23,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> CEngine<UTCfg> {
+fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     // This will be overridden

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -60,8 +60,5 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// Run a command produced by the engine.
     ///
     /// If a command can not be run, i.e., waiting for some event, it will be returned
-    async fn run_command<'e>(
-        &mut self,
-        cmd: Command<C::NodeId, C::Node, C::Entry>,
-    ) -> Result<Option<Command<C::NodeId, C::Node, C::Entry>>, StorageError<C::NodeId>>;
+    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C::NodeId>>;
 }

--- a/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -12,7 +12,7 @@ use openraft::RaftNetworkFactory;
 use openraft::Vote;
 use openraft_memstore::ClientRequest;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -66,7 +66,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
     let rpc = AppendEntriesRequest::<openraft_memstore::Config> {
         vote: Vote::new_committed(1, 1),
         prev_log_id: None,
-        entries: vec![blank(0, 0), blank(1, 1), Entry {
+        entries: vec![blank_ent(0, 0), blank_ent(1, 1), Entry {
             log_id: LogId::new(CommittedLeaderId::new(1, 0), 2),
             payload: EntryPayload::Normal(ClientRequest {
                 client: "foo".to_string(),

--- a/tests/tests/append_entries/t11_append_conflicts.rs
+++ b/tests/tests/append_entries/t11_append_conflicts.rs
@@ -14,7 +14,7 @@ use openraft::RaftTypeConfig;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -61,7 +61,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: None,
-        entries: vec![blank(0, 0)],
+        entries: vec![blank_ent(0, 0)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -89,7 +89,7 @@ async fn append_conflicts() -> Result<()> {
     let req = || AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
-        entries: vec![blank(1, 1), blank(1, 2), blank(1, 3), blank(1, 4)],
+        entries: vec![blank_ent(1, 1), blank_ent(1, 2), blank_ent(1, 3), blank_ent(1, 4)],
         // this set the last_applied to 2
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
@@ -114,7 +114,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 1)),
-        entries: vec![blank(1, 2)],
+        entries: vec![blank_ent(1, 2)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -129,7 +129,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
-        entries: vec![blank(2, 3)],
+        entries: vec![blank_ent(2, 3)],
         // this set the last_applied to 2
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
@@ -174,7 +174,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
-        entries: vec![blank(2, 3), blank(2, 4), blank(2, 5)],
+        entries: vec![blank_ent(2, 3), blank_ent(2, 4), blank_ent(2, 5)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -189,7 +189,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(2, 0), 3)),
-        entries: vec![blank(3, 4)],
+        entries: vec![blank_ent(3, 4)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -228,7 +228,7 @@ where
         .iter()
         .skip(skip)
         .enumerate()
-        .map(|(i, term)| blank(*term, (i + skip) as u64))
+        .map(|(i, term)| blank_ent(*term, (i + skip) as u64))
         .collect::<Vec<_>>();
 
     let w = format!("{:?}", &want);

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -10,7 +10,7 @@ use openraft::Config;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -57,9 +57,9 @@ async fn append_inconsistent_log() -> Result<()> {
     r2.shutdown().await?;
 
     for i in log_index + 1..=100 {
-        testing::blocking_append(&mut sto0, [blank(2, i)]).await?;
+        testing::blocking_append(&mut sto0, [blank_ent(2, i)]).await?;
 
-        testing::blocking_append(&mut sto2, [blank(3, i)]).await?;
+        testing::blocking_append(&mut sto2, [blank_ent(3, i)]).await?;
     }
 
     sto0.save_vote(&Vote::new(2, 0)).await?;

--- a/tests/tests/append_entries/t11_append_updates_membership.rs
+++ b/tests/tests/append_entries/t11_append_updates_membership.rs
@@ -14,7 +14,7 @@ use openraft::Membership;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -48,18 +48,18 @@ async fn append_updates_membership() -> Result<()> {
             vote: Vote::new_committed(1, 1),
             prev_log_id: None,
             entries: vec![
-                blank(0, 0),
-                blank(1, 1),
+                blank_ent(0, 0),
+                blank_ent(1, 1),
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 2),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {1,2}], None)),
                 },
-                blank(1, 3),
+                blank_ent(1, 3),
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 4),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {1,2,3,4}], None)),
                 },
-                blank(1, 5),
+                blank_ent(1, 5),
             ],
             leader_commit: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
         };
@@ -76,7 +76,7 @@ async fn append_updates_membership() -> Result<()> {
         let req = AppendEntriesRequest {
             vote: Vote::new_committed(2, 2),
             prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
-            entries: vec![blank(2, 3)],
+            entries: vec![blank_ent(2, 3)],
             leader_commit: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
         };
 

--- a/tests/tests/elect/t10_elect_compare_last_log.rs
+++ b/tests/tests/elect/t10_elect_compare_last_log.rs
@@ -13,7 +13,7 @@ use openraft::Membership;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
@@ -43,7 +43,7 @@ async fn elect_compare_last_log() -> Result<()> {
 
         testing::blocking_append(&mut sto0, [
             //
-            blank(0, 0),
+            blank_ent(0, 0),
             Entry::new_membership(log_id(2, 0, 1), Membership::new(vec![btreeset! {0,1}], None)),
         ])
         .await?;
@@ -54,9 +54,9 @@ async fn elect_compare_last_log() -> Result<()> {
         sto1.save_vote(&Vote::new(10, 0)).await?;
 
         testing::blocking_append(&mut sto1, [
-            blank(0, 0),
+            blank_ent(0, 0),
             Entry::new_membership(log_id(1, 0, 1), Membership::new(vec![btreeset! {0,1}], None)),
-            blank(1, 2),
+            blank_ent(1, 2),
         ])
         .await?;
     }

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -981,7 +981,7 @@ impl<T> From<std::ops::Range<T>> for ValueTest<T> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(5000))
+    Some(Duration::from_millis(5_000))
 }
 
 pub fn log_id(term: u64, node_id: MemNodeId, index: u64) -> LogId<MemNodeId> {
@@ -989,7 +989,7 @@ pub fn log_id(term: u64, node_id: MemNodeId, index: u64) -> LogId<MemNodeId> {
 }
 
 /// Create a blank log entry for test.
-pub fn blank<C: RaftTypeConfig>(term: u64, index: u64) -> Entry<C>
+pub fn blank_ent<C: RaftTypeConfig>(term: u64, index: u64) -> Entry<C>
 where C::NodeId: From<u64> {
     Entry {
         log_id: LogId::new(CommittedLeaderId::new(term, 0.into()), index),
@@ -997,6 +997,7 @@ where C::NodeId: From<u64> {
     }
 }
 
+/// Create a membership log entry for test.
 pub fn membership_ent(term: u64, node_id: MemNodeId, index: u64, config: Vec<BTreeSet<MemNodeId>>) -> Entry<MemConfig> {
     Entry::new_membership(log_id(term, node_id, index), Membership::new(config, None))
 }

--- a/tests/tests/log_compaction/t10_compaction.rs
+++ b/tests/tests/log_compaction/t10_compaction.rs
@@ -19,7 +19,7 @@ use openraft::ServerState;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -96,7 +96,7 @@ async fn compaction() -> Result<()> {
 
     // Add a new node and assert that it received the same snapshot.
     let (mut sto1, sm1) = router.new_store();
-    testing::blocking_append(&mut sto1, [blank(0, 0), Entry {
+    testing::blocking_append(&mut sto1, [blank_ent(0, 0), Entry {
         log_id: LogId::new(CommittedLeaderId::new(1, 0), 1),
         payload: EntryPayload::Membership(Membership::new(vec![btreeset! {0}], None)),
     }])

--- a/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
@@ -10,7 +10,7 @@ use openraft::RaftNetworkFactory;
 use openraft::Vote;
 use openraft_memstore::BlockOperation;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
@@ -59,7 +59,7 @@ async fn building_snapshot_does_not_block_append() -> Result<()> {
         let rpc = AppendEntriesRequest::<openraft_memstore::Config> {
             vote: Vote::new_committed(1, 0),
             prev_log_id: Some(log_id(1, 0, log_index)),
-            entries: vec![blank(1, 15)],
+            entries: vec![blank_ent(1, 15)],
             leader_commit: None,
         };
 

--- a/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
@@ -18,7 +18,7 @@ use openraft::RaftNetworkFactory;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -92,7 +92,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             let req = AppendEntriesRequest {
                 vote: Vote::new_committed(1, 0),
                 prev_log_id: None,
-                entries: vec![blank(0, 0), Entry {
+                entries: vec![blank_ent(0, 0), Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 1),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {2,3}], None)),
                 }],

--- a/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
+++ b/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
@@ -24,7 +24,7 @@ use openraft::SnapshotPolicy;
 use openraft::StorageHelper;
 use openraft::Vote;
 
-use crate::fixtures::blank;
+use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::membership_ent;
 use crate::fixtures::RaftRouter;
@@ -93,21 +93,21 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             vote: Vote::new_committed(1, 0),
             prev_log_id: None,
             entries: vec![
-                blank(0, 0),
-                blank(1, 1),
+                blank_ent(0, 0),
+                blank_ent(1, 1),
                 // conflict membership will be replaced with membership in snapshot
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 2),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {2,3}], None)),
                 },
-                blank(1, 3),
-                blank(1, 4),
-                blank(1, 5),
-                blank(1, 6),
-                blank(1, 7),
-                blank(1, 8),
-                blank(1, 9),
-                blank(1, 10),
+                blank_ent(1, 3),
+                blank_ent(1, 4),
+                blank_ent(1, 5),
+                blank_ent(1, 6),
+                blank_ent(1, 7),
+                blank_ent(1, 8),
+                blank_ent(1, 9),
+                blank_ent(1, 10),
                 // another conflict membership, will be removed
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 11),


### PR DESCRIPTION

## Changelog

##### Refactor: replace Engine and Command type parameter (NID, N, Entry) with C

To handle application-related data types, such as install-snapshot
requests and snapshot data, `Engine` requires a complete type
configuration `C: RaftTypeConfig`.


##### Chore: rename testing function blank() to blank_ent()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/776)
<!-- Reviewable:end -->
