### PR TITLE
Feature: `RaftNetwork::send_append_entries()` can return PartialSuccess

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1241,7 +1241,7 @@ where
                 match response {
                     replication::Response::Progress {
                         target,
-                        id,
+                        request_id: id,
                         result,
                         session_id,
                     } => {
@@ -1576,7 +1576,7 @@ where
                             let _ = node.tx_repl.send(Replicate::Heartbeat);
                         }
                         Inflight::Logs { id, log_id_range } => {
-                            let _ = node.tx_repl.send(Replicate::logs(id, log_id_range));
+                            let _ = node.tx_repl.send(Replicate::logs(Some(id), log_id_range));
                         }
                         Inflight::Snapshot { id, last_log_id } => {
                             let _ = last_log_id;

--- a/openraft/src/display_ext.rs
+++ b/openraft/src/display_ext.rs
@@ -19,6 +19,18 @@ impl<'a, T: fmt::Display> fmt::Display for DisplayOption<'a, T> {
     }
 }
 
+pub(crate) trait DisplayOptionExt<'a, T: fmt::Display> {
+    fn display(&'a self) -> DisplayOption<'a, T>;
+}
+
+impl<T> DisplayOptionExt<'_, T> for Option<T>
+where T: fmt::Display
+{
+    fn display(&self) -> DisplayOption<T> {
+        DisplayOption(self)
+    }
+}
+
 /// Implement `Display` for `&[T]` if T is `Display`.
 ///
 /// It outputs at most `MAX` elements, excluding those from the 5th to the second-to-last one:

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -289,7 +289,7 @@ where C: RaftTypeConfig
     /// `send_none` specifies whether to force to send a message even when there is no data to send.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn initiate_replication(&mut self, send_none: SendNone) {
-        tracing::debug!(progress = debug(&self.leader.progress), "send_to_all");
+        tracing::debug!(progress = debug(&self.leader.progress), "{}", func_name!());
 
         for (id, prog_entry) in self.leader.progress.iter_mut() {
             // TODO: update matching should be done here for leader
@@ -299,6 +299,7 @@ where C: RaftTypeConfig
             }
 
             let t = prog_entry.next_send(self.state, self.config.max_payload_entries);
+            tracing::debug!(target = display(*id), send = debug(&t), "next send");
 
             match t {
                 Ok(inflight) => {

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -143,6 +143,8 @@ impl<NID: NodeId> Inflight<NID> {
 
     /// Update inflight state when log upto `upto` is acknowledged by a follower/learner.
     pub(crate) fn ack(&mut self, upto: Option<LogId<NID>>) {
+        let request_id = self.get_id();
+
         match self {
             Inflight::None => {
                 unreachable!("no inflight data")
@@ -161,6 +163,10 @@ impl<NID: NodeId> Inflight<NID> {
                 debug_assert_eq!(&upto, last_log_id);
                 *self = Inflight::None;
             }
+        }
+
+        if let Some(request_id) = request_id {
+            self.set_id(request_id);
         }
     }
 

--- a/openraft/src/progress/inflight/tests.rs
+++ b/openraft/src/progress/inflight/tests.rs
@@ -129,6 +129,15 @@ fn test_inflight_ack() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_inflight_ack_inherit_request_id() -> anyhow::Result<()> {
+    let mut f = Inflight::logs(Some(log_id(5)), Some(log_id(10))).with_id(10);
+
+    f.ack(Some(log_id(5)));
+    assert_eq!(Some(10), f.get_id());
+    Ok(())
+}
+
+#[test]
 fn test_inflight_conflict() -> anyhow::Result<()> {
     {
         let mut f = Inflight::logs(Some(log_id(5)), Some(log_id(10)));

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -1,8 +1,8 @@
 //! Public Raft interface and data types.
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
-use std::fmt::Display;
 use std::marker::PhantomData;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -30,6 +30,7 @@ use crate::core::sm;
 use crate::core::RaftCore;
 use crate::core::Tick;
 use crate::core::TickHandle;
+use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySlice;
 use crate::engine::Engine;
 use crate::engine::EngineConfig;
@@ -357,7 +358,7 @@ where
     async fn send_external_command(
         &self,
         cmd: ExternalCommand,
-        cmd_desc: impl Display + Default,
+        cmd_desc: impl fmt::Display + Default,
     ) -> Result<(), Fatal<C::NodeId>> {
         let send_res = self.inner.tx_api.send(RaftMsg::ExternalCommand { cmd });
 
@@ -731,8 +732,8 @@ where
 
     async fn get_core_stopped_error(
         &self,
-        when: impl Display,
-        message_summary: Option<impl Display + Default>,
+        when: impl fmt::Display,
+        message_summary: Option<impl fmt::Display + Default>,
     ) -> Fatal<C::NodeId> {
         // Wait for the core task to finish.
         self.join_core_task().await;
@@ -1000,7 +1001,7 @@ pub struct AppendEntriesRequest<C: RaftTypeConfig> {
 impl<C: RaftTypeConfig> Debug for AppendEntriesRequest<C>
 where C::D: Debug
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AppendEntriesRequest")
             .field("vote", &self.vote)
             .field("prev_log_id", &self.prev_log_id)
@@ -1023,12 +1024,41 @@ impl<C: RaftTypeConfig> MessageSummary<AppendEntriesRequest<C>> for AppendEntrie
 }
 
 /// The response to an `AppendEntriesRequest`.
+///
+/// [`RaftNetwork::send_append_entries`] returns this type only when received an RPC reply.
+/// Otherwise it should return [`RPCError`].
+///
+/// [`RPCError`]: crate::error::RPCError
+/// [`RaftNetwork::send_append_entries`]: crate::network::RaftNetwork::send_append_entries
 #[derive(Debug)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum AppendEntriesResponse<NID: NodeId> {
+    /// Successfully replicated all log entries to the target node.
     Success,
+
+    /// Successfully sent the first portion of log entries.
+    ///
+    /// [`RaftNetwork::send_append_entries`] can return a partial success.
+    /// For example, it tries to send log entries `[1-2..3-10]`, the application is allowed to send
+    /// just `[1-2..1-3]` and return `PartialSuccess(1-3)`,
+    ///
+    /// ### Caution
+    ///
+    /// The returned matching log id must be **greater than or equal to** the first log
+    /// id([`AppendEntriesRequest::prev_log_id`]) of the entries to send. If no RPC reply is
+    /// received, [`RaftNetwork::send_append_entries`] must return an [`RPCError`] to inform
+    /// Openraft that the first log id([`AppendEntriesRequest::prev_log_id`]) may not match on
+    /// the remote target node.
+    ///
+    /// [`RPCError`]: crate::error::RPCError
+    /// [`RaftNetwork::send_append_entries`]: crate::network::RaftNetwork::send_append_entries
+    PartialSuccess(Option<LogId<NID>>),
+
+    /// The first log id([`AppendEntriesRequest::prev_log_id`]) of the entries to send does not
+    /// match on the remote target node.
     Conflict,
+
     /// Seen a vote `v` that does not hold `mine_vote >= v`.
     /// And a leader's vote(committed vote) must be total order with other vote.
     /// Therefore it has to be a higher vote: `mine_vote < v`
@@ -1045,12 +1075,15 @@ impl<NID: NodeId> AppendEntriesResponse<NID> {
     }
 }
 
-impl<NID: NodeId> MessageSummary<AppendEntriesResponse<NID>> for AppendEntriesResponse<NID> {
-    fn summary(&self) -> String {
+impl<NID: NodeId> fmt::Display for AppendEntriesResponse<NID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AppendEntriesResponse::Success => "Success".to_string(),
-            AppendEntriesResponse::HigherVote(vote) => format!("Higher vote, {}", vote),
-            AppendEntriesResponse::Conflict => "Conflict".to_string(),
+            AppendEntriesResponse::Success => write!(f, "Success"),
+            AppendEntriesResponse::PartialSuccess(m) => {
+                write!(f, "PartialSuccess({})", m.display())
+            }
+            AppendEntriesResponse::HigherVote(vote) => write!(f, "Higher vote, {}", vote),
+            AppendEntriesResponse::Conflict => write!(f, "Conflict"),
         }
     }
 }

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -21,7 +21,7 @@ where C: RaftTypeConfig
         /// The id of the subject that submit this replication action.
         ///
         /// It is only used for debugging purpose.
-        id: u64,
+        request_id: u64,
 
         /// Either the last log id that has been successfully replicated to the target,
         /// or an error in string.
@@ -61,7 +61,7 @@ where C: RaftTypeConfig
         match self {
             Self::Progress {
                 ref target,
-                ref id,
+                request_id: ref id,
                 ref result,
                 ref session_id,
             } => {

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -5,4 +5,5 @@
 #[path = "../fixtures/mod.rs"]
 mod fixtures;
 
+mod t10_append_entries_partial_success;
 mod t50_append_entries_backoff;

--- a/tests/tests/replication/t10_append_entries_partial_success.rs
+++ b/tests/tests/replication/t10_append_entries_partial_success.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// RaftNetwork::send_append_entries can return a partial success.
+/// For example, it tries to send log entries `[1-2..2-10]`, the application is allowed to send just
+/// `[1-2..1-3]` and return `PartialSuccess(1-3)`.
+#[async_entry::test(worker_threads = 4, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn append_entries_partial_success() -> Result<()> {
+    let config = Arc::new(Config { ..Default::default() }.validate()?);
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
+
+    let quota = 2;
+    let n = 5;
+
+    tracing::info!(
+        log_index,
+        "--- set append-entries quota to {}, wirte {} entries",
+        quota,
+        n
+    );
+    {
+        router.set_append_entries_quota(Some(quota));
+
+        let r = router.clone();
+        tokio::spawn(async move {
+            // client request will be blocked due to limited quota=2
+            r.client_request_many(0, "0", n as usize).await.unwrap();
+        });
+        log_index += quota;
+
+        router.wait(&0, timeout()).log(Some(log_index), format!("{} writes", quota)).await?;
+
+        log_index += 1;
+        tracing::info!(log_index, "--- can not send log at index {}", log_index,);
+
+        let res = router
+            .wait(&0, timeout())
+            .log(Some(log_index), format!("log index {} is limited by quota", log_index))
+            .await;
+
+        assert!(res.is_err(), "log index {} is limited by quota", log_index);
+    }
+
+    tracing::info!(log_index, "--- extend quota by 1, send 1 log at index {}", log_index,);
+    {
+        router.set_append_entries_quota(Some(1));
+        router
+            .wait(&0, timeout())
+            .log(Some(log_index), format!("log index {} can be replicated", log_index))
+            .await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2_000))
+}


### PR DESCRIPTION

## Changelog

##### Feature: `RaftNetwork::send_append_entries()` can return PartialSuccess

If there are too many log entries and the `RPCOption.ttl` is not
sufficient, an application can opt to only send a portion of the
entries, with `AppendEntriesResponse::PartialSuccess(Option<LogId>)`, to
inform Openraft with the last replicated log id. Thus replication can
still make progress.

For example, it tries to send log entries `[1-2..3-10]`, the application
is allowed to send just `[1-2..1-3]` and return `PartialSuccess(1-3)`,

### Caution

The returned matching log id must be **greater than or equal to** the
first log id(`AppendEntriesRequest::prev_log_id`) of the entries to
send. If no RPC reply is received, `RaftNetwork::send_append_entries`
**must** return an `RPCError` to inform Openraft that the first log
id(`AppendEntriesRequest::prev_log_id`) may not match on the remote
target node.

- Fix: #822

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/831)
<!-- Reviewable:end -->
