### PR TITLE
Refactor: collect replication response in variant `Notify::Network`

### DIFF
--- a/openraft/src/core/notify.rs
+++ b/openraft/src/core/notify.rs
@@ -1,10 +1,8 @@
 use crate::core::sm;
 use crate::raft::VoteResponse;
-use crate::replication::ReplicationResult;
-use crate::replication::ReplicationSessionId;
+use crate::replication;
 use crate::MessageSummary;
 use crate::RaftTypeConfig;
-use crate::StorageError;
 use crate::Vote;
 
 /// A message coming from the internal components.
@@ -19,41 +17,7 @@ where C: RaftTypeConfig
         vote: Vote<C::NodeId>,
     },
 
-    /// A tick event to wake up RaftCore to check timeout etc.
-    Tick {
-        /// ith tick
-        i: u64,
-    },
-
-    // /// Logs that are submitted to append has been persisted to disk.
-    // LogPersisted {},
-    /// Update the `matched` log id of a replication target.
-    /// Sent by a replication task `ReplicationCore`.
-    UpdateReplicationProgress {
-        /// The ID of the target node for which the match index is to be updated.
-        target: C::NodeId,
-
-        /// The id of the subject that submit this replication action.
-        ///
-        /// It is only used for debugging purpose.
-        id: u64,
-
-        /// Either the last log id that has been successfully replicated to the target,
-        /// or an error in string.
-        result: Result<ReplicationResult<C::NodeId>, String>,
-
-        /// In which session this message is sent.
-        /// A replication session(vote,membership_log_id) should ignore message from other session.
-        session_id: ReplicationSessionId<C::NodeId>,
-    },
-
-    /// [`StorageError`] error has taken place locally(not on remote node) when replicating, and
-    /// [`RaftCore`] needs to shutdown. Sent by a replication task
-    /// [`crate::replication::ReplicationCore`].
-    ReplicationStorageError { error: StorageError<C::NodeId> },
-
-    /// ReplicationCore has seen a higher `vote`.
-    /// Sent by a replication task `ReplicationCore`.
+    /// Seen a higher `vote`.
     HigherVote {
         /// The ID of the target node from which the new term was observed.
         target: C::NodeId,
@@ -68,8 +32,17 @@ where C: RaftTypeConfig
         // membership_log_id: Option<LogId<C::NodeId>>,
     },
 
+    /// Result of executing a command sent from network worker.
+    Network { response: replication::Response<C> },
+
     /// Result of executing a command sent from state machine worker.
     StateMachine { command_result: sm::CommandResult<C> },
+
+    /// A tick event to wake up RaftCore to check timeout etc.
+    Tick {
+        /// ith tick
+        i: u64,
+    },
 }
 
 impl<C> MessageSummary<Notify<C>> for Notify<C>
@@ -77,24 +50,10 @@ where C: RaftTypeConfig
 {
     fn summary(&self) -> String {
         match self {
-            Notify::VoteResponse { target, resp, vote } => {
+            Self::VoteResponse { target, resp, vote } => {
                 format!("VoteResponse: from: {}: {}, res-vote: {}", target, resp.summary(), vote)
             }
-            Notify::Tick { i } => {
-                format!("Tick {}", i)
-            }
-            Notify::UpdateReplicationProgress {
-                ref target,
-                ref id,
-                ref result,
-                ref session_id,
-            } => {
-                format!(
-                    "UpdateReplicationProgress: target: {}, id: {}, result: {:?}, session_id: {}",
-                    target, id, result, session_id,
-                )
-            }
-            Notify::HigherVote {
+            Self::HigherVote {
                 ref target,
                 higher: ref new_vote,
                 ref vote,
@@ -104,9 +63,14 @@ where C: RaftTypeConfig
                     target, new_vote, vote
                 )
             }
-            Notify::ReplicationStorageError { error } => format!("ReplicationFatal: {}", error),
-            Notify::StateMachine { command_result: done } => {
-                format!("StateMachine command done: {:?}", done)
+            Self::Network { response } => {
+                format!("Replication command done: {}", response.summary())
+            }
+            Self::StateMachine { command_result } => {
+                format!("StateMachine command done: {:?}", command_result)
+            }
+            Self::Tick { i } => {
+                format!("Tick {}", i)
             }
         }
     }

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -103,6 +103,7 @@ where
     }
 }
 
+// TODO: move to other mod, it is shared by log, sm and replication
 /// A sequence number of a state machine command.
 ///
 /// It is used to identify and consume a submitted command when the command callback is received by

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -1,0 +1,88 @@
+use crate::replication::ReplicationResult;
+use crate::replication::ReplicationSessionId;
+use crate::MessageSummary;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+use crate::Vote;
+
+/// The response of replication command.
+#[derive(Debug)]
+pub(crate) enum Response<C>
+where C: RaftTypeConfig
+{
+    // /// Logs that are submitted to append has been persisted to disk.
+    // LogPersisted {},
+    /// Update the `matched` log id of a replication target.
+    /// Sent by a replication task `ReplicationCore`.
+    Progress {
+        /// The ID of the target node for which the match index is to be updated.
+        target: C::NodeId,
+
+        /// The id of the subject that submit this replication action.
+        ///
+        /// It is only used for debugging purpose.
+        id: u64,
+
+        /// Either the last log id that has been successfully replicated to the target,
+        /// or an error in string.
+        result: Result<ReplicationResult<C::NodeId>, String>,
+
+        /// In which session this message is sent.
+        /// A replication session(vote,membership_log_id) should ignore message from other session.
+        session_id: ReplicationSessionId<C::NodeId>,
+    },
+
+    /// [`StorageError`] error has taken place locally(not on remote node) when replicating, and
+    /// [`RaftCore`] needs to shutdown. Sent by a replication task
+    /// [`crate::replication::ReplicationCore`].
+    StorageError { error: StorageError<C::NodeId> },
+
+    /// ReplicationCore has seen a higher `vote`.
+    /// Sent by a replication task `ReplicationCore`.
+    HigherVote {
+        /// The ID of the target node from which the new term was observed.
+        target: C::NodeId,
+
+        /// The higher vote observed.
+        higher: Vote<C::NodeId>,
+
+        /// Which ServerState sent this message
+        vote: Vote<C::NodeId>,
+        // TODO: need this?
+        // /// The cluster this replication works for.
+        // membership_log_id: Option<LogId<C::NodeId>>,
+    },
+}
+
+impl<C> MessageSummary<Response<C>> for Response<C>
+where C: RaftTypeConfig
+{
+    fn summary(&self) -> String {
+        match self {
+            Self::Progress {
+                ref target,
+                ref id,
+                ref result,
+                ref session_id,
+            } => {
+                format!(
+                    "UpdateReplicationProgress: target: {}, id: {}, result: {:?}, session_id: {}",
+                    target, id, result, session_id,
+                )
+            }
+
+            Self::StorageError { error } => format!("ReplicationStorageError: {}", error),
+
+            Self::HigherVote {
+                ref target,
+                higher: ref new_vote,
+                ref vote,
+            } => {
+                format!(
+                    "Seen a higher vote: target: {}, vote: {}, server_state_vote: {}",
+                    target, new_vote, vote
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Changelog

##### Refactor: collect replication response in variant `Notify::Network`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/796)
<!-- Reviewable:end -->
