### PR TITLE
Doc: explain election timeout for committed Vote and uncommitted Vote

### DIFF
--- a/openraft/src/docs/protocol/leader_lease.md
+++ b/openraft/src/docs/protocol/leader_lease.md
@@ -7,10 +7,12 @@ can be considered as heartbeat too) to the followers.
 If the followers do not receive any heartbeats within a certain time period `lease`,
 they will start an election to elect a new leader.
 
-## The lease for leader and follower
+
+## The Lease for Leader and Follower
 
 The `lease` stored on the leader is smaller than the `lease` stored on a follower.
-The leader must not believe it is still valid while the follower has already started an election. 
+The leader must not believe it is still valid while the follower has already started an election.
+
 
 ## Extend the lease
 
@@ -20,10 +22,50 @@ The leader must not believe it is still valid while the follower has already sta
 
   When a heartbeat RPC call succeeds,
   it means the target node acknowledged the leader's clock time when the RPC was sent.
-  
+
   If a time point `t` is acknowledged by a quorum, the leader can be sure that no
   other leader existed during the period `[t, t + lease]`. The leader can then extend its
   local lease to `t + lease`.
 
 The above `timeout` is the maximum time that can be taken by an operation that relies on the lease on the leader.
-  
+
+
+## Election-Related Timeout Configurations
+
+The timeout configs are specifically designed to efficiently resolve election
+conflicts.
+Different timeout settings are used for committed and uncommitted votes.
+This is because a committed vote indicates the presence of an established
+**leader**, while an uncommitted vote merely represents a **candidate**.
+
+
+For an uncommitted vote (the vote that is saved upon receiving a `VoteRequest`):
+
+- An incoming `VoteRequest` will be allowed and handled at any time;
+- The node **WILL NOT** elect itself until `election_timeout` has elapsed.
+
+```text
+
+             .- Election timeout
+             |
+--------+----+--------------> wall clock time
+        |
+        '- Vote.last_update_time
+```
+
+For a committed vote (the vote that is saved upon receiving `AppendEntriesRequest` or `InstallSnapshotRequest`):
+
+- The node **WILL NOT** handle a `VoteRequest` before the `leader_lease` expires;
+- The node **WILL NOT** elect itself until `leader_lease + election_timeout` has passed.
+
+```text
+
+             .--------- Accept VoteRequest
+             |
+             |       .- Next election time
+             |       |
+--------+----+-------+--------------> wall clock time
+        |
+        '- Vote.last_update_time
+
+```

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -81,7 +81,6 @@ impl<C> Engine<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(init_state: RaftState<C::NodeId, C::Node>, config: EngineConfig<C::NodeId>) -> Self {
-        // let now = Instant::now();
         Self {
             config,
             state: Valid::new(init_state),

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -6,7 +6,7 @@ use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::entry::RaftPayload;
 use crate::internal_server_state::LeaderQuorumSet;
-use crate::leader::Leader;
+use crate::leader::Leading;
 use crate::RaftLogId;
 use crate::RaftState;
 use crate::RaftTypeConfig;
@@ -23,7 +23,7 @@ pub(crate) struct LeaderHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
-    pub(crate) leader: &'x mut Leader<C::NodeId, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leading<C::NodeId, LeaderQuorumSet<C::NodeId>>,
     pub(crate) state: &'x mut RaftState<C::NodeId, C::Node>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -10,7 +10,7 @@ use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::entry::RaftEntry;
 use crate::internal_server_state::LeaderQuorumSet;
-use crate::leader::Leader;
+use crate::leader::Leading;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
@@ -41,7 +41,7 @@ pub(crate) struct ReplicationHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
-    pub(crate) leader: &'x mut Leader<C::NodeId, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leading<C::NodeId, LeaderQuorumSet<C::NodeId>>,
     pub(crate) state: &'x mut RaftState<C::NodeId, C::Node>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -10,7 +10,7 @@ use crate::engine::Respond;
 use crate::engine::ValueSender;
 use crate::error::RejectVoteRequest;
 use crate::internal_server_state::InternalServerState;
-use crate::leader::Leader;
+use crate::leader::Leading;
 use crate::progress::Progress;
 use crate::raft::ResultSender;
 use crate::raft_state::LogStateReader;
@@ -164,7 +164,7 @@ where C: RaftTypeConfig
         // Re-create a new Leader instance.
 
         let em = &self.state.membership_state.effective();
-        let mut leader = Leader::new(
+        let mut leader = Leading::new(
             Instant::now(),
             *self.state.vote_ref(),
             em.membership().to_quorum_set(),

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -34,7 +34,6 @@ fn eng() -> Engine<UTConfig> {
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id1(1, 1)), m01())));
     eng.vote_handler().become_leading();
 
-    // eng.timer.update_now(Instant::now() + Duration::from_millis(300));
     eng
 }
 

--- a/openraft/src/internal_server_state.rs
+++ b/openraft/src/internal_server_state.rs
@@ -1,4 +1,4 @@
-use crate::leader::Leader;
+use crate::leader::Leading;
 use crate::quorum::Joint;
 use crate::NodeId;
 
@@ -27,7 +27,7 @@ where NID: NodeId
     /// Leader or candidate.
     ///
     /// `vote.committed==true` means it is a leader.
-    Leading(Leader<NID, LeaderQuorumSet<NID>>),
+    Leading(Leading<NID, LeaderQuorumSet<NID>>),
 
     /// Follower or learner.
     ///
@@ -46,14 +46,14 @@ where NID: NodeId
 impl<NID> InternalServerState<NID>
 where NID: NodeId
 {
-    pub(crate) fn leading(&self) -> Option<&Leader<NID, LeaderQuorumSet<NID>>> {
+    pub(crate) fn leading(&self) -> Option<&Leading<NID, LeaderQuorumSet<NID>>> {
         match self {
             InternalServerState::Leading(l) => Some(l),
             InternalServerState::Following => None,
         }
     }
 
-    pub(crate) fn leading_mut(&mut self) -> Option<&mut Leader<NID, LeaderQuorumSet<NID>>> {
+    pub(crate) fn leading_mut(&mut self) -> Option<&mut Leading<NID, LeaderQuorumSet<NID>>> {
         match self {
             InternalServerState::Leading(l) => Some(l),
             InternalServerState::Following => None,

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -12,10 +12,10 @@ use crate::LogIdOptionExt;
 use crate::NodeId;
 use crate::Vote;
 
-/// Leader data.
+/// Leading state data.
 ///
-/// Openraft leader is the combination of Leader and Candidate in original raft.
-/// A node becomes Leader at once when starting election, although at this time, it can not propose
+/// Openraft leading state is the combination of Leader and Candidate in original raft.
+/// A node becomes Leading at once when starting election, although at this time, it can not propose
 /// any new log, because its `vote` has not yet been granted by a quorum. I.e., A leader without
 /// commit vote is a Candidate in original raft.
 ///
@@ -28,7 +28,7 @@ use crate::Vote;
 /// But instead it will be able to upgrade its `leader_id` without losing leadership.
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
-pub(crate) struct Leader<NID: NodeId, QS: QuorumSet<NID>> {
+pub(crate) struct Leading<NID: NodeId, QS: QuorumSet<NID>> {
     // TODO(1): set the utime,
     // TODO(1): update it when heartbeat is granted by a quorum
     /// The vote this leader works in.
@@ -48,7 +48,7 @@ pub(crate) struct Leader<NID: NodeId, QS: QuorumSet<NID>> {
     pub(crate) clock_progress: VecProgress<NID, Option<Instant>, Option<Instant>, QS>,
 }
 
-impl<NID, QS> Leader<NID, QS>
+impl<NID, QS> Leading<NID, QS>
 where
     NID: NodeId,
     QS: QuorumSet<NID> + fmt::Debug + 'static,

--- a/openraft/src/leader/mod.rs
+++ b/openraft/src/leader/mod.rs
@@ -1,4 +1,4 @@
 #[allow(clippy::module_inception)] mod leader;
 pub(crate) mod voting;
 
-pub(crate) use leader::Leader;
+pub(crate) use leader::Leading;


### PR DESCRIPTION

## Changelog

##### Doc: explain election timeout for committed Vote and uncommitted Vote


##### Chore: rename Leader to Leading

Because it actually includes two server state: Leader and Candidate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/850)
<!-- Reviewable:end -->
