### PR TITLE
Feature: add Raft::purge_log()

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1129,6 +1129,9 @@ where
                         self.send_heartbeat("ExternalCommand");
                     }
                     ExternalCommand::Snapshot => self.trigger_snapshot(),
+                    ExternalCommand::PurgeLog { upto } => {
+                        self.engine.trigger_purge_log(upto);
+                    }
                 }
             }
         };

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -51,12 +51,17 @@ where C: RaftTypeConfig
     /// This method is called after building a snapshot, because openraft only purge logs that are
     /// already included in snapshot.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_purge_upto(&mut self) {
+    pub(crate) fn schedule_policy_based_purge(&mut self) {
         if let Some(purge_upto) = self.calc_purge_upto() {
-            debug_assert!(self.state.purge_upto() <= Some(&purge_upto));
-
-            self.state.purge_upto = Some(purge_upto);
+            self.update_purge_upto(purge_upto);
         }
+    }
+
+    /// Update the log id it expect to purge up to. It won't trigger purge immediately.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) fn update_purge_upto(&mut self, purge_upto: LogId<C::NodeId>) {
+        debug_assert!(self.state.purge_upto() <= Some(&purge_upto));
+        self.state.purge_upto = Some(purge_upto);
     }
 
     /// Calculate the log id up to which to purge, inclusive.

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -46,6 +46,7 @@ mod tests {
     mod initialize_test;
     mod log_id_list_test;
     mod startup_test;
+    mod trigger_purge_log_test;
 }
 #[cfg(test)] mod testing;
 

--- a/openraft/src/engine/tests/trigger_purge_log_test.rs
+++ b/openraft/src/engine/tests/trigger_purge_log_test.rs
@@ -1,0 +1,125 @@
+use std::ops::Deref;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::engine::testing::UTConfig;
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::progress::Progress;
+use crate::testing::log_id;
+use crate::CommittedLeaderId;
+use crate::EffectiveMembership;
+use crate::LogId;
+use crate::Membership;
+use crate::MembershipState;
+use crate::SnapshotMeta;
+use crate::StoredMembership;
+
+fn m12() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+}
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::default();
+    eng.state.enable_validate = false; // Disable validation for incomplete state
+    eng.state.membership_state = MembershipState::new(
+        EffectiveMembership::new_arc(Some(log_id(1, 0, 1)), m12()),
+        EffectiveMembership::new_arc(Some(log_id(1, 0, 1)), m12()),
+    );
+
+    eng.state.log_ids = LogIdList::new([LogId::new(CommittedLeaderId::new(0, 0), 0)]);
+    eng
+}
+
+#[test]
+fn test_trigger_purge_log_no_snapshot() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.trigger_purge_log(1);
+
+    assert_eq!(None, eng.state.purge_upto, "no snapshot, can not purge");
+
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}
+
+#[test]
+fn test_trigger_purge_log_already_scheduled() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.snapshot_meta = SnapshotMeta {
+        last_log_id: Some(log_id(1, 0, 3)),
+        last_membership: StoredMembership::new(Some(log_id(1, 0, 1)), m12()),
+        snapshot_id: "1".to_string(),
+    };
+    eng.state.purge_upto = Some(log_id(1, 0, 2));
+    eng.state.io_state.purged = Some(log_id(1, 0, 2));
+
+    eng.trigger_purge_log(2);
+
+    assert_eq!(Some(log_id(1, 0, 2)), eng.state.purge_upto, "already purged, no update");
+
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}
+
+#[test]
+fn test_trigger_purge_log_delete_only_in_snapshot_logs() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.snapshot_meta = SnapshotMeta {
+        last_log_id: Some(log_id(1, 0, 3)),
+        last_membership: StoredMembership::new(Some(log_id(1, 0, 1)), m12()),
+        snapshot_id: "1".to_string(),
+    };
+    eng.state.purge_upto = Some(log_id(1, 0, 2));
+    eng.state.io_state.purged = Some(log_id(1, 0, 2));
+    eng.state.log_ids = LogIdList::new([log_id(1, 0, 2), log_id(1, 0, 10)]);
+
+    eng.trigger_purge_log(5);
+
+    assert_eq!(
+        Some(log_id(1, 0, 3)),
+        eng.state.purge_upto,
+        "delete only in snapshot logs"
+    );
+
+    assert_eq!(
+        vec![Command::PurgeLog { upto: log_id(1, 0, 3) },],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_trigger_purge_log_in_used_wont_be_delete() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.snapshot_meta = SnapshotMeta {
+        last_log_id: Some(log_id(1, 0, 3)),
+        last_membership: StoredMembership::new(Some(log_id(1, 0, 1)), m12()),
+        snapshot_id: "1".to_string(),
+    };
+    eng.state.purge_upto = Some(log_id(1, 0, 2));
+    eng.state.io_state.purged = Some(log_id(1, 0, 2));
+    eng.state.log_ids = LogIdList::new([log_id(1, 0, 2), log_id(1, 0, 10)]);
+
+    // Make it a leader and mark the logs are in flight.
+    eng.vote_handler().become_leading();
+    let l = eng.internal_server_state.leading_mut().unwrap();
+    let _ = l.progress.get_mut(&2).unwrap().next_send(eng.state.deref(), 10).unwrap();
+
+    eng.trigger_purge_log(5);
+
+    assert_eq!(
+        Some(log_id(1, 0, 3)),
+        eng.state.purge_upto,
+        "delete only in snapshot logs"
+    );
+
+    assert_eq!(0, eng.output.take_commands().len(), "in used log wont be deleted");
+
+    Ok(())
+}

--- a/tests/tests/client_api/main.rs
+++ b/tests/tests/client_api/main.rs
@@ -6,8 +6,9 @@
 mod fixtures;
 
 // The number indicate the preferred running order for these case.
-// The later tests may depend on the earlier ones.
+// See ./README.md
 
 mod t10_client_writes;
 mod t11_client_reads;
+mod t12_trigger_purge_log;
 mod t50_lagging_network_write;

--- a/tests/tests/client_api/t12_trigger_purge_log.rs
+++ b/tests/tests/client_api/t12_trigger_purge_log.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::testing::log_id;
+use openraft::Config;
+use openraft::SnapshotPolicy;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Call `Raft::trigger_purged()` to purge logs.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn trigger_purge_log() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            // Disable building snapshot by policy.
+            snapshot_policy: SnapshotPolicy::Never,
+            // Disable auto purge by policy.
+            max_in_snapshot_log_to_keep: u64::MAX,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- write some logs");
+    {
+        log_index += router.client_request_many(0, "0", 10).await?;
+
+        for id in [0, 1, 2] {
+            router.wait(&id, timeout()).log(Some(log_index), format_args!("node-{} write logs", id)).await?;
+        }
+    }
+
+    tracing::info!(log_index, "--- trigger snapshot for node-0");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.trigger_snapshot().await?;
+
+        router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "node-1 snapshot").await?;
+    }
+
+    let snapshot_index = log_index;
+
+    tracing::info!(log_index, "--- write another bunch of logs");
+    {
+        log_index += router.client_request_many(0, "0", 10).await?;
+
+        for id in [0, 1, 2] {
+            router.wait(&id, timeout()).log(Some(log_index), format_args!("node-{} write logs", id)).await?;
+        }
+    }
+
+    tracing::info!(log_index, "--- purge log for node 0");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.purge_log(snapshot_index).await?;
+
+        router
+            .wait(&0, timeout())
+            .purged(
+                Some(log_id(1, 0, snapshot_index)),
+                format_args!("node-0 purged upto {}", snapshot_index),
+            )
+            .await?;
+
+        n0.purge_log(log_index).await?;
+        let res = router
+            .wait(&0, timeout())
+            .purged(
+                Some(log_id(1, 0, log_index)),
+                format_args!("node-0 wont purged upto {}", log_index),
+            )
+            .await;
+
+        assert!(res.is_err(), "can not purge logs not in snapshot");
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### Feature: add Raft::purge_log()

This method allows users to purge logs when required.
It initiates the log purge up to and including the given `upto` log index.

Logs that are not included in a snapshot will **NOT** be purged.
In such scenario it will delete as many log as possible.
The `max_in_snapshot_log_to_keep` config is not taken into account when
purging logs.

Openraft won't purge logs at once, e.g. it may be delayed by several
seconds, because if it is a leader and a replication task has been
replicating the logs to a follower, the logs can't be purged until the
replication task is finished.

- Fix: #852

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/855)
<!-- Reviewable:end -->
