### PR TITLE
Chore: remove testing function assert_stable_cluster

### DIFF
--- a/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
@@ -60,7 +60,6 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 "send log to trigger snapshot",
             )
             .await?;
-        router.assert_stable_cluster(Some(1), Some(log_index));
 
         router
             .wait_for_snapshot(

--- a/tests/tests/snapshot/t50_snapshot_when_lacking_log.rs
+++ b/tests/tests/snapshot/t50_snapshot_when_lacking_log.rs
@@ -40,7 +40,6 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
         log_index = snapshot_threshold - 1;
 
         router.wait_for_log(&btreeset![0], Some(log_index), None, "send log to trigger snapshot").await?;
-        router.assert_stable_cluster(Some(1), Some(log_index));
 
         router
             .wait_for_snapshot(

--- a/tests/tests/snapshot/t51_after_snapshot_add_learner_and_request_a_log.rs
+++ b/tests/tests/snapshot/t51_after_snapshot_add_learner_and_request_a_log.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::testing::log_id;
 use openraft::CommittedLeaderId;
 use openraft::Config;
 use openraft::LogId;
@@ -46,14 +47,10 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
                 "send log to trigger snapshot",
             )
             .await?;
-        router.assert_stable_cluster(Some(1), Some(log_index));
 
         router
             .wait(&0, timeout())
-            .snapshot(
-                LogId::new(CommittedLeaderId::new(1, 0), snapshot_index),
-                "leader-0 has built snapshot",
-            )
+            .snapshot(log_id(1, 0, snapshot_index), "leader-0 has built snapshot")
             .await?;
 
         router
@@ -61,7 +58,7 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
                 1,
                 log_index,
                 Some(0),
-                LogId::new(CommittedLeaderId::new(1, 0), log_index),
+                log_id(1, 0, log_index),
                 Some((log_index.into(), 1)),
             )
             .await?;


### PR DESCRIPTION

## Changelog

##### Chore: remove testing function assert_stable_cluster

`assert_stable_cluster()` does too many things in one function.
Replace it with short and explicit assertions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/817)
<!-- Reviewable:end -->
