### PR TITLE
Refactor: extract voting management into a separate `Voting` struct

### DIFF
--- a/openraft/src/internal_server_state.rs
+++ b/openraft/src/internal_server_state.rs
@@ -1,3 +1,4 @@
+use crate::leader::voting::Voting;
 use crate::leader::Leading;
 use crate::quorum::Joint;
 use crate::NodeId;
@@ -46,6 +47,13 @@ where NID: NodeId
 impl<NID> InternalServerState<NID>
 where NID: NodeId
 {
+    pub(crate) fn voting_mut(&mut self) -> Option<&mut Voting<NID, LeaderQuorumSet<NID>>> {
+        match self {
+            InternalServerState::Leading(l) => l.voting_mut(),
+            InternalServerState::Following => None,
+        }
+    }
+
     pub(crate) fn leading(&self) -> Option<&Leading<NID, LeaderQuorumSet<NID>>> {
         match self {
             InternalServerState::Leading(l) => Some(l),

--- a/openraft/src/leader/voting.rs
+++ b/openraft/src/leader/voting.rs
@@ -66,6 +66,10 @@ where
         }
     }
 
+    pub(crate) fn vote_ref(&self) -> &Vote<NID> {
+        &self.vote
+    }
+
     pub(crate) fn progress(&self) -> &VecProgress<NID, bool, bool, QS> {
         &self.progress
     }


### PR DESCRIPTION

## Changelog

##### Refactor: extract voting management into a separate `Voting` struct

`Voting` should be a standalone state that does not depend on
`RaftState`.

Although it won't happen, the `vote` for a candidate(`Voting`) can be
different from the `vote` in `RaftState`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/853)
<!-- Reviewable:end -->
