### PR TITLE
Refactor: add testing::blank_ent() to create a blank entry for testing

### DIFF
--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::engine::testing::blank_ent;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id1;
@@ -20,7 +20,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
-use crate::engine::testing::blank_ent;
 use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::raft_state::LogStateReader;
+use crate::testing::blank_ent;
 use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -42,8 +42,8 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
 
     eng.following_handler().append_entries(Some(log_id1(2, 3)), vec![
         //
-        blank_ent(3, 4),
-        blank_ent(3, 5),
+        blank_ent(3, 1, 4),
+        blank_ent(3, 1, 5),
     ]);
 
     assert_eq!(
@@ -61,7 +61,7 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
 
     eng.following_handler().append_entries(Some(log_id1(2, 3)), vec![
         //
-        blank_ent(3, 4),
+        blank_ent(3, 1, 4),
     ]);
 
     assert_eq!(Some(&log_id1(3, 5)), eng.state.last_log_id());

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft_state::Accepted;
@@ -20,7 +20,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -4,7 +4,7 @@ use maplit::btreeset;
 
 use crate::core::ServerState;
 use crate::engine::testing::blank_ent;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
@@ -32,7 +32,7 @@ fn m45() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {4,5}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
@@ -51,7 +51,7 @@ fn eng() -> Engine<UTCfg> {
 fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    eng.following_handler().do_append_entries(Vec::<Entry<UTCfg>>::new(), 0);
+    eng.following_handler().do_append_entries(Vec::<Entry<UTConfig>>::new(), 0);
     eng.following_handler().do_append_entries(vec![blank_ent(3, 4)], 1);
 
     assert_eq!(
@@ -131,9 +131,9 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
             blank_ent(3, 3), // ignored
             blank_ent(3, 3), // ignored
             blank_ent(3, 4),
-            Entry::<UTCfg> {
+            Entry::<UTConfig> {
                 log_id: log_id1(3, 5),
-                payload: EntryPayload::<UTCfg>::Membership(m34()),
+                payload: EntryPayload::<UTConfig>::Membership(m34()),
             },
         ],
         3,
@@ -167,9 +167,9 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
             entries: vec![
                 //
                 blank_ent(3, 4),
-                Entry::<UTCfg> {
+                Entry::<UTConfig> {
                     log_id: log_id1(3, 5),
-                    payload: EntryPayload::<UTCfg>::Membership(m34()),
+                    payload: EntryPayload::<UTConfig>::Membership(m34()),
                 },
             ]
         },],
@@ -190,11 +190,11 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
 
     eng.following_handler().do_append_entries(
         vec![
-            Entry::<UTCfg>::new_membership(log_id1(3, 4), m01()), // ignored
+            Entry::<UTConfig>::new_membership(log_id1(3, 4), m01()), // ignored
             blank_ent(3, 4),
-            Entry::<UTCfg>::new_membership(log_id1(3, 5), m01()),
-            Entry::<UTCfg>::new_membership(log_id1(4, 6), m34()),
-            Entry::<UTCfg>::new_membership(log_id1(4, 7), m45()),
+            Entry::<UTConfig>::new_membership(log_id1(3, 5), m01()),
+            Entry::<UTConfig>::new_membership(log_id1(4, 6), m34()),
+            Entry::<UTConfig>::new_membership(log_id1(4, 7), m45()),
         ],
         1,
     );
@@ -227,9 +227,9 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
         vec![Command::AppendInputEntries {
             entries: vec![
                 blank_ent(3, 4),
-                Entry::<UTCfg>::new_membership(log_id1(3, 5), m01()),
-                Entry::<UTCfg>::new_membership(log_id1(4, 6), m34()),
-                Entry::<UTCfg>::new_membership(log_id1(4, 7), m45()),
+                Entry::<UTConfig>::new_membership(log_id1(3, 5), m01()),
+                Entry::<UTConfig>::new_membership(log_id1(4, 6), m34()),
+                Entry::<UTConfig>::new_membership(log_id1(4, 7), m45()),
             ]
         },],
         eng.output.take_commands()

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::core::ServerState;
-use crate::engine::testing::blank_ent;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
 use crate::raft_state::LogStateReader;
+use crate::testing::blank_ent;
 use crate::testing::log_id1;
 use crate::EffectiveMembership;
 use crate::Entry;
@@ -52,7 +52,7 @@ fn test_follower_do_append_entries_empty() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler().do_append_entries(Vec::<Entry<UTConfig>>::new(), 0);
-    eng.following_handler().do_append_entries(vec![blank_ent(3, 4)], 1);
+    eng.following_handler().do_append_entries(vec![blank_ent(3, 1, 4)], 1);
 
     assert_eq!(
         &[
@@ -81,8 +81,8 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
 
     eng.following_handler().do_append_entries(
         vec![
-            blank_ent(100, 100), // just be ignored
-            blank_ent(3, 4),
+            blank_ent(100, 1, 100), // just be ignored
+            blank_ent(3, 1, 4),
         ],
         1,
     );
@@ -108,7 +108,7 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
         vec![
             //
             Command::AppendInputEntries {
-                entries: vec![blank_ent(3, 4)]
+                entries: vec![blank_ent(3, 1, 4)]
             },
         ],
         eng.output.take_commands()
@@ -127,10 +127,10 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
 
     eng.following_handler().do_append_entries(
         vec![
-            blank_ent(3, 3), // ignored
-            blank_ent(3, 3), // ignored
-            blank_ent(3, 3), // ignored
-            blank_ent(3, 4),
+            blank_ent(3, 1, 3), // ignored
+            blank_ent(3, 1, 3), // ignored
+            blank_ent(3, 1, 3), // ignored
+            blank_ent(3, 1, 4),
             Entry::<UTConfig> {
                 log_id: log_id1(3, 5),
                 payload: EntryPayload::<UTConfig>::Membership(m34()),
@@ -166,7 +166,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
         vec![Command::AppendInputEntries {
             entries: vec![
                 //
-                blank_ent(3, 4),
+                blank_ent(3, 1, 4),
                 Entry::<UTConfig> {
                     log_id: log_id1(3, 5),
                     payload: EntryPayload::<UTConfig>::Membership(m34()),
@@ -191,7 +191,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
     eng.following_handler().do_append_entries(
         vec![
             Entry::<UTConfig>::new_membership(log_id1(3, 4), m01()), // ignored
-            blank_ent(3, 4),
+            blank_ent(3, 1, 4),
             Entry::<UTConfig>::new_membership(log_id1(3, 5), m01()),
             Entry::<UTConfig>::new_membership(log_id1(4, 6), m34()),
             Entry::<UTConfig>::new_membership(log_id1(4, 7), m45()),
@@ -226,7 +226,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
     assert_eq!(
         vec![Command::AppendInputEntries {
             entries: vec![
-                blank_ent(3, 4),
+                blank_ent(3, 1, 4),
                 Entry::<UTConfig>::new_membership(log_id1(3, 5), m01()),
                 Entry::<UTConfig>::new_membership(log_id1(4, 6), m34()),
                 Entry::<UTConfig>::new_membership(log_id1(4, 7), m45()),

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -23,7 +23,7 @@ fn m1234() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
@@ -164,7 +164,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     // Snapshot will be installed, all non-committed log will be deleted.
     // And there should be no conflicting logs left.
     let mut eng = {
-        let mut eng = Engine::<UTCfg>::default();
+        let mut eng = Engine::<UTConfig>::default();
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -25,7 +25,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use maplit::btreeset;
 
 use crate::core::ServerState;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::testing::log_id1;
 use crate::EffectiveMembership;
@@ -22,7 +22,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -7,7 +7,7 @@ use maplit::btreeset;
 use tokio::time::Instant;
 
 use crate::engine::testing::blank_ent;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
@@ -50,7 +50,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
@@ -73,7 +73,7 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.vote_handler().become_leading();
 
-    eng.leader_handler()?.leader_append_entries(Vec::<Entry<UTCfg>>::new());
+    eng.leader_handler()?.leader_append_entries(Vec::<Entry<UTConfig>>::new());
 
     assert_eq!(
         &[

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -6,7 +6,6 @@ use maplit::btreeset;
 #[allow(unused_imports)] use pretty_assertions::assert_str_eq;
 use tokio::time::Instant;
 
-use crate::engine::testing::blank_ent;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
@@ -14,6 +13,7 @@ use crate::entry::RaftEntry;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft_state::LogStateReader;
+use crate::testing::blank_ent;
 use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::vote::CommittedLeaderId;
@@ -102,9 +102,9 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
 
     // log id will be assigned by eng.
     eng.leader_handler()?.leader_append_entries(vec![
-        blank_ent(1, 1), //
-        blank_ent(1, 1),
-        blank_ent(1, 1),
+        blank_ent(1, 1, 1), //
+        blank_ent(1, 1, 1),
+        blank_ent(1, 1, 1),
     ]);
 
     assert_eq!(
@@ -131,9 +131,9 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
         vec![
             Command::AppendInputEntries {
                 entries: vec![
-                    blank_ent(3, 4), //
-                    blank_ent(3, 5),
-                    blank_ent(3, 6),
+                    blank_ent(3, 1, 4), //
+                    blank_ent(3, 1, 5),
+                    blank_ent(3, 1, 6),
                 ]
             },
             Command::Replicate {
@@ -163,9 +163,9 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
 
     // log id will be assigned by eng.
     eng.leader_handler()?.leader_append_entries(vec![
-        blank_ent(1, 1), //
-        blank_ent(1, 1),
-        blank_ent(1, 1),
+        blank_ent(1, 1, 1), //
+        blank_ent(1, 1, 1),
+        blank_ent(1, 1, 1),
     ]);
 
     assert_eq!(
@@ -197,9 +197,9 @@ fn test_leader_append_entries_fast_commit() -> anyhow::Result<()> {
         vec![
             Command::AppendInputEntries {
                 entries: vec![
-                    blank_ent(3, 4), //
-                    blank_ent(3, 5),
-                    blank_ent(3, 6),
+                    blank_ent(3, 1, 4), //
+                    blank_ent(3, 1, 5),
+                    blank_ent(3, 1, 6),
                 ]
             },
             Command::ReplicateCommitted {
@@ -228,9 +228,9 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
 
     // log id will be assigned by eng.
     eng.leader_handler()?.leader_append_entries(vec![
-        blank_ent(1, 1), //
+        blank_ent(1, 1, 1), //
         Entry::new_membership(log_id1(1, 1), m34()),
-        blank_ent(1, 1),
+        blank_ent(1, 1, 1),
     ]);
 
     assert_eq!(
@@ -264,9 +264,9 @@ fn test_leader_append_entries_fast_commit_upto_membership_entry() -> anyhow::Res
         vec![
             Command::AppendInputEntries {
                 entries: vec![
-                    blank_ent(3, 4), //
+                    blank_ent(3, 1, 4), //
                     Entry::new_membership(log_id1(3, 5), m34()),
-                    blank_ent(3, 6),
+                    blank_ent(3, 1, 6),
                 ]
             },
             Command::ReplicateCommitted {
@@ -308,9 +308,9 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
 
     // log id will be assigned by eng.
     eng.leader_handler()?.leader_append_entries(vec![
-        blank_ent(1, 1), //
+        blank_ent(1, 1, 1), //
         Entry::new_membership(log_id1(1, 1), m1_2()),
-        blank_ent(1, 1),
+        blank_ent(1, 1, 1),
     ]);
 
     assert_eq!(
@@ -342,9 +342,9 @@ fn test_leader_append_entries_fast_commit_membership_no_voter_change() -> anyhow
         vec![
             Command::AppendInputEntries {
                 entries: vec![
-                    blank_ent(3, 4), //
+                    blank_ent(3, 1, 4), //
                     Entry::new_membership(log_id1(3, 5), m1_2()),
-                    blank_ent(3, 6),
+                    blank_ent(3, 1, 6),
                 ]
             },
             // first commit upto the membership entry(exclusive).
@@ -393,9 +393,9 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
 
     // log id will be assigned by eng.
     eng.leader_handler()?.leader_append_entries(vec![
-        blank_ent(1, 1), //
+        blank_ent(1, 1, 1), //
         Entry::new_membership(log_id1(1, 1), m1_2()),
-        blank_ent(1, 1),
+        blank_ent(1, 1, 1),
     ]);
 
     assert_eq!(
@@ -427,9 +427,9 @@ fn test_leader_append_entries_fast_commit_if_membership_voter_change_to_1() -> a
         vec![
             Command::AppendInputEntries {
                 entries: vec![
-                    blank_ent(3, 4), //
+                    blank_ent(3, 1, 4), //
                     Entry::new_membership(log_id1(3, 5), m1_2()),
-                    blank_ent(3, 6),
+                    blank_ent(3, 1, 6),
                 ]
             },
             Command::RebuildReplicationStreams {

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -6,7 +6,7 @@ use maplit::btreeset;
 #[allow(unused_imports)] use pretty_assertions::assert_str_eq;
 use tokio::time::Instant;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Inflight;
@@ -26,7 +26,7 @@ fn m23() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
+++ b/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
@@ -1,4 +1,4 @@
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::CommittedLeaderId;
@@ -11,7 +11,7 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -1,11 +1,11 @@
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id1;
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -4,7 +4,7 @@ use maplit::btreeset;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -40,7 +40,7 @@ fn m4_356() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -4,7 +4,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Inflight;
@@ -25,7 +25,7 @@ fn m123() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -4,7 +4,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::testing::log_id1;
@@ -23,7 +23,7 @@ fn m123() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/snapshot_handler/trigger_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/trigger_snapshot_test.rs
@@ -1,10 +1,10 @@
 use pretty_assertions::assert_eq;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
@@ -1,7 +1,7 @@
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::testing::log_id1;
 use crate::Membership;
@@ -16,7 +16,7 @@ fn m1234() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -6,7 +6,7 @@ use tokio::sync::oneshot;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::Respond;
@@ -31,7 +31,7 @@ fn mk_res() -> Result<VoteResponse<u64>, Infallible> {
     })
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -5,7 +5,7 @@ use maplit::btreeset;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -20,7 +20,7 @@ fn m01() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -1,5 +1,3 @@
-use crate::entry::RaftEntry;
-use crate::testing::log_id1;
 use crate::RaftTypeConfig;
 
 /// Trivial Raft type config for Engine related unit test.
@@ -12,8 +10,4 @@ impl RaftTypeConfig for UTConfig {
     type NodeId = u64;
     type Node = ();
     type Entry = crate::Entry<UTConfig>;
-}
-
-pub(crate) fn blank_ent(term: u64, index: u64) -> crate::Entry<UTConfig> {
-    crate::Entry::<UTConfig>::new_blank(log_id1(term, index))
 }

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -2,35 +2,18 @@ use crate::entry::RaftEntry;
 use crate::testing::log_id1;
 use crate::RaftTypeConfig;
 
-/// Req for test
-#[derive(Clone)]
-#[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub(crate) struct Req {}
-
-/// Resp for test
-#[derive(Clone)]
-#[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub(crate) struct Resp {}
-
-// Config for test
-crate::declare_raft_types!(
-   pub(crate) Config: D = Req, R = Resp, NodeId = u64, Node=(), Entry = crate::Entry<Config>
-);
-
 /// Trivial Raft type config for Engine related unit test.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub(crate) struct UTCfg {}
-impl RaftTypeConfig for UTCfg {
+pub(crate) struct UTConfig {}
+impl RaftTypeConfig for UTConfig {
     type D = ();
     type R = ();
     type NodeId = u64;
     type Node = ();
-    type Entry = crate::Entry<UTCfg>;
+    type Entry = crate::Entry<UTConfig>;
 }
 
-pub(crate) fn blank_ent(term: u64, index: u64) -> crate::Entry<UTCfg> {
-    crate::Entry::<UTCfg>::new_blank(log_id1(term, index))
+pub(crate) fn blank_ent(term: u64, index: u64) -> crate::Entry<UTConfig> {
+    crate::Entry::<UTConfig>::new_blank(log_id1(term, index))
 }

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -6,7 +6,7 @@ use tokio::time::Instant;
 
 use crate::core::ServerState;
 use crate::engine::testing::blank_ent;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
@@ -32,7 +32,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
@@ -53,7 +53,7 @@ fn eng() -> Engine<UTCfg> {
 fn test_append_entries_vote_is_rejected() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    let res = eng.append_entries(&Vote::new(1, 1), None, Vec::<Entry<UTCfg>>::new());
+    let res = eng.append_entries(&Vote::new(1, 1), None, Vec::<Entry<UTConfig>>::new());
 
     assert_eq!(Err(RejectAppendEntries::ByVote(Vote::new(2, 1))), res);
     assert_eq!(
@@ -88,7 +88,7 @@ fn test_append_entries_prev_log_id_is_applied() -> anyhow::Result<()> {
     let res = eng.append_entries(
         &Vote::new_committed(2, 1),
         Some(log_id1(0, 0)),
-        Vec::<Entry<UTCfg>>::new(),
+        Vec::<Entry<UTConfig>>::new(),
     );
 
     assert_eq!(Ok(()), res);
@@ -126,7 +126,7 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
     let res = eng.append_entries(
         &Vote::new_committed(2, 1),
         Some(log_id1(2, 2)),
-        Vec::<Entry<UTCfg>>::new(),
+        Vec::<Entry<UTConfig>>::new(),
     );
 
     assert_eq!(

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -5,13 +5,13 @@ use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::blank_ent;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
 use crate::error::RejectAppendEntries;
 use crate::raft_state::LogStateReader;
+use crate::testing::blank_ent;
 use crate::testing::log_id1;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
@@ -170,8 +170,8 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let res = eng.append_entries(&Vote::new_committed(2, 1), Some(log_id1(0, 0)), vec![
-        blank_ent(1, 1),
-        blank_ent(2, 2),
+        blank_ent(1, 1, 1),
+        blank_ent(2, 1, 2),
     ]);
 
     assert_eq!(Ok(()), res);
@@ -199,7 +199,7 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
             },
             Command::DeleteConflictLog { since: log_id1(1, 2) },
             Command::AppendInputEntries {
-                entries: vec![blank_ent(2, 2)]
+                entries: vec![blank_ent(2, 1, 2)]
             },
         ],
         eng.output.take_commands()
@@ -215,8 +215,8 @@ fn test_append_entries_prev_log_id_not_exists() -> anyhow::Result<()> {
     eng.vote_handler().become_leading();
 
     let res = eng.append_entries(&Vote::new_committed(2, 1), Some(log_id1(2, 4)), vec![
-        blank_ent(2, 5),
-        blank_ent(2, 6),
+        blank_ent(2, 1, 5),
+        blank_ent(2, 1, 6),
     ]);
 
     assert_eq!(
@@ -263,7 +263,7 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let resp = eng.append_entries(&Vote::new_committed(2, 1), Some(log_id1(1, 1)), vec![
-        blank_ent(1, 2),
+        blank_ent(1, 1, 2),
         Entry::new_membership(log_id1(3, 3), m34()),
     ]);
 

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -29,7 +29,7 @@ fn m12() -> Membership<u64, ()> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.log_ids = LogIdList::new([LogId::new(CommittedLeaderId::new(0, 0), 0)]);
     eng.state.enable_validate = false; // Disable validation for incomplete state
@@ -65,7 +65,7 @@ fn test_elect() -> anyhow::Result<()> {
                 Command::BecomeLeader,
                 Command::RebuildReplicationStreams { targets: vec![] },
                 Command::AppendEntry {
-                    entry: Entry::<UTCfg>::new_blank(log_id(1, 1, 1))
+                    entry: Entry::<UTConfig>::new_blank(log_id(1, 1, 1))
                 },
                 Command::ReplicateCommitted {
                     committed: Some(LogId {
@@ -117,7 +117,7 @@ fn test_elect() -> anyhow::Result<()> {
                 Command::BecomeLeader,
                 Command::RebuildReplicationStreams { targets: vec![] },
                 Command::AppendEntry {
-                    entry: Entry::<UTCfg>::new_blank(log_id(2, 1, 1))
+                    entry: Entry::<UTConfig>::new_blank(log_id(2, 1, 1))
                 },
                 Command::ReplicateCommitted {
                     committed: Some(LogId {

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -5,7 +5,7 @@ use maplit::btreeset;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -21,7 +21,7 @@ fn m01() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -31,7 +31,7 @@ fn m1234() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
@@ -218,7 +218,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                     targets: vec![(2, ProgressEntry::empty(1))]
                 },
                 Command::AppendEntry {
-                    entry: Entry::<UTCfg>::new_blank(log_id(2, 1, 1)),
+                    entry: Entry::<UTConfig>::new_blank(log_id(2, 1, 1)),
                 },
                 Command::Replicate {
                     target: 2,

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use tokio::time::Instant;
 
 use crate::core::ServerState;
-use crate::engine::testing::Config;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
@@ -25,7 +25,7 @@ use crate::Vote;
 #[test]
 fn test_initialize_single_node() -> anyhow::Result<()> {
     let eng = || {
-        let mut eng = Engine::<Config>::default();
+        let mut eng = Engine::<UTConfig>::default();
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.server_state = eng.calc_server_state();
@@ -38,7 +38,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
     };
 
     let m1 = || Membership::<u64, ()>::new(vec![btreeset! {1}], None);
-    let entry = Entry::<Config>::new_membership(LogId::default(), m1());
+    let entry = Entry::<UTConfig>::new_membership(LogId::default(), m1());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");
     tracing::info!("--- expect OK result, check output commands and state changes");
@@ -58,7 +58,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
         assert_eq!(
             vec![
                 Command::AppendEntry {
-                    entry: Entry::<Config>::new_membership(LogId::default(), m1())
+                    entry: Entry::<UTConfig>::new_membership(LogId::default(), m1())
                 },
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output
@@ -72,7 +72,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
                 Command::BecomeLeader,
                 Command::RebuildReplicationStreams { targets: vec![] },
                 Command::AppendEntry {
-                    entry: Entry::<Config>::new_blank(log_id(1, 1, 1))
+                    entry: Entry::<UTConfig>::new_blank(log_id(1, 1, 1))
                 },
                 Command::ReplicateCommitted {
                     committed: Some(LogId {
@@ -97,7 +97,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 #[test]
 fn test_initialize() -> anyhow::Result<()> {
     let eng = || {
-        let mut eng = Engine::<Config>::default();
+        let mut eng = Engine::<UTConfig>::default();
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
         eng.state.server_state = eng.calc_server_state();
@@ -110,7 +110,7 @@ fn test_initialize() -> anyhow::Result<()> {
     };
 
     let m12 = || Membership::<u64, ()>::new(vec![btreeset! {1,2}], None);
-    let entry = || Entry::<Config>::new_membership(LogId::default(), m12());
+    let entry = || Entry::<UTConfig>::new_membership(LogId::default(), m12());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");
     tracing::info!("--- expect OK result, check output commands and state changes");

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use maplit::btreeset;
 use tokio::time::Instant;
 
-use crate::engine::testing::UTCfg;
+use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::entry::ProgressEntry;
@@ -23,7 +23,7 @@ fn m34() -> Membership<u64, ()> {
     Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
 }
 
-fn eng() -> Engine<UTCfg> {
+fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.config.id = 2;
     // This will be overridden

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -9,18 +9,11 @@ use tokio::sync::oneshot;
 use crate::log_id::RaftLogId;
 use crate::storage::LogFlushed;
 use crate::storage::RaftLogStorage;
-use crate::BasicNode;
 use crate::CommittedLeaderId;
 use crate::LogId;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::StorageIOError;
-
-crate::declare_raft_types!(
-    /// Dummy Raft types for the purpose of testing internal structures requiring
-    /// `RaftTypeConfig`, like `MembershipConfig`.
-    pub(crate) DummyConfig: D = u64, R = u64, NodeId = u64, Node = BasicNode, Entry = crate::entry::Entry<DummyConfig>
-);
 
 /// Builds a log id with node_id set to 1, for testing purposes.
 pub fn log_id1(term: u64, index: u64) -> LogId<u64> {

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -6,6 +6,7 @@ pub use store_builder::StoreBuilder;
 pub use suite::Suite;
 use tokio::sync::oneshot;
 
+use crate::entry::RaftEntry;
 use crate::log_id::RaftLogId;
 use crate::storage::LogFlushed;
 use crate::storage::RaftLogStorage;
@@ -29,6 +30,11 @@ pub fn log_id(term: u64, node_id: u64, index: u64) -> LogId<u64> {
         leader_id: CommittedLeaderId::new(term, node_id),
         index,
     }
+}
+
+/// Create a blank log entry for test.
+pub fn blank_ent<C: RaftTypeConfig>(term: u64, node_id: C::NodeId, index: u64) -> crate::Entry<C> {
+    crate::Entry::<C>::new_blank(LogId::new(CommittedLeaderId::new(term, node_id), index))
 }
 
 /// Append to log and wait for the log to be flushed.

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -126,8 +126,8 @@ where
         tracing::info!("--- no log, do not read membership from state machine");
         {
             apply(&mut sm, [
-                blank_ent::<C>(1, 1),
-                membership_ent::<C>(1, 1, btreeset! {3,4,5}),
+                blank_ent_0::<C>(1, 1),
+                membership_ent_0::<C>(1, 1, btreeset! {3,4,5}),
             ])
             .await?;
 
@@ -138,7 +138,7 @@ where
 
         tracing::info!("--- membership presents in log, smaller than last_applied, read from log");
         {
-            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent_0::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
             let mem = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
             assert_eq!(1, mem.len());
@@ -157,9 +157,9 @@ where
         tracing::info!("--- membership presents in log and > sm.last_applied, read 2 membership entries from log");
         {
             append(&mut store, [
-                blank_ent::<C>(1, 2),
-                membership_ent::<C>(1, 3, btreeset! {7,8,9}),
-                blank_ent::<C>(1, 4),
+                blank_ent_0::<C>(1, 2),
+                membership_ent_0::<C>(1, 3, btreeset! {7,8,9}),
+                blank_ent_0::<C>(1, 4),
             ])
             .await?;
 
@@ -181,7 +181,7 @@ where
 
         tracing::info!("--- 3 memberships in log, only return the last 2 of them");
         {
-            append(&mut store, [membership_ent::<C>(1, 5, btreeset! {10,11})]).await?;
+            append(&mut store, [membership_ent_0::<C>(1, 5, btreeset! {10,11})]).await?;
 
             let mems = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
             assert_eq!(2, mems.len());
@@ -201,16 +201,16 @@ where
         {
             append(&mut store, [
                 //
-                membership_ent::<C>(1, 1, btreeset! {1,2,3}),
-                membership_ent::<C>(1, 2, btreeset! {3,4,5}),
+                membership_ent_0::<C>(1, 1, btreeset! {1,2,3}),
+                membership_ent_0::<C>(1, 2, btreeset! {3,4,5}),
             ])
             .await?;
 
             for i in 3..100 {
-                append(&mut store, [blank_ent::<C>(1, i)]).await?;
+                append(&mut store, [blank_ent_0::<C>(1, i)]).await?;
             }
 
-            append(&mut store, [membership_ent::<C>(1, 100, btreeset! {5,6,7})]).await?;
+            append(&mut store, [membership_ent_0::<C>(1, 100, btreeset! {5,6,7})]).await?;
 
             let mems = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
             assert_eq!(2, mems.len());
@@ -241,7 +241,7 @@ where
         {
             // There is an empty membership config in an empty state machine.
 
-            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent_0::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
             let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
@@ -259,8 +259,8 @@ where
         tracing::info!("--- no log, read membership from state machine");
         {
             apply(&mut sm, [
-                blank_ent::<C>(1, 1),
-                membership_ent::<C>(1, 2, btreeset! {3,4,5}),
+                blank_ent_0::<C>(1, 1),
+                membership_ent_0::<C>(1, 2, btreeset! {3,4,5}),
             ])
             .await?;
 
@@ -278,7 +278,7 @@ where
 
         tracing::info!("--- membership presents in log, but smaller than last_applied, read from state machine");
         {
-            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent_0::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
             let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
@@ -295,8 +295,8 @@ where
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
         {
             append(&mut store, [
-                blank_ent::<C>(1, 2),
-                membership_ent::<C>(1, 3, btreeset! {7,8,9}),
+                blank_ent_0::<C>(1, 2),
+                membership_ent_0::<C>(1, 3, btreeset! {7,8,9}),
             ])
             .await?;
 
@@ -315,8 +315,8 @@ where
         tracing::info!("--- two membership present in log and > sm.last_applied, read 2 from log");
         {
             append(&mut store, [
-                blank_ent::<C>(1, 4),
-                membership_ent::<C>(1, 5, btreeset! {10,11}),
+                blank_ent_0::<C>(1, 4),
+                membership_ent_0::<C>(1, 5, btreeset! {10,11}),
             ])
             .await?;
 
@@ -348,24 +348,24 @@ where
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [
-            blank_ent::<C>(0, 0),
-            blank_ent::<C>(1, 1),
-            blank_ent::<C>(3, 2),
+            blank_ent_0::<C>(0, 0),
+            blank_ent_0::<C>(1, 1),
+            blank_ent_0::<C>(3, 2),
         ])
         .await?;
 
-        apply(&mut sm, [blank_ent::<C>(3, 1)]).await?;
+        apply(&mut sm, [blank_ent_0::<C>(3, 1)]).await?;
 
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
         assert_eq!(
-            Some(&log_id(3, 2)),
+            Some(&log_id_0(3, 2)),
             initial.last_log_id(),
             "state machine has higher log"
         );
         assert_eq!(
             initial.committed(),
-            Some(&log_id(3, 1)),
+            Some(&log_id_0(3, 1)),
             "unexpected value for last applied log"
         );
         assert_eq!(
@@ -389,8 +389,8 @@ where
         tracing::info!("--- no log, read membership from state machine");
         {
             apply(&mut sm, [
-                blank_ent::<C>(1, 1),
-                membership_ent::<C>(1, 2, btreeset! {3,4,5}),
+                blank_ent_0::<C>(1, 1),
+                membership_ent_0::<C>(1, 2, btreeset! {3,4,5}),
             ])
             .await?;
 
@@ -404,7 +404,7 @@ where
 
         tracing::info!("--- membership presents in log, but smaller than last_applied, read from state machine");
         {
-            append(&mut store, [membership_ent::<C>(1, 1, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent_0::<C>(1, 1, btreeset! {1,2,3})]).await?;
 
             let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
@@ -416,7 +416,7 @@ where
 
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
         {
-            append(&mut store, [membership_ent::<C>(1, 3, btreeset! {1,2,3})]).await?;
+            append(&mut store, [membership_ent_0::<C>(1, 3, btreeset! {1,2,3})]).await?;
 
             let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
@@ -432,14 +432,14 @@ where
     pub async fn get_initial_state_last_log_gt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::default_vote(&mut store).await?;
 
-        append(&mut store, [blank_ent::<C>(0, 0), blank_ent::<C>(2, 1)]).await?;
+        append(&mut store, [blank_ent_0::<C>(0, 0), blank_ent_0::<C>(2, 1)]).await?;
 
-        apply(&mut sm, [blank_ent::<C>(1, 1), blank_ent::<C>(1, 2)]).await?;
+        apply(&mut sm, [blank_ent_0::<C>(1, 1), blank_ent_0::<C>(1, 2)]).await?;
 
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
         assert_eq!(
-            Some(&log_id(2, 1)),
+            Some(&log_id_0(2, 1)),
             initial.last_log_id(),
             "state machine has higher log"
         );
@@ -449,20 +449,20 @@ where
     pub async fn get_initial_state_last_log_lt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::default_vote(&mut store).await?;
 
-        append(&mut store, [blank_ent::<C>(1, 2)]).await?;
+        append(&mut store, [blank_ent_0::<C>(1, 2)]).await?;
 
-        apply(&mut sm, [blank_ent::<C>(3, 1)]).await?;
+        apply(&mut sm, [blank_ent_0::<C>(3, 1)]).await?;
 
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
 
         assert_eq!(
-            Some(&log_id(3, 1)),
+            Some(&log_id_0(3, 1)),
             initial.last_log_id(),
             "state machine has higher log"
         );
         assert_eq!(
             initial.last_purged_log_id().copied(),
-            Some(log_id(3, 1)),
+            Some(log_id_0(3, 1)),
             "state machine has higher log"
         );
         Ok(())
@@ -482,7 +482,7 @@ where
 
         tracing::info!("--- log terms: [0], last_purged_log_id is None, expect [(0,0)]");
         {
-            append(&mut store, [blank_ent::<C>(0, 0)]).await?;
+            append(&mut store, [blank_ent_0::<C>(0, 0)]).await?;
 
             let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
             assert_eq!(vec![log_id(0, 0, 0)], initial.log_ids.key_log_ids());
@@ -491,9 +491,9 @@ where
         tracing::info!("--- log terms: [0,1,1,2], last_purged_log_id is None, expect [(0,0),(1,1),(2,3)]");
         {
             append(&mut store, [
-                blank_ent::<C>(1, 1),
-                blank_ent::<C>(1, 2),
-                blank_ent::<C>(2, 3),
+                blank_ent_0::<C>(1, 1),
+                blank_ent_0::<C>(1, 2),
+                blank_ent_0::<C>(2, 3),
             ])
             .await?;
 
@@ -509,9 +509,9 @@ where
         );
         {
             append(&mut store, [
-                blank_ent::<C>(2, 4),
-                blank_ent::<C>(3, 5),
-                blank_ent::<C>(3, 6),
+                blank_ent_0::<C>(2, 4),
+                blank_ent_0::<C>(3, 5),
+                blank_ent_0::<C>(3, 6),
             ])
             .await?;
 
@@ -614,8 +614,8 @@ where
             let logs = store.get_log_entries(5..7).await?;
 
             assert_eq!(logs.len(), 2);
-            assert_eq!(*logs[0].get_log_id(), log_id(1, 5));
-            assert_eq!(*logs[1].get_log_id(), log_id(1, 6));
+            assert_eq!(*logs[0].get_log_id(), log_id_0(1, 5));
+            assert_eq!(*logs[1].get_log_id(), log_id_0(1, 6));
         }
 
         Ok(())
@@ -627,7 +627,7 @@ where
         store.purge(LogId::new(CommittedLeaderId::new(0, C::NodeId::default()), 0)).await?;
 
         let ent = store.try_get_log_entry(3).await?;
-        assert_eq!(Some(log_id(1, 3)), ent.map(|x| *x.get_log_id()));
+        assert_eq!(Some(log_id_0(1, 3)), ent.map(|x| *x.get_log_id()));
 
         let ent = store.try_get_log_entry(0).await?;
         assert_eq!(None, ent.map(|x| *x.get_log_id()));
@@ -654,45 +654,45 @@ where
         tracing::info!("--- only logs");
         {
             append(&mut store, [
-                blank_ent::<C>(0, 0),
-                blank_ent::<C>(1, 1),
-                blank_ent::<C>(1, 2),
+                blank_ent_0::<C>(0, 0),
+                blank_ent_0::<C>(1, 1),
+                blank_ent_0::<C>(1, 2),
             ])
             .await?;
 
             let st = store.get_log_state().await?;
             assert_eq!(None, st.last_purged_log_id);
-            assert_eq!(Some(log_id(1, 2)), st.last_log_id);
+            assert_eq!(Some(log_id_0(1, 2)), st.last_log_id);
         }
 
         tracing::info!("--- delete log 0-0");
         {
-            store.purge(log_id(0, 0)).await?;
+            store.purge(log_id_0(0, 0)).await?;
 
             let st = store.get_log_state().await?;
             assert_eq!(
                 Some(LogId::new(CommittedLeaderId::new(0, C::NodeId::default()), 0)),
                 st.last_purged_log_id
             );
-            assert_eq!(Some(log_id(1, 2)), st.last_log_id);
+            assert_eq!(Some(log_id_0(1, 2)), st.last_log_id);
         }
 
         tracing::info!("--- delete all log");
         {
-            store.purge(log_id(1, 2)).await?;
+            store.purge(log_id_0(1, 2)).await?;
 
             let st = store.get_log_state().await?;
-            assert_eq!(Some(log_id(1, 2)), st.last_purged_log_id);
-            assert_eq!(Some(log_id(1, 2)), st.last_log_id);
+            assert_eq!(Some(log_id_0(1, 2)), st.last_purged_log_id);
+            assert_eq!(Some(log_id_0(1, 2)), st.last_log_id);
         }
 
         tracing::info!("--- delete advance last present logs");
         {
-            store.purge(log_id(2, 3)).await?;
+            store.purge(log_id_0(2, 3)).await?;
 
             let st = store.get_log_state().await?;
-            assert_eq!(Some(log_id(2, 3)), st.last_purged_log_id);
-            assert_eq!(Some(log_id(2, 3)), st.last_log_id);
+            assert_eq!(Some(log_id_0(2, 3)), st.last_purged_log_id);
+            assert_eq!(Some(log_id_0(2, 3)), st.last_log_id);
         }
 
         Ok(())
@@ -701,7 +701,7 @@ where
     pub async fn get_log_id(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge(log_id(1, 3)).await?;
+        store.purge(log_id_0(1, 3)).await?;
 
         let res = store.get_log_id(0).await;
         assert!(res.is_err());
@@ -710,10 +710,10 @@ where
         assert!(res.is_err());
 
         let res = store.get_log_id(3).await?;
-        assert_eq!(log_id(1, 3), res);
+        assert_eq!(log_id_0(1, 3), res);
 
         let res = store.get_log_id(4).await?;
-        assert_eq!(log_id(1, 4), res);
+        assert_eq!(log_id_0(1, 4), res);
 
         Ok(())
     }
@@ -725,29 +725,29 @@ where
         tracing::info!("--- only logs");
         {
             append(&mut store, [
-                blank_ent::<C>(0, 0),
-                blank_ent::<C>(1, 1),
-                blank_ent::<C>(1, 2),
+                blank_ent_0::<C>(0, 0),
+                blank_ent_0::<C>(1, 1),
+                blank_ent_0::<C>(1, 2),
             ])
             .await?;
 
             let last_log_id = store.get_log_state().await?.last_log_id;
-            assert_eq!(Some(log_id(1, 2)), last_log_id);
+            assert_eq!(Some(log_id_0(1, 2)), last_log_id);
         }
 
         tracing::info!("--- last id in logs < last applied id in sm, only return the id in logs");
         {
-            apply(&mut sm, [blank_ent::<C>(1, 3)]).await?;
+            apply(&mut sm, [blank_ent_0::<C>(1, 3)]).await?;
             let last_log_id = store.get_log_state().await?.last_log_id;
-            assert_eq!(Some(log_id(1, 2)), last_log_id);
+            assert_eq!(Some(log_id_0(1, 2)), last_log_id);
         }
 
         tracing::info!("--- no logs, return default");
         {
-            store.purge(log_id(1, 2)).await?;
+            store.purge(log_id_0(1, 2)).await?;
 
             let last_log_id = store.get_log_state().await?.last_log_id;
-            assert_eq!(Some(log_id(1, 2)), last_log_id);
+            assert_eq!(Some(log_id_0(1, 2)), last_log_id);
         }
 
         Ok(())
@@ -760,24 +760,24 @@ where
 
         tracing::info!("--- with last_applied and last_membership");
         {
-            apply(&mut sm, [membership_ent::<C>(1, 3, btreeset! {1,2})]).await?;
+            apply(&mut sm, [membership_ent_0::<C>(1, 3, btreeset! {1,2})]).await?;
 
             let (applied, mem) = sm.applied_state().await?;
-            assert_eq!(Some(log_id(1, 3)), applied);
+            assert_eq!(Some(log_id_0(1, 3)), applied);
             assert_eq!(
-                StoredMembership::new(Some(log_id(1, 3)), Membership::new(vec![btreeset! {1,2}], None)),
+                StoredMembership::new(Some(log_id_0(1, 3)), Membership::new(vec![btreeset! {1,2}], None)),
                 mem
             );
         }
 
         tracing::info!("--- no logs, return default");
         {
-            apply(&mut sm, [blank_ent::<C>(1, 5)]).await?;
+            apply(&mut sm, [blank_ent_0::<C>(1, 5)]).await?;
 
             let (applied, mem) = sm.applied_state().await?;
-            assert_eq!(Some(log_id(1, 5)), applied);
+            assert_eq!(Some(log_id_0(1, 5)), applied);
             assert_eq!(
-                StoredMembership::new(Some(log_id(1, 3)), Membership::new(vec![btreeset! {1,2}], None)),
+                StoredMembership::new(Some(log_id_0(1, 3)), Membership::new(vec![btreeset! {1,2}], None)),
                 mem
             );
         }
@@ -790,7 +790,7 @@ where
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge(log_id(0, 0)).await?;
+        store.purge(log_id_0(0, 0)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 10);
@@ -798,8 +798,8 @@ where
 
         assert_eq!(
             LogState {
-                last_purged_log_id: Some(log_id(0, 0)),
-                last_log_id: Some(log_id(1, 10)),
+                last_purged_log_id: Some(log_id_0(0, 0)),
+                last_log_id: Some(log_id_0(1, 10)),
             },
             store.get_log_state().await?
         );
@@ -811,7 +811,7 @@ where
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge(log_id(1, 5)).await?;
+        store.purge(log_id_0(1, 5)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 5);
@@ -819,8 +819,8 @@ where
 
         assert_eq!(
             LogState {
-                last_purged_log_id: Some(log_id(1, 5)),
-                last_log_id: Some(log_id(1, 10)),
+                last_purged_log_id: Some(log_id_0(1, 5)),
+                last_log_id: Some(log_id_0(1, 10)),
             },
             store.get_log_state().await?
         );
@@ -832,15 +832,15 @@ where
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge(log_id(1, 20)).await?;
+        store.purge(log_id_0(1, 20)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 0);
 
         assert_eq!(
             LogState {
-                last_purged_log_id: Some(log_id(1, 20)),
-                last_log_id: Some(log_id(1, 20)),
+                last_purged_log_id: Some(log_id_0(1, 20)),
+                last_log_id: Some(log_id_0(1, 20)),
             },
             store.get_log_state().await?
         );
@@ -852,7 +852,7 @@ where
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.truncate(log_id(1, 11)).await?;
+        store.truncate(log_id_0(1, 11)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 11);
@@ -860,7 +860,7 @@ where
         assert_eq!(
             LogState {
                 last_purged_log_id: None,
-                last_log_id: Some(log_id(1, 10)),
+                last_log_id: Some(log_id_0(1, 10)),
             },
             store.get_log_state().await?
         );
@@ -872,7 +872,7 @@ where
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.truncate(log_id(0, 0)).await?;
+        store.truncate(log_id_0(0, 0)).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 0);
@@ -891,28 +891,28 @@ where
     pub async fn append_to_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.purge(log_id(0, 0)).await?;
+        store.purge(log_id_0(0, 0)).await?;
 
-        append(&mut store, [blank_ent::<C>(2, 10)]).await?;
+        append(&mut store, [blank_ent_0::<C>(2, 10)]).await?;
 
         let l = store.try_get_log_entries(0..).await?.len();
         let last = store.try_get_log_entries(0..).await?.into_iter().last().unwrap();
 
         assert_eq!(l, 10, "expected 10 entries to exist in the log");
-        assert_eq!(*last.get_log_id(), log_id(2, 10), "unexpected log id");
+        assert_eq!(*last.get_log_id(), log_id_0(2, 10), "unexpected log id");
         Ok(())
     }
 
     pub async fn snapshot_meta(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         tracing::info!("--- just initialized");
         {
-            apply(&mut sm, [membership_ent::<C>(0, 0, btreeset! {1,2})]).await?;
+            apply(&mut sm, [membership_ent_0::<C>(0, 0, btreeset! {1,2})]).await?;
 
             let mut b = sm.get_snapshot_builder().await;
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
-            assert_eq!(Some(log_id(0, 0)), meta.last_log_id);
-            assert_eq!(&Some(log_id(0, 0)), meta.last_membership.log_id());
+            assert_eq!(Some(log_id_0(0, 0)), meta.last_log_id);
+            assert_eq!(&Some(log_id_0(0, 0)), meta.last_membership.log_id());
             assert_eq!(
                 &Membership::new(vec![btreeset! {1,2}], None),
                 meta.last_membership.membership()
@@ -922,16 +922,16 @@ where
         tracing::info!("--- one app log, one membership log");
         {
             apply(&mut sm, [
-                blank_ent::<C>(1, 1),
-                membership_ent::<C>(2, 2, btreeset! {3,4}),
+                blank_ent_0::<C>(1, 1),
+                membership_ent_0::<C>(2, 2, btreeset! {3,4}),
             ])
             .await?;
 
             let mut b = sm.get_snapshot_builder().await;
             let snap = b.build_snapshot().await?;
             let meta = snap.meta;
-            assert_eq!(Some(log_id(2, 2)), meta.last_log_id);
-            assert_eq!(&Some(log_id(2, 2)), meta.last_membership.log_id());
+            assert_eq!(Some(log_id_0(2, 2)), meta.last_log_id);
+            assert_eq!(&Some(log_id_0(2, 2)), meta.last_membership.log_id());
             assert_eq!(
                 &Membership::new(vec![btreeset! {3,4}], None),
                 meta.last_membership.membership()
@@ -1058,10 +1058,10 @@ where
     // }
 
     pub async fn feed_10_logs_vote_self(sto: &mut LS) -> Result<(), StorageError<C::NodeId>> {
-        append(sto, [blank_ent::<C>(0, 0)]).await?;
+        append(sto, [blank_ent_0::<C>(0, 0)]).await?;
 
         for i in 1..=10 {
-            append(sto, [blank_ent::<C>(1, i)]).await?;
+            append(sto, [blank_ent_0::<C>(1, i)]).await?;
         }
 
         Self::default_vote(sto).await?;
@@ -1076,7 +1076,7 @@ where
     }
 }
 
-fn log_id<NID: NodeId>(term: u64, index: u64) -> LogId<NID>
+fn log_id_0<NID: NodeId>(term: u64, index: u64) -> LogId<NID>
 where NID: From<u64> {
     LogId {
         leader_id: CommittedLeaderId::new(term, NODE_ID.into()),
@@ -1084,15 +1084,16 @@ where NID: From<u64> {
     }
 }
 
-/// Create a blank log entry for test
-fn blank_ent<C: RaftTypeConfig>(term: u64, index: u64) -> C::Entry
+/// Create a blank log entry with node_id 0 for test.
+fn blank_ent_0<C: RaftTypeConfig>(term: u64, index: u64) -> C::Entry
 where C::NodeId: From<u64> {
-    C::Entry::new_blank(log_id(term, index))
+    C::Entry::new_blank(log_id_0(term, index))
 }
 
-fn membership_ent<C: RaftTypeConfig>(term: u64, index: u64, bs: BTreeSet<C::NodeId>) -> C::Entry
+/// Create a membership entry with node_id 0 for test.
+fn membership_ent_0<C: RaftTypeConfig>(term: u64, index: u64, bs: BTreeSet<C::NodeId>) -> C::Entry
 where C::NodeId: From<u64> {
-    C::Entry::new_membership(log_id(term, index), Membership::new(vec![bs], ()))
+    C::Entry::new_membership(log_id_0(term, index), Membership::new(vec![bs], ()))
 }
 
 /// Block until a future is finished.

--- a/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use openraft::raft::AppendEntriesRequest;
+use openraft::testing::blank_ent;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::Entry;
@@ -12,7 +13,6 @@ use openraft::RaftNetworkFactory;
 use openraft::Vote;
 use openraft_memstore::ClientRequest;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -66,7 +66,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
     let rpc = AppendEntriesRequest::<openraft_memstore::Config> {
         vote: Vote::new_committed(1, 1),
         prev_log_id: None,
-        entries: vec![blank_ent(0, 0), blank_ent(1, 1), Entry {
+        entries: vec![blank_ent(0, 0, 0), blank_ent(1, 0, 1), Entry {
             log_id: LogId::new(CommittedLeaderId::new(1, 0), 2),
             payload: EntryPayload::Normal(ClientRequest {
                 client: "foo".to_string(),

--- a/tests/tests/append_entries/t11_append_conflicts.rs
+++ b/tests/tests/append_entries/t11_append_conflicts.rs
@@ -6,6 +6,7 @@ use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::RaftLogReaderExt;
 use openraft::storage::RaftLogStorage;
+use openraft::testing::blank_ent;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::Entry;
@@ -14,7 +15,6 @@ use openraft::RaftTypeConfig;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -61,7 +61,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: None,
-        entries: vec![blank_ent(0, 0)],
+        entries: vec![blank_ent(0, 0, 0)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -89,7 +89,12 @@ async fn append_conflicts() -> Result<()> {
     let req = || AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
-        entries: vec![blank_ent(1, 1), blank_ent(1, 2), blank_ent(1, 3), blank_ent(1, 4)],
+        entries: vec![
+            blank_ent(1, 0, 1),
+            blank_ent(1, 0, 2),
+            blank_ent(1, 0, 3),
+            blank_ent(1, 0, 4),
+        ],
         // this set the last_applied to 2
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
@@ -114,7 +119,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 1)),
-        entries: vec![blank_ent(1, 2)],
+        entries: vec![blank_ent(1, 0, 2)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -129,7 +134,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
-        entries: vec![blank_ent(2, 3)],
+        entries: vec![blank_ent(2, 0, 3)],
         // this set the last_applied to 2
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
@@ -174,7 +179,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
-        entries: vec![blank_ent(2, 3), blank_ent(2, 4), blank_ent(2, 5)],
+        entries: vec![blank_ent(2, 0, 3), blank_ent(2, 0, 4), blank_ent(2, 0, 5)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -189,7 +194,7 @@ async fn append_conflicts() -> Result<()> {
     let req = AppendEntriesRequest {
         vote: Vote::new_committed(1, 2),
         prev_log_id: Some(LogId::new(CommittedLeaderId::new(2, 0), 3)),
-        entries: vec![blank_ent(3, 4)],
+        entries: vec![blank_ent(3, 0, 4)],
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
     };
 
@@ -228,7 +233,7 @@ where
         .iter()
         .skip(skip)
         .enumerate()
-        .map(|(i, term)| blank_ent(*term, (i + skip) as u64))
+        .map(|(i, term)| blank_ent(*term, 0, (i + skip) as u64))
         .collect::<Vec<_>>();
 
     let w = format!("{:?}", &want);

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -6,11 +6,11 @@ use maplit::btreeset;
 use openraft::storage::RaftLogReaderExt;
 use openraft::storage::RaftLogStorage;
 use openraft::testing;
+use openraft::testing::blank_ent;
 use openraft::Config;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -57,9 +57,9 @@ async fn append_inconsistent_log() -> Result<()> {
     r2.shutdown().await?;
 
     for i in log_index + 1..=100 {
-        testing::blocking_append(&mut sto0, [blank_ent(2, i)]).await?;
+        testing::blocking_append(&mut sto0, [blank_ent(2, 0, i)]).await?;
 
-        testing::blocking_append(&mut sto2, [blank_ent(3, i)]).await?;
+        testing::blocking_append(&mut sto2, [blank_ent(3, 0, i)]).await?;
     }
 
     sto0.save_vote(&Vote::new(2, 0)).await?;

--- a/tests/tests/append_entries/t11_append_updates_membership.rs
+++ b/tests/tests/append_entries/t11_append_updates_membership.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
+use openraft::testing::blank_ent;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::Entry;
@@ -14,7 +15,6 @@ use openraft::Membership;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -48,18 +48,18 @@ async fn append_updates_membership() -> Result<()> {
             vote: Vote::new_committed(1, 1),
             prev_log_id: None,
             entries: vec![
-                blank_ent(0, 0),
-                blank_ent(1, 1),
+                blank_ent(0, 0, 0),
+                blank_ent(1, 0, 1),
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 2),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {1,2}], None)),
                 },
-                blank_ent(1, 3),
+                blank_ent(1, 0, 3),
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 4),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {1,2,3,4}], None)),
                 },
-                blank_ent(1, 5),
+                blank_ent(1, 0, 5),
             ],
             leader_commit: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
         };
@@ -76,7 +76,7 @@ async fn append_updates_membership() -> Result<()> {
         let req = AppendEntriesRequest {
             vote: Vote::new_committed(2, 2),
             prev_log_id: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
-            entries: vec![blank_ent(2, 3)],
+            entries: vec![blank_ent(2, 0, 3)],
             leader_commit: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
         };
 

--- a/tests/tests/elect/t10_elect_compare_last_log.rs
+++ b/tests/tests/elect/t10_elect_compare_last_log.rs
@@ -7,13 +7,13 @@ use maplit::btreeset;
 use openraft::entry::RaftEntry;
 use openraft::storage::RaftLogStorage;
 use openraft::testing;
+use openraft::testing::blank_ent;
 use openraft::Config;
 use openraft::Entry;
 use openraft::Membership;
 use openraft::ServerState;
 use openraft::Vote;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
@@ -43,7 +43,7 @@ async fn elect_compare_last_log() -> Result<()> {
 
         testing::blocking_append(&mut sto0, [
             //
-            blank_ent(0, 0),
+            blank_ent(0, 0, 0),
             Entry::new_membership(log_id(2, 0, 1), Membership::new(vec![btreeset! {0,1}], None)),
         ])
         .await?;
@@ -54,9 +54,9 @@ async fn elect_compare_last_log() -> Result<()> {
         sto1.save_vote(&Vote::new(10, 0)).await?;
 
         testing::blocking_append(&mut sto1, [
-            blank_ent(0, 0),
+            blank_ent(0, 0, 0),
             Entry::new_membership(log_id(1, 0, 1), Membership::new(vec![btreeset! {0,1}], None)),
-            blank_ent(1, 2),
+            blank_ent(1, 0, 2),
         ])
         .await?;
     }

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -44,7 +44,6 @@ use openraft::storage::RaftStateMachine;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::Entry;
-use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::LogIdOptionExt;
 use openraft::Membership;
@@ -55,7 +54,6 @@ use openraft::RaftMetrics;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
 use openraft::RaftState;
-use openraft::RaftTypeConfig;
 use openraft::ServerState;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::ClientResponse;
@@ -1049,15 +1047,6 @@ fn timeout() -> Option<Duration> {
 
 pub fn log_id(term: u64, node_id: MemNodeId, index: u64) -> LogId<MemNodeId> {
     LogId::new(CommittedLeaderId::new(term, node_id), index)
-}
-
-/// Create a blank log entry for test.
-pub fn blank_ent<C: RaftTypeConfig>(term: u64, index: u64) -> Entry<C>
-where C::NodeId: From<u64> {
-    Entry {
-        log_id: LogId::new(CommittedLeaderId::new(term, 0.into()), index),
-        payload: EntryPayload::Blank,
-    }
 }
 
 /// Create a membership log entry for test.

--- a/tests/tests/log_compaction/t10_compaction.rs
+++ b/tests/tests/log_compaction/t10_compaction.rs
@@ -7,6 +7,7 @@ use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::RaftLogReaderExt;
 use openraft::testing;
+use openraft::testing::blank_ent;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::Entry;
@@ -19,7 +20,6 @@ use openraft::ServerState;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -96,7 +96,7 @@ async fn compaction() -> Result<()> {
 
     // Add a new node and assert that it received the same snapshot.
     let (mut sto1, sm1) = router.new_store();
-    testing::blocking_append(&mut sto1, [blank_ent(0, 0), Entry {
+    testing::blocking_append(&mut sto1, [blank_ent(0, 0, 0), Entry {
         log_id: LogId::new(CommittedLeaderId::new(1, 0), 1),
         payload: EntryPayload::Membership(Membership::new(vec![btreeset! {0}], None)),
     }])

--- a/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
+use openraft::testing::blank_ent;
 use openraft::Config;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
 use openraft::Vote;
 use openraft_memstore::BlockOperation;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
@@ -59,7 +59,7 @@ async fn building_snapshot_does_not_block_append() -> Result<()> {
         let rpc = AppendEntriesRequest::<openraft_memstore::Config> {
             vote: Vote::new_committed(1, 0),
             prev_log_id: Some(log_id(1, 0, log_index)),
-            entries: vec![blank_ent(1, 15)],
+            entries: vec![blank_ent(1, 0, 15)],
             leader_commit: None,
         };
 

--- a/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::StorageHelper;
+use openraft::testing::blank_ent;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::EffectiveMembership;
@@ -18,7 +19,6 @@ use openraft::RaftNetworkFactory;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
@@ -92,7 +92,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             let req = AppendEntriesRequest {
                 vote: Vote::new_committed(1, 0),
                 prev_log_id: None,
-                entries: vec![blank_ent(0, 0), Entry {
+                entries: vec![blank_ent(0, 0, 0), Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 1),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {2,3}], None)),
                 }],

--- a/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
+++ b/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
@@ -9,6 +9,7 @@ use openraft::raft::InstallSnapshotRequest;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::testing;
+use openraft::testing::blank_ent;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::Entry;
@@ -24,7 +25,6 @@ use openraft::SnapshotPolicy;
 use openraft::StorageHelper;
 use openraft::Vote;
 
-use crate::fixtures::blank_ent;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::membership_ent;
 use crate::fixtures::RaftRouter;
@@ -93,21 +93,21 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             vote: Vote::new_committed(1, 0),
             prev_log_id: None,
             entries: vec![
-                blank_ent(0, 0),
-                blank_ent(1, 1),
+                blank_ent(0, 0, 0),
+                blank_ent(1, 0, 1),
                 // conflict membership will be replaced with membership in snapshot
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 2),
                     payload: EntryPayload::Membership(Membership::new(vec![btreeset! {2,3}], None)),
                 },
-                blank_ent(1, 3),
-                blank_ent(1, 4),
-                blank_ent(1, 5),
-                blank_ent(1, 6),
-                blank_ent(1, 7),
-                blank_ent(1, 8),
-                blank_ent(1, 9),
-                blank_ent(1, 10),
+                blank_ent(1, 0, 3),
+                blank_ent(1, 0, 4),
+                blank_ent(1, 0, 5),
+                blank_ent(1, 0, 6),
+                blank_ent(1, 0, 7),
+                blank_ent(1, 0, 8),
+                blank_ent(1, 0, 9),
+                blank_ent(1, 0, 10),
                 // another conflict membership, will be removed
                 Entry {
                     log_id: LogId::new(CommittedLeaderId::new(1, 0), 11),


### PR DESCRIPTION

## Changelog

##### Refactor: add testing::blank_ent() to create a blank entry for testing


##### Refactor: remove unused testing RaftTypeConfig implementation

Keep only one of them for testing: `UTConfig`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/790)
<!-- Reviewable:end -->
