### PR TITLE
Feature: add `RaftMetrics.vote`, `Wait::vote()`

### DIFF
--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -64,7 +64,7 @@ where
     NID: NodeId,
 {
     fn summary(&self) -> String {
-        let mut res = vec!["members:[".to_string()];
+        let mut res = vec!["voters:[".to_string()];
         for (i, c) in self.configs.iter().enumerate() {
             if i > 0 {
                 res.push(",".to_string());

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -37,10 +37,10 @@ fn test_membership_summary() -> anyhow::Result<()> {
     };
 
     let m = Membership::<u64, ()>::new(vec![btreeset! {1,2}, btreeset! {3}], None);
-    assert_eq!("members:[{1:{()},2:{()}},{3:{()}}],learners:[]", m.summary());
+    assert_eq!("voters:[{1:{()},2:{()}},{3:{()}}],learners:[]", m.summary());
 
     let m = Membership::<u64, ()>::new(vec![btreeset! {1,2}, btreeset! {3}], Some(btreeset! {4}));
-    assert_eq!("members:[{1:{()},2:{()}},{3:{()}}],learners:[4:{()}]", m.summary());
+    assert_eq!("voters:[{1:{()},2:{()}},{3:{()}}],learners:[4:{()}]", m.summary());
 
     let m = Membership::<u64, TestNode>::new_unchecked(vec![btreeset! {1,2}, btreeset! {3}], btreemap! {
         1=>node("127.0.0.1", "k1"),
@@ -50,7 +50,7 @@ fn test_membership_summary() -> anyhow::Result<()> {
 
     });
     assert_eq!(
-        "members:[{1:{TestNode { addr: \"127.0.0.1\", data: {\"k1\": \"k1\"} }},2:{TestNode { addr: \"127.0.0.2\", data: {\"k2\": \"k2\"} }}},{3:{TestNode { addr: \"127.0.0.3\", data: {\"k3\": \"k3\"} }}}],learners:[4:{TestNode { addr: \"127.0.0.4\", data: {\"k4\": \"k4\"} }}]",
+        "voters:[{1:{TestNode { addr: \"127.0.0.1\", data: {\"k1\": \"k1\"} }},2:{TestNode { addr: \"127.0.0.2\", data: {\"k2\": \"k2\"} }}},{3:{TestNode { addr: \"127.0.0.3\", data: {\"k3\": \"k3\"} }}}],learners:[4:{TestNode { addr: \"127.0.0.4\", data: {\"k4\": \"k4\"} }}]",
         m.summary()
     );
 

--- a/openraft/src/membership/stored_membership.rs
+++ b/openraft/src/membership/stored_membership.rs
@@ -1,3 +1,4 @@
+use crate::display_ext::DisplayOption;
 use crate::LogId;
 use crate::Membership;
 use crate::MessageSummary;
@@ -60,6 +61,10 @@ where
     NID: NodeId,
 {
     fn summary(&self) -> String {
-        format!("{{log_id:{}, {}}}", self.log_id.summary(), self.membership.summary())
+        format!(
+            "{{log_id:{}, {}}}",
+            DisplayOption(&self.log_id),
+            self.membership.summary()
+        )
     }
 }

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -8,6 +8,7 @@ use crate::summary::MessageSummary;
 use crate::LogId;
 use crate::NodeId;
 use crate::StoredMembership;
+use crate::Vote;
 
 /// A set of metrics describing the current state of a Raft node.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -27,6 +28,9 @@ where
     // ---
     /// The current term of the Raft node.
     pub current_term: u64,
+
+    /// The last accepted vote.
+    pub vote: Vote<NID>,
 
     /// The last log index has been appended to this Raft node's log.
     pub last_log_index: Option<u64>,
@@ -70,10 +74,11 @@ where
 {
     // TODO: make this more readable
     fn summary(&self) -> String {
-        format!("Metrics{{id:{},{:?}, term:{}, last_log:{:?}, last_applied:{:?}, leader:{:?}, membership:{}, snapshot:{:?}, purged:{}, replication:{{{}}}",
+        format!("Metrics{{id:{},{:?}, term:{}, vote:{}, last_log:{:?}, last_applied:{:?}, leader:{:?}, membership:{}, snapshot:{:?}, purged:{}, replication:{{{}}}",
                 self.id,
                 self.state,
                 self.current_term,
+                self.vote,
                 self.last_log_index,
                 self.last_applied.summary(),
                 self.current_leader,
@@ -98,6 +103,7 @@ where
             id,
 
             current_term: 0,
+            vote: Vote::default(),
             last_log_index: None,
             last_applied: None,
             snapshot: None,

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -1,6 +1,8 @@
+use std::fmt;
 use std::sync::Arc;
 
 use crate::core::ServerState;
+use crate::display_ext::DisplayOption;
 use crate::error::Fatal;
 use crate::metrics::ReplicationMetrics;
 use crate::node::Node;
@@ -67,28 +69,50 @@ where
     pub replication: Option<ReplicationMetrics<NID>>,
 }
 
+impl<NID, N> fmt::Display for RaftMetrics<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Metrics{{")?;
+
+        write!(
+            f,
+            "id:{}, {:?}, term:{}, vote:{}, last_log:{}, last_applied:{}, leader:{}",
+            self.id,
+            self.state,
+            self.current_term,
+            self.vote,
+            DisplayOption(&self.last_log_index),
+            DisplayOption(&self.last_applied),
+            DisplayOption(&self.current_leader),
+        )?;
+
+        write!(f, ", ")?;
+        write!(
+            f,
+            "membership:{}, snapshot:{}, purged:{}, replication:{{{}}}",
+            self.membership_config.summary(),
+            DisplayOption(&self.snapshot),
+            DisplayOption(&self.purged),
+            self.replication
+                .as_ref()
+                .map(|x| { x.iter().map(|(k, v)| format!("{}:{}", k, DisplayOption(v))).collect::<Vec<_>>().join(",") })
+                .unwrap_or_default(),
+        )?;
+
+        write!(f, "}}")?;
+        Ok(())
+    }
+}
 impl<NID, N> MessageSummary<RaftMetrics<NID, N>> for RaftMetrics<NID, N>
 where
     NID: NodeId,
     N: Node,
 {
-    // TODO: make this more readable
     fn summary(&self) -> String {
-        format!("Metrics{{id:{},{:?}, term:{}, vote:{}, last_log:{:?}, last_applied:{:?}, leader:{:?}, membership:{}, snapshot:{:?}, purged:{}, replication:{{{}}}",
-                self.id,
-                self.state,
-                self.current_term,
-                self.vote,
-                self.last_log_index,
-                self.last_applied.summary(),
-                self.current_leader,
-                self.membership_config.summary(),
-                self.snapshot,
-                self.purged.summary(),
-                self.replication.as_ref().map(|x| {
-                    x.iter().map(|(k, v)| format!("{}:{}", k, v.summary())).collect::<Vec<_>>().join(",")
-                }).unwrap_or_default(),
-        )
+        self.to_string()
     }
 }
 

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -12,6 +12,7 @@ use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::MessageSummary;
 use crate::NodeId;
+use crate::Vote;
 
 // Error variants related to metrics.
 #[derive(Debug, thiserror::Error)]
@@ -103,6 +104,12 @@ where
                 }
             };
         }
+    }
+
+    /// Wait for `vote` to become `want` or timeout.
+    #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
+    pub async fn vote(&self, want: Vote<NID>, msg: impl ToString) -> Result<RaftMetrics<NID, N>, WaitError> {
+        self.metrics(|m| m.vote == want, &format!("{} .vote -> {}", msg.to_string(), want)).await
     }
 
     /// Wait for `current_leader` to become `Some(leader_id)` until timeout.

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -2,6 +2,7 @@ use crate::display_ext::DisplayOption;
 use crate::LeaderId;
 use crate::LogId;
 use crate::NodeId;
+use crate::Vote;
 
 #[derive(Debug, Clone, Copy)]
 #[derive(Default)]
@@ -23,6 +24,9 @@ pub(crate) struct IOState<NID: NodeId> {
     /// Whether it is building a snapshot
     building_snapshot: bool,
 
+    // The last flushed vote.
+    pub(crate) vote: Vote<NID>,
+
     /// The last log id that has been flushed to storage.
     pub(crate) flushed: LogIOId<NID>,
 
@@ -38,14 +42,29 @@ pub(crate) struct IOState<NID: NodeId> {
 }
 
 impl<NID: NodeId> IOState<NID> {
-    pub(crate) fn new(flushed: LogIOId<NID>, applied: Option<LogId<NID>>, purged: Option<LogId<NID>>) -> Self {
+    pub(crate) fn new(
+        vote: Vote<NID>,
+        flushed: LogIOId<NID>,
+        applied: Option<LogId<NID>>,
+        purged: Option<LogId<NID>>,
+    ) -> Self {
         Self {
             building_snapshot: false,
+            vote,
             flushed,
             applied,
             purged,
         }
     }
+
+    pub(crate) fn update_vote(&mut self, vote: Vote<NID>) {
+        self.vote = vote;
+    }
+
+    pub(crate) fn vote(&self) -> &Vote<NID> {
+        &self.vote
+    }
+
     pub(crate) fn update_applied(&mut self, log_id: Option<LogId<NID>>) {
         tracing::debug!(applied = display(DisplayOption(&log_id)), "{}", func_name!());
 

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -245,6 +245,20 @@ where
         &mut self.io_state
     }
 
+    // TODO: move these doc to the [`IOState`]
+    /// Returns the state of the already happened IO.
+    ///
+    /// [`RaftState`] stores the expected state when all queued IO are completed,
+    /// which may advance the actual IO state.
+    ///
+    /// [`IOState`] stores the actual state of the storage.
+    ///
+    /// Usually, when a client request is handled, [`RaftState`] is updated and several IO command
+    /// is enqueued. And when the IO commands are completed, [`IOState`] is updated.
+    pub(crate) fn io_state(&self) -> &IOState<NID> {
+        &self.io_state
+    }
+
     /// Find the first entry in the input that does not exist on local raft-log,
     /// by comparing the log id.
     pub(crate) fn first_conflicting_index<Ent>(&self, entries: &[Ent]) -> usize

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -43,7 +43,7 @@ impl<NID: NodeId> std::fmt::Display for Vote<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "vote:{}:{}",
+            "{}:{}",
             self.leader_id,
             if self.is_committed() {
                 "committed"


### PR DESCRIPTION

## Changelog

##### Chore: refine Metrics display


##### Feature: add `RaftMetrics.vote`, `Wait::vote()`

The latest approved value of `Vote`, which has been saved to disk, is
referred to as `RaftMetrics.vote`. Additionally, a new `vote()` method
has been included in `Wait` to enable the application to wait for `vote`
to reach the anticipated value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/815)
<!-- Reviewable:end -->
