### PR TITLE
Improve: reduce rate to flush metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,15 @@ minimized store and network. This is **NOT a real world** application benchmark!
 
 Benchmark history:
 
-|  Date      | clients | put/s       | ns/op      | Changes                             |
-| :--        | --:     | --:         | --:        | :--                                 |
+|  Date      | clients | put/s       | ns/op      | Changes                              |
+| :--        | --:     | --:         | --:        | :--                                  |
+| 2023-04-24 |  64     | **652,000** |    1,532   | Reduce metrics report rate           |
 | 2023-04-23 |  64     | **467,000** |    2,139   | State-machine moved to separate task |
-|            |   1     |    70,000   | **14,273** |                                     |
-| 2023-02-28 |   1     |    48,000   | **20,558** |                                     |
-| 2022-07-09 |   1     |    45,000   | **21,784** | Batch purge applied log             |
-| 2022-07-07 |   1     |    43,000   | **23,218** | Use `Progress` to track replication |
-| 2022-07-01 |   1     |    41,000   | **23,255** |                                     |
+|            |   1     |    70,000   | **14,273** |                                      |
+| 2023-02-28 |   1     |    48,000   | **20,558** |                                      |
+| 2022-07-09 |   1     |    45,000   | **21,784** | Batch purge applied log              |
+| 2022-07-07 |   1     |    43,000   | **23,218** | Use `Progress` to track replication  |
+| 2022-07-01 |   1     |    41,000   | **23,255** |                                      |
 
 
 To access the benchmark, go to the `./cluster_benchmark` folder and run `make


### PR DESCRIPTION

## Changelog

##### Improve: reduce rate to flush metrics

The performance increases by 40% with this optimization:

| clients | put/s       | ns/op      | Changes                    |
| --:     | --:         | --:        | :--                        |
|  64     | **652,000** |    1,532   | Reduce metrics report rate |
|  64     | **467,000** |    2,139   |                            |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/782)
<!-- Reviewable:end -->
