### PR TITLE
Refactor: move cluster-benchmark to separate dir cluster_benchmark/

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "rocksstore-compat07",
     "sledstore"]
 exclude = [
+    "cluster_benchmark",
     "stores/rocksstore-v2",
     "examples/raft-kv-memstore",
     "examples/raft-kv-rocksdb",

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,13 @@ bench:
 	cargo bench --features bench
 
 bench_cluster_of_1:
-	cargo test --package tests --test benchmark --release bench_cluster_of_1 -- --ignored --nocapture
+	cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release bench_cluster_of_1 -- --ignored --nocapture
 
 bench_cluster_of_3:
-	cargo test --package tests --test benchmark --release bench_cluster_of_3 -- --ignored --nocapture
+	cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release bench_cluster_of_3 -- --ignored --nocapture
 
 bench_cluster_of_5:
-	cargo test --package tests --test benchmark --release bench_cluster_of_5 -- --ignored --nocapture
+	cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release bench_cluster_of_5 -- --ignored --nocapture
 
 fmt:
 	cargo fmt

--- a/README.md
+++ b/README.md
@@ -80,25 +80,42 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 
 - [ ] Goal performance is 1,000,000 put/sec.
 
-    Bench history:
-    - 2022 Jul 01: 41,000 put/sec; 23,255 ns/op;
-    - 2022 Jul 07: 43,000 put/sec; 23,218 ns/op; Use `Progress` to track replication.
-    - 2022 Jul 09: 45,000 put/sec; 21,784 ns/op; Batch purge applied log
-    - 2023 Feb 28: 48,000 put/sec; 20,558 ns/op;
-
-    Run the benchmark: `make bench_cluster_of_3`
-
-    Benchmark setting:
-    - No network.
-    - In memory store.
-    - A cluster of 3 nodes on one server.
-    - Single client.
-
 <!--
    - - [ ] Consider to separate log storage and log order storage.
    -   Leader only determines and replicates the index of log entries, not log
    -   payload.
       -->
+
+# Performance
+
+The benchmark is focused on the Openraft framework itself and is run on a
+minimized store and network. This is **NOT a real world** application benchmark!!!
+
+Benchmark history:
+
+|  Date      | clients | put/s       | ns/op      | Changes                             |
+| :--        | --:     | --:         | --:        | :--                                 |
+| 2023-04-23 |  64     | **467,000** |    2,139   | State-machine moved to separate task |
+|            |   1     |    70,000   | **14,273** |                                     |
+| 2023-02-28 |   1     |    48,000   | **20,558** |                                     |
+| 2022-07-09 |   1     |    45,000   | **21,784** | Batch purge applied log             |
+| 2022-07-07 |   1     |    43,000   | **23,218** | Use `Progress` to track replication |
+| 2022-07-01 |   1     |    41,000   | **23,255** |                                     |
+
+
+To access the benchmark, go to the `./cluster_benchmark` folder and run `make
+bench_cluster_of_3`.
+
+The benchmark is carried out with varying numbers of clients because:
+- The `1 client` benchmark shows the average **latency** to commit each log.
+- The `64 client` benchmark shows the maximum **throughput**.
+
+The benchmark is conducted with the following settings:
+- No network.
+- In-memory store.
+- A cluster of 3 nodes in a single process on a Mac M1-Max laptop.
+- Request: empty
+- Response: empty
 
 
 # Features

--- a/cluster_benchmark/Cargo.toml
+++ b/cluster_benchmark/Cargo.toml
@@ -1,0 +1,40 @@
+# These tests depend on `memstore`, while `memstore` enables `serde` feature of `openraft`.
+# This make it impossible to test openraft with `serde` feature off.
+
+[package]
+name = "cluster-benchmark"
+description = "openraft cluster benchmark"
+
+version = "0.1.0"
+edition = "2021"
+authors = [
+    "drdr xp <drdr.xp@gmail.com>",
+]
+categories = ["algorithms", "asynchronous", "data-structures"]
+homepage = "https://github.com/datafuselabs/openraft"
+keywords = ["raft", "consensus"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/datafuselabs/openraft"
+
+[dependencies]
+
+[dev-dependencies]
+openraft           = { path="../openraft", version = "0.8.4", features = ["serde", "storage-v2"] }
+
+anyhow = "1.0.63"
+maplit = "1.0.2"
+serde = { version="1.0.114", features=["derive", "rc"]}
+serde_json = "1.0.57"
+tokio = { version="1.8", default-features=false, features=["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
+tracing = "0.1.29"
+
+[features]
+
+bt = ["openraft/bt"]
+single-term-leader = ["openraft/single-term-leader"]
+
+[profile.release]
+debug = 2
+lto = "thin"
+overflow-checks = false
+codegen-units = 1

--- a/cluster_benchmark/tests/README.md
+++ b/cluster_benchmark/tests/README.md
@@ -1,0 +1,4 @@
+# Benchmark openraft cluster
+
+It builds a cluster locally with a **minimized** store and network layer,
+and is meant to benchmark and find performance bottleneck of the openraft framework.

--- a/cluster_benchmark/tests/benchmark/main.rs
+++ b/cluster_benchmark/tests/benchmark/main.rs
@@ -1,8 +1,9 @@
+#![deny(unused_crate_dependencies)]
+#![deny(unused_qualifications)]
 #![cfg_attr(feature = "bt", feature(error_generic_member_access))]
 #![cfg_attr(feature = "bt", feature(provide_any))]
 
-#[macro_use]
-#[path = "../fixtures/mod.rs"]
-mod fixtures;
+pub(crate) mod network;
+pub(crate) mod store;
 
 mod bench_cluster;

--- a/cluster_benchmark/tests/benchmark/network.rs
+++ b/cluster_benchmark/tests/benchmark/network.rs
@@ -1,0 +1,128 @@
+//! A minimized store with least cost for benchmarking Openraft.
+
+#[cfg(feature = "bt")] use std::backtrace::Backtrace;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use openraft::async_trait::async_trait;
+use openraft::error::InstallSnapshotError;
+use openraft::error::RPCError;
+use openraft::error::RaftError;
+use openraft::error::RemoteError;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::raft::InstallSnapshotResponse;
+use openraft::raft::VoteRequest;
+use openraft::raft::VoteResponse;
+use openraft::Config;
+use openraft::Raft;
+use openraft::RaftNetwork;
+use openraft::RaftNetworkFactory;
+
+use crate::store::Config as MemConfig;
+use crate::store::LogStore;
+use crate::store::NodeId;
+use crate::store::StateMachineStore;
+
+pub type BenchRaft = Raft<MemConfig, Router, Arc<LogStore>, Arc<StateMachineStore>>;
+
+#[derive(Clone)]
+pub struct Router {
+    pub(crate) table: Arc<Mutex<BTreeMap<NodeId, BenchRaft>>>,
+}
+
+impl Router {
+    pub fn new() -> Self {
+        Router {
+            table: Default::default(),
+        }
+    }
+
+    pub(crate) fn get_raft(&self, id: NodeId) -> BenchRaft {
+        self.table.lock().unwrap().get(&id).unwrap().clone()
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn new_cluster(&mut self, config: Arc<Config>, voter_ids: BTreeSet<NodeId>) -> anyhow::Result<()> {
+        let mut rafts = BTreeMap::new();
+
+        for id in voter_ids.iter() {
+            let log_store = Arc::new(LogStore::default());
+            let sm = Arc::new(StateMachineStore::new());
+
+            let raft = Raft::new(*id, config.clone(), self.clone(), log_store, sm).await?;
+
+            rafts.insert(*id, raft);
+        }
+
+        {
+            let mut t = self.table.lock().unwrap();
+            *t = rafts.clone();
+        }
+
+        tracing::info!("--- initializing single node cluster: {}", 0);
+        rafts.get_mut(&0).unwrap().initialize(voter_ids.clone()).await?;
+        let log_index = 1; // log 0: initial membership log
+
+        tracing::info!("--- wait for init node to become leader");
+
+        for (id, s) in rafts.iter_mut() {
+            tracing::info!("--- wait init log: {}, index: {}", id, log_index);
+            s.wait(timeout()).log(Some(log_index), "init").await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RaftNetworkFactory<MemConfig> for Router {
+    type Network = Network;
+
+    async fn new_client(&mut self, target: NodeId, _node: &()) -> Self::Network {
+        Network {
+            target,
+            target_raft: self.table.lock().unwrap().get(&target).unwrap().clone(),
+        }
+    }
+}
+
+pub struct Network {
+    target: NodeId,
+    target_raft: BenchRaft,
+}
+
+#[async_trait]
+impl RaftNetwork<MemConfig> for Network {
+    async fn send_append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<MemConfig>,
+    ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId>>> {
+        let resp = self.target_raft.append_entries(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
+        Ok(resp)
+    }
+
+    async fn send_install_snapshot(
+        &mut self,
+        rpc: InstallSnapshotRequest<MemConfig>,
+    ) -> Result<InstallSnapshotResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId, InstallSnapshotError>>> {
+        let resp = self.target_raft.install_snapshot(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
+        Ok(resp)
+    }
+
+    async fn send_vote(
+        &mut self,
+        rpc: VoteRequest<NodeId>,
+    ) -> Result<VoteResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId>>> {
+        let resp = self.target_raft.vote(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
+        Ok(resp)
+    }
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(5_000))
+}

--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -1,0 +1,328 @@
+mod test;
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::io::Cursor;
+use std::ops::RangeBounds;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use openraft::async_trait::async_trait;
+use openraft::storage::LogFlushed;
+use openraft::storage::LogState;
+use openraft::storage::RaftLogReader;
+use openraft::storage::RaftLogStorage;
+use openraft::storage::RaftSnapshotBuilder;
+use openraft::storage::RaftStateMachine;
+use openraft::storage::Snapshot;
+use openraft::Entry;
+use openraft::EntryPayload;
+use openraft::LogId;
+use openraft::RaftLogId;
+use openraft::SnapshotMeta;
+use openraft::StorageError;
+use openraft::StorageIOError;
+use openraft::StoredMembership;
+use openraft::Vote;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ClientRequest {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ClientResponse {}
+
+pub type NodeId = u64;
+
+openraft::declare_raft_types!(
+    pub Config: D = ClientRequest, R = ClientResponse, NodeId = NodeId, Node = (), Entry = Entry<Config>
+);
+
+#[derive(Debug)]
+pub struct StoredSnapshot {
+    pub meta: SnapshotMeta<NodeId, ()>,
+    pub data: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct StateMachine {
+    pub last_applied_log: Option<LogId<NodeId>>,
+    pub last_membership: StoredMembership<NodeId, ()>,
+}
+
+pub struct LogStore {
+    vote: RwLock<Option<Vote<NodeId>>>,
+    log: RwLock<BTreeMap<u64, Entry<Config>>>,
+    last_purged_log_id: RwLock<Option<LogId<NodeId>>>,
+}
+
+impl LogStore {
+    pub fn new() -> Self {
+        let log = RwLock::new(BTreeMap::new());
+
+        Self {
+            vote: RwLock::new(None),
+            log,
+            last_purged_log_id: RwLock::new(None),
+        }
+    }
+
+    pub async fn new_async() -> Arc<Self> {
+        Arc::new(Self::new())
+    }
+}
+
+impl Default for LogStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct StateMachineStore {
+    sm: RwLock<StateMachine>,
+    snapshot_idx: AtomicU64,
+    current_snapshot: RwLock<Option<StoredSnapshot>>,
+}
+
+impl StateMachineStore {
+    pub fn new() -> Self {
+        Self {
+            sm: RwLock::new(StateMachine::default()),
+            snapshot_idx: AtomicU64::new(0),
+            current_snapshot: RwLock::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl RaftLogReader<Config> for Arc<LogStore> {
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<Entry<Config>>, StorageError<NodeId>> {
+        let mut entries = vec![];
+        {
+            let log = self.log.read().await;
+            for (_, ent) in log.range(range.clone()) {
+                entries.push(ent.clone());
+            }
+        };
+
+        Ok(entries)
+    }
+
+    async fn get_log_state(&mut self) -> Result<LogState<Config>, StorageError<NodeId>> {
+        let log = self.log.read().await;
+        let last_serialized = log.iter().rev().next().map(|(_, ent)| ent);
+
+        let last = match last_serialized {
+            None => None,
+            Some(ent) => Some(*ent.get_log_id()),
+        };
+
+        let last_purged = self.last_purged_log_id.read().await.clone();
+
+        let last = match last {
+            None => last_purged,
+            Some(x) => Some(x),
+        };
+
+        Ok(LogState {
+            last_purged_log_id: last_purged,
+            last_log_id: last,
+        })
+    }
+}
+
+#[async_trait]
+impl RaftSnapshotBuilder<Config, Cursor<Vec<u8>>> for Arc<StateMachineStore> {
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn build_snapshot(&mut self) -> Result<Snapshot<NodeId, (), Cursor<Vec<u8>>>, StorageError<NodeId>> {
+        let data;
+        let last_applied_log;
+        let last_membership;
+
+        {
+            // Serialize the data of the state machine.
+            let sm = self.sm.read().await;
+            data = serde_json::to_vec(&*sm).map_err(|e| StorageIOError::read_state_machine(&e))?;
+
+            last_applied_log = sm.last_applied_log;
+            last_membership = sm.last_membership.clone();
+        }
+
+        let snapshot_size = data.len();
+
+        let snapshot_idx = self.snapshot_idx.fetch_add(1, Ordering::Relaxed);
+
+        let snapshot_id = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.leader_id, last.index, snapshot_idx)
+        } else {
+            format!("--{}", snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id: last_applied_log,
+            last_membership,
+            snapshot_id,
+        };
+
+        let snapshot = StoredSnapshot {
+            meta: meta.clone(),
+            data: data.clone(),
+        };
+
+        {
+            let mut current_snapshot = self.current_snapshot.write().await;
+            *current_snapshot = Some(snapshot);
+        }
+
+        tracing::info!(snapshot_size, "log compaction complete");
+
+        Ok(Snapshot {
+            meta,
+            snapshot: Box::new(Cursor::new(data)),
+        })
+    }
+}
+
+#[async_trait]
+impl RaftLogStorage<Config> for Arc<LogStore> {
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<NodeId>> {
+        let mut v = self.vote.write().await;
+        *v = Some(*vote);
+        Ok(())
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<NodeId>> {
+        Ok(self.vote.read().await.clone())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn truncate(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
+        let mut log = self.log.write().await;
+        log.split_off(&log_id.index);
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
+        {
+            let mut p = self.last_purged_log_id.write().await;
+            *p = Some(log_id);
+        }
+
+        let mut log = self.log.write().await;
+        *log = log.split_off(&(log_id.index + 1));
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn append<I>(&mut self, entries: I, callback: LogFlushed<NodeId>) -> Result<(), StorageError<NodeId>>
+    where I: IntoIterator<Item = Entry<Config>> + Send {
+        {
+            let mut log = self.log.write().await;
+            log.extend(entries.into_iter().map(|entry| (entry.get_log_id().index, entry)));
+        }
+        callback.log_io_completed(Ok(()));
+        Ok(())
+    }
+
+    type LogReader = Self;
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        self.clone()
+    }
+}
+
+#[async_trait]
+impl RaftStateMachine<Config> for Arc<StateMachineStore> {
+    type SnapshotData = Cursor<Vec<u8>>;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, ()>), StorageError<NodeId>> {
+        let sm = self.sm.read().await;
+        Ok((sm.last_applied_log, sm.last_membership.clone()))
+    }
+
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<ClientResponse>, StorageError<NodeId>>
+    where I: IntoIterator<Item = Entry<Config>> + Send {
+        let mut sm = self.sm.write().await;
+
+        let it = entries.into_iter();
+        let mut res = Vec::with_capacity(it.size_hint().1.unwrap_or(0));
+
+        for entry in it {
+            sm.last_applied_log = Some(entry.log_id);
+
+            match entry.payload {
+                EntryPayload::Blank => res.push(ClientResponse {}),
+                EntryPayload::Normal(_) => res.push(ClientResponse {}),
+                EntryPayload::Membership(ref mem) => {
+                    sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
+                    res.push(ClientResponse {})
+                }
+            };
+        }
+        Ok(res)
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError<NodeId>> {
+        Ok(Box::new(Cursor::new(Vec::new())))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, snapshot))]
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapshotMeta<NodeId, ()>,
+        snapshot: Box<Self::SnapshotData>,
+    ) -> Result<(), StorageError<NodeId>> {
+        let new_snapshot = StoredSnapshot {
+            meta: meta.clone(),
+            data: snapshot.into_inner(),
+        };
+
+        // Update the state machine.
+        {
+            let new_sm: StateMachine = serde_json::from_slice(&new_snapshot.data)
+                .map_err(|e| StorageIOError::read_snapshot(Some(new_snapshot.meta.signature()), &e))?;
+            let mut sm = self.sm.write().await;
+            *sm = new_sm;
+        }
+
+        // Update current snapshot.
+        let mut current_snapshot = self.current_snapshot.write().await;
+        *current_snapshot = Some(new_snapshot);
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<NodeId, (), Self::SnapshotData>>, StorageError<NodeId>> {
+        match &*self.current_snapshot.read().await {
+            Some(snapshot) => {
+                let data = snapshot.data.clone();
+                Ok(Some(Snapshot {
+                    meta: snapshot.meta.clone(),
+                    snapshot: Box::new(Cursor::new(data)),
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    type SnapshotBuilder = Self;
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+}

--- a/cluster_benchmark/tests/benchmark/store/test.rs
+++ b/cluster_benchmark/tests/benchmark/store/test.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use openraft::async_trait::async_trait;
+use openraft::testing::StoreBuilder;
+use openraft::testing::Suite;
+use openraft::StorageError;
+
+use crate::store::Config;
+use crate::store::LogStore;
+use crate::store::NodeId;
+use crate::store::StateMachineStore;
+
+struct Builder {}
+#[async_trait]
+impl StoreBuilder<Config, Arc<LogStore>, Arc<StateMachineStore>> for Builder {
+    async fn build(&self) -> Result<((), Arc<LogStore>, Arc<StateMachineStore>), StorageError<NodeId>> {
+        let log_store = LogStore::new_async().await;
+        let sm = Arc::new(StateMachineStore::new());
+        Ok(((), log_store, sm))
+    }
+}
+
+#[test]
+pub fn test_store() -> Result<(), StorageError<NodeId>> {
+    Suite::test_all(Builder {})?;
+    Ok(())
+}


### PR DESCRIPTION
## Changelog

##### Refactor: move cluster-benchmark to separate dir cluster_benchmark/

The `cluster_benchmark` should be moved to a separate directory `cluster_benchmark/`.
Crate `cluster_benchmark` enables the `storage-v2` feature and utilizes a minimized
store and network for benchmarking purposes. The store and network has
been optimized to eliminate any unnecessary performance loss.

Benchmark result:

|  Date      | clients | put/s       | ns/op      |
| :--        | --:     | --:         | --:        |
| 2023-04-23 |  64     | **467,000** |    2,139   |
|            |   1     |    70,000   | **14,273** |


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/781)
<!-- Reviewable:end -->
