### PR TITLE
Chore: add info level log to vote and snapshot handlers

### DIFF
--- a/openraft/src/core/sm/mod.rs
+++ b/openraft/src/core/sm/mod.rs
@@ -153,20 +153,37 @@ where
 
             let command_result = match cmd.payload {
                 CommandPayload::BuildSnapshot => {
+                    tracing::info!("{}: build snapshot", func_name!());
+
                     let resp = self.build_snapshot().await?;
                     CommandResult::new(cmd.seq, Ok(Response::BuildSnapshot(resp)))
                 }
                 CommandPayload::GetSnapshot { tx } => {
+                    tracing::info!("{}: get snapshot", func_name!());
+
                     #[allow(clippy::let_unit_value)]
                     let resp = self.get_snapshot(tx).await?;
                     CommandResult::new(cmd.seq, Ok(Response::GetSnapshot(resp)))
                 }
                 CommandPayload::ReceiveSnapshotChunk { req, tx } => {
+                    tracing::info!(
+                        req = display(req.summary()),
+                        "{}: received snapshot chunk",
+                        func_name!()
+                    );
+
                     #[allow(clippy::let_unit_value)]
                     let resp = self.receive_snapshot_chunk(req, tx).await?;
                     CommandResult::new(cmd.seq, Ok(Response::ReceiveSnapshotChunk(resp)))
                 }
                 CommandPayload::FinalizeSnapshot { install, snapshot_meta } => {
+                    tracing::info!(
+                        install = display(install),
+                        snapshot_meta = display(snapshot_meta.summary()),
+                        "{}: finalize and install snapshot",
+                        func_name!()
+                    );
+
                     let resp = if install {
                         let resp = self.install_snapshot(snapshot_meta).await?;
                         Some(resp)

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -39,8 +39,10 @@ where C: RaftTypeConfig
         let is_leader = server_state == ServerState::Leader;
 
         if !was_leader && is_leader {
+            tracing::info!(id = display(self.config.id), "become leader");
             self.output.push_command(Command::BecomeLeader);
         } else if was_leader && !is_leader {
+            tracing::info!(id = display(self.config.id), "quit leader");
             self.output.push_command(Command::QuitLeader);
         } else {
             // nothing to do

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -61,6 +61,12 @@ where
     /// Update that a node has granted the vote.
     pub(crate) fn grant_vote_by(&mut self, target: NID) {
         self.vote_granted_by.insert(target);
+        tracing::info!(
+            target = display(target),
+            granted = debug(&self.vote_granted_by),
+            "{}",
+            func_name!()
+        );
     }
 
     /// Return if a quorum of `membership` has granted it.

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -375,7 +375,7 @@ where
     /// (§5.2).
     #[tracing::instrument(level = "debug", skip(self, rpc))]
     pub async fn vote(&self, rpc: VoteRequest<C::NodeId>) -> Result<VoteResponse<C::NodeId>, RaftError<C::NodeId>> {
-        tracing::debug!(rpc = display(rpc.summary()), "Raft::vote()");
+        tracing::info!(rpc = display(rpc.summary()), "Raft::vote()");
 
         let (tx, rx) = oneshot::channel();
         self.call_core(RaftMsg::RequestVote { rpc, tx }, rx).await


### PR DESCRIPTION

## Changelog

##### Chore: add info level log to vote and snapshot handlers

Vote operations are crucial to ensuring the correctness of the
consensus, while snapshot operations carry a relatively heavy load.
Although both of these operations are important, they occur less
frequently than raft-log operations. As a result, the log level for
these operations should be upgraded to "info".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/792)
<!-- Reviewable:end -->
