### PR TITLE
Chore: refine tracing format for tests

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -542,12 +542,14 @@ where
     ///
     /// It is allowed to initialize only when `last_log_id.is_none()` and `vote==(0,0)`.
     /// See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, tx))]
     pub(crate) fn handle_initialize(
         &mut self,
         member_nodes: BTreeMap<C::NodeId, C::Node>,
         tx: ResultSender<(), InitializeError<C::NodeId, C::Node>>,
     ) {
+        tracing::debug!(member_nodes = debug(&member_nodes), "{}", func_name!());
+
         let membership = Membership::from(member_nodes);
 
         let entry = C::Entry::new_membership(LogId::default(), membership);

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -87,7 +87,7 @@ where
         let all_node_ids = self.nodes.keys().cloned().collect::<BTreeSet<_>>();
         let members = self.voter_ids().collect::<BTreeSet<_>>();
 
-        res.push(",learners:[".to_string());
+        res.push(", learners:[".to_string());
         for (learner_cnt, learner_id) in all_node_ids.difference(&members).enumerate() {
             if learner_cnt > 0 {
                 res.push(",".to_string());

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -37,10 +37,10 @@ fn test_membership_summary() -> anyhow::Result<()> {
     };
 
     let m = Membership::<u64, ()>::new(vec![btreeset! {1,2}, btreeset! {3}], None);
-    assert_eq!("voters:[{1:{()},2:{()}},{3:{()}}],learners:[]", m.summary());
+    assert_eq!("voters:[{1:{()},2:{()}},{3:{()}}], learners:[]", m.summary());
 
     let m = Membership::<u64, ()>::new(vec![btreeset! {1,2}, btreeset! {3}], Some(btreeset! {4}));
-    assert_eq!("voters:[{1:{()},2:{()}},{3:{()}}],learners:[4:{()}]", m.summary());
+    assert_eq!("voters:[{1:{()},2:{()}},{3:{()}}], learners:[4:{()}]", m.summary());
 
     let m = Membership::<u64, TestNode>::new_unchecked(vec![btreeset! {1,2}, btreeset! {3}], btreemap! {
         1=>node("127.0.0.1", "k1"),
@@ -50,7 +50,7 @@ fn test_membership_summary() -> anyhow::Result<()> {
 
     });
     assert_eq!(
-        "voters:[{1:{TestNode { addr: \"127.0.0.1\", data: {\"k1\": \"k1\"} }},2:{TestNode { addr: \"127.0.0.2\", data: {\"k2\": \"k2\"} }}},{3:{TestNode { addr: \"127.0.0.3\", data: {\"k3\": \"k3\"} }}}],learners:[4:{TestNode { addr: \"127.0.0.4\", data: {\"k4\": \"k4\"} }}]",
+        r#"voters:[{1:{TestNode { addr: "127.0.0.1", data: {"k1": "k1"} }},2:{TestNode { addr: "127.0.0.2", data: {"k2": "k2"} }}},{3:{TestNode { addr: "127.0.0.3", data: {"k3": "k3"} }}}], learners:[4:{TestNode { addr: "127.0.0.4", data: {"k4": "k4"} }}]"#,
         m.summary()
     );
 

--- a/openraft/src/membership/stored_membership.rs
+++ b/openraft/src/membership/stored_membership.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::display_ext::DisplayOption;
 use crate::LogId;
 use crate::Membership;
@@ -55,16 +57,27 @@ where
     }
 }
 
+impl<NID, N> fmt::Display for StoredMembership<NID, N>
+where
+    N: Node,
+    NID: NodeId,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{{log_id:{}, {}}}",
+            DisplayOption(&self.log_id),
+            self.membership.summary()
+        )
+    }
+}
+
 impl<NID, N> MessageSummary<StoredMembership<NID, N>> for StoredMembership<NID, N>
 where
     N: Node,
     NID: NodeId,
 {
     fn summary(&self) -> String {
-        format!(
-            "{{log_id:{}, {}}}",
-            DisplayOption(&self.log_id),
-            self.membership.summary()
-        )
+        self.to_string()
     }
 }

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -1123,7 +1123,7 @@ pub struct InstallSnapshotRequest<C: RaftTypeConfig> {
 impl<C: RaftTypeConfig> MessageSummary<InstallSnapshotRequest<C>> for InstallSnapshotRequest<C> {
     fn summary(&self) -> String {
         format!(
-            "vote={}, meta={:?}, offset={}, len={}, done={}",
+            "vote={}, meta={}, offset={}, len={}, done={}",
             self.vote,
             self.meta,
             self.offset,
@@ -1136,6 +1136,8 @@ impl<C: RaftTypeConfig> MessageSummary<InstallSnapshotRequest<C>> for InstallSna
 /// The response to an `InstallSnapshotRequest`.
 #[derive(Debug)]
 #[derive(PartialEq, Eq)]
+#[derive(derive_more::Display)]
+#[display(fmt = "{{vote:{}}}", vote)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct InstallSnapshotResponse<NID: NodeId> {
     pub vote: Vote<NID>,

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -7,6 +7,7 @@ mod log_store_ext;
 mod snapshot_signature;
 mod v2;
 
+use std::fmt;
 use std::fmt::Debug;
 use std::ops::RangeBounds;
 
@@ -18,6 +19,7 @@ pub use snapshot_signature::SnapshotSignature;
 pub use v2::RaftLogStorage;
 pub use v2::RaftStateMachine;
 
+use crate::display_ext::DisplayOption;
 use crate::node::Node;
 use crate::raft_types::SnapshotId;
 pub use crate::storage::callback::LogApplied;
@@ -49,18 +51,29 @@ where
     pub snapshot_id: SnapshotId,
 }
 
+impl<NID, N> fmt::Display for SnapshotMeta<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{{snapshot_id: {}, last_log:{}, last_membership: {}}}",
+            self.snapshot_id,
+            DisplayOption(&self.last_log_id),
+            self.last_membership
+        )
+    }
+}
+
 impl<NID, N> MessageSummary<SnapshotMeta<NID, N>> for SnapshotMeta<NID, N>
 where
     NID: NodeId,
     N: Node,
 {
     fn summary(&self) -> String {
-        format!(
-            "{{snapshot_id: {}, last_membership: {}, last_log_id: {}}}",
-            self.snapshot_id,
-            self.last_log_id.summary(),
-            self.last_membership.summary()
-        )
+        self.to_string()
     }
 }
 

--- a/tests/tests/fixtures/logging.rs
+++ b/tests/tests/fixtures/logging.rs
@@ -37,13 +37,10 @@ where
         write!(writer, "{:0>2?} ", std::thread::current().id())?;
 
         if let Some(scope) = ctx.event_scope() {
-            let mut seen = false;
-
             for span in scope.from_root() {
-                write!(writer, "{}", span.metadata().name())?;
+                write!(writer, "{}", span.metadata().target())?;
+                write!(writer, "@{}", span.metadata().name())?;
                 write!(writer, "#{:x}", span.id().into_u64())?;
-
-                seen = true;
 
                 let ext = span.extensions();
                 if let Some(fields) = &ext.get::<FormattedFields<N>>() {
@@ -51,11 +48,7 @@ where
                         write!(writer, "{{{}}}", fields)?;
                     }
                 }
-                write!(writer, ":")?;
-            }
-
-            if seen {
-                writer.write_char(' ')?;
+                write!(writer, ": ")?;
             }
         };
 


### PR DESCRIPTION

## Changelog

##### Chore: refine tracing format for tests

Add span target(mod path) to log:

Previously:
```
<func>#<span_id>:<func>#<span_id>: <message>
```

In this commit:
```
<mod>@<func>#<span_id>: <mod>@<func>#<span_id>: <message>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/824)
<!-- Reviewable:end -->
