### PR TITLE
Refactor: remove Command::AppendBlankLog, use Command::AppendEntry instead

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1414,11 +1414,6 @@ where
                 tracing::debug!("AppendInputEntries: {}", DisplaySlice::<_>(&entries),);
                 self.append_to_log(entries, last_log_id).await?
             }
-            Command::AppendBlankLog { log_id } => {
-                let ent = C::Entry::new_blank(log_id);
-                let entries = [ent];
-                self.append_to_log(entries, log_id).await?
-            }
             Command::SaveVote { vote } => {
                 self.log_store.save_vote(&vote).await?;
             }

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -39,12 +39,6 @@ where C: RaftTypeConfig
     /// Append a `range` of entries.
     AppendInputEntries { entries: Vec<C::Entry> },
 
-    /// Append a blank log.
-    ///
-    /// One of the usage is when a leader is established, a blank log is written to commit the
-    /// state.
-    AppendBlankLog { log_id: LogId<C::NodeId> },
-
     /// Replicate the committed log id to other nodes
     ReplicateCommitted { committed: Option<LogId<C::NodeId>> },
 
@@ -124,7 +118,6 @@ where
             (Command::QuitLeader,                            Command::QuitLeader)                                                => true,
             (Command::AppendEntry { entry },                 Command::AppendEntry { entry: b }, )                                => entry == b,
             (Command::AppendInputEntries { entries },        Command::AppendInputEntries { entries: b }, )                       => entries == b,
-            (Command::AppendBlankLog { log_id },             Command::AppendBlankLog { log_id: b }, )                            => log_id == b,
             (Command::ReplicateCommitted { committed },      Command::ReplicateCommitted { committed: b }, )                     => committed == b,
             (Command::Apply { already_committed, upto, },    Command::Apply { already_committed: b_committed, upto: b_upto, }, ) => already_committed == b_committed && upto == b_upto,
             (Command::Replicate { target, req },             Command::Replicate { target: b_target, req: other_req, }, )         => target == b_target && req == other_req,
@@ -156,7 +149,6 @@ where C: RaftTypeConfig
 
             Command::AppendEntry { .. }               => CommandKind::Log,
             Command::AppendInputEntries { .. }        => CommandKind::Log,
-            Command::AppendBlankLog { .. }            => CommandKind::Log,
             Command::SaveVote { .. }                  => CommandKind::Log,
             Command::PurgeLog { .. }                  => CommandKind::Log,
             Command::DeleteConflictLog { .. }         => CommandKind::Log,
@@ -181,7 +173,6 @@ where C: RaftTypeConfig
             Command::QuitLeader                       => None,
             Command::AppendEntry { .. }               => None,
             Command::AppendInputEntries { .. }        => None,
-            Command::AppendBlankLog { .. }            => None,
             Command::ReplicateCommitted { .. }        => None,
             Command::Apply { .. }                     => None,
             Command::Replicate { .. }                 => None,

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -6,7 +6,7 @@ use crate::engine::testing::blank_ent;
 use crate::engine::testing::UTCfg;
 use crate::engine::Engine;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -26,11 +26,11 @@ fn eng() -> Engine<UTCfg> {
 
     eng.config.id = 2;
     eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
-    eng.state.log_ids.append(log_id(1, 1));
-    eng.state.log_ids.append(log_id(2, 3));
+    eng.state.log_ids.append(log_id1(1, 1));
+    eng.state.log_ids.append(log_id1(2, 3));
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
     );
     eng.state.server_state = eng.calc_server_state();
     eng
@@ -40,7 +40,7 @@ fn eng() -> Engine<UTCfg> {
 fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    eng.following_handler().append_entries(Some(log_id(2, 3)), vec![
+    eng.following_handler().append_entries(Some(log_id1(2, 3)), vec![
         //
         blank_ent(3, 4),
         blank_ent(3, 5),
@@ -48,24 +48,24 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
 
     assert_eq!(
         &[
-            log_id(1, 1), //
-            log_id(2, 3),
-            log_id(3, 4),
-            log_id(3, 5),
+            log_id1(1, 1), //
+            log_id1(2, 3),
+            log_id1(3, 4),
+            log_id1(3, 5),
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(&log_id(3, 5)), eng.state.accepted());
+    assert_eq!(Some(&log_id1(3, 5)), eng.state.accepted());
 
     // Update again, accept should not decrease.
 
-    eng.following_handler().append_entries(Some(log_id(2, 3)), vec![
+    eng.following_handler().append_entries(Some(log_id1(2, 3)), vec![
         //
         blank_ent(3, 4),
     ]);
 
-    assert_eq!(Some(&log_id(3, 5)), eng.state.last_log_id());
-    assert_eq!(Some(&log_id(3, 5)), eng.state.accepted());
+    assert_eq!(Some(&log_id1(3, 5)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(3, 5)), eng.state.accepted());
 
     Ok(())
 }

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -7,7 +7,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft_state::Accepted;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -24,10 +24,10 @@ fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
-    eng.state.committed = Some(log_id(1, 1));
+    eng.state.committed = Some(log_id1(1, 1));
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
     );
     eng
 }
@@ -38,11 +38,11 @@ fn test_following_handler_commit_entries_empty() -> anyhow::Result<()> {
 
     eng.following_handler().commit_entries(None);
 
-    assert_eq!(Some(&log_id(1, 1)), eng.state.committed());
+    assert_eq!(Some(&log_id1(1, 1)), eng.state.committed());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
         ),
         eng.state.membership_state
     );
@@ -55,22 +55,22 @@ fn test_following_handler_commit_entries_empty() -> anyhow::Result<()> {
 fn test_following_handler_commit_entries_ge_accepted() -> anyhow::Result<()> {
     let mut eng = eng();
     let l = eng.state.vote_ref().leader_id();
-    eng.state.accepted = Accepted::new(*l, Some(log_id(1, 2)));
+    eng.state.accepted = Accepted::new(*l, Some(log_id1(1, 2)));
 
-    eng.following_handler().commit_entries(Some(log_id(2, 3)));
+    eng.following_handler().commit_entries(Some(log_id1(2, 3)));
 
-    assert_eq!(Some(&log_id(1, 2)), eng.state.committed());
+    assert_eq!(Some(&log_id1(1, 2)), eng.state.committed());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
         ),
         eng.state.membership_state
     );
     assert_eq!(
         vec![Command::Apply {
-            already_committed: Some(log_id(1, 1)),
-            upto: log_id(1, 2),
+            already_committed: Some(log_id1(1, 1)),
+            upto: log_id1(1, 2),
         }],
         eng.output.take_commands()
     );
@@ -82,15 +82,15 @@ fn test_following_handler_commit_entries_ge_accepted() -> anyhow::Result<()> {
 fn test_following_handler_commit_entries_le_accepted() -> anyhow::Result<()> {
     let mut eng = eng();
     let l = eng.state.vote_ref().leader_id();
-    eng.state.accepted = Accepted::new(*l, Some(log_id(3, 4)));
+    eng.state.accepted = Accepted::new(*l, Some(log_id1(3, 4)));
 
-    eng.following_handler().commit_entries(Some(log_id(2, 3)));
+    eng.following_handler().commit_entries(Some(log_id1(2, 3)));
 
-    assert_eq!(Some(&log_id(2, 3)), eng.state.committed());
+    assert_eq!(Some(&log_id1(2, 3)), eng.state.committed());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23()))
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23()))
         ),
         eng.state.membership_state
     );
@@ -98,8 +98,8 @@ fn test_following_handler_commit_entries_le_accepted() -> anyhow::Result<()> {
         vec![
             //
             Command::Apply {
-                already_committed: Some(log_id(1, 1)),
-                upto: log_id(2, 3)
+                already_committed: Some(log_id1(1, 1)),
+                upto: log_id1(2, 3)
             },
         ],
         eng.output.take_commands()

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -9,7 +9,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::EntryPayload;
@@ -37,11 +37,11 @@ fn eng() -> Engine<UTCfg> {
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
     eng.config.id = 2;
-    eng.state.log_ids.append(log_id(1, 1));
-    eng.state.log_ids.append(log_id(2, 3));
+    eng.state.log_ids.append(log_id1(1, 1));
+    eng.state.log_ids.append(log_id1(2, 3));
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
     );
     eng.state.server_state = eng.calc_server_state();
     eng
@@ -56,16 +56,16 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
 
     assert_eq!(
         &[
-            log_id(1, 1), //
-            log_id(2, 3),
+            log_id1(1, 1), //
+            log_id1(2, 3),
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(2, 3)), eng.state.last_log_id());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
         ),
         eng.state.membership_state
     );
@@ -89,17 +89,17 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
 
     assert_eq!(
         &[
-            log_id(1, 1), //
-            log_id(2, 3),
-            log_id(3, 4),
+            log_id1(1, 1), //
+            log_id1(2, 3),
+            log_id1(3, 4),
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(&log_id(3, 4)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(3, 4)), eng.state.last_log_id());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
         ),
         eng.state.membership_state
     );
@@ -132,7 +132,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
             blank_ent(3, 3), // ignored
             blank_ent(3, 4),
             Entry::<UTCfg> {
-                log_id: log_id(3, 5),
+                log_id: log_id1(3, 5),
                 payload: EntryPayload::<UTCfg>::Membership(m34()),
             },
         ],
@@ -141,18 +141,18 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
 
     assert_eq!(
         &[
-            log_id(1, 1), //
-            log_id(2, 3),
-            log_id(3, 4),
-            log_id(3, 5),
+            log_id1(1, 1), //
+            log_id1(2, 3),
+            log_id1(3, 4),
+            log_id1(3, 5),
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(&log_id(3, 5)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(3, 5)), eng.state.last_log_id());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
-            Arc::new(EffectiveMembership::new(Some(log_id(3, 5)), m34())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(3, 5)), m34())),
         ),
         eng.state.membership_state,
         "previous effective become committed"
@@ -168,7 +168,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
                 //
                 blank_ent(3, 4),
                 Entry::<UTCfg> {
-                    log_id: log_id(3, 5),
+                    log_id: log_id1(3, 5),
                     payload: EntryPayload::<UTCfg>::Membership(m34()),
                 },
             ]
@@ -190,30 +190,30 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
 
     eng.following_handler().do_append_entries(
         vec![
-            Entry::<UTCfg>::new_membership(log_id(3, 4), m01()), // ignored
+            Entry::<UTCfg>::new_membership(log_id1(3, 4), m01()), // ignored
             blank_ent(3, 4),
-            Entry::<UTCfg>::new_membership(log_id(3, 5), m01()),
-            Entry::<UTCfg>::new_membership(log_id(4, 6), m34()),
-            Entry::<UTCfg>::new_membership(log_id(4, 7), m45()),
+            Entry::<UTCfg>::new_membership(log_id1(3, 5), m01()),
+            Entry::<UTCfg>::new_membership(log_id1(4, 6), m34()),
+            Entry::<UTCfg>::new_membership(log_id1(4, 7), m45()),
         ],
         1,
     );
 
     assert_eq!(
         &[
-            log_id(1, 1), //
-            log_id(2, 3),
-            log_id(3, 4),
-            log_id(4, 6),
-            log_id(4, 7),
+            log_id1(1, 1), //
+            log_id1(2, 3),
+            log_id1(3, 4),
+            log_id1(4, 6),
+            log_id1(4, 7),
         ],
         eng.state.log_ids.key_log_ids()
     );
-    assert_eq!(Some(&log_id(4, 7)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 7)), eng.state.last_log_id());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(4, 6)), m34())),
-            Arc::new(EffectiveMembership::new(Some(log_id(4, 7)), m45())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(4, 6)), m34())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(4, 7)), m45())),
         ),
         eng.state.membership_state,
         "seen 3 membership, the last 2 become committed and effective"
@@ -227,9 +227,9 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
         vec![Command::AppendInputEntries {
             entries: vec![
                 blank_ent(3, 4),
-                Entry::<UTCfg>::new_membership(log_id(3, 5), m01()),
-                Entry::<UTCfg>::new_membership(log_id(4, 6), m34()),
-                Entry::<UTCfg>::new_membership(log_id(4, 7), m45()),
+                Entry::<UTCfg>::new_membership(log_id1(3, 5), m01()),
+                Entry::<UTCfg>::new_membership(log_id1(4, 6), m34()),
+                Entry::<UTCfg>::new_membership(log_id1(4, 7), m45()),
             ]
         },],
         eng.output.take_commands()

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -8,7 +8,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::SnapshotMeta;
@@ -28,17 +28,17 @@ fn eng() -> Engine<UTCfg> {
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
     eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
-    eng.state.committed = Some(log_id(4, 5));
+    eng.state.committed = Some(log_id1(4, 5));
     eng.state.log_ids = LogIdList::new(vec![
         //
-        log_id(2, 2),
-        log_id(3, 5),
-        log_id(4, 6),
-        log_id(4, 8),
+        log_id1(2, 2),
+        log_id1(3, 5),
+        log_id1(4, 6),
+        log_id1(4, 8),
     ]);
     eng.state.snapshot_meta = SnapshotMeta {
-        last_log_id: Some(log_id(2, 2)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
+        last_log_id: Some(log_id1(2, 2)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m12()),
         snapshot_id: "1-2-3-4".to_string(),
     };
     eng.state.server_state = eng.calc_server_state();
@@ -53,15 +53,15 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler().install_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(2, 2)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+        last_log_id: Some(log_id1(2, 2)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
     assert_eq!(
         SnapshotMeta {
-            last_log_id: Some(log_id(2, 2)),
-            last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
+            last_log_id: Some(log_id1(2, 2)),
+            last_membership: StoredMembership::new(Some(log_id1(1, 1)), m12()),
             snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
@@ -69,8 +69,8 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
     assert_eq!(
         vec![Command::CancelSnapshot {
             snapshot_meta: SnapshotMeta {
-                last_log_id: Some(log_id(2, 2)),
-                last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+                last_log_id: Some(log_id1(2, 2)),
+                last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
                 snapshot_id: "1-2-3-4".to_string(),
             }
         }],
@@ -89,15 +89,15 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler().install_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(4, 5)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+        last_log_id: Some(log_id1(4, 5)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
     assert_eq!(
         SnapshotMeta {
-            last_log_id: Some(log_id(2, 2)),
-            last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
+            last_log_id: Some(log_id1(2, 2)),
+            last_membership: StoredMembership::new(Some(log_id1(1, 1)), m12()),
             snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
@@ -105,8 +105,8 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
     assert_eq!(
         vec![Command::CancelSnapshot {
             snapshot_meta: SnapshotMeta {
-                last_log_id: Some(log_id(4, 5)),
-                last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+                last_log_id: Some(log_id1(4, 5)),
+                last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
                 snapshot_id: "1-2-3-4".to_string(),
             }
         }],
@@ -122,23 +122,23 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler().install_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(4, 6)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+        last_log_id: Some(log_id1(4, 6)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
     assert_eq!(
         SnapshotMeta {
-            last_log_id: Some(log_id(4, 6)),
-            last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+            last_log_id: Some(log_id1(4, 6)),
+            last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
-    assert_eq!(&[log_id(4, 6), log_id(4, 8)], eng.state.log_ids.key_log_ids());
-    assert_eq!(Some(&log_id(4, 6)), eng.state.committed());
+    assert_eq!(&[log_id1(4, 6), log_id1(4, 8)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(&log_id1(4, 6)), eng.state.committed());
     assert_eq!(
-        &Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        &Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m1234())),
         eng.state.membership_state.committed()
     );
     assert_eq!(
@@ -146,12 +146,12 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
             //
             Command::InstallSnapshot {
                 snapshot_meta: SnapshotMeta {
-                    last_log_id: Some(log_id(4, 6)),
-                    last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+                    last_log_id: Some(log_id1(4, 6)),
+                    last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
                     snapshot_id: "1-2-3-4".to_string(),
                 }
             },
-            Command::PurgeLog { upto: log_id(4, 6) },
+            Command::PurgeLog { upto: log_id1(4, 6) },
         ],
         eng.output.take_commands()
     );
@@ -168,18 +168,18 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
-        eng.state.committed = Some(log_id(2, 3));
+        eng.state.committed = Some(log_id1(2, 3));
         eng.state.log_ids = LogIdList::new(vec![
             //
-            log_id(2, 2),
-            log_id(3, 5),
-            log_id(4, 6),
-            log_id(4, 8),
+            log_id1(2, 2),
+            log_id1(3, 5),
+            log_id1(4, 6),
+            log_id1(4, 8),
         ]);
 
         eng.state.snapshot_meta = SnapshotMeta {
-            last_log_id: Some(log_id(2, 2)),
-            last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
+            last_log_id: Some(log_id1(2, 2)),
+            last_membership: StoredMembership::new(Some(log_id1(1, 1)), m12()),
             snapshot_id: "1-2-3-4".to_string(),
         };
 
@@ -189,37 +189,37 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     };
 
     eng.following_handler().install_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(5, 6)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+        last_log_id: Some(log_id1(5, 6)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
     assert_eq!(
         SnapshotMeta {
-            last_log_id: Some(log_id(5, 6)),
-            last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+            last_log_id: Some(log_id1(5, 6)),
+            last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
-    assert_eq!(&[log_id(5, 6)], eng.state.log_ids.key_log_ids());
-    assert_eq!(Some(&log_id(5, 6)), eng.state.committed());
+    assert_eq!(&[log_id1(5, 6)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(&log_id1(5, 6)), eng.state.committed());
     assert_eq!(
-        &Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        &Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m1234())),
         eng.state.membership_state.committed()
     );
     assert_eq!(
         vec![
-            Command::DeleteConflictLog { since: log_id(2, 4) },
+            Command::DeleteConflictLog { since: log_id1(2, 4) },
             //
             Command::InstallSnapshot {
                 snapshot_meta: SnapshotMeta {
-                    last_log_id: Some(log_id(5, 6)),
-                    last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+                    last_log_id: Some(log_id1(5, 6)),
+                    last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
                     snapshot_id: "1-2-3-4".to_string(),
                 }
             },
-            Command::PurgeLog { upto: log_id(5, 6) },
+            Command::PurgeLog { upto: log_id1(5, 6) },
         ],
         eng.output.take_commands()
     );
@@ -233,27 +233,27 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler().install_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(100, 100)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+        last_log_id: Some(log_id1(100, 100)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
     assert_eq!(
         SnapshotMeta {
-            last_log_id: Some(log_id(100, 100)),
-            last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+            last_log_id: Some(log_id1(100, 100)),
+            last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
-    assert_eq!(&[log_id(100, 100)], eng.state.log_ids.key_log_ids());
-    assert_eq!(Some(&log_id(100, 100)), eng.state.committed());
+    assert_eq!(&[log_id1(100, 100)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(&log_id1(100, 100)), eng.state.committed());
     assert_eq!(
-        &Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        &Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m1234())),
         eng.state.membership_state.committed()
     );
     assert_eq!(
-        &Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())),
+        &Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m1234())),
         eng.state.membership_state.effective()
     );
     assert_eq!(
@@ -261,12 +261,14 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
             //
             Command::InstallSnapshot {
                 snapshot_meta: SnapshotMeta {
-                    last_log_id: Some(log_id(100, 100)),
-                    last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+                    last_log_id: Some(log_id1(100, 100)),
+                    last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
                     snapshot_id: "1-2-3-4".to_string(),
                 }
             },
-            Command::PurgeLog { upto: log_id(100, 100) },
+            Command::PurgeLog {
+                upto: log_id1(100, 100)
+            },
         ],
         eng.output.take_commands()
     );
@@ -280,12 +282,12 @@ fn test_install_snapshot_update_accepted() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler().install_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(100, 100)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+        last_log_id: Some(log_id1(100, 100)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
-    assert_eq!(Some(&log_id(100, 100)), eng.state.accepted());
+    assert_eq!(Some(&log_id1(100, 100)), eng.state.accepted());
 
     Ok(())
 }

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -7,7 +7,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -31,13 +31,13 @@ fn eng() -> Engine<UTCfg> {
 
     eng.config.id = 2;
     eng.state.log_ids = LogIdList::new(vec![
-        log_id(2, 2), //
-        log_id(4, 4),
-        log_id(4, 6),
+        log_id1(2, 2), //
+        log_id1(4, 4),
+        log_id1(4, 6),
     ]);
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
     );
 
     eng.state.server_state = ServerState::Follower;
@@ -51,12 +51,12 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
 
     eng.following_handler().truncate_logs(3);
 
-    assert_eq!(Some(&log_id(2, 2)), eng.state.last_log_id());
-    assert_eq!(&[log_id(2, 2)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(&log_id1(2, 2)), eng.state.last_log_id());
+    assert_eq!(&[log_id1(2, 2)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
         ),
         eng.state.membership_state
     );
@@ -65,7 +65,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::DeleteConflictLog { since: log_id(2, 3) },
+            Command::DeleteConflictLog { since: log_id1(2, 3) },
         ],
         eng.output.take_commands()
     );
@@ -79,19 +79,19 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
 
     eng.following_handler().truncate_logs(4);
 
-    assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
-    assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(&log_id1(2, 3)), eng.state.last_log_id());
+    assert_eq!(&[log_id1(2, 2), log_id1(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
         ),
         eng.state.membership_state
     );
     assert_eq!(ServerState::Follower, eng.state.server_state);
 
     assert_eq!(
-        vec![Command::DeleteConflictLog { since: log_id(4, 4) }],
+        vec![Command::DeleteConflictLog { since: log_id1(4, 4) }],
         eng.output.take_commands()
     );
 
@@ -104,10 +104,10 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
 
     eng.following_handler().truncate_logs(5);
 
-    assert_eq!(Some(&log_id(4, 4)), eng.state.last_log_id());
-    assert_eq!(&[log_id(2, 2), log_id(4, 4)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(&log_id1(4, 4)), eng.state.last_log_id());
+    assert_eq!(&[log_id1(2, 2), log_id1(4, 4)], eng.state.log_ids.key_log_ids());
     assert_eq!(
-        vec![Command::DeleteConflictLog { since: log_id(4, 5) }],
+        vec![Command::DeleteConflictLog { since: log_id1(4, 5) }],
         eng.output.take_commands()
     );
 
@@ -120,13 +120,13 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
 
     eng.following_handler().truncate_logs(6);
 
-    assert_eq!(Some(&log_id(4, 5)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 5)), eng.state.last_log_id());
     assert_eq!(
-        &[log_id(2, 2), log_id(4, 4), log_id(4, 5)],
+        &[log_id1(2, 2), log_id1(4, 4), log_id1(4, 5)],
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(
-        vec![Command::DeleteConflictLog { since: log_id(4, 6) }],
+        vec![Command::DeleteConflictLog { since: log_id1(4, 6) }],
         eng.output.take_commands()
     );
 
@@ -139,9 +139,9 @@ fn test_truncate_logs_since_7() -> anyhow::Result<()> {
 
     eng.following_handler().truncate_logs(7);
 
-    assert_eq!(Some(&log_id(4, 6)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 6)), eng.state.last_log_id());
     assert_eq!(
-        &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
+        &[log_id1(2, 2), log_id1(4, 4), log_id1(4, 6)],
         eng.state.log_ids.key_log_ids()
     );
     assert!(eng.output.take_commands().is_empty());
@@ -155,9 +155,9 @@ fn test_truncate_logs_since_8() -> anyhow::Result<()> {
 
     eng.following_handler().truncate_logs(8);
 
-    assert_eq!(Some(&log_id(4, 6)), eng.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 6)), eng.state.last_log_id());
     assert_eq!(
-        &[log_id(2, 2), log_id(4, 4), log_id(4, 6)],
+        &[log_id1(2, 2), log_id1(4, 4), log_id1(4, 6)],
         eng.state.log_ids.key_log_ids()
     );
     assert!(eng.output.take_commands().is_empty());
@@ -169,19 +169,19 @@ fn test_truncate_logs_since_8() -> anyhow::Result<()> {
 fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(4, 4)), m12())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(4, 4)), m12())),
     );
     eng.state.server_state = eng.calc_server_state();
 
     eng.following_handler().truncate_logs(4);
 
-    assert_eq!(Some(&log_id(2, 3)), eng.state.last_log_id());
-    assert_eq!(&[log_id(2, 2), log_id(2, 3)], eng.state.log_ids.key_log_ids());
+    assert_eq!(Some(&log_id1(2, 3)), eng.state.last_log_id());
+    assert_eq!(&[log_id1(2, 2), log_id1(2, 3)], eng.state.log_ids.key_log_ids());
     assert_eq!(
         vec![
             //
-            Command::DeleteConflictLog { since: log_id(4, 4) },
+            Command::DeleteConflictLog { since: log_id1(4, 4) },
         ],
         eng.output.take_commands()
     );

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -5,7 +5,7 @@ use maplit::btreeset;
 use crate::core::ServerState;
 use crate::engine::testing::UTCfg;
 use crate::engine::Engine;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -26,8 +26,8 @@ fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
     );
 
     eng.state.server_state = eng.calc_server_state();
@@ -40,12 +40,12 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler()
-        .update_committed_membership(EffectiveMembership::new(Some(log_id(3, 4)), m34()));
+        .update_committed_membership(EffectiveMembership::new(Some(log_id1(3, 4)), m34()));
 
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34())),
-            Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34()))
+            Arc::new(EffectiveMembership::new(Some(log_id1(3, 4)), m34())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(3, 4)), m34()))
         ),
         eng.state.membership_state
     );

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -11,7 +11,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Inflight;
 use crate::progress::Progress;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -31,13 +31,13 @@ fn eng() -> Engine<UTCfg> {
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
     eng.config.id = 1;
-    eng.state.committed = Some(log_id(0, 0));
+    eng.state.committed = Some(log_id1(0, 0));
     eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(3, 1));
-    eng.state.log_ids.append(log_id(1, 1));
-    eng.state.log_ids.append(log_id(2, 3));
+    eng.state.log_ids.append(log_id1(1, 1));
+    eng.state.log_ids.append(log_id1(2, 3));
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
     );
     eng.state.server_state = eng.calc_server_state();
 
@@ -56,11 +56,11 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
             vec![
                 Command::Replicate {
                     target: 2,
-                    req: Inflight::logs(None, Some(log_id(2, 3))).with_id(1),
+                    req: Inflight::logs(None, Some(log_id1(2, 3))).with_id(1),
                 },
                 Command::Replicate {
                     target: 3,
-                    req: Inflight::logs(None, Some(log_id(2, 3))).with_id(1),
+                    req: Inflight::logs(None, Some(log_id1(2, 3))).with_id(1),
                 },
             ],
             eng.output.take_commands()
@@ -77,8 +77,8 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
     // No data to send, sending a heartbeat is to send empty RPC:
     {
         let l = eng.leader_handler()?;
-        let _ = l.leader.progress.update_with(&2, |ent| ent.update_matching(Some(log_id(2, 3))));
-        let _ = l.leader.progress.update_with(&3, |ent| ent.update_matching(Some(log_id(2, 3))));
+        let _ = l.leader.progress.update_with(&2, |ent| ent.update_matching(Some(log_id1(2, 3))));
+        let _ = l.leader.progress.update_with(&3, |ent| ent.update_matching(Some(log_id1(2, 3))));
     }
     eng.output.clear_commands();
     eng.leader_handler()?.send_heartbeat();
@@ -86,11 +86,11 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
         vec![
             Command::Replicate {
                 target: 2,
-                req: Inflight::logs(Some(log_id(2, 3)), Some(log_id(2, 3))).with_id(1),
+                req: Inflight::logs(Some(log_id1(2, 3)), Some(log_id1(2, 3))).with_id(1),
             },
             Command::Replicate {
                 target: 3,
-                req: Inflight::logs(Some(log_id(2, 3)), Some(log_id(2, 3))).with_id(1),
+                req: Inflight::logs(Some(log_id1(2, 3)), Some(log_id1(2, 3))).with_id(1),
             },
         ],
         eng.output.take_commands()

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -3,13 +3,13 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 
 fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 2), log_id(4, 4), log_id(4, 6)]);
+    eng.state.log_ids = LogIdList::new(vec![log_id1(2, 2), log_id1(4, 4), log_id1(4, 6)]);
     eng.state.purged_next = 3;
     eng
 }
@@ -19,12 +19,12 @@ fn test_purge_log_already_purged() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(1, 1));
+    lh.state.purge_upto = Some(log_id1(1, 1));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(2, 2)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(2, 2), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(2, 2)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(2, 2), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(4, 6)), lh.state.last_log_id());
 
     assert_eq!(0, lh.output.take_commands().len());
 
@@ -36,12 +36,12 @@ fn test_purge_log_equal_prev_last_purged() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(2, 2));
+    lh.state.purge_upto = Some(log_id1(2, 2));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(2, 2)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(2, 2), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(2, 2)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(2, 2), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(4, 6)), lh.state.last_log_id());
 
     assert_eq!(0, lh.output.take_commands().len());
 
@@ -52,15 +52,15 @@ fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(2, 3));
+    lh.state.purge_upto = Some(log_id1(2, 3));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(2, 3)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(2, 3), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(2, 3)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(2, 3), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(4, 6)), lh.state.last_log_id());
 
     assert_eq!(
-        vec![Command::PurgeLog { upto: log_id(2, 3) }],
+        vec![Command::PurgeLog { upto: log_id1(2, 3) }],
         lh.output.take_commands()
     );
 
@@ -72,15 +72,15 @@ fn test_purge_log_to_last_key_log() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(4, 4));
+    lh.state.purge_upto = Some(log_id1(4, 4));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(4, 4)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 4), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 4)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(4, 4), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(4, 6)), lh.state.last_log_id());
 
     assert_eq!(
-        vec![Command::PurgeLog { upto: log_id(4, 4) }],
+        vec![Command::PurgeLog { upto: log_id1(4, 4) }],
         lh.output.take_commands()
     );
 
@@ -92,15 +92,15 @@ fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(4, 5));
+    lh.state.purge_upto = Some(log_id1(4, 5));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(4, 5)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 5), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 5)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(4, 5), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(4, 6)), lh.state.last_log_id());
 
     assert_eq!(
-        vec![Command::PurgeLog { upto: log_id(4, 5) }],
+        vec![Command::PurgeLog { upto: log_id1(4, 5) }],
         lh.output.take_commands()
     );
 
@@ -112,15 +112,15 @@ fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(4, 6));
+    lh.state.purge_upto = Some(log_id1(4, 6));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(4, 6)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 6), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(4, 6)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 6)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(4, 6), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(4, 6)), lh.state.last_log_id());
 
     assert_eq!(
-        vec![Command::PurgeLog { upto: log_id(4, 6) }],
+        vec![Command::PurgeLog { upto: log_id1(4, 6) }],
         lh.output.take_commands()
     );
 
@@ -132,15 +132,15 @@ fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(4, 7));
+    lh.state.purge_upto = Some(log_id1(4, 7));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(4, 7)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 7), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(4, 7)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(4, 7)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(4, 7), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(4, 7)), lh.state.last_log_id());
 
     assert_eq!(
-        vec![Command::PurgeLog { upto: log_id(4, 7) }],
+        vec![Command::PurgeLog { upto: log_id1(4, 7) }],
         lh.output.take_commands()
     );
 
@@ -152,15 +152,15 @@ fn test_purge_log_to_higher_leader_lgo() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(5, 7));
+    lh.state.purge_upto = Some(log_id1(5, 7));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(5, 7)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(5, 7), lh.state.log_ids.key_log_ids()[0],);
-    assert_eq!(Some(&log_id(5, 7)), lh.state.last_log_id());
+    assert_eq!(Some(&log_id1(5, 7)), lh.state.last_purged_log_id());
+    assert_eq!(log_id1(5, 7), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id1(5, 7)), lh.state.last_log_id());
 
     assert_eq!(
-        vec![Command::PurgeLog { upto: log_id(5, 7) }],
+        vec![Command::PurgeLog { upto: log_id1(5, 7) }],
         lh.output.take_commands()
     );
 

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -11,7 +11,7 @@ use crate::engine::LogIdList;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
@@ -44,8 +44,8 @@ fn eng() -> Engine<UTCfg> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
     );
     eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
     eng.state.server_state = eng.calc_server_state();
@@ -60,12 +60,12 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
     eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
     eng.vote_handler().become_leading();
 
-    eng.replication_handler().append_membership(&log_id(3, 4), &m34());
+    eng.replication_handler().append_membership(&log_id1(3, 4), &m34());
 
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())),
-            Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m34()))
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(3, 4)), m34()))
         ),
         eng.state.membership_state
     );
@@ -101,65 +101,69 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
     // learner or vice versa.
 
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new([LogId::new(CommittedLeaderId::new(0, 0), 0), log_id(1, 1), log_id(5, 10)]);
+    eng.state.log_ids = LogIdList::new([
+        LogId::new(CommittedLeaderId::new(0, 0), 0),
+        log_id1(1, 1),
+        log_id1(5, 10),
+    ]);
 
     eng.state.server_state = ServerState::Leader;
     // Make it a real leader: voted for itself and vote is committed.
     eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23_45())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23_45())));
     eng.vote_handler().become_leading();
 
     if let Some(l) = &mut eng.internal_server_state.leading_mut() {
         assert_eq!(&ProgressEntry::empty(11), l.progress.get(&4));
         assert_eq!(&ProgressEntry::empty(11), l.progress.get(&5));
 
-        let p = ProgressEntry::new(Some(log_id(1, 4)));
+        let p = ProgressEntry::new(Some(log_id1(1, 4)));
         let _ = l.progress.update(&4, p);
         assert_eq!(&p, l.progress.get(&4));
 
-        let p = ProgressEntry::new(Some(log_id(1, 5)));
+        let p = ProgressEntry::new(Some(log_id1(1, 5)));
         let _ = l.progress.update(&5, p);
         assert_eq!(&p, l.progress.get(&5));
 
-        let p = ProgressEntry::new(Some(log_id(1, 3)));
+        let p = ProgressEntry::new(Some(log_id1(1, 3)));
         let _ = l.progress.update(&3, p);
         assert_eq!(&p, l.progress.get(&3));
     } else {
         unreachable!("leader should not be None");
     }
 
-    eng.replication_handler().append_membership(&log_id(3, 4), &m4_356());
+    eng.replication_handler().append_membership(&log_id1(3, 4), &m4_356());
 
     assert_eq!(
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23_45())),
-            Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m4_356()))
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23_45())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(3, 4)), m4_356()))
         ),
         eng.state.membership_state
     );
 
     if let Some(l) = &mut eng.internal_server_state.leading_mut() {
         assert_eq!(
-            &ProgressEntry::new(Some(log_id(1, 4)))
-                .with_inflight(Inflight::logs(Some(log_id(1, 4)), Some(log_id(5, 10))).with_id(1))
+            &ProgressEntry::new(Some(log_id1(1, 4)))
+                .with_inflight(Inflight::logs(Some(log_id1(1, 4)), Some(log_id1(5, 10))).with_id(1))
                 .with_curr_inflight_id(1),
             l.progress.get(&4),
             "learner-4 progress should be transferred to voter progress"
         );
 
         assert_eq!(
-            &ProgressEntry::new(Some(log_id(1, 3)))
-                .with_inflight(Inflight::logs(Some(log_id(1, 3)), Some(log_id(5, 10))).with_id(1))
+            &ProgressEntry::new(Some(log_id1(1, 3)))
+                .with_inflight(Inflight::logs(Some(log_id1(1, 3)), Some(log_id1(5, 10))).with_id(1))
                 .with_curr_inflight_id(1),
             l.progress.get(&3),
             "voter-3 progress should be transferred to learner progress"
         );
 
         assert_eq!(
-            &ProgressEntry::new(Some(log_id(1, 5)))
-                .with_inflight(Inflight::logs(Some(log_id(1, 5)), Some(log_id(5, 10))).with_id(1))
+            &ProgressEntry::new(Some(log_id1(1, 5)))
+                .with_inflight(Inflight::logs(Some(log_id1(1, 5)), Some(log_id1(5, 10))).with_id(1))
                 .with_curr_inflight_id(1),
             l.progress.get(&5),
             "learner-5 has previous value"
@@ -167,7 +171,7 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
 
         assert_eq!(
             &ProgressEntry::empty(11)
-                .with_inflight(Inflight::logs(None, Some(log_id(5, 10))).with_id(1))
+                .with_inflight(Inflight::logs(None, Some(log_id1(5, 10))).with_id(1))
                 .with_curr_inflight_id(1),
             l.progress.get(&6)
         );

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -5,6 +5,7 @@ use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::entry::RaftEntry;
 use crate::internal_server_state::LeaderQuorumSet;
 use crate::leader::Leader;
 use crate::progress::entry::ProgressEntry;
@@ -64,7 +65,8 @@ where C: RaftTypeConfig
             self.state.last_log_id().next_index(),
         );
         self.state.log_ids.append(log_id);
-        self.output.push_command(Command::AppendBlankLog { log_id });
+        let entry = C::Entry::new_blank(log_id);
+        self.output.push_command(Command::AppendEntry { entry });
 
         self.update_local_progress(Some(log_id));
     }

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -10,7 +10,7 @@ use crate::engine::Engine;
 use crate::progress::Inflight;
 use crate::progress::Progress;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -32,8 +32,8 @@ fn eng() -> Engine<UTCfg> {
     eng.config.id = 2;
     eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 1));
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m123())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m123())),
     );
 
     eng
@@ -45,7 +45,7 @@ fn test_update_matching_no_leader() -> anyhow::Result<()> {
 
     let res = std::panic::catch_unwind(move || {
         let mut eng = eng();
-        eng.replication_handler().update_matching(3, 0, Some(log_id(1, 2)));
+        eng.replication_handler().update_matching(3, 0, Some(log_id1(1, 2)));
     });
     tracing::info!("res: {:?}", res);
     assert!(res.is_err());
@@ -61,23 +61,23 @@ fn test_update_matching() -> anyhow::Result<()> {
     let mut rh = eng.replication_handler();
     let inflight_id_1 = {
         let prog_entry = rh.leader.progress.get_mut(&1).unwrap();
-        prog_entry.inflight = Inflight::logs(Some(log_id(2, 3)), Some(log_id(2, 4)));
+        prog_entry.inflight = Inflight::logs(Some(log_id1(2, 3)), Some(log_id1(2, 4)));
         prog_entry.inflight.get_id().unwrap()
     };
     let inflight_id_2 = {
         let prog_entry = rh.leader.progress.get_mut(&2).unwrap();
-        prog_entry.inflight = Inflight::logs(Some(log_id(1, 0)), Some(log_id(2, 4)));
+        prog_entry.inflight = Inflight::logs(Some(log_id1(1, 0)), Some(log_id1(2, 4)));
         prog_entry.inflight.get_id().unwrap()
     };
     let inflight_id_3 = {
         let prog_entry = rh.leader.progress.get_mut(&3).unwrap();
-        prog_entry.inflight = Inflight::logs(Some(log_id(1, 1)), Some(log_id(2, 4)));
+        prog_entry.inflight = Inflight::logs(Some(log_id1(1, 1)), Some(log_id1(2, 4)));
         prog_entry.inflight.get_id().unwrap()
     };
 
     // progress: None, None, (1,2)
     {
-        rh.update_matching(3, inflight_id_3, Some(log_id(1, 2)));
+        rh.update_matching(3, inflight_id_3, Some(log_id1(1, 2)));
         assert_eq!(None, rh.state.committed());
         assert_eq!(0, rh.output.take_commands().len());
     }
@@ -85,7 +85,7 @@ fn test_update_matching() -> anyhow::Result<()> {
     // progress: None, (2,1), (1,2); quorum-ed: (1,2), not at leader vote, not committed
     {
         rh.output.clear_commands();
-        rh.update_matching(2, inflight_id_2, Some(log_id(2, 1)));
+        rh.update_matching(2, inflight_id_2, Some(log_id1(2, 1)));
         assert_eq!(None, rh.state.committed());
         assert_eq!(0, rh.output.take_commands().len());
     }
@@ -93,16 +93,16 @@ fn test_update_matching() -> anyhow::Result<()> {
     // progress: None, (2,1), (2,3); committed: (2,1)
     {
         rh.output.clear_commands();
-        rh.update_matching(3, inflight_id_3, Some(log_id(2, 3)));
-        assert_eq!(Some(&log_id(2, 1)), rh.state.committed());
+        rh.update_matching(3, inflight_id_3, Some(log_id1(2, 3)));
+        assert_eq!(Some(&log_id1(2, 1)), rh.state.committed());
         assert_eq!(
             vec![
                 Command::ReplicateCommitted {
-                    committed: Some(log_id(2, 1))
+                    committed: Some(log_id1(2, 1))
                 },
                 Command::Apply {
                     already_committed: None,
-                    upto: log_id(2, 1)
+                    upto: log_id1(2, 1)
                 }
             ],
             rh.output.take_commands()
@@ -112,16 +112,16 @@ fn test_update_matching() -> anyhow::Result<()> {
     // progress: (2,4), (2,1), (2,3); committed: (1,3)
     {
         rh.output.clear_commands();
-        rh.update_matching(1, inflight_id_1, Some(log_id(2, 4)));
-        assert_eq!(Some(&log_id(2, 3)), rh.state.committed());
+        rh.update_matching(1, inflight_id_1, Some(log_id1(2, 4)));
+        assert_eq!(Some(&log_id1(2, 3)), rh.state.committed());
         assert_eq!(
             vec![
                 Command::ReplicateCommitted {
-                    committed: Some(log_id(2, 3))
+                    committed: Some(log_id1(2, 3))
                 },
                 Command::Apply {
-                    already_committed: Some(log_id(2, 1)),
-                    upto: log_id(2, 3)
+                    already_committed: Some(log_id1(2, 1)),
+                    upto: log_id1(2, 3)
                 }
             ],
             rh.output.take_commands()

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -7,7 +7,7 @@ use tokio::time::Instant;
 use crate::engine::testing::UTCfg;
 use crate::engine::Command;
 use crate::engine::Engine;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -30,8 +30,8 @@ fn eng() -> Engine<UTCfg> {
     eng.config.id = 2;
     eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(2, 2));
     eng.state.membership_state = MembershipState::new(
-        Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())),
-        Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m123())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())),
+        Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m123())),
     );
     eng.state.server_state = eng.state.calc_server_state(&eng.config.id);
 

--- a/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 
 use crate::engine::testing::UTCfg;
 use crate::engine::Engine;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::Membership;
 use crate::SnapshotMeta;
 use crate::StoredMembership;
@@ -21,8 +21,8 @@ fn eng() -> Engine<UTCfg> {
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
     eng.state.snapshot_meta = SnapshotMeta {
-        last_log_id: Some(log_id(2, 2)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
+        last_log_id: Some(log_id1(2, 2)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m12()),
         snapshot_id: "1-2-3-4".to_string(),
     };
     eng
@@ -34,8 +34,8 @@ fn test_update_snapshot_no_update() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let got = eng.snapshot_handler().update_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(2, 2)),
-        last_membership: StoredMembership::new(Some(log_id(1, 1)), m1234()),
+        last_log_id: Some(log_id1(2, 2)),
+        last_membership: StoredMembership::new(Some(log_id1(1, 1)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
@@ -43,8 +43,8 @@ fn test_update_snapshot_no_update() -> anyhow::Result<()> {
 
     assert_eq!(
         SnapshotMeta {
-            last_log_id: Some(log_id(2, 2)),
-            last_membership: StoredMembership::new(Some(log_id(1, 1)), m12()),
+            last_log_id: Some(log_id1(2, 2)),
+            last_membership: StoredMembership::new(Some(log_id1(1, 1)), m12()),
             snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
@@ -61,8 +61,8 @@ fn test_update_snapshot_updated() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let got = eng.snapshot_handler().update_snapshot(SnapshotMeta {
-        last_log_id: Some(log_id(2, 3)),
-        last_membership: StoredMembership::new(Some(log_id(2, 2)), m1234()),
+        last_log_id: Some(log_id1(2, 3)),
+        last_membership: StoredMembership::new(Some(log_id1(2, 2)), m1234()),
         snapshot_id: "1-2-3-4".to_string(),
     });
 
@@ -70,8 +70,8 @@ fn test_update_snapshot_updated() -> anyhow::Result<()> {
 
     assert_eq!(
         SnapshotMeta {
-            last_log_id: Some(log_id(2, 3)),
-            last_membership: StoredMembership::new(Some(log_id(2, 2)), m1234()),
+            last_log_id: Some(log_id1(2, 3)),
+            last_membership: StoredMembership::new(Some(log_id1(2, 2)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -12,7 +12,7 @@ use crate::engine::Engine;
 use crate::engine::Respond;
 use crate::error::Infallible;
 use crate::raft::VoteResponse;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -40,7 +40,7 @@ fn eng() -> Engine<UTCfg> {
     eng.state.server_state = ServerState::Candidate;
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())));
 
     eng.vote_handler().become_leading();
     eng

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -10,7 +10,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::error::RejectVoteRequest;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -29,7 +29,7 @@ fn eng() -> Engine<UTCfg> {
     eng.state.server_state = ServerState::Candidate;
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())));
 
     eng.vote_handler().become_leading();
     eng
@@ -56,7 +56,7 @@ fn test_handle_message_vote_reject_smaller_vote() -> anyhow::Result<()> {
 #[test]
 fn test_handle_message_vote_committed_vote() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
+    eng.state.log_ids = LogIdList::new(vec![log_id1(2, 3)]);
     eng.timer.update_now(*eng.timer.now() + Duration::from_millis(1));
     let now = *eng.timer.now();
 
@@ -85,7 +85,7 @@ fn test_handle_message_vote_granted_equal_vote() -> anyhow::Result<()> {
     // Equal vote should not emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
+    eng.state.log_ids = LogIdList::new(vec![log_id1(2, 3)]);
     eng.timer.update_now(*eng.timer.now() + Duration::from_millis(1));
     let now = *eng.timer.now();
 
@@ -107,7 +107,7 @@ fn test_handle_message_vote_granted_greater_vote() -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
+    eng.state.log_ids = LogIdList::new(vec![log_id1(2, 3)]);
 
     let resp = eng.vote_handler().handle_message_vote(&Vote::new(3, 1));
 

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -1,5 +1,5 @@
 use crate::entry::RaftEntry;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::RaftTypeConfig;
 
 /// Req for test
@@ -32,5 +32,5 @@ impl RaftTypeConfig for UTCfg {
 }
 
 pub(crate) fn blank_ent(term: u64, index: u64) -> crate::Entry<UTCfg> {
-    crate::Entry::<UTCfg>::new_blank(log_id(term, index))
+    crate::Entry::<UTCfg>::new_blank(log_id1(term, index))
 }

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -11,7 +11,7 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -30,7 +30,7 @@ fn eng() -> Engine<UTCfg> {
     eng.state.server_state = ServerState::Candidate;
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m01())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())));
     eng.vote_handler().become_leading();
 
     // By default expire the leader lease so that the vote can be overridden in these tests.
@@ -45,7 +45,7 @@ fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 2),
-        last_log_id: Some(log_id(2, 3)),
+        last_log_id: Some(log_id1(2, 3)),
     });
 
     assert_eq!(
@@ -96,18 +96,18 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
 #[test]
 fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
+    eng.state.log_ids = LogIdList::new(vec![log_id1(2, 3)]);
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 2),
-        last_log_id: Some(log_id(1, 3)),
+        last_log_id: Some(log_id1(1, 3)),
     });
 
     assert_eq!(
         VoteResponse {
             vote: Vote::new(2, 1),
             vote_granted: false,
-            last_log_id: Some(log_id(2, 3))
+            last_log_id: Some(log_id1(2, 3))
         },
         resp
     );
@@ -127,20 +127,20 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     let mut eng = eng();
     eng.config.id = 0;
     eng.vote_handler().update_internal_server_state();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
+    eng.state.log_ids = LogIdList::new(vec![log_id1(2, 3)]);
 
     eng.output.clear_commands();
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(2, 1),
-        last_log_id: Some(log_id(2, 3)),
+        last_log_id: Some(log_id1(2, 3)),
     });
 
     assert_eq!(
         VoteResponse {
             vote: Vote::new(2, 1),
             vote_granted: true,
-            last_log_id: Some(log_id(2, 3))
+            last_log_id: Some(log_id1(2, 3))
         },
         resp
     );
@@ -160,13 +160,13 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.config.id = 0;
     eng.vote_handler().update_internal_server_state();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 3)]);
+    eng.state.log_ids = LogIdList::new(vec![log_id1(2, 3)]);
 
     eng.output.clear_commands();
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 1),
-        last_log_id: Some(log_id(2, 3)),
+        last_log_id: Some(log_id1(2, 3)),
     });
 
     assert_eq!(
@@ -174,7 +174,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
             // respond the updated vote.
             vote: Vote::new(3, 1),
             vote_granted: true,
-            last_log_id: Some(log_id(2, 3))
+            last_log_id: Some(log_id1(2, 3))
         },
         resp
     );
@@ -206,7 +206,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
 
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
-            last_log_id: Some(log_id(2, 3)),
+            last_log_id: Some(log_id1(2, 3)),
         });
 
         assert_eq!(st, eng.state.server_state);
@@ -230,7 +230,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
 
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
-            last_log_id: Some(log_id(2, 3)),
+            last_log_id: Some(log_id1(2, 3)),
         });
 
         assert_eq!(st, eng.state.server_state);

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -9,13 +9,16 @@ use crate::engine::testing::UTCfg;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::entry::RaftEntry;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft::VoteResponse;
 use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
+use crate::Entry;
 use crate::LogId;
 use crate::Membership;
 use crate::Vote;
@@ -45,12 +48,12 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.vote = UTime::new(Instant::now(), Vote::new(2, 1));
         eng.state
             .membership_state
-            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())));
+            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m12())));
 
         eng.handle_vote_resp(2, VoteResponse {
             vote: Vote::new(2, 2),
             vote_granted: true,
-            last_log_id: Some(log_id(2, 2)),
+            last_log_id: Some(log_id1(2, 2)),
         });
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
@@ -68,7 +71,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.vote = UTime::new(Instant::now(), Vote::new(2, 1));
         eng.state
             .membership_state
-            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())));
+            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m12())));
         eng.vote_handler().become_leading();
         eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
@@ -76,7 +79,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse {
             vote: Vote::new(1, 1),
             vote_granted: false,
-            last_log_id: Some(log_id(2, 2)),
+            last_log_id: Some(log_id1(2, 2)),
         });
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
@@ -96,10 +99,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         let mut eng = eng();
         eng.config.id = 1;
         eng.state.vote = UTime::new(Instant::now(), Vote::new(2, 1));
-        eng.state.log_ids = LogIdList::new(vec![log_id(3, 3)]);
+        eng.state.log_ids = LogIdList::new(vec![log_id1(3, 3)]);
         eng.state
             .membership_state
-            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())));
+            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m12())));
         eng.vote_handler().become_leading();
         eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
@@ -107,7 +110,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse {
             vote: Vote::new(3, 2),
             vote_granted: false,
-            last_log_id: Some(log_id(2, 2)),
+            last_log_id: Some(log_id1(2, 2)),
         });
 
         assert_eq!(Vote::new(3, 2), *eng.state.vote_ref());
@@ -128,7 +131,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.vote = UTime::new(Instant::now(), Vote::new(2, 1));
         eng.state
             .membership_state
-            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())));
+            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m12())));
         eng.vote_handler().become_leading();
         eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
@@ -136,7 +139,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse {
             vote: Vote::new(2, 1),
             vote_granted: false,
-            last_log_id: Some(log_id(2, 2)),
+            last_log_id: Some(log_id1(2, 2)),
         });
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
@@ -157,7 +160,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.vote = UTime::new(Instant::now(), Vote::new(2, 1));
         eng.state
             .membership_state
-            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m1234())));
+            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m1234())));
         eng.vote_handler().become_leading();
         eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
@@ -165,7 +168,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse {
             vote: Vote::new(2, 1),
             vote_granted: true,
-            last_log_id: Some(log_id(2, 2)),
+            last_log_id: Some(log_id1(2, 2)),
         });
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
@@ -186,7 +189,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state.vote = UTime::new(Instant::now(), Vote::new(2, 1));
         eng.state
             .membership_state
-            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())));
+            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m12())));
         eng.vote_handler().become_leading();
         eng.internal_server_state.leading_mut().map(|l| l.vote_granted_by.insert(1));
         eng.state.server_state = ServerState::Candidate;
@@ -194,7 +197,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse {
             vote: Vote::new(2, 1),
             vote_granted: true,
-            last_log_id: Some(log_id(2, 2)),
+            last_log_id: Some(log_id1(2, 2)),
         });
 
         assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
@@ -214,15 +217,12 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 Command::RebuildReplicationStreams {
                     targets: vec![(2, ProgressEntry::empty(1))]
                 },
-                Command::AppendBlankLog {
-                    log_id: LogId {
-                        leader_id: CommittedLeaderId::new(2, 1),
-                        index: 1,
-                    },
+                Command::AppendEntry {
+                    entry: Entry::<UTCfg>::new_blank(log_id(2, 1, 1)),
                 },
                 Command::Replicate {
                     target: 2,
-                    req: Inflight::logs(None, Some(log_id(2, 1))).with_id(1),
+                    req: Inflight::logs(None, Some(log_id1(2, 1))).with_id(1),
                 },
             ],
             eng.output.take_commands()

--- a/openraft/src/engine/tests/log_id_list_test.rs
+++ b/openraft/src/engine/tests/log_id_list_test.rs
@@ -6,20 +6,20 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
-    ids.extend_from_same_leader(&[log_id(1, 2)]);
-    assert_eq!(vec![log_id(1, 2)], ids.key_log_ids());
+    ids.extend_from_same_leader(&[log_id1(1, 2)]);
+    assert_eq!(vec![log_id1(1, 2)], ids.key_log_ids());
 
     // Extend two log ids that are adjacent to the last stored one.
     // It should append only one log id as the new ending log id.
 
     ids.extend_from_same_leader(&[
-        log_id(1, 3), //
-        log_id(1, 4),
+        log_id1(1, 3), //
+        log_id1(1, 4),
     ]);
     assert_eq!(
         vec![
-            log_id(1, 2), //
-            log_id(1, 4)
+            log_id1(1, 2), //
+            log_id1(1, 4)
         ],
         ids.key_log_ids(),
         "same leader as the last"
@@ -29,15 +29,15 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
     // It should just store every log id for each leader, plus one last-log-id.
 
     ids.extend_from_same_leader(&[
-        log_id(2, 5), //
-        log_id(2, 6),
-        log_id(2, 7),
+        log_id1(2, 5), //
+        log_id1(2, 6),
+        log_id1(2, 7),
     ]);
     assert_eq!(
         vec![
-            log_id(1, 2), //
-            log_id(2, 5),
-            log_id(2, 7)
+            log_id1(1, 2), //
+            log_id1(2, 5),
+            log_id1(2, 7)
         ],
         ids.key_log_ids(),
         "different leader as the last"
@@ -52,20 +52,20 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
-    ids.extend(&[log_id(1, 2)]);
-    assert_eq!(vec![log_id(1, 2)], ids.key_log_ids());
+    ids.extend(&[log_id1(1, 2)]);
+    assert_eq!(vec![log_id1(1, 2)], ids.key_log_ids());
 
     // Extend two log ids that are adjacent to the last stored one.
     // It should append only one log id as the new ending log id.
 
     ids.extend(&[
-        log_id(1, 3), //
-        log_id(1, 4),
+        log_id1(1, 3), //
+        log_id1(1, 4),
     ]);
     assert_eq!(
         vec![
-            log_id(1, 2), //
-            log_id(1, 4)
+            log_id1(1, 2), //
+            log_id1(1, 4)
         ],
         ids.key_log_ids(),
         "same leader as the last"
@@ -75,15 +75,15 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     // Last two has the same leader id.
 
     ids.extend(&[
-        log_id(1, 5), //
-        log_id(2, 6),
-        log_id(2, 7),
+        log_id1(1, 5), //
+        log_id1(2, 6),
+        log_id1(2, 7),
     ]);
     assert_eq!(
         vec![
-            log_id(1, 2), //
-            log_id(2, 6),
-            log_id(2, 7)
+            log_id1(1, 2), //
+            log_id1(2, 6),
+            log_id1(2, 7)
         ],
         ids.key_log_ids(),
         "last 2 have the same leaders"
@@ -93,15 +93,15 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     // Last two have different leader id.
 
     ids.extend(&[
-        log_id(2, 8), //
-        log_id(2, 9),
-        log_id(3, 10),
+        log_id1(2, 8), //
+        log_id1(2, 9),
+        log_id1(3, 10),
     ]);
     assert_eq!(
         vec![
-            log_id(1, 2), //
-            log_id(2, 6),
-            log_id(3, 10),
+            log_id1(1, 2), //
+            log_id1(2, 6),
+            log_id1(3, 10),
         ],
         ids.key_log_ids(),
         "last 2 have different leaders"
@@ -117,12 +117,12 @@ fn test_log_id_list_append() -> anyhow::Result<()> {
     // Append log id one by one, check the internally constructed `key_log_id` as expected.
 
     let cases = vec![
-        (log_id(1, 2), vec![log_id(1, 2)]), //
-        (log_id(1, 3), vec![log_id(1, 2), log_id(1, 3)]),
-        (log_id(1, 4), vec![log_id(1, 2), log_id(1, 4)]),
-        (log_id(2, 5), vec![log_id(1, 2), log_id(2, 5)]),
-        (log_id(2, 7), vec![log_id(1, 2), log_id(2, 5), log_id(2, 7)]),
-        (log_id(2, 9), vec![log_id(1, 2), log_id(2, 5), log_id(2, 9)]),
+        (log_id1(1, 2), vec![log_id1(1, 2)]), //
+        (log_id1(1, 3), vec![log_id1(1, 2), log_id1(1, 3)]),
+        (log_id1(1, 4), vec![log_id1(1, 2), log_id1(1, 4)]),
+        (log_id1(2, 5), vec![log_id1(1, 2), log_id1(2, 5)]),
+        (log_id1(2, 7), vec![log_id1(1, 2), log_id1(2, 5), log_id1(2, 7)]),
+        (log_id1(2, 9), vec![log_id1(1, 2), log_id1(2, 5), log_id1(2, 9)]),
     ];
 
     for (new_log_id, want) in cases {
@@ -138,11 +138,11 @@ fn test_log_id_list_truncate() -> anyhow::Result<()> {
     // Sample data for test
     let make_ids = || {
         LogIdList::<u64>::new(vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ])
     };
 
@@ -157,65 +157,65 @@ fn test_log_id_list_truncate() -> anyhow::Result<()> {
             //
         ]),
         (3, vec![
-            log_id(2, 2), //
+            log_id1(2, 2), //
         ]),
         (4, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
+            log_id1(2, 2), //
+            log_id1(3, 3),
         ]),
         (5, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(3, 4),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(3, 4),
         ]),
         (6, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(3, 5),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(3, 5),
         ]),
         (7, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
         ]),
         (8, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(6, 7),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(6, 7),
         ]),
         (9, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(6, 8),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(6, 8),
         ]),
         (10, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
         ]),
         (11, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 10),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 10),
         ]),
         (12, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ]),
         (13, vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ]),
     ];
 
@@ -234,62 +234,62 @@ fn test_log_id_list_purge() -> anyhow::Result<()> {
     // Purge on an empty log id list:
     {
         let mut ids = LogIdList::<u64>::new(vec![]);
-        ids.purge(&log_id(2, 2));
-        assert_eq!(vec![log_id(2, 2)], ids.key_log_ids());
+        ids.purge(&log_id1(2, 2));
+        assert_eq!(vec![log_id1(2, 2)], ids.key_log_ids());
     }
 
     // Sample data for test
     let make_ids = || {
         LogIdList::<u64>::new(vec![
-            log_id(2, 2), //
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+            log_id1(2, 2), //
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ])
     };
 
     let cases = vec![
-        (log_id(2, 1), vec![
-            log_id(2, 2),
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+        (log_id1(2, 1), vec![
+            log_id1(2, 2),
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ]),
-        (log_id(2, 2), vec![
-            log_id(2, 2),
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+        (log_id1(2, 2), vec![
+            log_id1(2, 2),
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ]),
-        (log_id(3, 3), vec![
-            log_id(3, 3),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+        (log_id1(3, 3), vec![
+            log_id1(3, 3),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ]),
-        (log_id(3, 4), vec![
-            log_id(3, 4),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+        (log_id1(3, 4), vec![
+            log_id1(3, 4),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ]),
-        (log_id(3, 5), vec![
-            log_id(3, 5),
-            log_id(6, 6),
-            log_id(9, 9),
-            log_id(9, 11),
+        (log_id1(3, 5), vec![
+            log_id1(3, 5),
+            log_id1(6, 6),
+            log_id1(9, 9),
+            log_id1(9, 11),
         ]),
-        (log_id(6, 6), vec![log_id(6, 6), log_id(9, 9), log_id(9, 11)]),
-        (log_id(6, 7), vec![log_id(6, 7), log_id(9, 9), log_id(9, 11)]),
-        (log_id(6, 8), vec![log_id(6, 8), log_id(9, 9), log_id(9, 11)]),
-        (log_id(9, 9), vec![log_id(9, 9), log_id(9, 11)]),
-        (log_id(9, 10), vec![log_id(9, 10), log_id(9, 11)]),
-        (log_id(9, 11), vec![log_id(9, 11)]),
-        (log_id(9, 12), vec![log_id(9, 12)]),
-        (log_id(10, 12), vec![log_id(10, 12)]),
+        (log_id1(6, 6), vec![log_id1(6, 6), log_id1(9, 9), log_id1(9, 11)]),
+        (log_id1(6, 7), vec![log_id1(6, 7), log_id1(9, 9), log_id1(9, 11)]),
+        (log_id1(6, 8), vec![log_id1(6, 8), log_id1(9, 9), log_id1(9, 11)]),
+        (log_id1(9, 9), vec![log_id1(9, 9), log_id1(9, 11)]),
+        (log_id1(9, 10), vec![log_id1(9, 10), log_id1(9, 11)]),
+        (log_id1(9, 11), vec![log_id1(9, 11)]),
+        (log_id1(9, 12), vec![log_id1(9, 12)]),
+        (log_id1(10, 12), vec![log_id1(10, 12)]),
     ];
 
     for (upto, want) in cases {
@@ -315,27 +315,27 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
     // Get log id that is a key log id or not.
 
     let ids = LogIdList::<u64>::new(vec![
-        log_id(1, 1),
-        log_id(1, 2),
-        log_id(3, 3),
-        log_id(5, 6),
-        log_id(7, 8),
-        log_id(7, 10),
+        log_id1(1, 1),
+        log_id1(1, 2),
+        log_id1(3, 3),
+        log_id1(5, 6),
+        log_id1(7, 8),
+        log_id1(7, 10),
     ]);
 
     assert_eq!(None, ids.get(0));
-    assert_eq!(Some(log_id(1, 1)), ids.get(1));
-    assert_eq!(Some(log_id(1, 2)), ids.get(2));
-    assert_eq!(Some(log_id(3, 3)), ids.get(3));
-    assert_eq!(Some(log_id(3, 4)), ids.get(4));
-    assert_eq!(Some(log_id(3, 5)), ids.get(5));
-    assert_eq!(Some(log_id(5, 6)), ids.get(6));
-    assert_eq!(Some(log_id(5, 7)), ids.get(7));
-    assert_eq!(Some(log_id(7, 8)), ids.get(8));
-    assert_eq!(Some(log_id(7, 9)), ids.get(9));
-    assert_eq!(Some(log_id(7, 10)), ids.get(10));
+    assert_eq!(Some(log_id1(1, 1)), ids.get(1));
+    assert_eq!(Some(log_id1(1, 2)), ids.get(2));
+    assert_eq!(Some(log_id1(3, 3)), ids.get(3));
+    assert_eq!(Some(log_id1(3, 4)), ids.get(4));
+    assert_eq!(Some(log_id1(3, 5)), ids.get(5));
+    assert_eq!(Some(log_id1(5, 6)), ids.get(6));
+    assert_eq!(Some(log_id1(5, 7)), ids.get(7));
+    assert_eq!(Some(log_id1(7, 8)), ids.get(8));
+    assert_eq!(Some(log_id1(7, 9)), ids.get(9));
+    assert_eq!(Some(log_id1(7, 10)), ids.get(10));
     assert_eq!(None, ids.get(11));
 
     Ok(())
 }
-use crate::testing::log_id;
+use crate::testing::log_id1;

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -8,7 +8,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -37,7 +37,7 @@ fn test_startup_as_leader() -> anyhow::Result<()> {
     // self.id==2 is a voter:
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())));
     // Committed vote makes it a leader at startup.
     eng.state.vote = UTime::new(Instant::now(), Vote::new_committed(1, 2));
 
@@ -69,7 +69,7 @@ fn test_startup_candidate_becomes_follower() -> anyhow::Result<()> {
     // self.id==2 is a voter:
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())));
     // Non-committed vote makes it a candidate at startup.
     eng.state.vote = UTime::new(Instant::now(), Vote::new(1, 2));
 
@@ -86,7 +86,7 @@ fn test_startup_as_follower() -> anyhow::Result<()> {
     // self.id==2 is a voter:
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m23())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m23())));
 
     eng.startup();
 
@@ -102,7 +102,7 @@ fn test_startup_as_learner() -> anyhow::Result<()> {
     // self.id==2 is not a voter:
     eng.state
         .membership_state
-        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m34())));
+        .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m34())));
 
     eng.startup();
 

--- a/openraft/src/raft_state/membership_state/change_handler_test.rs
+++ b/openraft/src/raft_state/membership_state/change_handler_test.rs
@@ -7,7 +7,7 @@ use crate::error::ChangeMembershipError;
 use crate::error::EmptyMembership;
 use crate::error::InProgress;
 use crate::error::LearnerNotFound;
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::ChangeMembers;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -15,7 +15,7 @@ use crate::MembershipState;
 
 /// Create an Arc<EffectiveMembership>
 fn effmem(term: u64, index: u64, m: Membership<u64, ()>) -> Arc<EffectiveMembership<u64, ()>> {
-    let lid = Some(log_id(term, index));
+    let lid = Some(log_id1(term, index));
     Arc::new(EffectiveMembership::new(lid, m))
 }
 
@@ -38,8 +38,8 @@ fn test_apply_not_committed() -> anyhow::Result<()> {
 
     assert_eq!(
         Err(ChangeMembershipError::InProgress(InProgress {
-            committed: Some(log_id(2, 2)),
-            membership_log_id: Some(log_id(3, 4))
+            committed: Some(log_id1(2, 2)),
+            membership_log_id: Some(log_id1(3, 4))
         })),
         res
     );

--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
-use crate::testing::log_id;
+use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
 
 /// Create an Arc<EffectiveMembership>
 fn effmem(term: u64, index: u64, m: Membership<u64, ()>) -> Arc<EffectiveMembership<u64, ()>> {
-    let lid = Some(log_id(term, index));
+    let lid = Some(log_id1(term, index));
     Arc::new(EffectiveMembership::new(lid, m))
 }
 
@@ -44,36 +44,36 @@ fn test_membership_state_is_member() -> anyhow::Result<()> {
 fn test_membership_state_update_committed() -> anyhow::Result<()> {
     let new = || {
         MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(2, 2)), m1())),
-            Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m123_345())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(2, 2)), m1())),
+            Arc::new(EffectiveMembership::new(Some(log_id1(3, 4)), m123_345())),
         )
     };
 
     // Smaller new committed wont take effect.
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())));
+        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m12())));
         assert!(res.is_none());
-        assert_eq!(&Some(log_id(2, 2)), x.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), x.effective().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), x.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), x.effective().log_id());
     }
 
     // Update committed, not effective.
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(2, 3)), m12())));
+        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id1(2, 3)), m12())));
         assert!(res.is_none());
-        assert_eq!(&Some(log_id(2, 3)), x.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), x.effective().log_id());
+        assert_eq!(&Some(log_id1(2, 3)), x.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), x.effective().log_id());
     }
 
     // Update both
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(3, 4)), m12())));
+        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id1(3, 4)), m12())));
         assert_eq!(Some(x.effective().clone()), res);
-        assert_eq!(&Some(log_id(3, 4)), x.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), x.effective().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), x.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), x.effective().log_id());
         assert_eq!(&m12(), x.effective().membership());
     }
 
@@ -81,10 +81,10 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Because leader may have a smaller log_id that is committed.
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id(2, 5)), m12())));
+        let res = x.update_committed(Arc::new(EffectiveMembership::new(Some(log_id1(2, 5)), m12())));
         assert_eq!(Some(x.effective().clone()), res);
-        assert_eq!(&Some(log_id(2, 5)), x.committed().log_id());
-        assert_eq!(&Some(log_id(2, 5)), x.effective().log_id());
+        assert_eq!(&Some(log_id1(2, 5)), x.committed().log_id());
+        assert_eq!(&Some(log_id1(2, 5)), x.effective().log_id());
         assert_eq!(&m12(), x.effective().membership());
     }
 
@@ -98,8 +98,8 @@ fn test_membership_state_append() -> anyhow::Result<()> {
     let mut ms = new();
     ms.append(effmem(4, 5, m12()));
 
-    assert_eq!(&Some(log_id(3, 4)), ms.committed().log_id());
-    assert_eq!(&Some(log_id(4, 5)), ms.effective().log_id());
+    assert_eq!(&Some(log_id1(3, 4)), ms.committed().log_id());
+    assert_eq!(&Some(log_id1(4, 5)), ms.effective().log_id());
     assert_eq!(&m12(), ms.effective().membership());
 
     Ok(())
@@ -112,33 +112,33 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Less than committed
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(1, 1)));
-        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
+        ms.commit(&Some(log_id1(1, 1)));
+        assert_eq!(&Some(log_id1(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), ms.effective().log_id());
     }
 
     // Equal committed
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(2, 2)));
-        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
+        ms.commit(&Some(log_id1(2, 2)));
+        assert_eq!(&Some(log_id1(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), ms.effective().log_id());
     }
 
     // Greater than committed, smaller than effective
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(2, 3)));
-        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
+        ms.commit(&Some(log_id1(2, 3)));
+        assert_eq!(&Some(log_id1(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), ms.effective().log_id());
     }
 
     // Greater than committed, equal effective
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(3, 4)));
-        assert_eq!(&Some(log_id(3, 4)), ms.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
+        ms.commit(&Some(log_id1(3, 4)));
+        assert_eq!(&Some(log_id1(3, 4)), ms.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), ms.effective().log_id());
     }
 
     Ok(())
@@ -152,24 +152,24 @@ fn test_membership_state_truncate() -> anyhow::Result<()> {
         let mut ms = new();
         let res = ms.truncate(5);
         assert!(res.is_none());
-        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
-        assert_eq!(&Some(log_id(3, 4)), ms.effective().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id1(3, 4)), ms.effective().log_id());
     }
 
     {
         let mut ms = new();
         let res = ms.truncate(4);
-        assert_eq!(&Some(log_id(2, 2)), res.unwrap().log_id());
-        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
-        assert_eq!(&Some(log_id(2, 2)), ms.effective().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), res.unwrap().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), ms.effective().log_id());
     }
 
     {
         let mut ms = new();
         let res = ms.truncate(3);
-        assert_eq!(&Some(log_id(2, 2)), res.unwrap().log_id());
-        assert_eq!(&Some(log_id(2, 2)), ms.committed().log_id());
-        assert_eq!(&Some(log_id(2, 2)), ms.effective().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), res.unwrap().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), ms.committed().log_id());
+        assert_eq!(&Some(log_id1(2, 2)), ms.effective().log_id());
     }
 
     Ok(())

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -22,10 +22,18 @@ crate::declare_raft_types!(
     pub(crate) DummyConfig: D = u64, R = u64, NodeId = u64, Node = BasicNode, Entry = crate::entry::Entry<DummyConfig>
 );
 
-/// Builds a log id with node_id set to 0, for testing purposes.
-pub fn log_id(term: u64, index: u64) -> LogId<u64> {
+/// Builds a log id with node_id set to 1, for testing purposes.
+pub fn log_id1(term: u64, index: u64) -> LogId<u64> {
     LogId::<u64> {
         leader_id: CommittedLeaderId::new(term, 1),
+        index,
+    }
+}
+
+/// Builds a log id, for testing purposes.
+pub fn log_id(term: u64, node_id: u64, index: u64) -> LogId<u64> {
+    LogId::<u64> {
+        leader_id: CommittedLeaderId::new(term, node_id),
         index,
     }
 }

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::VoteRequest;
-use openraft::testing::log_id;
+use openraft::testing::log_id1;
 use openraft::Config;
 use openraft::Vote;
 use tokio::time::sleep;
@@ -61,7 +61,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
 
     tracing::info!("--- leader lease rejects vote request");
     {
-        let res = node1.vote(VoteRequest::new(Vote::new(10, 2), Some(log_id(10, 10)))).await?;
+        let res = node1.vote(VoteRequest::new(Vote::new(10, 2), Some(log_id1(10, 10)))).await?;
         assert!(!res.vote_granted);
     }
 
@@ -79,7 +79,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
 
         router.wait(&1, timeout()).log(Some(log_index), "no log is written").await?;
 
-        let res = node1.vote(VoteRequest::new(Vote::new(10, 2), Some(log_id(10, 10)))).await?;
+        let res = node1.vote(VoteRequest::new(Vote::new(10, 2), Some(log_id1(10, 10)))).await?;
         assert!(res.vote_granted, "vote is granted after leader lease expired");
     }
 


### PR DESCRIPTION

## Changelog

##### Refactor: remove Command::AppendBlankLog, use Command::AppendEntry instead

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/789)
<!-- Reviewable:end -->
