### PR TITLE
Change: remove unused error CommittedAdvanceTooMany

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -326,6 +326,10 @@ pub struct CommittedAdvanceTooMany {
     pub target_index: u64,
 }
 
+/// Error that indicates a **temporary** network error and when it is returned, Openraft will retry
+/// immediately.
+///
+/// Unlike [`Unreachable`], which indicates a error that should backoff before retrying.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("NetworkError: {source}")]

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -318,14 +318,6 @@ pub struct HigherVote<NID: NodeId> {
     pub mine: Vote<NID>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-#[error("leader committed index {committed_index} advances target log index {target_index} too many")]
-pub struct CommittedAdvanceTooMany {
-    pub committed_index: u64,
-    pub target_index: u64,
-}
-
 /// Error that indicates a **temporary** network error and when it is returned, Openraft will retry
 /// immediately.
 ///

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -73,7 +73,7 @@ async fn append_inconsistent_log() -> Result<()> {
     );
     {
         router.new_raft_node_with_sto(1, sto1.clone(), sm1.clone()).await;
-        router.isolate_node(1);
+        router.set_node_network_failure(1, true);
     }
 
     tracing::info!(log_index, "--- restart node 0 and 2");

--- a/tests/tests/append_entries/t30_replication_1_voter_to_isolated_learner.rs
+++ b/tests/tests/append_entries/t30_replication_1_voter_to_isolated_learner.rs
@@ -30,7 +30,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
 
     tracing::info!(log_index, "--- stop replication to node 1");
     {
-        router.isolate_node(1);
+        router.set_node_network_failure(1, true);
 
         router.client_request_many(0, "0", (10 - log_index) as usize).await?;
         log_index = 10;
@@ -47,7 +47,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
 
     tracing::info!(log_index, "--- restore replication to node 1");
     {
-        router.restore_node(1);
+        router.set_node_network_failure(1, false);
 
         router.client_request_many(0, "0", (10 - log_index) as usize).await?;
         log_index = 10;

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -44,12 +44,12 @@ async fn client_reads() -> Result<()> {
 
     tracing::info!(log_index, "--- isolate node 1 then is_leader should work");
 
-    router.isolate_node(1);
+    router.set_node_network_failure(1, true);
     router.is_leader(leader).await?;
 
     tracing::info!(log_index, "--- isolate node 2 then is_leader should fail");
 
-    router.isolate_node(2);
+    router.set_node_network_failure(2, true);
     let rst = router.is_leader(leader).await;
     tracing::debug!(?rst, "is_leader with majority down");
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -134,6 +134,7 @@ pub fn log_panic(panic: &PanicInfo) {
 }
 
 /// A type which emulates a network transport and implements the `RaftNetworkFactory` trait.
+#[derive(Clone)]
 pub struct TypedRaftRouter {
     /// The Raft runtime config which all nodes are using.
     config: Arc<Config>,
@@ -142,8 +143,8 @@ pub struct TypedRaftRouter {
     #[allow(clippy::type_complexity)]
     routing_table: Arc<Mutex<BTreeMap<MemNodeId, (MemRaft, MemLogStore, MemStateMachine)>>>,
 
-    /// Nodes which are isolated can neither send nor receive frames, it returns an `NetworkError`.
-    isolated_nodes: Arc<Mutex<HashSet<MemNodeId>>>,
+    /// Nodes that can neither send nor receive frames, and will return an `NetworkError`.
+    network_failure_nodes: Arc<Mutex<HashSet<MemNodeId>>>,
 
     /// Nodes to which an RPC is sent return an `Unreachable` error.
     unreachable_nodes: Arc<Mutex<HashSet<MemNodeId>>>,
@@ -197,25 +198,11 @@ impl Builder {
         TypedRaftRouter {
             config: self.config,
             routing_table: Default::default(),
-            isolated_nodes: Default::default(),
+            network_failure_nodes: Default::default(),
             unreachable_nodes: Default::default(),
             send_delay: Arc::new(AtomicU64::new(send_delay)),
             append_entries_quota: Arc::new(Mutex::new(None)),
             rpc_count: Default::default(),
-        }
-    }
-}
-
-impl Clone for TypedRaftRouter {
-    fn clone(&self) -> Self {
-        Self {
-            config: self.config.clone(),
-            routing_table: self.routing_table.clone(),
-            isolated_nodes: self.isolated_nodes.clone(),
-            unreachable_nodes: self.unreachable_nodes.clone(),
-            send_delay: self.send_delay.clone(),
-            append_entries_quota: self.append_entries_quota.clone(),
-            rpc_count: self.rpc_count.clone(),
         }
     }
 }
@@ -388,7 +375,7 @@ impl TypedRaftRouter {
         };
 
         {
-            let mut isolated = self.isolated_nodes.lock().unwrap();
+            let mut isolated = self.network_failure_nodes.lock().unwrap();
             isolated.remove(&id);
         }
 
@@ -415,8 +402,13 @@ impl TypedRaftRouter {
 
     /// Isolate the network of the specified node.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub fn isolate_node(&self, id: MemNodeId) {
-        self.isolated_nodes.lock().unwrap().insert(id);
+    pub fn set_node_network_failure(&self, id: MemNodeId, emit_failure: bool) {
+        let mut nodes = self.network_failure_nodes.lock().unwrap();
+        if emit_failure {
+            nodes.insert(id);
+        } else {
+            nodes.remove(&id);
+        }
     }
 
     /// Set to `true` to return [`Unreachable`](`openraft::errors::Unreachable`) when sending RPC to
@@ -559,7 +551,7 @@ impl TypedRaftRouter {
     /// Get the ID of the current leader.
     pub fn leader(&self) -> Option<MemNodeId> {
         let isolated = {
-            let isolated = self.isolated_nodes.lock().unwrap();
+            let isolated = self.network_failure_nodes.lock().unwrap();
             isolated.clone()
         };
 
@@ -581,7 +573,7 @@ impl TypedRaftRouter {
     /// Restore the network of the specified node.
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn restore_node(&self, id: MemNodeId) {
-        let mut nodes = self.isolated_nodes.lock().unwrap();
+        let mut nodes = self.network_failure_nodes.lock().unwrap();
         nodes.remove(&id);
     }
 
@@ -825,7 +817,7 @@ impl TypedRaftRouter {
 
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn check_network_error(&self, id: MemNodeId, target: MemNodeId) -> Result<(), NetworkError> {
-        let isolated = self.isolated_nodes.lock().unwrap();
+        let isolated = self.network_failure_nodes.lock().unwrap();
 
         if isolated.contains(&target) || isolated.contains(&id) {
             let network_err = NetworkError::new(&AnyError::error(format!("isolated:{} -> {}", id, target)));

--- a/tests/tests/membership/t11_add_learner.rs
+++ b/tests/tests/membership/t11_add_learner.rs
@@ -125,7 +125,7 @@ async fn add_learner_non_blocking() -> Result<()> {
         router.new_raft_node(1).await;
 
         // Replication problem should not block adding-learner in non-blocking mode.
-        router.isolate_node(1);
+        router.set_node_network_failure(1, true);
 
         let raft = router.get_raft_handle(&0)?;
         raft.add_learner(1, (), false).await?;
@@ -160,7 +160,7 @@ async fn add_learner_when_previous_membership_not_committed() -> Result<()> {
 
     tracing::info!(log_index, "--- block replication to prevent committing any log");
     {
-        router.isolate_node(1);
+        router.set_node_network_failure(1, true);
 
         let node = router.get_raft_handle(&0)?;
         tokio::spawn(async move {

--- a/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
+++ b/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
@@ -55,7 +55,7 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
 
     tracing::info!("--- initializing cluster of 1 node");
     {
-        router.initialize_from_single_node(0).await?;
+        router.initialize(0).await?;
         log_index = 1;
 
         wait_log(&router, &btreeset![0], log_index).await?;

--- a/tests/tests/membership/t30_commit_joint_config.rs
+++ b/tests/tests/membership/t30_commit_joint_config.rs
@@ -58,8 +58,8 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
         "--- isolate node 1,2, so that membership [0,1,2] wont commit"
     );
 
-    router.isolate_node(1);
-    router.isolate_node(2);
+    router.set_node_network_failure(1, true);
+    router.set_node_network_failure(2, true);
 
     tracing::info!(log_index, "--- changing cluster config, should timeout");
 
@@ -109,8 +109,8 @@ async fn commit_joint_config_during_012_to_234() -> Result<()> {
 
     tracing::info!(log_index, "--- isolate 3,4");
 
-    router.isolate_node(3);
-    router.isolate_node(4);
+    router.set_node_network_failure(3, true);
+    router.set_node_network_failure(4, true);
 
     tracing::info!(log_index, "--- changing config to 0,1,2");
     let node = router.get_raft_handle(&0)?;

--- a/tests/tests/membership/t30_commit_joint_config.rs
+++ b/tests/tests/membership/t30_commit_joint_config.rs
@@ -32,7 +32,7 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
-    router.initialize_from_single_node(0).await?;
+    router.initialize(0).await?;
     // Assert all nodes are in learner state & have no entries.
     let mut log_index = 1;
 

--- a/tests/tests/membership/t30_elect_with_new_config.rs
+++ b/tests/tests/membership/t30_elect_with_new_config.rs
@@ -38,7 +38,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
 
     // Isolate old leader and assert that a new leader takes over.
     tracing::info!(log_index, "--- isolating leader node 0");
-    router.isolate_node(0);
+    router.set_node_network_failure(0, true);
 
     // Wait for leader lease to expire
     sleep(Duration::from_millis(700)).await;
@@ -62,7 +62,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     let leader_id = 1;
 
     tracing::info!(log_index, "--- restore node 0, log_index:{}", log_index);
-    router.restore_node(0);
+    router.set_node_network_failure(0, false);
     router
         .wait(&0, timeout())
         .metrics(

--- a/tests/tests/membership/t51_remove_unreachable_follower.rs
+++ b/tests/tests/membership/t51_remove_unreachable_follower.rs
@@ -27,7 +27,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
 
     tracing::info!(log_index, "--- isolate node 4");
     {
-        router.isolate_node(4);
+        router.set_node_network_failure(4, true);
     }
 
     // logs on node 4 will stop here:
@@ -74,7 +74,7 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
         "--- restore network isolation, node 4 won't catch up log and will enter candidate state"
     );
     {
-        router.restore_node(4);
+        router.set_node_network_failure(4, false);
 
         router
             .wait(&4, timeout())

--- a/tests/tests/snapshot/t30_purge_in_snapshot_logs.rs
+++ b/tests/tests/snapshot/t30_purge_in_snapshot_logs.rs
@@ -61,7 +61,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
     // Learner: 0..10
     tracing::info!(log_index, "--- block replication, build another snapshot");
     {
-        router.isolate_node(1);
+        router.set_node_network_failure(1, true);
 
         log_index += router.client_request_many(0, "0", 5).await?;
         router.wait(&0, timeout()).log(Some(log_index), "write another 5 logs").await?;
@@ -85,7 +85,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
         "--- restore replication, install the 2nd snapshot on learner"
     );
     {
-        router.restore_node(1);
+        router.set_node_network_failure(1, false);
 
         learner
             .wait(timeout())

--- a/tests/tests/snapshot/t34_replication_does_not_block_purge.rs
+++ b/tests/tests/snapshot/t34_replication_does_not_block_purge.rs
@@ -39,8 +39,8 @@ async fn replication_does_not_block_purge() -> Result<()> {
 
     let leader = router.get_raft_handle(&0)?;
 
-    router.isolate_node(1);
-    router.isolate_node(2);
+    router.set_node_network_failure(1, true);
+    router.set_node_network_failure(2, true);
 
     tracing::info!(log_index, "--- build snapshot on leader, check purged log");
     {

--- a/tests/tests/snapshot/t50_snapshot_line_rate_to_snapshot.rs
+++ b/tests/tests/snapshot/t50_snapshot_line_rate_to_snapshot.rs
@@ -56,7 +56,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
     tracing::info!(log_index, "--- stop replication to node 1");
     tracing::info!(log_index, "--- send just enough logs to trigger snapshot");
     {
-        router.isolate_node(1);
+        router.set_node_network_failure(1, true);
 
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold - 1;
@@ -81,7 +81,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
 
     tracing::info!(log_index, "--- restore node 1 and replication");
     {
-        router.restore_node(1);
+        router.set_node_network_failure(1, false);
 
         router.wait_for_log(&btreeset![1], Some(log_index), timeout(), "replicate by snapshot").await?;
         router

--- a/tests/tests/snapshot/t60_snapshot_chunk_size.rs
+++ b/tests/tests/snapshot/t60_snapshot_chunk_size.rs
@@ -43,7 +43,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
         router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
 
-        router.initialize_from_single_node(0).await?;
+        router.initialize(0).await?;
         log_index += 1;
 
         router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "init leader").await?;

--- a/tests/tests/snapshot/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
+++ b/tests/tests/snapshot/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
@@ -27,7 +27,7 @@ async fn snapshot_to_unreachable_node_should_not_block() -> Result<()> {
     let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {2}).await?;
 
     tracing::info!(log_index, "--- isolate replication 0 -> 2");
-    router.isolate_node(2);
+    router.set_node_network_failure(2, true);
 
     let n = 10;
     tracing::info!(log_index, "--- write {} logs", n);


### PR DESCRIPTION

## Changelog

##### Change: remove unused error CommittedAdvanceTooMany

Upgrade tip:

Do not use it.


##### Chore: explain NetworkError and Unreachable


##### Chore: Rename `isolate_node()` to `set_node_network_failure()`

Rename `isolate_node()` to `set_node_network_failure()`, to better reflect its functionality:
The struct `TypedRaftRouter` now derives the `Clone` trait.


##### Chore: rename testing method router.initialize_from_single_node() to initialize()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/838)
<!-- Reviewable:end -->
