### PR TITLE
Feature: leader lease

### DIFF
--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -98,7 +98,7 @@ pub struct Store {
 impl RaftLogReader<TypeConfig> for Arc<Store> {
     async fn get_log_state(&mut self) -> Result<LogState<TypeConfig>, StorageError<NodeId>> {
         let log = self.log.read().await;
-        let last = log.iter().rev().next().map(|(_, ent)| ent.log_id);
+        let last = log.iter().next_back().map(|(_, ent)| ent.log_id);
 
         let last_purged = *self.last_purged_log_id.read().await;
 

--- a/openraft/src/docs/docs.md
+++ b/openraft/src/docs/docs.md
@@ -24,6 +24,7 @@ To learn about the data structures used in Openraft and the commit protocol, see
   - [`Effective membership`](`data::effective_membership`) explains when membership config takes effect;
 - [`protocol`] :
   - [`replication`](`protocol::replication`);
+    - [`leader_lease`](`protocol::replication::leader_lease`);
     - [`log_replication`](`protocol::replication::log_replication`);
     - [`snapshot_replication`](`protocol::replication::snapshot_replication`);
 

--- a/openraft/src/docs/protocol/leader_lease.md
+++ b/openraft/src/docs/protocol/leader_lease.md
@@ -1,0 +1,29 @@
+# Leader lease
+
+Leader lease is a mechanism to prevent split-brain scenarios in which multiple leaders are elected in a cluster.
+
+It is implemented by the leader sending heartbeats(append-entries and install-snapshot request
+can be considered as heartbeat too) to the followers.
+If the followers do not receive any heartbeats within a certain time period `lease`,
+they will start an election to elect a new leader.
+
+## The lease for leader and follower
+
+The `lease` stored on the leader is smaller than the `lease` stored on a follower.
+The leader must not believe it is still valid while the follower has already started an election. 
+
+## Extend the lease
+
+- A follower will extend the lease to `now + lease + timeout` when it receives a valid heartbeat from the leader, i.e., `leader.vote >= local.vote` .
+
+- A leader will extend the lease to `t + lease` when a quorum grants the leader at time `t`.
+
+  When a heartbeat RPC call succeeds,
+  it means the target node acknowledged the leader's clock time when the RPC was sent.
+  
+  If a time point `t` is acknowledged by a quorum, the leader can be sure that no
+  other leader existed during the period `[t, t + lease]`. The leader can then extend its
+  local lease to `t + lease`.
+
+The above `timeout` is the maximum time that can be taken by an operation that relies on the lease on the leader.
+  

--- a/openraft/src/docs/protocol/mod.rs
+++ b/openraft/src/docs/protocol/mod.rs
@@ -3,6 +3,10 @@
 pub mod replication {
     #![doc = include_str!("replication.md")]
 
+    pub mod leader_lease {
+        #![doc = include_str!("leader_lease.md")]
+    }
+
     pub mod log_replication {
         #![doc = include_str!("log_replication.md")]
     }

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -13,8 +13,6 @@ use crate::engine::handler::replication_handler::SendNone;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::handler::vote_handler::VoteHandler;
-use crate::engine::time_state;
-use crate::engine::time_state::TimeState;
 use crate::engine::Command;
 use crate::engine::Condition;
 use crate::engine::EngineOutput;
@@ -72,8 +70,6 @@ where C: RaftTypeConfig
     /// should be greater.
     pub(crate) seen_greater_log: bool,
 
-    pub(crate) timer: TimeState,
-
     /// The internal server state used by Engine.
     pub(crate) internal_server_state: InternalServerState<C::NodeId>,
 
@@ -85,12 +81,11 @@ impl<C> Engine<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(init_state: RaftState<C::NodeId, C::Node>, config: EngineConfig<C::NodeId>) -> Self {
-        let now = Instant::now();
+        // let now = Instant::now();
         Self {
             config,
             state: Valid::new(init_state),
             seen_greater_log: false,
-            timer: time_state::TimeState::new(now),
             internal_server_state: InternalServerState::default(),
             output: EngineOutput::new(4096),
         }
@@ -228,7 +223,7 @@ where C: RaftTypeConfig
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn handle_vote_req(&mut self, req: VoteRequest<C::NodeId>) -> VoteResponse<C::NodeId> {
-        let now = *self.timer.now();
+        let now = Instant::now();
         let lease = self.config.timer_config.leader_lease;
         let vote = self.state.vote_ref();
 
@@ -637,7 +632,6 @@ where C: RaftTypeConfig
         VoteHandler {
             config: &self.config,
             state: &mut self.state,
-            timer: &mut self.timer,
             output: &mut self.output,
             internal_server_state: &mut self.internal_server_state,
         }

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use maplit::btreeset;
+use tokio::time::Instant;
 
 use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
@@ -25,7 +26,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
     eng.config.id = 2;
-    eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
+    eng.state.vote.update(Instant::now(), Vote::new_committed(2, 1));
     eng.state.log_ids.append(log_id1(1, 1));
     eng.state.log_ids.append(log_id1(2, 3));
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
+use tokio::time::Instant;
 
 use crate::core::sm;
 use crate::engine::testing::UTConfig;
@@ -28,7 +29,7 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
-    eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
+    eng.state.vote.update(Instant::now(), Vote::new_committed(2, 1));
     eng.state.committed = Some(log_id1(4, 5));
     eng.state.log_ids = LogIdList::new(vec![
         //
@@ -171,7 +172,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
         let mut eng = Engine::<UTConfig>::default();
         eng.state.enable_validate = false; // Disable validation for incomplete state
 
-        eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
+        eng.state.vote.update(Instant::now(), Vote::new_committed(2, 1));
         eng.state.committed = Some(log_id1(2, 3));
         eng.state.log_ids = LogIdList::new(vec![
             //

--- a/openraft/src/engine/handler/following_handler/receive_snapshot_chunk_test.rs
+++ b/openraft/src/engine/handler/following_handler/receive_snapshot_chunk_test.rs
@@ -1,5 +1,6 @@
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
+use tokio::time::Instant;
 
 use crate::core::sm;
 use crate::engine::testing::UTConfig;
@@ -24,7 +25,7 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::default();
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
-    eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
+    eng.state.vote.update(Instant::now(), Vote::new_committed(2, 1));
     eng.state.server_state = eng.calc_server_state();
 
     eng

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -26,22 +26,22 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validate = false; // Disable validation for incomplete state
 
     eng.config.id = 1;
-    eng.state.vote = UTime::new(Instant::now(), Vote::new(2, 1));
+    // By default expire the leader lease so that the vote can be overridden in these tests.
+    eng.state.vote = UTime::new(Instant::now() - Duration::from_millis(300), Vote::new(2, 1));
     eng.state.server_state = ServerState::Candidate;
     eng.state
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())));
     eng.vote_handler().become_leading();
 
-    // By default expire the leader lease so that the vote can be overridden in these tests.
-    eng.timer.update_now(Instant::now() + Duration::from_millis(300));
+    // eng.timer.update_now(Instant::now() + Duration::from_millis(300));
     eng
 }
 
 #[test]
 fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.vote.update(*eng.timer.now(), Vote::new_committed(2, 1));
+    eng.state.vote.update(Instant::now(), Vote::new_committed(2, 1));
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 2),

--- a/openraft/src/engine/time_state.rs
+++ b/openraft/src/engine/time_state.rs
@@ -1,7 +1,5 @@
 use std::time::Duration;
 
-use tokio::time::Instant;
-
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct Config {
@@ -31,37 +29,5 @@ impl Default for Config {
             smaller_log_timeout: Duration::from_millis(200),
             leader_lease: Duration::from_millis(150),
         }
-    }
-}
-
-/// Wall clock time related state that track current wall clock time, leader lease, timeout etc.
-#[derive(Debug)]
-#[derive(PartialEq, Eq)]
-pub(crate) struct TimeState {
-    /// Cached current time.
-    now: Instant,
-}
-
-impl Default for TimeState {
-    fn default() -> Self {
-        let now = Instant::now();
-        Self { now }
-    }
-}
-
-impl TimeState {
-    pub(crate) fn new(now: Instant) -> Self {
-        Self { now }
-    }
-
-    pub(crate) fn now(&self) -> &Instant {
-        &self.now
-    }
-
-    pub(crate) fn update_now(&mut self, now: Instant) {
-        tracing::debug!("update_now: {:?}", now);
-        debug_assert!(now >= self.now, "monotonic time expects {:?} >= {:?}", now, self.now);
-
-        self.now = now;
     }
 }

--- a/openraft/src/leader/voting.rs
+++ b/openraft/src/leader/voting.rs
@@ -6,7 +6,6 @@ use crate::display_ext::DisplayOptionExt;
 use crate::progress::Progress;
 use crate::progress::VecProgress;
 use crate::quorum::QuorumSet;
-use crate::utime::UTime;
 use crate::LogId;
 use crate::NodeId;
 use crate::Vote;
@@ -19,14 +18,16 @@ where
     NID: NodeId,
     QS: QuorumSet<NID>,
 {
-    /// The vote to request the voters to grant.
-    vote: UTime<Vote<NID>>,
+    /// When the voting is started.
+    starting_time: Instant,
 
-    /// The last log id when the voting process is started.
+    /// The vote.
+    vote: Vote<NID>,
+
     last_log_id: Option<LogId<NID>>,
 
     /// Which nodes have granted the the vote at certain time point.
-    progress: VecProgress<NID, Option<Instant>, Option<Instant>, QS>,
+    progress: VecProgress<NID, bool, bool, QS>,
 }
 
 impl<NID, QS> fmt::Display for Voting<NID, QS>
@@ -37,8 +38,9 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{{vote: {}, last_log: {}, progress:{:?} }}",
+            "{{{}@{:?}, last_log_id:{} progress:{}}}",
             self.vote,
+            self.starting_time,
             self.last_log_id.display(),
             self.progress
         )
@@ -57,24 +59,29 @@ where
         quorum_set: QS,
     ) -> Self {
         Self {
-            vote: UTime::new(starting_time, vote),
+            starting_time,
+            vote,
             last_log_id,
-            progress: VecProgress::new(quorum_set, [], None),
+            progress: VecProgress::new(quorum_set, [], false),
         }
+    }
+
+    pub(crate) fn progress(&self) -> &VecProgress<NID, bool, bool, QS> {
+        &self.progress
     }
 
     /// Grant the vote by a node.
     pub(crate) fn grant_by(&mut self, target: &NID) -> bool {
-        let granted = *self.progress.update(target, self.vote.utime()).expect("target not in quorum set");
+        let granted = *self.progress.update(target, true).expect("target not in quorum set");
 
         tracing::info!(voting = debug(&self), "{}", func_name!());
 
-        granted.is_some()
+        granted
     }
 
     /// Return the node ids that has granted this vote.
     #[allow(dead_code)]
     pub(crate) fn granters(&self) -> impl Iterator<Item = NID> + '_ {
-        self.progress.iter().filter(|(_target, granted)| granted.is_some()).map(|(target, _)| *target)
+        self.progress().iter().filter(|(_, granted)| *granted).map(|(target, _)| *target)
     }
 }

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -143,7 +143,6 @@ where
     }
 
     /// Returns an Iterator of all learner node ids. Voters are not included.
-    #[allow(dead_code)]
     pub(crate) fn learner_ids(&self) -> impl Iterator<Item = NID> + '_ {
         self.membership().learner_ids()
     }

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -271,7 +271,7 @@ where
 
         let new_progress = elt.1.borrow();
 
-        debug_assert!(new_progress >= &prev_progress);
+        debug_assert!(new_progress >= &prev_progress,);
 
         let prev_le_granted = prev_progress <= self.granted;
         let new_gt_granted = new_progress > &self.granted;

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -1099,9 +1099,15 @@ pub struct VoteRequest<NID: NodeId> {
     pub last_log_id: Option<LogId<NID>>,
 }
 
+impl<NID: NodeId> fmt::Display for VoteRequest<NID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{vote:{}, last_log:{}}}", self.vote, self.last_log_id.display(),)
+    }
+}
+
 impl<NID: NodeId> MessageSummary<VoteRequest<NID>> for VoteRequest<NID> {
     fn summary(&self) -> String {
-        format!("{}, last_log:{:?}", self.vote, self.last_log_id.map(|x| x.to_string()),)
+        self.to_string()
     }
 }
 

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -1,5 +1,6 @@
 use crate::replication::ReplicationResult;
 use crate::replication::ReplicationSessionId;
+use crate::utime::UTime;
 use crate::MessageSummary;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -23,12 +24,23 @@ where C: RaftTypeConfig
         /// It is only used for debugging purpose.
         request_id: u64,
 
-        /// Either the last log id that has been successfully replicated to the target,
+        /// The request by this leader has been successfully handled by the target node,
         /// or an error in string.
-        result: Result<ReplicationResult<C::NodeId>, String>,
+        ///
+        /// A successful result can still be log matching or log conflicting.
+        /// In either case, the request is considered accepted, i.e., this leader is still valid to
+        /// the target node.
+        ///
+        /// The result also track the time when this request is sent.
+        result: Result<UTime<ReplicationResult<C::NodeId>>, String>,
 
         /// In which session this message is sent.
-        /// A replication session(vote,membership_log_id) should ignore message from other session.
+        ///
+        /// This session id identifies a certain leader(by vote) that is replicating to a certain
+        /// group of nodes.
+        ///
+        /// A message should be discarded if it does not match the present vote and
+        /// membership_log_id.
         session_id: ReplicationSessionId<C::NodeId>,
     },
 

--- a/openraft/src/utime.rs
+++ b/openraft/src/utime.rs
@@ -57,9 +57,19 @@ impl<T> UTime<T> {
         Self { data, utime: Some(now) }
     }
 
+    /// Creates a new object that has no last-updated time.
+    pub(crate) fn without_utime(data: T) -> Self {
+        Self { data, utime: None }
+    }
+
     /// Return the last updated time of this object.
     pub(crate) fn utime(&self) -> Option<Instant> {
         self.utime
+    }
+
+    /// Consumes this object and returns the inner data.
+    pub(crate) fn into_inner(self) -> T {
+        self.data
     }
 
     /// Update the content of the object and the last updated time.
@@ -70,6 +80,13 @@ impl<T> UTime<T> {
 
     /// Update the last updated time.
     pub(crate) fn touch(&mut self, now: Instant) {
+        debug_assert!(
+            Some(now) >= self.utime,
+            "expect now: {:?}, must >= self.utime: {:?}, {:?}",
+            now,
+            self.utime,
+            self.utime.unwrap() - now
+        );
         self.utime = Some(now);
     }
 }

--- a/tests/tests/metrics/t30_leader_metrics.rs
+++ b/tests/tests/metrics/t30_leader_metrics.rs
@@ -19,8 +19,6 @@ use crate::fixtures::RaftRouter;
 
 /// Cluster leader_metrics test.
 ///
-/// What does this test do?
-///
 /// - brings 5 nodes online: one leader and 4 learner.
 /// - add 4 learner as follower.
 /// - asserts that the leader was able to successfully commit logs and that the followers has

--- a/tests/tests/replication/t50_append_entries_backoff.rs
+++ b/tests/tests/replication/t50_append_entries_backoff.rs
@@ -45,9 +45,6 @@ async fn append_entries_backoff() -> Result<()> {
     let c0 = *counts0.get(&RPCType::AppendEntries).unwrap_or(&0);
     let c1 = *counts1.get(&RPCType::AppendEntries).unwrap_or(&0);
 
-    // dbg!(counts0);
-    // dbg!(counts1);
-
     // Without backoff, the leader would send about 40 append-entries RPC.
     // 20 for append log entries, 20 for updating committed.
     assert!(


### PR DESCRIPTION

## Changelog

##### Feature: leader lease

The leader records the most recent time point when an RPC is initiated
towards a target node. The highest timestamp associated with RPCs made
to a quorum serves as the starting time point for a leader lease.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/848)
<!-- Reviewable:end -->
