### PR TITLE
Refactor: ReplicationCore returns StorageError to RaftCore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,6 +209,38 @@ jobs:
           RUST_BACKTRACE: full
           OPENRAFT_STORE_DEFENSIVE: on
 
+  # Test external crate.
+  # cluster_benchmark is a standalone crate for benchmarking openraft cluster.
+  cluster-benchmark:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - crate: "cluster_benchmark"
+
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+
+
+      - name: Setup | Toolchain
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: "nightly"
+          override: true
+
+
+      - name: Unit Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --tests nothing --manifest-path "${{ matrix.crate }}/Cargo.toml"
+        env:
+          RUST_LOG: debug
+          RUST_BACKTRACE: full
+
   # Feature "serde" will be enabled if one of the member carge enables
   # "serde", such as `memstore`, when building cargo workspace.
   #

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1215,8 +1215,8 @@ where
                 }
             }
 
-            RaftMsg::ReplicationFatal => {
-                return Err(Fatal::Stopped);
+            RaftMsg::ReplicationStorageError { error } => {
+                return Err(Fatal::from(error));
             }
         };
         Ok(())

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -207,11 +207,11 @@ where
                             });
                             return Ok(());
                         }
-                        ReplicationError::StorageError(err) => {
-                            tracing::error!(error=%err, "error replication to target={}", self.target);
+                        ReplicationError::StorageError(error) => {
+                            tracing::error!(error=%error, "error replication to target={}", self.target);
 
                             // TODO: report this error
-                            let _ = self.tx_raft_core.send(RaftMsg::ReplicationFatal);
+                            let _ = self.tx_raft_core.send(RaftMsg::ReplicationStorageError { error });
                             return Ok(());
                         }
                         ReplicationError::RPCError(err) => {

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -27,11 +27,8 @@ pub fn log_id1(term: u64, index: u64) -> LogId<u64> {
 }
 
 /// Builds a log id, for testing purposes.
-pub fn log_id(term: u64, node_id: u64, index: u64) -> LogId<u64> {
-    LogId::<u64> {
-        leader_id: CommittedLeaderId::new(term, node_id),
-        index,
-    }
+pub fn log_id<NID: crate::NodeId>(term: u64, node_id: NID, index: u64) -> LogId<NID> {
+    LogId::new(CommittedLeaderId::new(term, node_id), index)
 }
 
 /// Create a blank log entry for test.

--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -1,6 +1,8 @@
 mod store_builder;
 mod suite;
 
+use std::collections::BTreeSet;
+
 use anyerror::AnyError;
 pub use store_builder::StoreBuilder;
 pub use suite::Suite;
@@ -35,6 +37,19 @@ pub fn log_id(term: u64, node_id: u64, index: u64) -> LogId<u64> {
 /// Create a blank log entry for test.
 pub fn blank_ent<C: RaftTypeConfig>(term: u64, node_id: C::NodeId, index: u64) -> crate::Entry<C> {
     crate::Entry::<C>::new_blank(LogId::new(CommittedLeaderId::new(term, node_id), index))
+}
+
+/// Create a membership log entry without learner config for test.
+pub fn membership_ent<C: RaftTypeConfig>(
+    term: u64,
+    node_id: C::NodeId,
+    index: u64,
+    config: Vec<BTreeSet<C::NodeId>>,
+) -> crate::Entry<C> {
+    crate::Entry::new_membership(
+        LogId::new(CommittedLeaderId::new(term, node_id), index),
+        crate::Membership::new(config, None),
+    )
 }
 
 /// Append to log and wait for the log to be flushed.

--- a/tests/tests/elect/t10_elect_compare_last_log.rs
+++ b/tests/tests/elect/t10_elect_compare_last_log.rs
@@ -1,21 +1,17 @@
-use std::option::Option::None;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::entry::RaftEntry;
 use openraft::storage::RaftLogStorage;
 use openraft::testing;
 use openraft::testing::blank_ent;
+use openraft::testing::membership_ent;
 use openraft::Config;
-use openraft::Entry;
-use openraft::Membership;
 use openraft::ServerState;
 use openraft::Vote;
 
 use crate::fixtures::init_default_ut_tracing;
-use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
 
 /// The last_log in a vote request must be greater or equal than the local one.
@@ -44,7 +40,7 @@ async fn elect_compare_last_log() -> Result<()> {
         testing::blocking_append(&mut sto0, [
             //
             blank_ent(0, 0, 0),
-            Entry::new_membership(log_id(2, 0, 1), Membership::new(vec![btreeset! {0,1}], None)),
+            membership_ent(2, 0, 1, vec![btreeset! {0,1}]),
         ])
         .await?;
     }
@@ -55,7 +51,7 @@ async fn elect_compare_last_log() -> Result<()> {
 
         testing::blocking_append(&mut sto1, [
             blank_ent(0, 0, 0),
-            Entry::new_membership(log_id(1, 0, 1), Membership::new(vec![btreeset! {0,1}], None)),
+            membership_ent(1, 0, 1, vec![btreeset! {0,1}]),
             blank_ent(1, 0, 2),
         ])
         .await?;

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -21,7 +21,6 @@ use anyhow::Context;
 use lazy_static::lazy_static;
 use maplit::btreeset;
 use openraft::async_trait::async_trait;
-use openraft::entry::RaftEntry;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::ClientWriteError;
 use openraft::error::InstallSnapshotError;
@@ -43,10 +42,8 @@ use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::CommittedLeaderId;
 use openraft::Config;
-use openraft::Entry;
 use openraft::LogId;
 use openraft::LogIdOptionExt;
-use openraft::Membership;
 use openraft::MessageSummary;
 use openraft::Raft;
 use openraft::RaftLogReader;
@@ -1047,9 +1044,4 @@ fn timeout() -> Option<Duration> {
 
 pub fn log_id(term: u64, node_id: MemNodeId, index: u64) -> LogId<MemNodeId> {
     LogId::new(CommittedLeaderId::new(term, node_id), index)
-}
-
-/// Create a membership log entry for test.
-pub fn membership_ent(term: u64, node_id: MemNodeId, index: u64, config: Vec<BTreeSet<MemNodeId>>) -> Entry<MemConfig> {
-    Entry::new_membership(log_id(term, node_id, index), Membership::new(config, None))
 }

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -40,7 +40,6 @@ use openraft::raft::VoteResponse;
 use openraft::storage::Adaptor;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
-use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::LogId;
 use openraft::LogIdOptionExt;
@@ -1040,8 +1039,4 @@ impl<T> From<std::ops::Range<T>> for ValueTest<T> {
 
 fn timeout() -> Option<Duration> {
     Some(Duration::from_millis(5_000))
-}
-
-pub fn log_id(term: u64, node_id: MemNodeId, index: u64) -> LogId<MemNodeId> {
-    LogId::new(CommittedLeaderId::new(term, node_id), index)
 }

--- a/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
+use openraft::testing::log_id;
 use openraft::Config;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
@@ -12,7 +13,6 @@ use openraft::Vote;
 use openraft_memstore::BlockOperation;
 
 use crate::fixtures::init_default_ut_tracing;
-use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
 
 /// When building a snapshot, append-entries request should not be blocked.

--- a/tests/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/tests/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::testing;
+use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -10,7 +11,6 @@ use openraft::Membership;
 use openraft::Raft;
 
 use crate::fixtures::init_default_ut_tracing;
-use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
 
 /// Cluster members_leader_fix_partial test.

--- a/tests/tests/metrics/t30_leader_metrics.rs
+++ b/tests/tests/metrics/t30_leader_metrics.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use futures::stream::StreamExt;
 use maplit::btreemap;
 use maplit::btreeset;
+use openraft::testing::log_id;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::LogId;
@@ -14,7 +15,6 @@ use openraft::ServerState;
 use tokio::time::sleep;
 
 use crate::fixtures::init_default_ut_tracing;
-use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
 
 /// Cluster leader_metrics test.

--- a/tests/tests/snapshot/t20_startup_snapshot.rs
+++ b/tests/tests/snapshot/t20_startup_snapshot.rs
@@ -4,11 +4,11 @@ use std::time::Duration;
 use maplit::btreeset;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
+use openraft::testing::log_id;
 use openraft::Config;
 use openraft::SnapshotPolicy;
 
 use crate::fixtures::init_default_ut_tracing;
-use crate::fixtures::log_id;
 use crate::fixtures::RaftRouter;
 
 /// When startup, if there is no snapshot and there are logs purged, it should build a snapshot at

--- a/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
+++ b/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
@@ -10,6 +10,7 @@ use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::testing;
 use openraft::testing::blank_ent;
+use openraft::testing::membership_ent;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::Entry;
@@ -26,7 +27,6 @@ use openraft::StorageHelper;
 use openraft::Vote;
 
 use crate::fixtures::init_default_ut_tracing;
-use crate::fixtures::membership_ent;
 use crate::fixtures::RaftRouter;
 
 /// Installing snapshot on a node that has logs conflict with snapshot.meta.last_log_id will delete


### PR DESCRIPTION

## Changelog

##### Refactor: ReplicationCore returns StorageError to RaftCore


##### CI: build crate cluster_benchmark


##### Refactor: use testing::log_id() in crate "tests"


##### Refactor: add testing::membership_ent() to create a membership config log entry for testing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/791)
<!-- Reviewable:end -->
