### PR TITLE
Refactor: merge Command::LeaderCommit and Command::FollowerCommit into one command `Apply`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1441,13 +1441,7 @@ where
                     unreachable!("it has to be a leader!!!");
                 }
             }
-            Command::LeaderCommit {
-                ref already_committed,
-                ref upto,
-            } => {
-                self.apply_to_state_machine(already_committed.next_index(), upto.index).await?;
-            }
-            Command::FollowerCommit {
+            Command::Apply {
                 ref already_committed,
                 ref upto,
             } => {

--- a/openraft/src/engine/command_kind.rs
+++ b/openraft/src/engine/command_kind.rs
@@ -1,9 +1,16 @@
+/// Command kind is used to categorize commands.
+///
+/// Commands of the different kinds can be paralleled.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 #[derive(PartialEq, Eq)]
 pub(crate) enum CommandKind {
+    /// Log IO command
     Log,
+    /// Network IO command
     Network,
+    /// State machine IO command
     StateMachine,
-    Other,
+    /// RaftCore main thread command
+    Main,
 }

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -68,7 +68,7 @@ fn test_following_handler_commit_entries_ge_accepted() -> anyhow::Result<()> {
         eng.state.membership_state
     );
     assert_eq!(
-        vec![Command::FollowerCommit {
+        vec![Command::Apply {
             already_committed: Some(log_id(1, 1)),
             upto: log_id(1, 2),
         }],
@@ -97,7 +97,7 @@ fn test_following_handler_commit_entries_le_accepted() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::FollowerCommit {
+            Command::Apply {
                 already_committed: Some(log_id(1, 1)),
                 upto: log_id(2, 3)
             },

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -152,7 +152,7 @@ where C: RaftTypeConfig
         );
 
         if let Some(prev_committed) = self.state.update_committed(&committed) {
-            self.output.push_command(Command::FollowerCommit {
+            self.output.push_command(Command::Apply {
                 // TODO(xp): when restart, commit is reset to None. Use last_applied instead.
                 already_committed: prev_committed,
                 upto: committed.unwrap(),

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -205,7 +205,7 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
             Command::ReplicateCommitted {
                 committed: Some(log_id(3, 6))
             },
-            Command::LeaderCommit {
+            Command::Apply {
                 already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
@@ -272,7 +272,7 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
             Command::ReplicateCommitted {
                 committed: Some(log_id(3, 4))
             },
-            Command::LeaderCommit {
+            Command::Apply {
                 already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 4)
             },
@@ -351,7 +351,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
             Command::ReplicateCommitted {
                 committed: Some(log_id(3, 4))
             },
-            Command::LeaderCommit {
+            Command::Apply {
                 already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 4)
             },
@@ -366,7 +366,7 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
             Command::ReplicateCommitted {
                 committed: Some(log_id(3, 6))
             },
-            Command::LeaderCommit {
+            Command::Apply {
                 already_committed: Some(LogId::new(CommittedLeaderId::new(3, 1), 4)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },
@@ -443,7 +443,7 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
             Command::ReplicateCommitted {
                 committed: Some(log_id(3, 6))
             },
-            Command::LeaderCommit {
+            Command::Apply {
                 already_committed: Some(log_id(0, 0)),
                 upto: LogId::new(CommittedLeaderId::new(3, 1), 6)
             },

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -173,7 +173,7 @@ where C: RaftTypeConfig
                 committed: self.state.committed().copied(),
             });
 
-            self.output.push_command(Command::LeaderCommit {
+            self.output.push_command(Command::Apply {
                 already_committed: prev_committed,
                 upto: self.state.committed().copied().unwrap(),
             });

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -100,7 +100,7 @@ fn test_update_matching() -> anyhow::Result<()> {
                 Command::ReplicateCommitted {
                     committed: Some(log_id(2, 1))
                 },
-                Command::LeaderCommit {
+                Command::Apply {
                     already_committed: None,
                     upto: log_id(2, 1)
                 }
@@ -119,7 +119,7 @@ fn test_update_matching() -> anyhow::Result<()> {
                 Command::ReplicateCommitted {
                     committed: Some(log_id(2, 3))
                 },
-                Command::LeaderCommit {
+                Command::Apply {
                     already_committed: Some(log_id(2, 1)),
                     upto: log_id(2, 3)
                 }

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -73,7 +73,7 @@ fn test_elect() -> anyhow::Result<()> {
                         index: 1,
                     },),
                 },
-                Command::LeaderCommit {
+                Command::Apply {
                     already_committed: None,
                     upto: LogId {
                         leader_id: CommittedLeaderId::new(1, 1),
@@ -128,7 +128,7 @@ fn test_elect() -> anyhow::Result<()> {
                         index: 1,
                     },),
                 },
-                Command::LeaderCommit {
+                Command::Apply {
                     already_committed: None,
                     upto: LogId {
                         leader_id: CommittedLeaderId::new(2, 1),

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -86,7 +86,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                         index: 1,
                     },),
                 },
-                Command::LeaderCommit {
+                Command::Apply {
                     already_committed: None,
                     upto: LogId {
                         leader_id: CommittedLeaderId::new(1, 1),


### PR DESCRIPTION

## Changelog

##### Refactor: merge Command::LeaderCommit and Command::FollowerCommit into one command `Apply`

These two commands do exactly the same thing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/788)
<!-- Reviewable:end -->
