### PR TITLE
Improve: build snapshot in anohter task

### DIFF
--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -166,6 +166,10 @@ pub enum Violation<NID: NodeId> {
 
 /// A storage error could be either a defensive check error or an error occurred when doing the
 /// actual io operation.
+///
+/// It indicates a data crash.
+/// An application returning this error will shutdown the Openraft node immediately to prevent
+/// further damage.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum StorageError<NID>
@@ -212,6 +216,10 @@ where NID: NodeId
 }
 
 /// Error that occurs when operating the store.
+///
+/// It indicates a data crash.
+/// An application returning this error will shutdown the Openraft node immediately to prevent
+/// further damage.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct StorageIOError<NID>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,27 @@
+### `build_change_log.py`
+
+Build change log since a previous git-tag
+
+- Usage: `./scripts/build_change_log.py`: build change log since last tag.
+- Usage: `./scripts/build_change_log.py <commit>`: build since specified commit.
+- Install: `pip install -r requirements.txt`.
+
+This script buils change log from git commit messages, outputs a versioned
+change log to `./change-log/<version>.md` and concatenates all versioned change log
+into `./change-log.md`.
+
+If `./change-log/<version>.md` exists, it skips re-building it from git-log.
+Thus you can generate semi-automatic change-logs by editing `./change-log/<version>.md` and running the script again, which will just only the `./change-log.md`.
+
+
+### `check.kdl`
+
+Run daily tests in parallel:
+
+- Usage: `zellij --layout ./scripts/check.kdl`.
+- Install: `cargo install zellij`.
+
+It opens 3 panes to run:
+- `cargo test --libs`: run only lib tests
+- `cargo test --test *`: run only integration tests.
+- `cargo clippy`: lint

--- a/scripts/check.kdl
+++ b/scripts/check.kdl
@@ -1,0 +1,39 @@
+// Use zellij to run test in parallel.
+//
+// Install:
+//   cargo install zellij
+//
+// Usage:
+//   zellij action new-tab --layout check.kdl
+//   zellij --layout check.kdl
+
+simplified_ui true
+
+layout {
+
+    tab name="3m1q" {
+        // tab-bar
+        pane size=1 borderless=true {
+            plugin location="zellij:tab-bar"
+        }
+
+        pane split_direction="vertical" {
+            pane {
+                command "cargo"
+                args "test" "--lib"
+            }
+            pane {
+                command "cargo"
+                args "test" "--test" "*"
+            }
+            pane {
+                command "cargo"
+                args "clippy" "--no-deps" "--all-targets" "--" "-D" "warnings"
+            }
+        }
+        // status-bar
+        pane size=2 borderless=true {
+            plugin location="zellij:status-bar"
+        }
+    }
+}

--- a/tests/tests/log_compaction/main.rs
+++ b/tests/tests/log_compaction/main.rs
@@ -7,3 +7,4 @@ mod fixtures;
 
 mod t10_compaction;
 mod t35_building_snapshot_does_not_block_append;
+mod t35_building_snapshot_does_not_block_apply;

--- a/tests/tests/log_compaction/t35_building_snapshot_does_not_block_apply.rs
+++ b/tests/tests/log_compaction/t35_building_snapshot_does_not_block_apply.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::raft::AppendEntriesRequest;
+use openraft::testing::blank_ent;
+use openraft::testing::log_id;
+use openraft::Config;
+use openraft::RaftNetwork;
+use openraft::RaftNetworkFactory;
+use openraft::Vote;
+use openraft_memstore::BlockOperation;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// When building a snapshot, applying-entries request should not be blocked.
+///
+/// Issue: https://github.com/datafuselabs/openraft/issues/596
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn building_snapshot_does_not_block_apply() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
+
+    let follower = router.get_raft_handle(&1)?;
+
+    tracing::info!(log_index, "--- set flag to delay snapshot building");
+    {
+        let (mut _sto1, sm1) = router.get_storage_handle(&1)?;
+        sm1.storage_mut()
+            .await
+            .set_blocking(BlockOperation::DelayBuildingSnapshot, Duration::from_millis(5_000));
+    }
+
+    tracing::info!(log_index, "--- build snapshot on follower, it should block");
+    {
+        log_index += router.client_request_many(0, "0", 10).await?;
+        router.wait(&1, timeout()).log(Some(log_index), "written 10 logs").await?;
+
+        follower.trigger_snapshot().await?;
+
+        tracing::info!(log_index, "--- sleep 500 ms to make sure snapshot is started");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let res = router
+            .wait(&1, Some(Duration::from_millis(500)))
+            .snapshot(log_id(1, 0, log_index), "building snapshot is blocked")
+            .await;
+        assert!(res.is_err(), "snapshot should be blocked and can not finish");
+    }
+
+    tracing::info!(
+        log_index,
+        "--- send append-entries request to the follower that is building snapshot"
+    );
+    {
+        let next = log_index + 1;
+
+        let rpc = AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 0),
+            prev_log_id: Some(log_id(1, 0, log_index)),
+            entries: vec![blank_ent(1, 0, next)],
+            // Append and commit this entry
+            leader_commit: Some(log_id(1, 0, next)),
+        };
+
+        let mut cli = router.new_client(1, &()).await;
+        let fu = cli.send_append_entries(rpc);
+        let fu = tokio::time::timeout(Duration::from_millis(500), fu);
+        let resp = fu.await??;
+        assert!(resp.is_success());
+
+        router
+            .wait(&1, timeout())
+            .log(
+                Some(next),
+                format!("log at index {} can be applied, while snapshot is building", next),
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### Improve: build snapshot in anohter task

Before this commit, snapshot is built in the `sm::Worker`, which blocks
other state-machine writes, such as applying log entries.

This commit parallels applying log entries and building snapshot: A
snapshot is built in another `tokio::task`.

Because building snapshot is a read operation, it does not have to
block the entire state machine. Instead, it only needs a consistent view
of the state machine or holding a lock of the state machine.

- Fix: #596


##### Chore: add check.kdl to run local check in parallel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/816)
<!-- Reviewable:end -->
