### PR TITLE
Chore: add doc comment to v2 storage api

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -10,7 +10,6 @@ use anyerror::AnyError;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use futures::TryFutureExt;
-use maplit::btreemap;
 use maplit::btreeset;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1097,9 +1097,6 @@ where
             RaftMsg::Initialize { members, tx } => {
                 self.handle_initialize(members, tx);
             }
-            RaftMsg::AddLearner { id, node, tx } => {
-                self.change_membership(ChangeMembers::AddNodes(btreemap! {id=>node}), true, tx);
-            }
             RaftMsg::ChangeMembership { changes, retain, tx } => {
                 self.change_membership(changes, retain, tx);
             }
@@ -1133,7 +1130,6 @@ where
 
                 self.handle_tick_election();
 
-                // TODO: test: with heartbeat log, election is automatically rejected.
                 // TODO: test: fixture: make isolated_nodes a single-way isolating.
 
                 // Leader send heartbeat

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -162,7 +162,8 @@ where
 {
     /// Build snapshot
     ///
-    /// A snapshot has to contain information about exactly all logs up to the last applied.
+    /// A snapshot has to contain state of all applied log, including membership. Usually it is just
+    /// a serialized state machine.
     ///
     /// Building snapshot can be done by:
     /// - Performing log compaction, e.g. merge log entries that operates on the same key, like a
@@ -313,6 +314,7 @@ where C: RaftTypeConfig
     /// Raft will use this handle to receive snapshot data.
     ///
     /// ### implementation guide
+    ///
     /// See the [storage chapter of the guide](https://datafuselabs.github.io/openraft/storage.html)
     /// for details on log compaction / snapshotting.
     async fn begin_receiving_snapshot(&mut self) -> Result<Box<Self::SnapshotData>, StorageError<C::NodeId>>;


### PR DESCRIPTION

## Changelog

##### Chore: add doc comment to v2 storage api


##### Refactor: remove RaftMsg::AddLearner, use RaftMsg::ChangeMembership instead, which supports all membership operations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/786)
<!-- Reviewable:end -->
