### PR TITLE
Refactor: let Inflight::ack() check request-id

### DIFF
--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -77,8 +77,8 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
     // No data to send, sending a heartbeat is to send empty RPC:
     {
         let l = eng.leader_handler()?;
-        let _ = l.leader.progress.update_with(&2, |ent| ent.update_matching(Some(log_id1(2, 3))));
-        let _ = l.leader.progress.update_with(&3, |ent| ent.update_matching(Some(log_id1(2, 3))));
+        let _ = l.leader.progress.update_with(&2, |ent| ent.update_matching(1, Some(log_id1(2, 3))).unwrap());
+        let _ = l.leader.progress.update_with(&3, |ent| ent.update_matching(1, Some(log_id1(2, 3))).unwrap());
     }
     eng.output.clear_commands();
     eng.leader_handler()?.send_heartbeat();

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -41,12 +41,12 @@ fn test_update_matching() -> anyhow::Result<()> {
     {
         let mut pe = ProgressEntry::empty(20);
         pe.inflight = inflight_logs(5, 10);
-        pe.update_matching(Some(log_id(6)));
+        pe.update_matching(pe.inflight.id(), Some(log_id(6)))?;
         assert_eq!(inflight_logs(6, 10), pe.inflight);
         assert_eq!(Some(log_id(6)), pe.matching);
         assert_eq!(20, pe.searching_end);
 
-        pe.update_matching(Some(log_id(10)));
+        pe.update_matching(pe.inflight.id(), Some(log_id(10)))?;
         assert_eq!(Inflight::None, pe.inflight);
         assert_eq!(Some(log_id(10)), pe.matching);
         assert_eq!(20, pe.searching_end);
@@ -58,7 +58,7 @@ fn test_update_matching() -> anyhow::Result<()> {
         pe.matching = Some(log_id(6));
         pe.inflight = inflight_logs(5, 20);
 
-        pe.update_matching(Some(log_id(20)));
+        pe.update_matching(pe.inflight.id(), Some(log_id(20)))?;
         assert_eq!(21, pe.searching_end);
     }
 
@@ -70,7 +70,7 @@ fn test_update_conflicting() -> anyhow::Result<()> {
     let mut pe = ProgressEntry::empty(20);
     pe.matching = Some(log_id(3));
     pe.inflight = inflight_logs(5, 10);
-    pe.update_conflicting(5);
+    pe.update_conflicting(pe.inflight.id(), 5)?;
     assert_eq!(Inflight::None, pe.inflight);
     assert_eq!(&Some(log_id(3)), pe.borrow());
     assert_eq!(5, pe.searching_end);

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -9,7 +9,7 @@
 #[cfg(test)]
 mod bench;
 pub(crate) mod entry;
-mod inflight;
+pub(crate) mod inflight;
 
 use std::borrow::Borrow;
 use std::fmt::Debug;


### PR DESCRIPTION

## Changelog

##### Refactor: let Inflight::ack() check request-id

The callers to it do not need to check request-id anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/832)
<!-- Reviewable:end -->
