### PR TITLE
Feature: add backoff strategy for unreachable nodes

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -223,8 +223,8 @@ where
     #[error(transparent)]
     HigherVote(#[from] HigherVote<NID>),
 
-    #[error("Replication is closed")]
-    Closed,
+    #[error(transparent)]
+    Closed(#[from] ReplicationClosed),
 
     // TODO(xp): two sub type: StorageError / TransportError
     // TODO(xp): a sub error for just send_append_entries()
@@ -234,6 +234,11 @@ where
     #[error(transparent)]
     RPCError(#[from] RPCError<NID, N, RaftError<NID, Infallible>>),
 }
+
+/// Error occurs when replication is closed.
+#[derive(Debug, thiserror::Error)]
+#[error("Replication is closed by RaftCore")]
+pub(crate) struct ReplicationClosed {}
 
 /// Error occurs when invoking a remote raft API.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -246,6 +251,11 @@ pub enum RPCError<NID: NodeId, N: Node, E: Error> {
     #[error(transparent)]
     Timeout(#[from] Timeout<NID>),
 
+    /// The node is temporarily unreachable and should backoff before retrying.
+    #[error(transparent)]
+    Unreachable(#[from] Unreachable),
+
+    /// Failed to send the RPC request and should retry immediately.
     #[error(transparent)]
     Network(#[from] NetworkError),
 
@@ -264,6 +274,7 @@ where
     where E: TryAsRef<ForwardToLeader<NID, N>> {
         match self {
             RPCError::Timeout(_) => None,
+            RPCError::Unreachable(_) => None,
             RPCError::Network(_) => None,
             RPCError::RemoteError(remote_err) => remote_err.source.forward_to_leader(),
         }
@@ -323,6 +334,27 @@ pub struct NetworkError {
 }
 
 impl NetworkError {
+    pub fn new<E: Error + 'static>(e: &E) -> Self {
+        Self {
+            source: AnyError::new(e),
+        }
+    }
+}
+
+/// Error that indicates a node is unreachable and should not retry sending anything to it
+/// immediately.
+///
+/// It is similar to [`NetworkError`] but indicating a backoff.
+/// When a [`NetworkError`] is returned, Openraft will retry immediately.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+#[error("Unreachable node: {source}")]
+pub struct Unreachable {
+    #[from]
+    source: AnyError,
+}
+
+impl Unreachable {
     pub fn new<E: Error + 'static>(e: &E) -> Self {
         Self {
             source: AnyError::new(e),

--- a/openraft/src/membership/stored_membership.rs
+++ b/openraft/src/membership/stored_membership.rs
@@ -60,6 +60,6 @@ where
     NID: NodeId,
 {
     fn summary(&self) -> String {
-        format!("{{log_id:{:?} membership:{}}}", self.log_id, self.membership.summary())
+        format!("{{log_id:{}, {}}}", self.log_id.summary(), self.membership.summary())
     }
 }

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -63,13 +63,14 @@ where
     NID: NodeId,
     N: Node,
 {
+    // TODO: make this more readable
     fn summary(&self) -> String {
         format!("Metrics{{id:{},{:?}, term:{}, last_log:{:?}, last_applied:{:?}, leader:{:?}, membership:{}, snapshot:{:?}, replication:{}",
                 self.id,
                 self.state,
                 self.current_term,
                 self.last_log_index,
-                self.last_applied,
+                self.last_applied.summary(),
                 self.current_leader,
                 self.membership_config.summary(),
                 self.snapshot,

--- a/tests/tests/append_entries/main.rs
+++ b/tests/tests/append_entries/main.rs
@@ -15,6 +15,7 @@ mod t11_append_entries_with_bigger_term;
 mod t11_append_inconsistent_log;
 mod t11_append_updates_membership;
 mod t30_replication_1_voter_to_isolated_learner;
+mod t50_append_entries_backoff;
 mod t60_enable_heartbeat;
 mod t61_heartbeat_reject_vote;
 mod t61_large_heartbeat;

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "bt", feature(error_generic_member_access))]
+#![cfg_attr(feature = "bt", feature(provide_any))]
+
+#[macro_use]
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+mod t50_append_entries_backoff;

--- a/tests/tests/replication/t50_append_entries_backoff.rs
+++ b/tests/tests/replication/t50_append_entries_backoff.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RPCType;
+use crate::fixtures::RaftRouter;
+
+/// Append-entries should backoff when a `Unreachable` error is found.
+#[async_entry::test(worker_threads = 4, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn append_entries_backoff() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            heartbeat_interval: 5_000,
+            election_timeout_min: 10_000,
+            election_timeout_max: 10_001,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let counts0 = router.get_rpc_count();
+    let n = 10u64;
+
+    tracing::info!("--- set node 2 to unreachable, and write 10 entries");
+    {
+        router.set_unreachable(2, true);
+
+        router.client_request_many(0, "0", n as usize).await?;
+        log_index += n;
+
+        router.wait(&0, timeout()).log(Some(log_index), format!("{} writes", n)).await?;
+    }
+
+    let counts1 = router.get_rpc_count();
+
+    let c0 = *counts0.get(&RPCType::AppendEntries).unwrap_or(&0);
+    let c1 = *counts1.get(&RPCType::AppendEntries).unwrap_or(&0);
+
+    dbg!(counts0);
+    dbg!(counts1);
+
+    // Without backoff, the leader would send about 40 append-entries RPC.
+    // 20 for append log entries, 20 for updating committed.
+    assert!(
+        n < c1 - c0 && c1 - c0 < n * 4,
+        "append-entries should backoff when a `Unreachable` error is found"
+    );
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### Feature: add backoff strategy for unreachable nodes

Implements a backoff strategy for temporarily or permanently unreachable nodes.
If the `Network` implementation returns `Unreachable` error, Openraft
will backoff for a while before sending next RPC to this target.
This mechanism prevents error logging flood.

Adds a new method `backoff()` to `RaftNetwork` to let an application
return a customized backoff policy, the default provided backoff just
constantly sleep 500ms.

Adds an `unreachable_nodes` setting to the testing router `TypedRaftRouteryped` to emulate unreachable nodes.
Add new error `Unreachable` and an `RPCError` variant `Unreachable`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/778)
<!-- Reviewable:end -->
