### PR TITLE
CI: fix mergify condition according to CI name changes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ queue_rules:
       # - '#check-pending=0'
       - '#check-success>=2'
       - check-success=check-subject
-      - check-success=openraft-test (nightly, on, 0)
+      - check-success=openraft-test (stable, 0)
       - check-success~=openraft-test
 
 pull_request_rules:
@@ -14,7 +14,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - check-success=check-subject
-      - check-success=openraft-test (nightly, on, 0)
+      - check-success=openraft-test (stable, 0)
     actions:
       queue:
         name: feature_queue

--- a/README.md
+++ b/README.md
@@ -93,16 +93,17 @@ minimized store and network. This is **NOT a real world** application benchmark!
 
 Benchmark history:
 
-|  Date      | clients | put/s       | ns/op      | Changes                              |
-| :--        | --:     | --:         | --:        | :--                                  |
-| 2023-04-25 |  64     | **730,000** |    1,369   | Split channels                       |
-| 2023-04-24 |  64     | **652,000** |    1,532   | Reduce metrics report rate           |
-| 2023-04-23 |  64     | **467,000** |    2,139   | State-machine moved to separate task |
-|            |   1     |    70,000   | **14,273** |                                      |
-| 2023-02-28 |   1     |    48,000   | **20,558** |                                      |
-| 2022-07-09 |   1     |    45,000   | **21,784** | Batch purge applied log              |
-| 2022-07-07 |   1     |    43,000   | **23,218** | Use `Progress` to track replication  |
-| 2022-07-01 |   1     |    41,000   | **23,255** |                                      |
+|  Date      | clients | put/s        | ns/op      | Changes                              |
+| :--        | --:     | --:          | --:        | :--                                  |
+| 2023-04-26 | 256     | **1014,000** |      985   |                                      |
+| 2023-04-25 |  64     |  **730,000** |    1,369   | Split channels                       |
+| 2023-04-24 |  64     |  **652,000** |    1,532   | Reduce metrics report rate           |
+| 2023-04-23 |  64     |  **467,000** |    2,139   | State-machine moved to separate task |
+|            |   1     |     70,000   | **14,273** |                                      |
+| 2023-02-28 |   1     |     48,000   | **20,558** |                                      |
+| 2022-07-09 |   1     |     45,000   | **21,784** | Batch purge applied log              |
+| 2022-07-07 |   1     |     43,000   | **23,218** | Use `Progress` to track replication  |
+| 2022-07-01 |   1     |     41,000   | **23,255** |                                      |
 
 
 To access the benchmark, go to the `./cluster_benchmark` folder and run `make

--- a/cluster_benchmark/README.md
+++ b/cluster_benchmark/README.md
@@ -1,0 +1,31 @@
+Benchmark openraft without any actual business.
+
+This benchmark is designed to measure the performance overhead caused by
+Openraft itself.
+
+The benchmark comes with an in-memory log store, a state machine with no data,
+and an in-process network that uses function calls to simulate RPC.
+
+
+## Benchmark result
+
+| clients | put/s        | ns/op      |
+| --:     | --:          | --:        |
+| 256     | **1014,000** |      985   |
+|  64     |  **730,000** |    1,369   |
+|   1     |     70,000   | **14,273** |
+
+
+The benchmark is conducted with the following settings:
+- No network.
+- In-memory store.
+- A cluster of 3 nodes in a single process on a Mac M1-Max laptop.
+- Request: empty
+- Response: empty
+
+
+## Run it
+
+```sh
+cargo test --test benchmark --release bench_cluster_of_3 -- --ignored --nocapture
+```

--- a/cluster_benchmark/tests/benchmark/bench_cluster.rs
+++ b/cluster_benchmark/tests/benchmark/bench_cluster.rs
@@ -36,7 +36,7 @@ fn bench_cluster_of_1() -> anyhow::Result<()> {
     bench_with_config(&BenchConfig {
         worker_threads: 32,
         n_operations: 100_000,
-        n_client: 64,
+        n_client: 256,
         members: btreeset! {0},
     })?;
     Ok(())
@@ -48,7 +48,7 @@ fn bench_cluster_of_3() -> anyhow::Result<()> {
     bench_with_config(&BenchConfig {
         worker_threads: 32,
         n_operations: 100_000,
-        n_client: 64,
+        n_client: 256,
         members: btreeset! {0,1,2},
     })?;
     Ok(())
@@ -60,7 +60,7 @@ fn bench_cluster_of_5() -> anyhow::Result<()> {
     bench_with_config(&BenchConfig {
         worker_threads: 32,
         n_operations: 100_000,
-        n_client: 64,
+        n_client: 256,
         members: btreeset! {0,1,2,3,4},
     })?;
     Ok(())


### PR DESCRIPTION

## Changelog

##### CI: fix mergify condition according to CI name changes


##### Doc: update benchmark result

Add another setup with 256 clients:

| clients | put/s        | ns/op      |
| --:     | --:          | --:        |
| 256     | **1014,000** |      985   |
|  64     |  **730,000** |    1,369   |
|   1     |     70,000   | **14,273** |