### PR TITLE
Change: pass an RCPOption to RaftNetwork methods

### DIFF
--- a/cluster_benchmark/tests/benchmark/bench_cluster.rs
+++ b/cluster_benchmark/tests/benchmark/bench_cluster.rs
@@ -112,7 +112,8 @@ async fn do_bench(bench_config: &BenchConfig) -> anyhow::Result<()> {
                 l.client_write(ClientRequest {})
                     .await
                     .map_err(|e| {
-                        tracing::error!("client_write error: {:?}", e);
+                        eprintln!("client_write error: {:?}", e);
+                        e
                     })
                     .unwrap();
             }

--- a/cluster_benchmark/tests/benchmark/network.rs
+++ b/cluster_benchmark/tests/benchmark/network.rs
@@ -12,6 +12,7 @@ use openraft::error::InstallSnapshotError;
 use openraft::error::RPCError;
 use openraft::error::RaftError;
 use openraft::error::RemoteError;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -101,6 +102,7 @@ impl RaftNetwork<MemConfig> for Network {
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<MemConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId>>> {
         let resp = self.target_raft.append_entries(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
         Ok(resp)
@@ -109,6 +111,7 @@ impl RaftNetwork<MemConfig> for Network {
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<MemConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId, InstallSnapshotError>>> {
         let resp = self.target_raft.install_snapshot(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
         Ok(resp)
@@ -117,6 +120,7 @@ impl RaftNetwork<MemConfig> for Network {
     async fn send_vote(
         &mut self,
         rpc: VoteRequest<NodeId>,
+        _option: RPCOption,
     ) -> Result<VoteResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId>>> {
         let resp = self.target_raft.vote(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
         Ok(resp)

--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use openraft::error::InstallSnapshotError;
 use openraft::error::NetworkError;
 use openraft::error::RemoteError;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -83,6 +84,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     async fn send_append_entries(
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-append", req).await
     }
@@ -90,11 +92,16 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     async fn send_install_snapshot(
         &mut self,
         req: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<NodeId>, typ::RPCError<InstallSnapshotError>> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-snapshot", req).await
     }
 
-    async fn send_vote(&mut self, req: VoteRequest<NodeId>) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    async fn send_vote(
+        &mut self,
+        req: VoteRequest<NodeId>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-vote", req).await
     }
 }

--- a/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
@@ -7,6 +7,7 @@ use openraft::error::NetworkError;
 use openraft::error::RPCError;
 use openraft::error::RaftError;
 use openraft::error::RemoteError;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -96,6 +97,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     async fn send_append_entries(
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId>>> {
         tracing::debug!(req = debug(&req), "send_append_entries");
 
@@ -112,6 +114,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     async fn send_install_snapshot(
         &mut self,
         req: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId, InstallSnapshotError>>> {
         tracing::debug!(req = debug(&req), "send_install_snapshot");
         self.c().await?.raft().snapshot(req).await.map_err(|e| to_error(e, self.target))
@@ -121,6 +124,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     async fn send_vote(
         &mut self,
         req: VoteRequest<NodeId>,
+        _option: RPCOption,
     ) -> Result<VoteResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId>>> {
         tracing::debug!(req = debug(&req), "send_vote");
         self.c().await?.raft().vote(req).await.map_err(|e| to_error(e, self.target))

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -51,6 +51,7 @@ use crate::log_id::LogIdOptionExt;
 use crate::log_id::RaftLogId;
 use crate::metrics::RaftMetrics;
 use crate::metrics::ReplicationMetrics;
+use crate::network::RPCOption;
 use crate::network::RPCTypes;
 use crate::network::RaftNetwork;
 use crate::network::RaftNetworkFactory;
@@ -307,8 +308,10 @@ where
             let target_node = eff_mem.get_node(&target).unwrap().clone();
             let mut client = self.network.new_client(target, &target_node).await;
 
+            let option = RPCOption::new(ttl);
+
             let fu = async move {
-                let outer_res = timeout(ttl, client.send_append_entries(rpc)).await;
+                let outer_res = timeout(ttl, client.send_append_entries(rpc, option)).await;
                 match outer_res {
                     Ok(append_res) => match append_res {
                         Ok(x) => Ok((target, x)),
@@ -989,10 +992,11 @@ where
 
             let ttl = Duration::from_millis(self.config.election_timeout_min);
             let id = self.id;
+            let option = RPCOption::new(ttl);
 
             let _ = tokio::spawn(
                 async move {
-                    let tm_res = timeout(ttl, client.send_vote(req)).await;
+                    let tm_res = timeout(ttl, client.send_vote(req, option)).await;
                     let res = match tm_res {
                         Ok(res) => res,
 

--- a/openraft/src/network/mod.rs
+++ b/openraft/src/network/mod.rs
@@ -3,9 +3,11 @@
 mod backoff;
 mod factory;
 #[allow(clippy::module_inception)] mod network;
+mod rpc_option;
 mod rpc_type;
 
 pub use backoff::Backoff;
 pub use factory::RaftNetworkFactory;
 pub use network::RaftNetwork;
+pub use rpc_option::RPCOption;
 pub use rpc_type::RPCTypes;

--- a/openraft/src/network/network.rs
+++ b/openraft/src/network/network.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use crate::error::InstallSnapshotError;
 use crate::error::RPCError;
 use crate::error::RaftError;
+use crate::network::rpc_option::RPCOption;
 use crate::network::Backoff;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
@@ -32,12 +33,14 @@ where C: RaftTypeConfig
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,
+        option: RPCOption,
     ) -> Result<AppendEntriesResponse<C::NodeId>, RPCError<C::NodeId, C::Node, RaftError<C::NodeId>>>;
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<C>,
+        option: RPCOption,
     ) -> Result<
         InstallSnapshotResponse<C::NodeId>,
         RPCError<C::NodeId, C::Node, RaftError<C::NodeId, InstallSnapshotError>>,
@@ -47,6 +50,7 @@ where C: RaftTypeConfig
     async fn send_vote(
         &mut self,
         rpc: VoteRequest<C::NodeId>,
+        option: RPCOption,
     ) -> Result<VoteResponse<C::NodeId>, RPCError<C::NodeId, C::Node, RaftError<C::NodeId>>>;
 
     /// Build a backoff instance if the target node is temporarily(or permanently) unreachable.

--- a/openraft/src/network/rpc_option.rs
+++ b/openraft/src/network/rpc_option.rs
@@ -1,0 +1,22 @@
+use std::time::Duration;
+
+/// An additional argument to the [`RaftNetwork`] methods to allow applications to customize
+/// networking behaviors.
+///
+/// [`RaftNetwork`]: `crate::network::RaftNetwork`
+pub struct RPCOption {
+    /// The expected time-to-last for an RPC.
+    ///
+    /// The caller will cancel an RPC if it takes longer than this duration.
+    ttl: Duration,
+}
+
+impl RPCOption {
+    pub fn new(ttl: Duration) -> Self {
+        Self { ttl }
+    }
+
+    pub fn ttl(&self) -> Duration {
+        self.ttl
+    }
+}

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -33,6 +33,7 @@ use crate::error::Timeout;
 use crate::log_id::LogIdOptionExt;
 use crate::log_id_range::LogIdRange;
 use crate::network::Backoff;
+use crate::network::RPCOption;
 use crate::network::RPCTypes;
 use crate::network::RaftNetwork;
 use crate::network::RaftNetworkFactory;
@@ -292,7 +293,8 @@ where
         );
 
         let the_timeout = Duration::from_millis(self.config.heartbeat_interval);
-        let res = timeout(the_timeout, self.network.send_append_entries(payload)).await;
+        let option = RPCOption::new(the_timeout);
+        let res = timeout(the_timeout, self.network.send_append_entries(payload, option)).await;
 
         tracing::debug!("append_entries res: {:?}", res);
 
@@ -576,7 +578,9 @@ where
                 self.config.send_snapshot_timeout()
             };
 
-            let res = timeout(snap_timeout, self.network.send_install_snapshot(req)).await;
+            let option = RPCOption::new(snap_timeout);
+
+            let res = timeout(snap_timeout, self.network.send_install_snapshot(req, option)).await;
 
             let res = match res {
                 Ok(outer_res) => match outer_res {

--- a/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -57,7 +59,8 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.new_client(0, &()).await.send_append_entries(rpc).await?;
+    let option = RPCOption::new(Duration::from_millis(1_000));
+    let resp = router.new_client(0, &()).await.send_append_entries(rpc, option).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 
@@ -77,7 +80,9 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.new_client(0, &()).await.send_append_entries(rpc).await?;
+    let option = RPCOption::new(Duration::from_millis(1_000));
+
+    let resp = router.new_client(0, &()).await.send_append_entries(rpc, option).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -90,7 +95,9 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 5)),
     };
 
-    let resp = router.new_client(0, &()).await.send_append_entries(rpc).await?;
+    let option = RPCOption::new(Duration::from_millis(1_000));
+
+    let resp = router.new_client(0, &()).await.send_append_entries(rpc, option).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::VoteRequest;
@@ -40,13 +41,18 @@ async fn append_sees_higher_vote() -> Result<()> {
         // Let leader lease expire
         sleep(Duration::from_millis(800)).await;
 
+        let option = RPCOption::new(Duration::from_millis(1_000));
+
         let resp = router
             .new_client(1, &())
             .await
-            .send_vote(VoteRequest {
-                vote: Vote::new(10, 1),
-                last_log_id: Some(LogId::new(CommittedLeaderId::new(10, 1), 5)),
-            })
+            .send_vote(
+                VoteRequest {
+                    vote: Vote::new(10, 1),
+                    last_log_id: Some(LogId::new(CommittedLeaderId::new(10, 1), 5)),
+                },
+                option,
+            )
             .await?;
 
         assert!(resp.vote_granted);

--- a/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
+++ b/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -51,7 +53,9 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), log_index)),
     };
 
-    let resp = router.new_client(0, &()).await.send_append_entries(req).await?;
+    let option = RPCOption::new(Duration::from_millis(1_000));
+
+    let resp = router.new_client(0, &()).await.send_append_entries(req, option).await?;
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -30,6 +30,7 @@ use openraft::error::RaftError;
 use openraft::error::RemoteError;
 use openraft::error::Unreachable;
 use openraft::metrics::Wait;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -852,6 +853,7 @@ impl RaftNetwork<MemConfig> for RaftRouterNetwork {
     async fn send_append_entries(
         &mut self,
         rpc: AppendEntriesRequest<MemConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<MemNodeId>, RPCError<MemNodeId, (), RaftError<MemNodeId>>> {
         tracing::debug!("append_entries to id={} {}", self.target, rpc.summary());
         self.owner.count_rpc(RPCType::AppendEntries);
@@ -874,6 +876,7 @@ impl RaftNetwork<MemConfig> for RaftRouterNetwork {
     async fn send_install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<MemConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<MemNodeId>, RPCError<MemNodeId, (), RaftError<MemNodeId, InstallSnapshotError>>>
     {
         self.owner.count_rpc(RPCType::InstallSnapshot);
@@ -894,6 +897,7 @@ impl RaftNetwork<MemConfig> for RaftRouterNetwork {
     async fn send_vote(
         &mut self,
         rpc: VoteRequest<MemNodeId>,
+        _option: RPCOption,
     ) -> Result<VoteResponse<MemNodeId>, RPCError<MemNodeId, (), RaftError<MemNodeId>>> {
         self.owner.count_rpc(RPCType::Vote);
 

--- a/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/log_compaction/t35_building_snapshot_does_not_block_append.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -67,7 +68,8 @@ async fn building_snapshot_does_not_block_append() -> Result<()> {
         };
 
         let mut cli = router.new_client(1, &()).await;
-        let fu = cli.send_append_entries(rpc);
+        let option = RPCOption::new(Duration::from_millis(1_000));
+        let fu = cli.send_append_entries(rpc, option);
         let fu = tokio::time::timeout(Duration::from_millis(500), fu);
         let resp = fu.await??;
         assert!(resp.is_success());

--- a/tests/tests/log_compaction/t35_building_snapshot_does_not_block_apply.rs
+++ b/tests/tests/log_compaction/t35_building_snapshot_does_not_block_apply.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -74,7 +75,9 @@ async fn building_snapshot_does_not_block_apply() -> Result<()> {
         };
 
         let mut cli = router.new_client(1, &()).await;
-        let fu = cli.send_append_entries(rpc);
+        let option = RPCOption::new(Duration::from_millis(1_000));
+
+        let fu = cli.send_append_entries(rpc, option);
         let fu = tokio::time::timeout(Duration::from_millis(500), fu);
         let resp = fu.await??;
         assert!(resp.is_success());

--- a/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot/t31_snapshot_overrides_membership.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -97,7 +98,9 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 }],
                 leader_commit: Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
             };
-            router.new_client(1, &()).await.send_append_entries(req).await?;
+            let option = RPCOption::new(Duration::from_millis(1_000));
+
+            router.new_client(1, &()).await.send_append_entries(req, option).await?;
 
             tracing::info!(log_index, "--- check that learner membership is affected");
             {

--- a/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
+++ b/tests/tests/snapshot/t33_snapshot_delete_conflict_logs.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -117,7 +118,9 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             ],
             leader_commit: Some(LogId::new(CommittedLeaderId::new(1, 0), 2)),
         };
-        router.new_client(1, &()).await.send_append_entries(req).await?;
+        let option = RPCOption::new(Duration::from_millis(1_000));
+
+        router.new_client(1, &()).await.send_append_entries(req, option).await?;
 
         tracing::info!(log_index, "--- check that learner membership is affected");
         {
@@ -153,7 +156,9 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
             done: true,
         };
 
-        router.new_client(1, &()).await.send_install_snapshot(req).await?;
+        let option = RPCOption::new(Duration::from_millis(1_000));
+
+        router.new_client(1, &()).await.send_install_snapshot(req, option).await?;
 
         tracing::info!(log_index, "--- DONE installing snapshot");
 


### PR DESCRIPTION

## Changelog

##### Change: pass an RCPOption to RaftNetwork methods

Add an additional argument `RPCOption` to `RaftNetwork` methods,
to enable an application control the networking behaviors based on the
parameters in `RPCOption`.

The `ttl` parameter in `RPCOption` sets the duration for which an RPC
should run. Once the `ttl` ends, the caller will terminate the ongoing
RPC.

- Fix: #819

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/821)
<!-- Reviewable:end -->
