### PR TITLE
Refactor: deprecate `Membership::is_in_joint_consensus()`

### DIFF
--- a/cluster_benchmark/tests/benchmark/network.rs
+++ b/cluster_benchmark/tests/benchmark/network.rs
@@ -68,10 +68,10 @@ impl Router {
         rafts.get_mut(&0).unwrap().initialize(voter_ids.clone()).await?;
         let log_index = 1; // log 0: initial membership log
 
-        tracing::info!("--- wait for init node to become leader");
+        tracing::info!(log_index, "--- wait for init node to become leader");
 
         for (id, s) in rafts.iter_mut() {
-            tracing::info!("--- wait init log: {}, index: {}", id, log_index);
+            tracing::info!(log_index, "--- wait init log: {}, index: {}", id, log_index);
             s.wait(timeout()).log(Some(log_index), "init").await?;
         }
 

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -80,8 +80,8 @@ fn test_membership() -> anyhow::Result<()> {
     assert!(m123_345.is_voter(&4));
     assert!(!m123_345.is_voter(&6));
 
-    assert!(!m123.is_in_joint_consensus());
-    assert!(m123_345.is_in_joint_consensus());
+    assert!(!m123.get_joint_config().len() > 1);
+    assert!(m123_345.get_joint_config().len() > 1);
 
     Ok(())
 }

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -673,7 +673,7 @@ where
 
         let (log_id, joint) = (res.log_id, res.membership.clone().unwrap());
 
-        if !joint.is_in_joint_consensus() {
+        if joint.get_joint_config().len() == 1 {
             return Ok(res);
         }
 

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -46,7 +46,7 @@ async fn append_inconsistent_log() -> Result<()> {
 
     let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
-    tracing::info!("--- remove all nodes and fake the logs");
+    tracing::info!(log_index, "--- remove all nodes and fake the logs");
 
     let (r0, mut sto0, sm0) = router.remove_node(0).unwrap();
     let (r1, sto1, sm1) = router.remove_node(1).unwrap();
@@ -67,13 +67,16 @@ async fn append_inconsistent_log() -> Result<()> {
 
     log_index = 100;
 
-    tracing::info!("--- restart node 1 and isolate. To let node-2 to become leader, node-1 should not vote for node-0");
+    tracing::info!(
+        log_index,
+        "--- restart node 1 and isolate. To let node-2 to become leader, node-1 should not vote for node-0"
+    );
     {
         router.new_raft_node_with_sto(1, sto1.clone(), sm1.clone()).await;
         router.isolate_node(1);
     }
 
-    tracing::info!("--- restart node 0 and 2");
+    tracing::info!(log_index, "--- restart node 0 and 2");
     {
         router.new_raft_node_with_sto(0, sto0.clone(), sm0.clone()).await;
         router.new_raft_node_with_sto(2, sto2.clone(), sm2.clone()).await;
@@ -82,7 +85,7 @@ async fn append_inconsistent_log() -> Result<()> {
     // leader appends at least one blank log. There may be more than one transient leaders
     log_index += 1;
 
-    tracing::info!("--- wait for node states");
+    tracing::info!(log_index, "--- wait for node states");
     {
         router
             .wait_for_state(

--- a/tests/tests/append_entries/t30_replication_1_voter_to_isolated_learner.rs
+++ b/tests/tests/append_entries/t30_replication_1_voter_to_isolated_learner.rs
@@ -28,7 +28,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
 
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
-    tracing::info!("--- stop replication to node 1");
+    tracing::info!(log_index, "--- stop replication to node 1");
     {
         router.isolate_node(1);
 
@@ -45,7 +45,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- restore replication to node 1");
+    tracing::info!(log_index, "--- restore replication to node 1");
     {
         router.restore_node(1);
 

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -34,7 +34,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
     let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
 
     let vote_modified_time = Arc::new(Mutex::new(Some(Instant::now())));
-    tracing::info!("--- leader lease is set by heartbeat");
+    tracing::info!(log_index, "--- leader lease is set by heartbeat");
     {
         let m = vote_modified_time.clone();
 
@@ -59,20 +59,20 @@ async fn heartbeat_reject_vote() -> Result<()> {
     let node0 = router.get_raft_handle(&0)?;
     let node1 = router.get_raft_handle(&1)?;
 
-    tracing::info!("--- leader lease rejects vote request");
+    tracing::info!(log_index, "--- leader lease rejects vote request");
     {
         let res = node1.vote(VoteRequest::new(Vote::new(10, 2), Some(log_id1(10, 10)))).await?;
         assert!(!res.vote_granted);
     }
 
-    tracing::info!("--- ensures no more blank-log heartbeat is used");
+    tracing::info!(log_index, "--- ensures no more blank-log heartbeat is used");
     {
         // TODO: this part can be removed when blank-log heartbeat is removed.
         sleep(Duration::from_millis(1500)).await;
         router.wait(&1, timeout()).log(Some(log_index), "no log is written").await?;
     }
 
-    tracing::info!("--- disable heartbeat, vote request will be granted");
+    tracing::info!(log_index, "--- disable heartbeat, vote request will be granted");
     {
         node0.enable_heartbeat(false);
         sleep(Duration::from_millis(1500)).await;

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -41,7 +41,7 @@ async fn client_reads() -> Result<()> {
     router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
     router.initialize_from_single_node(0).await?;
     log_index += 1;
 
@@ -59,12 +59,12 @@ async fn client_reads() -> Result<()> {
     router.is_leader(1).await.expect_err("expected is_leader on follower node 1 to fail");
     router.is_leader(2).await.expect_err("expected is_leader on follower node 2 to fail");
 
-    tracing::info!("--- isolate node 1 then is_leader should work");
+    tracing::info!(log_index, "--- isolate node 1 then is_leader should work");
 
     router.isolate_node(1);
     router.is_leader(leader).await?;
 
-    tracing::info!("--- isolate node 2 then is_leader should fail");
+    tracing::info!(log_index, "--- isolate node 2 then is_leader should fail");
 
     router.isolate_node(2);
     let rst = router.is_leader(leader).await;

--- a/tests/tests/client_api/t50_lagging_network_write.rs
+++ b/tests/tests/client_api/t50_lagging_network_write.rs
@@ -40,7 +40,7 @@ async fn lagging_network_write() -> Result<()> {
     router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
     router.initialize_from_single_node(0).await?;
     log_index += 1; // log 0: initial membership log; log 1: leader commits a blank log
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -270,7 +270,7 @@ impl TypedRaftRouter {
         self.initialize_from_single_node(leader_id).await?;
         let mut log_index = 1; // log 0: initial membership log; log 1: leader initial log
 
-        tracing::info!("--- wait for init node to become leader");
+        tracing::info!(log_index, "--- wait for init node to become leader");
 
         self.wait_for_log(&btreeset![leader_id], Some(log_index), timeout(), "init").await?;
         self.assert_stable_cluster(Some(1), Some(log_index));
@@ -279,7 +279,7 @@ impl TypedRaftRouter {
             if *id == leader_id {
                 continue;
             }
-            tracing::info!("--- add voter: {}", id);
+            tracing::info!(log_index, "--- add voter: {}", id);
 
             self.new_raft_node(*id).await;
             self.add_learner(leader_id, *id).await?;
@@ -294,7 +294,7 @@ impl TypedRaftRouter {
         .await?;
 
         if voter_ids.len() > 1 {
-            tracing::info!("--- change membership to setup voters: {:?}", voter_ids);
+            tracing::info!(log_index, "--- change membership to setup voters: {:?}", voter_ids);
 
             let node = self.get_raft_handle(&MemNodeId::default())?;
             node.change_membership(voter_ids.clone(), false).await?;
@@ -310,7 +310,7 @@ impl TypedRaftRouter {
         }
 
         for id in learners.clone() {
-            tracing::info!("--- add learner: {}", id);
+            tracing::info!(log_index, "--- add learner: {}", id);
             self.new_raft_node(id).await;
             self.add_learner(MemNodeId::default(), id).await?;
             log_index += 1;

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -690,8 +690,9 @@ impl TypedRaftRouter {
             let nodes_count = node.membership_config.nodes().count();
             assert_eq!(0, nodes_count, "expected empty configs, got: {:?}", nodes_count);
 
-            assert!(
-                !node.membership_config.membership().is_in_joint_consensus(),
+            assert_eq!(
+                0,
+                node.membership_config.membership().get_joint_config().len(),
                 "node {} is in joint consensus, expected uniform consensus",
                 node.id
             );
@@ -777,8 +778,9 @@ impl TypedRaftRouter {
                 "node {} has membership {:?}, expected {:?}",
                 node.id, members, all_nodes
             );
-            assert!(
-                !node.membership_config.membership().is_in_joint_consensus(),
+            assert_eq!(
+                1,
+                node.membership_config.membership().get_joint_config().len(),
                 "node {} was not in uniform consensus state",
                 node.id
             );

--- a/tests/tests/life_cycle/t10_initialization.rs
+++ b/tests/tests/life_cycle/t10_initialization.rs
@@ -76,7 +76,7 @@ async fn initialization() -> anyhow::Result<()> {
     }
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
     {
         let n0 = router.get_raft_handle(&0)?;
         n0.initialize(btreeset! {0,1,2}).await?;
@@ -89,7 +89,7 @@ async fn initialization() -> anyhow::Result<()> {
 
     router.assert_stable_cluster(Some(1), Some(log_index));
 
-    tracing::info!("--- check membership state");
+    tracing::info!(log_index, "--- check membership state");
     for node_id in [0, 1, 2] {
         router.external_request(node_id, move |s, _sto, _net| {
             let want = EffectiveMembership::new(
@@ -116,7 +116,12 @@ async fn initialization() -> anyhow::Result<()> {
         let (mut sto, mut sm) = router.get_storage_handle(&1)?;
         let first = sto.get_log_entries(0..2).await?.into_iter().next();
 
-        tracing::info!("--- check membership is replicated: id: {}, first log: {:?}", i, first);
+        tracing::info!(
+            log_index,
+            "--- check membership is replicated: id: {}, first log: {:?}",
+            i,
+            first
+        );
         let mem = match first.unwrap().payload {
             EntryPayload::Membership(ref x) => x.clone(),
             _ => {

--- a/tests/tests/life_cycle/t11_shutdown.rs
+++ b/tests/tests/life_cycle/t11_shutdown.rs
@@ -53,14 +53,17 @@ async fn return_error_after_panic() -> Result<()> {
     let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
     let _ = log_index; // unused;
 
-    tracing::info!("--- panic the RaftCore");
+    tracing::info!(log_index, "--- panic the RaftCore");
     {
         router.external_request(0, |_s, _sto, _net| {
             panic!("foo");
         });
     }
 
-    tracing::info!("--- calls the panicked raft should get a Fatal::Panicked error");
+    tracing::info!(
+        log_index,
+        "--- calls the panicked raft should get a Fatal::Panicked error"
+    );
     {
         let res = router.client_request(0, "foo", 2).await;
         let err = res.unwrap_err();
@@ -87,13 +90,16 @@ async fn return_error_after_shutdown() -> Result<()> {
     let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
     let _ = log_index; // unused;
 
-    tracing::info!("--- shutdown the raft");
+    tracing::info!(log_index, "--- shutdown the raft");
     {
         let n = router.get_raft_handle(&0)?;
         n.shutdown().await?;
     }
 
-    tracing::info!("--- calls the panicked raft should get a Fatal::Panicked error");
+    tracing::info!(
+        log_index,
+        "--- calls the panicked raft should get a Fatal::Panicked error"
+    );
     {
         let res = router.client_request(0, "foo", 2).await;
         let err = res.unwrap_err();

--- a/tests/tests/life_cycle/t50_follower_restart_does_not_interrupt.rs
+++ b/tests/tests/life_cycle/t50_follower_restart_does_not_interrupt.rs
@@ -26,7 +26,7 @@ async fn follower_restart_does_not_interrupt() -> anyhow::Result<()> {
     let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
     let _ = log_index;
 
-    tracing::info!("--- stop and restart follower nodes 1,2");
+    tracing::info!(log_index, "--- stop and restart follower nodes 1,2");
     {
         // Stop followers first or the follower may start re-electing.
 
@@ -42,7 +42,7 @@ async fn follower_restart_does_not_interrupt() -> anyhow::Result<()> {
         let (n0, _sto0, _sm0) = router.remove_node(0).unwrap();
         n0.shutdown().await?;
 
-        tracing::info!("--- restart node 1,2");
+        tracing::info!(log_index, "--- restart node 1,2");
 
         router.new_raft_node_with_sto(1, sto1, sm1).await;
         router.new_raft_node_with_sto(2, sto2, sm2).await;

--- a/tests/tests/life_cycle/t50_single_follower_restart.rs
+++ b/tests/tests/life_cycle/t50_single_follower_restart.rs
@@ -31,13 +31,13 @@ async fn single_follower_restart() -> anyhow::Result<()> {
     tracing::info!("--- bring up cluster of 1 node");
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
-    tracing::info!("--- write to 1 log");
+    tracing::info!(log_index, "--- write to 1 log");
     {
         router.client_request_many(0, "foo", 1).await?;
         log_index += 1;
     }
 
-    tracing::info!("--- stop and restart node-0");
+    tracing::info!(log_index, "--- stop and restart node-0");
     {
         let (node, mut sto, sm) = router.remove_node(0).unwrap();
         node.shutdown().await?;
@@ -46,7 +46,7 @@ async fn single_follower_restart() -> anyhow::Result<()> {
         // Set a non-committed vote so that the node restarts as a follower.
         sto.save_vote(&Vote::new(v.leader_id.get_term() + 1, v.leader_id.voted_for().unwrap())).await?;
 
-        tracing::info!("--- restart node-0");
+        tracing::info!(log_index, "--- restart node-0");
 
         router.new_raft_node_with_sto(0, sto, sm).await;
         router
@@ -58,7 +58,7 @@ async fn single_follower_restart() -> anyhow::Result<()> {
         log_index += 1;
     }
 
-    tracing::info!("--- write to 1 log after restart");
+    tracing::info!(log_index, "--- write to 1 log after restart");
     {
         router.client_request_many(0, "foo", 1).await?;
         log_index += 1;

--- a/tests/tests/life_cycle/t90_issue_607_single_restart.rs
+++ b/tests/tests/life_cycle/t90_issue_607_single_restart.rs
@@ -27,23 +27,23 @@ async fn single_restart() -> anyhow::Result<()> {
     tracing::info!("--- bring up cluster of 1 node");
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
-    tracing::info!("--- write to 1 log");
+    tracing::info!(log_index, "--- write to 1 log");
     {
         router.client_request_many(0, "foo", 1).await?;
         log_index += 1;
     }
 
-    tracing::info!("--- stop and restart node 0");
+    tracing::info!(log_index, "--- stop and restart node 0");
     {
         let (node, sto, sm) = router.remove_node(0).unwrap();
         node.shutdown().await?;
 
-        tracing::info!("--- restart node 0");
+        tracing::info!(log_index, "--- restart node 0");
 
         router.new_raft_node_with_sto(0, sto, sm).await;
     }
 
-    tracing::info!("--- write to 1 log after restart");
+    tracing::info!(log_index, "--- write to 1 log after restart");
     {
         router.client_request_many(0, "foo", 1).await?;
         log_index += 1;

--- a/tests/tests/membership/t10_single_node.rs
+++ b/tests/tests/membership/t10_single_node.rs
@@ -41,7 +41,7 @@ async fn single_node() -> Result<()> {
     router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
     router.initialize_from_single_node(0).await?;
     log_index += 1;
 

--- a/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
+++ b/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
@@ -61,7 +61,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
         wait_log(&router, &btreeset![0], log_index).await?;
     }
 
-    tracing::info!("--- adding two candidate nodes");
+    tracing::info!(log_index, "--- adding two candidate nodes");
     {
         // Sync some new nodes.
         router.new_raft_node(1).await;
@@ -70,7 +70,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
         router.add_learner(0, 2).await?;
         log_index += 2; // two add_learner logs
 
-        tracing::info!("--- changing cluster config");
+        tracing::info!(log_index, "--- changing cluster config");
 
         let node = router.get_raft_handle(&0)?;
         node.change_membership(candidates.clone(), false).await?;
@@ -83,7 +83,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
 
     let leader = router.leader().unwrap();
 
-    tracing::info!("--- write one log");
+    tracing::info!(log_index, "--- write one log");
     {
         router.client_request_many(leader, "client", 1).await?;
         log_index += 1;
@@ -92,7 +92,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     }
 
     // Concurrently add Learner and write another log.
-    tracing::info!("--- concurrently add learner and write another log");
+    tracing::info!(log_index, "--- concurrently add learner and write another log");
     {
         router.new_raft_node(3).await;
         let r = router.clone();

--- a/tests/tests/membership/t21_change_membership_cases.rs
+++ b/tests/tests/membership/t21_change_membership_cases.rs
@@ -118,7 +118,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
 
     let mut log_index = router.new_cluster(old.clone(), btreeset! {}).await?;
 
-    tracing::info!("--- write 10 logs");
+    tracing::info!(log_index, "--- write 10 logs");
     {
         router.client_request_many(0, "client", 10).await?;
         log_index += 10;
@@ -128,7 +128,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
 
     let orig_leader = router.leader().expect("expected the cluster to have a leader");
 
-    tracing::info!("--- change to {:?}", new);
+    tracing::info!(log_index, "--- change to {:?}", new);
     {
         for id in only_in_new {
             router.new_raft_node(*id).await;
@@ -145,13 +145,13 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
             log_index += 1;
         }
 
-        tracing::info!("--- let a node in the new cluster elect");
+        tracing::info!(log_index, "--- let a node in the new cluster elect");
         {
             let n = router.get_raft_handle(new.iter().next().unwrap())?;
             n.enable_elect(true);
         }
 
-        tracing::info!("--- wait for old leader or new leader");
+        tracing::info!(log_index, "--- wait for old leader or new leader");
         {
             for id in new.iter() {
                 router
@@ -181,7 +181,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
         }
     }
 
-    tracing::info!("--- removed nodes are left in non-leader state");
+    tracing::info!(log_index, "--- removed nodes are left in non-leader state");
     {
         for id in only_in_old.clone() {
             router
@@ -198,7 +198,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
         }
     }
 
-    tracing::info!("--- write another 10 logs");
+    tracing::info!(log_index, "--- write another 10 logs");
     {
         // get new leader
 
@@ -224,7 +224,7 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
             .await?;
     }
 
-    tracing::info!("--- log will not be sync to removed node");
+    tracing::info!(log_index, "--- log will not be sync to removed node");
     {
         for id in only_in_old {
             let res = router
@@ -262,7 +262,7 @@ async fn change_by_add(old: BTreeSet<MemNodeId>, add: &[MemNodeId]) -> anyhow::R
 
     let mut log_index = router.new_cluster(old.clone(), btreeset! {}).await?;
 
-    tracing::info!("--- write 10 logs");
+    tracing::info!(log_index, "--- write 10 logs");
     {
         log_index += router.client_request_many(0, "client", 10).await?;
         for id in old.iter() {
@@ -272,7 +272,7 @@ async fn change_by_add(old: BTreeSet<MemNodeId>, add: &[MemNodeId]) -> anyhow::R
 
     let leader_id = router.leader().expect("expected the cluster to have a leader");
 
-    tracing::info!("--- add learner before change-membership");
+    tracing::info!(log_index, "--- add learner before change-membership");
     {
         for id in only_in_new {
             router.new_raft_node(*id).await;
@@ -282,7 +282,7 @@ async fn change_by_add(old: BTreeSet<MemNodeId>, add: &[MemNodeId]) -> anyhow::R
         }
     }
 
-    tracing::info!("--- change: {:?}", change);
+    tracing::info!(log_index, "--- change: {:?}", change);
     {
         let node = router.get_raft_handle(&0)?;
         node.change_membership(change, false).await?;
@@ -296,7 +296,7 @@ async fn change_by_add(old: BTreeSet<MemNodeId>, add: &[MemNodeId]) -> anyhow::R
         }
     }
 
-    tracing::info!("--- write another 10 logs");
+    tracing::info!(log_index, "--- write another 10 logs");
     {
         log_index += router.client_request_many(leader_id, "client", 10).await?;
 
@@ -331,7 +331,7 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
 
     let mut log_index = router.new_cluster(old.clone(), btreeset! {}).await?;
 
-    tracing::info!("--- write 10 logs");
+    tracing::info!(log_index, "--- write 10 logs");
     {
         log_index += router.client_request_many(0, "client", 10).await?;
         for id in old.iter() {
@@ -341,7 +341,7 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
 
     let orig_leader = router.leader().expect("expected the cluster to have a leader");
 
-    tracing::info!("--- change {:?}", &change);
+    tracing::info!(log_index, "--- change {:?}", &change);
     {
         let node = router.get_raft_handle(&0)?;
         node.change_membership(change.clone(), false).await?;
@@ -351,13 +351,13 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
             log_index += 1;
         }
 
-        tracing::info!("--- let a node in the new cluster elect");
+        tracing::info!(log_index, "--- let a node in the new cluster elect");
         {
             let n = router.get_raft_handle(new.iter().next().unwrap())?;
             n.enable_elect(true);
         }
 
-        tracing::info!("--- wait for old leader or new leader");
+        tracing::info!(log_index, "--- wait for old leader or new leader");
         {
             for id in new.iter() {
                 router
@@ -387,7 +387,7 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
         }
     }
 
-    tracing::info!("--- removed nodes are left in follower state");
+    tracing::info!(log_index, "--- removed nodes are left in follower state");
     {
         for id in only_in_old.clone() {
             // The removed node will be left in follower state, it can never elect itself
@@ -402,7 +402,7 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
         }
     }
 
-    tracing::info!("--- write another 10 logs");
+    tracing::info!(log_index, "--- write another 10 logs");
     {
         // TODO(xp): leader may not be stable, other node may take leadership by a higher vote.
         //           Then client write may receive a ForwardToLeader Error with empty leader.
@@ -425,7 +425,7 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
             .await?;
     }
 
-    tracing::info!("--- log will not be sync to removed node");
+    tracing::info!(log_index, "--- log will not be sync to removed node");
     {
         for id in only_in_old {
             let res = router

--- a/tests/tests/membership/t30_elect_with_new_config.rs
+++ b/tests/tests/membership/t30_elect_with_new_config.rs
@@ -37,7 +37,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     let mut log_index = router.new_cluster(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
     // Isolate old leader and assert that a new leader takes over.
-    tracing::info!("--- isolating leader node 0");
+    tracing::info!(log_index, "--- isolating leader node 0");
     router.isolate_node(0);
 
     // Wait for leader lease to expire
@@ -61,7 +61,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
 
     let leader_id = 1;
 
-    tracing::info!("--- restore node 0, log_index:{}", log_index);
+    tracing::info!(log_index, "--- restore node 0, log_index:{}", log_index);
     router.restore_node(0);
     router
         .wait(&0, timeout())

--- a/tests/tests/membership/t31_add_remove_follower.rs
+++ b/tests/tests/membership/t31_add_remove_follower.rs
@@ -32,7 +32,7 @@ async fn add_remove_voter() -> Result<()> {
 
     let mut log_index = router.new_cluster(c01234.clone(), btreeset! {}).await?;
 
-    tracing::info!("--- write 100 logs");
+    tracing::info!(log_index, "--- write 100 logs");
     {
         router.client_request_many(0, "client", 100).await?;
         log_index += 100;
@@ -40,7 +40,7 @@ async fn add_remove_voter() -> Result<()> {
         router.wait_for_log(&c01234, Some(log_index), timeout(), "write 100 logs").await?;
     }
 
-    tracing::info!("--- remove n{}", 4);
+    tracing::info!(log_index, "--- remove n{}", 4);
     {
         let node = router.get_raft_handle(&0)?;
         node.change_membership(c0123.clone(), false).await?;
@@ -49,7 +49,7 @@ async fn add_remove_voter() -> Result<()> {
         router.wait_for_log(&c0123, Some(log_index), timeout(), "removed node-4 from membership").await?;
     }
 
-    tracing::info!("--- write another 100 logs");
+    tracing::info!(log_index, "--- write another 100 logs");
     {
         router.client_request_many(0, "client", 100).await?;
         log_index += 100;
@@ -57,7 +57,7 @@ async fn add_remove_voter() -> Result<()> {
 
     router.wait_for_log(&c0123, Some(log_index), timeout(), "4 nodes recv logs 100~200").await?;
 
-    tracing::info!("--- log will not be sync to removed node");
+    tracing::info!(log_index, "--- log will not be sync to removed node");
     {
         let x = router.latest_metrics();
         assert!(x[4].last_log_index < Some(log_index - 50));

--- a/tests/tests/membership/t31_remove_leader.rs
+++ b/tests/tests/membership/t31_remove_leader.rs
@@ -104,7 +104,7 @@ async fn remove_leader() -> Result<()> {
         assert_eq!(metrics.membership_config.membership().get_joint_config().clone(), vec![
             btreeset![1, 2, 3]
         ]);
-        assert!(!cfg.is_in_joint_consensus());
+        assert_eq!(1, cfg.get_joint_config().len());
     }
 
     Ok(())

--- a/tests/tests/membership/t31_remove_leader.rs
+++ b/tests/tests/membership/t31_remove_leader.rs
@@ -46,7 +46,7 @@ async fn remove_leader() -> Result<()> {
     // 2 for change_membership
     log_index += 2;
 
-    tracing::info!("--- old leader commits 2 membership log");
+    tracing::info!(log_index, "--- old leader commits 2 membership log");
     {
         router
             .wait(&orig_leader, timeout())
@@ -62,7 +62,7 @@ async fn remove_leader() -> Result<()> {
         .log_at_least(Some(log_index), "node in old cluster commits at least 1 membership log")
         .await?;
 
-    tracing::info!("--- new cluster commits 2 membership logs");
+    tracing::info!(log_index, "--- new cluster commits 2 membership logs");
     {
         // leader commit a new log.
         log_index += 1;
@@ -79,7 +79,7 @@ async fn remove_leader() -> Result<()> {
         }
     }
 
-    tracing::info!("--- check term in new cluster");
+    tracing::info!(log_index, "--- check term in new cluster");
     {
         for id in [1, 2, 3] {
             router
@@ -92,7 +92,7 @@ async fn remove_leader() -> Result<()> {
         }
     }
 
-    tracing::info!("--- check state of the old leader");
+    tracing::info!(log_index, "--- check state of the old leader");
     {
         let metrics = router.get_metrics(&0)?;
         let cfg = &metrics.membership_config.membership();
@@ -130,7 +130,7 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
 
     let orig_leader = 0;
 
-    tracing::info!("--- change membership 012 to 2");
+    tracing::info!(log_index, "--- change membership 012 to 2");
     {
         let node = router.get_raft_handle(&orig_leader)?;
         node.change_membership(btreeset![2], false).await?;
@@ -149,7 +149,7 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- old leader commits 2 membership log");
+    tracing::info!(log_index, "--- old leader commits 2 membership log");
     {
         router
             .wait(&orig_leader, timeout())
@@ -173,7 +173,7 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
         },
     }
 
-    tracing::info!("--- elect node-2, handle write");
+    tracing::info!(log_index, "--- elect node-2, handle write");
     {
         let n2 = router.get_raft_handle(&2)?;
         n2.enable_elect(true);

--- a/tests/tests/membership/t31_removed_follower.rs
+++ b/tests/tests/membership/t31_removed_follower.rs
@@ -24,7 +24,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
 
     let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
-    tracing::info!("--- add node 3,4");
+    tracing::info!(log_index, "--- add node 3,4");
 
     router.new_raft_node(3).await;
     router.new_raft_node(4).await;
@@ -34,7 +34,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
     log_index += 2;
     router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "cluster of 2 learners").await?;
 
-    tracing::info!("--- changing config to 0,3,4");
+    tracing::info!(log_index, "--- changing config to 0,3,4");
     {
         let node = router.get_raft_handle(&0)?;
         node.change_membership(btreeset![0, 3, 4], false).await?;
@@ -75,7 +75,7 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
         );
     }
 
-    tracing::info!("--- write to new cluster, current log={}", log_index);
+    tracing::info!(log_index, "--- write to new cluster, current log={}", log_index);
     {
         let n = 10;
         router.client_request_many(0, "after_change", n).await?;

--- a/tests/tests/membership/t51_remove_unreachable_follower.rs
+++ b/tests/tests/membership/t51_remove_unreachable_follower.rs
@@ -25,7 +25,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
 
     let mut log_index = router.new_cluster(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
-    tracing::info!("--- isolate node 4");
+    tracing::info!(log_index, "--- isolate node 4");
     {
         router.isolate_node(4);
     }
@@ -33,7 +33,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
     // logs on node 4 will stop here:
     let node4_log_index = log_index;
 
-    tracing::info!("--- changing config to 0,1,2");
+    tracing::info!(log_index, "--- changing config to 0,1,2");
     {
         let node = router.get_raft_handle(&0)?;
         node.change_membership(btreeset![0, 1, 2], false).await?;
@@ -58,7 +58,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
             .await?;
     }
 
-    tracing::info!("--- replication to node 4 will be removed");
+    tracing::info!(log_index, "--- replication to node 4 will be removed");
     {
         router
             .wait(&0, timeout())
@@ -69,7 +69,10 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
             .await?;
     }
 
-    tracing::info!("--- restore network isolation, node 4 won't catch up log and will enter candidate state");
+    tracing::info!(
+        log_index,
+        "--- restore network isolation, node 4 won't catch up log and will enter candidate state"
+    );
     {
         router.restore_node(4);
 

--- a/tests/tests/membership/t99_issue_584_replication_state_reverted.rs
+++ b/tests/tests/membership/t99_issue_584_replication_state_reverted.rs
@@ -29,7 +29,7 @@ async fn t99_issue_584_replication_state_reverted() -> Result<()> {
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     let n = 500u64;
-    tracing::info!("--- write up to {} logs", n);
+    tracing::info!(log_index, "--- write up to {} logs", n);
     {
         router.client_request_many(0, "foo", (n - log_index) as usize).await?;
         log_index = n;
@@ -37,7 +37,10 @@ async fn t99_issue_584_replication_state_reverted() -> Result<()> {
         router.wait(&1, timeout()).log(Some(log_index), "replicate all logs to learner").await?;
     }
 
-    tracing::info!("--- change-membership: make learner node-1 a voter. This should not panic");
+    tracing::info!(
+        log_index,
+        "--- change-membership: make learner node-1 a voter. This should not panic"
+    );
     {
         let leader = router.get_raft_handle(&0)?;
         leader.change_membership(btreeset![0, 1], false).await?;

--- a/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -34,7 +34,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     router.new_raft_node(0).await;
     router.new_raft_node(1).await;
 
-    tracing::info!("--- initializing single node cluster");
+    tracing::info!(log_index, "--- initializing single node cluster");
     {
         let n0 = router.get_raft_handle(&0)?;
         n0.initialize(btreeset! {0}).await?;
@@ -43,16 +43,16 @@ async fn metrics_state_machine_consistency() -> Result<()> {
         router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
     }
 
-    tracing::info!("--- add one learner");
+    tracing::info!(log_index, "--- add one learner");
     router.add_learner(0, 1).await?;
     log_index += 1;
 
-    tracing::info!("--- write one log");
+    tracing::info!(log_index, "--- write one log");
     router.client_request(0, "foo", 1).await?;
 
     // Wait for metrics to be up to date.
     // Once last_applied updated, the key should be visible in state machine.
-    tracing::info!("--- wait for log to sync");
+    tracing::info!(log_index, "--- wait for log to sync");
     log_index += 1;
     for node_id in 0..2 {
         router.wait_for_log(&btreeset![node_id], Some(log_index), None, "write one log").await?;

--- a/tests/tests/metrics/t30_leader_metrics.rs
+++ b/tests/tests/metrics/t30_leader_metrics.rs
@@ -52,7 +52,7 @@ async fn leader_metrics() -> Result<()> {
 
     router.assert_pristine_cluster();
 
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
 
     router.initialize_from_single_node(0).await?;
     log_index += 1;
@@ -83,7 +83,7 @@ async fn leader_metrics() -> Result<()> {
     router.new_raft_node(3).await;
     router.new_raft_node(4).await;
 
-    tracing::info!("--- adding 4 new nodes to cluster");
+    tracing::info!(log_index, "--- adding 4 new nodes to cluster");
 
     {
         let mut new_nodes = futures::stream::FuturesUnordered::new();
@@ -98,7 +98,7 @@ async fn leader_metrics() -> Result<()> {
     log_index += 4; // 4 add_learner log
     router.wait_for_log(&c01234, Some(log_index), timeout(), "add learner 1,2,3,4").await?;
 
-    tracing::info!("--- changing cluster config to 01234");
+    tracing::info!(log_index, "--- changing cluster config to 01234");
 
     let node = router.get_raft_handle(&0)?;
     node.change_membership(c01234.clone(), false).await?;
@@ -129,7 +129,7 @@ async fn leader_metrics() -> Result<()> {
     router.client_request_many(0, "client", 10).await?;
     log_index += 10;
 
-    tracing::info!("--- remove n{}", 4);
+    tracing::info!(log_index, "--- remove n{}", 4);
     {
         let node = router.get_raft_handle(&0)?;
         node.change_membership(c0123.clone(), false).await?;
@@ -145,7 +145,10 @@ async fn leader_metrics() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- replication metrics should reflect the replication state");
+    tracing::info!(
+        log_index,
+        "--- replication metrics should reflect the replication state"
+    );
     {
         let ww = Some(LogId::new(CommittedLeaderId::new(1, 0), log_index));
         let want_repl = btreemap! { 0=>ww, 1=>ww, 2=>ww, 3=>ww};
@@ -168,7 +171,7 @@ async fn leader_metrics() -> Result<()> {
     let n0 = router.get_raft_handle(&0)?;
     let n1 = router.get_raft_handle(&1)?;
 
-    tracing::info!("--- let node-1 to elect to take leadership from node-0");
+    tracing::info!(log_index, "--- let node-1 to elect to take leadership from node-0");
     {
         // Let the leader lease expire
         sleep(Duration::from_millis(700)).await;

--- a/tests/tests/replication/t50_append_entries_backoff.rs
+++ b/tests/tests/replication/t50_append_entries_backoff.rs
@@ -30,7 +30,7 @@ async fn append_entries_backoff() -> Result<()> {
     let counts0 = router.get_rpc_count();
     let n = 10u64;
 
-    tracing::info!("--- set node 2 to unreachable, and write 10 entries");
+    tracing::info!(log_index, "--- set node 2 to unreachable, and write 10 entries");
     {
         router.set_unreachable(2, true);
 

--- a/tests/tests/snapshot/t10_api_install_snapshot.rs
+++ b/tests/tests/snapshot/t10_api_install_snapshot.rs
@@ -35,7 +35,7 @@ async fn snapshot_arguments() -> Result<()> {
 
     let mut log_index = 0;
 
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
     {
         router.new_raft_node(0).await;
 
@@ -66,7 +66,7 @@ async fn snapshot_arguments() -> Result<()> {
         done: false,
     };
 
-    tracing::info!("--- only allow to begin a new session when offset is 0");
+    tracing::info!(log_index, "--- only allow to begin a new session when offset is 0");
     {
         let mut req = make_req();
         req.offset = 2;
@@ -77,7 +77,7 @@ async fn snapshot_arguments() -> Result<()> {
         );
     }
 
-    tracing::info!("--- install and write ss1:[0,3)");
+    tracing::info!(log_index, "--- install and write ss1:[0,3)");
     {
         n.0.install_snapshot(make_req()).await?;
     }

--- a/tests/tests/snapshot/t20_trigger_snapshot.rs
+++ b/tests/tests/snapshot/t20_trigger_snapshot.rs
@@ -25,7 +25,7 @@ async fn trigger_snapshot() -> anyhow::Result<()> {
     tracing::info!("--- initializing cluster");
     let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
 
-    tracing::info!("--- trigger snapshot for node-1");
+    tracing::info!(log_index, "--- trigger snapshot for node-1");
     {
         let n1 = router.get_raft_handle(&1)?;
         n1.trigger_snapshot().await?;
@@ -36,7 +36,7 @@ async fn trigger_snapshot() -> anyhow::Result<()> {
             .await?;
     }
 
-    tracing::info!("--- send some logs");
+    tracing::info!(log_index, "--- send some logs");
     {
         router.client_request_many(0, "0", 10).await?;
         log_index += 10;
@@ -45,7 +45,7 @@ async fn trigger_snapshot() -> anyhow::Result<()> {
         router.wait(&1, timeout()).log(Some(log_index), "node-1 write logs").await?;
     }
 
-    tracing::info!("--- trigger snapshot for node-0");
+    tracing::info!(log_index, "--- trigger snapshot for node-0");
     {
         let n0 = router.get_raft_handle(&0)?;
         n0.trigger_snapshot().await?;

--- a/tests/tests/snapshot/t30_purge_in_snapshot_logs.rs
+++ b/tests/tests/snapshot/t30_purge_in_snapshot_logs.rs
@@ -37,7 +37,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
 
     let (mut sto0, mut _sm0) = router.get_storage_handle(&0)?;
 
-    tracing::info!("--- build snapshot on leader, check purged log");
+    tracing::info!(log_index, "--- build snapshot on leader, check purged log");
     {
         log_index += router.client_request_many(0, "0", 10).await?;
         leader.trigger_snapshot().await?;
@@ -59,7 +59,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
 
     // Leader:  -------15..20
     // Learner: 0..10
-    tracing::info!("--- block replication, build another snapshot");
+    tracing::info!(log_index, "--- block replication, build another snapshot");
     {
         router.isolate_node(1);
 
@@ -80,7 +80,10 @@ async fn purge_in_snapshot_logs() -> Result<()> {
     // just before building snapshot.
     sleep(Duration::from_millis(500)).await;
 
-    tracing::info!("--- restore replication, install the 2nd snapshot on learner");
+    tracing::info!(
+        log_index,
+        "--- restore replication, install the 2nd snapshot on learner"
+    );
     {
         router.restore_node(1);
 

--- a/tests/tests/snapshot/t32_snapshot_uses_prev_snap_membership.rs
+++ b/tests/tests/snapshot/t32_snapshot_uses_prev_snap_membership.rs
@@ -50,7 +50,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
 
     let (mut sto0, mut sm0) = router.get_storage_handle(&0)?;
 
-    tracing::info!("--- send just enough logs to trigger snapshot");
+    tracing::info!(log_index, "--- send just enough logs to trigger snapshot");
     {
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold - 1;
@@ -90,7 +90,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         );
     }
 
-    tracing::info!("--- send just enough logs to trigger the 2nd snapshot");
+    tracing::info!(log_index, "--- send just enough logs to trigger the 2nd snapshot");
     {
         router.client_request_many(0, "0", (snapshot_threshold * 2 - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold * 2 - 1;
@@ -106,7 +106,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- check membership");
+    tracing::info!(log_index, "--- check membership");
     {
         {
             let logs = sto0.get_log_entries(..).await?;

--- a/tests/tests/snapshot/t34_replication_does_not_block_purge.rs
+++ b/tests/tests/snapshot/t34_replication_does_not_block_purge.rs
@@ -42,7 +42,7 @@ async fn replication_does_not_block_purge() -> Result<()> {
     router.isolate_node(1);
     router.isolate_node(2);
 
-    tracing::info!("--- build snapshot on leader, check purged log");
+    tracing::info!(log_index, "--- build snapshot on leader, check purged log");
     {
         log_index += router.client_request_many(0, "0", 10).await?;
 

--- a/tests/tests/snapshot/t50_snapshot_line_rate_to_snapshot.rs
+++ b/tests/tests/snapshot/t50_snapshot_line_rate_to_snapshot.rs
@@ -38,7 +38,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
 
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
-    tracing::info!("--- send more than half threshold logs");
+    tracing::info!(log_index, "--- send more than half threshold logs");
     {
         router.client_request_many(0, "0", (snapshot_threshold / 2 + 2 - log_index) as usize).await?;
         log_index = snapshot_threshold / 2 + 2;
@@ -53,8 +53,8 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- stop replication to node 1");
-    tracing::info!("--- send just enough logs to trigger snapshot");
+    tracing::info!(log_index, "--- stop replication to node 1");
+    tracing::info!(log_index, "--- send just enough logs to trigger snapshot");
     {
         router.isolate_node(1);
 
@@ -79,7 +79,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- restore node 1 and replication");
+    tracing::info!(log_index, "--- restore node 1 and replication");
     {
         router.restore_node(1);
 

--- a/tests/tests/snapshot/t50_snapshot_when_lacking_log.rs
+++ b/tests/tests/snapshot/t50_snapshot_when_lacking_log.rs
@@ -34,7 +34,7 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
 
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
-    tracing::info!("--- send just enough logs to trigger snapshot");
+    tracing::info!(log_index, "--- send just enough logs to trigger snapshot");
     {
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold - 1;
@@ -61,13 +61,16 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- send logs to make distance between snapshot index and last_log_index");
+    tracing::info!(
+        log_index,
+        "--- send logs to make distance between snapshot index and last_log_index"
+    );
     {
         router.client_request_many(0, "0", (log_cnt - log_index) as usize).await?;
         log_index = log_cnt;
     }
 
-    tracing::info!("--- add learner to receive snapshot and logs");
+    tracing::info!(log_index, "--- add learner to receive snapshot and logs");
     {
         router.new_raft_node(1).await;
         router.add_learner(0, 1).await.expect("failed to add new node as learner");

--- a/tests/tests/snapshot/t51_after_snapshot_add_learner_and_request_a_log.rs
+++ b/tests/tests/snapshot/t51_after_snapshot_add_learner_and_request_a_log.rs
@@ -32,7 +32,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
     let snapshot_index;
 
-    tracing::info!("--- send just enough logs to trigger snapshot");
+    tracing::info!(log_index, "--- send just enough logs to trigger snapshot");
     {
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold - 1;
@@ -67,13 +67,16 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- add learner to the cluster to receive snapshot, which overrides the learner storage");
+    tracing::info!(
+        log_index,
+        "--- add learner to the cluster to receive snapshot, which overrides the learner storage"
+    );
     {
         router.new_raft_node(1).await;
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
         log_index += 1;
 
-        tracing::info!("--- DONE add learner");
+        tracing::info!(log_index, "--- DONE add learner");
 
         router
             .wait(&1, timeout())
@@ -84,7 +87,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
             .await?;
 
         log_index += router.client_request_many(0, "0", 1).await?;
-        tracing::info!("--- after request a log");
+        tracing::info!(log_index, "--- after request a log");
 
         router
             .wait_for_log(

--- a/tests/tests/snapshot/t60_snapshot_chunk_size.rs
+++ b/tests/tests/snapshot/t60_snapshot_chunk_size.rs
@@ -36,7 +36,7 @@ async fn snapshot_chunk_size() -> Result<()> {
 
     let mut log_index = 0;
 
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
     {
         router.new_raft_node(0).await;
 
@@ -49,7 +49,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init leader").await?;
     }
 
-    tracing::info!("--- send just enough logs to trigger snapshot");
+    tracing::info!(log_index, "--- send just enough logs to trigger snapshot");
     {
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold - 1;
@@ -83,7 +83,7 @@ async fn snapshot_chunk_size() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- add learner to receive snapshot and logs");
+    tracing::info!(log_index, "--- add learner to receive snapshot and logs");
     {
         router.new_raft_node(1).await;
         router.add_learner(0, 1).await.expect("failed to add new node as learner");

--- a/tests/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/tests/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -45,7 +45,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     router.assert_pristine_cluster();
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
-    tracing::info!("--- initializing cluster");
+    tracing::info!(log_index, "--- initializing cluster");
     router.initialize_from_single_node(0).await?;
     log_index += 1;
 
@@ -69,7 +69,7 @@ async fn state_machine_apply_membership() -> Result<()> {
     router.new_raft_node(3).await;
     router.new_raft_node(4).await;
 
-    tracing::info!("--- adding new nodes to cluster");
+    tracing::info!(log_index, "--- adding new nodes to cluster");
     let mut new_nodes = futures::stream::FuturesUnordered::new();
     new_nodes.push(router.add_learner(0, 1));
     new_nodes.push(router.add_learner(0, 2));
@@ -81,13 +81,13 @@ async fn state_machine_apply_membership() -> Result<()> {
     log_index += 4;
     router.wait_for_log(&btreeset![0], Some(log_index), None, "add learner").await?;
 
-    tracing::info!("--- changing cluster config");
+    tracing::info!(log_index, "--- changing cluster config");
     let node = router.get_raft_handle(&0)?;
     node.change_membership(btreeset![0, 1, 2], false).await?;
 
     log_index += 2;
 
-    tracing::info!("--- every node receives joint log");
+    tracing::info!(log_index, "--- every node receives joint log");
     for i in 0..5 {
         router
             .wait(&i, None)
@@ -95,7 +95,7 @@ async fn state_machine_apply_membership() -> Result<()> {
             .await?;
     }
 
-    tracing::info!("--- only 3 node applied membership config");
+    tracing::info!(log_index, "--- only 3 node applied membership config");
     for i in 0..3 {
         router
             .wait(&i, None)


### PR DESCRIPTION

## Changelog

##### Refactor: deprecate `Membership::is_in_joint_consensus()`

Use `get_joint_config().len() > 1` instead.


##### Chore: print log_index in log for tests/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/812)
<!-- Reviewable:end -->
