### PR TITLE
Issue #741: add AsyncRuntime trait to allow users to choose an asynchronous runtime

### DIFF
--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -26,6 +26,7 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
+use openraft::Tokio;
 use openraft::Vote;
 use serde::Deserialize;
 use serde::Serialize;
@@ -74,7 +75,7 @@ pub type MemNodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration for `MemStore`.
     pub TypeConfig: D = ClientRequest, R = ClientResponse, NodeId = MemNodeId, Node = (),
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>
+    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = Tokio
 );
 
 /// The application snapshot type which the `MemStore` works with.

--- a/openraft/src/async_runtime.rs
+++ b/openraft/src/async_runtime.rs
@@ -1,0 +1,48 @@
+use std::future::Future;
+
+/// A trait defining interfaces with an asynchronous runtime.
+///
+/// The intention of this trait is to allow an application this crate to choose an asynchronous
+/// runtime that best suits it.
+///
+/// ## Note
+///
+/// The default asynchronous runtime is `tokio`.
+pub trait AsyncRuntime: Send + Sync + 'static {
+    /// The type that [`Self::JoinHandle`] returns on failure.
+    type JoinError: std::fmt::Display;
+
+    /// The return type of [`Self::spawn`].
+    type JoinHandle<T: Send + 'static>: Future<Output = Result<T, Self::JoinError>> + Send + Sync;
+
+    /// Spawn a new task.
+    fn spawn<T>(future: T) -> Self::JoinHandle<T::Output>
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static;
+
+    /// Abort the task associated with the supplied join handle.
+    fn abort<T: Send + 'static>(join_handle: &Self::JoinHandle<T>);
+}
+
+/// `Tokio` is the default asynchronous executor.
+pub struct Tokio;
+
+impl AsyncRuntime for Tokio {
+    type JoinError = tokio::task::JoinError;
+    type JoinHandle<T: Send + 'static> = tokio::task::JoinHandle<T>;
+
+    #[inline]
+    fn spawn<T>(future: T) -> Self::JoinHandle<T::Output>
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        tokio::task::spawn(future)
+    }
+
+    #[inline]
+    fn abort<T: Send + 'static>(join_handle: &Self::JoinHandle<T>) {
+        join_handle.abort();
+    }
+}

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 use tokio::time::sleep_until;
 use tokio::time::Instant;
 use tracing::Instrument;
@@ -14,6 +13,7 @@ use tracing::Level;
 use tracing::Span;
 
 use crate::core::notify::Notify;
+use crate::AsyncRuntime;
 use crate::RaftTypeConfig;
 
 /// Emit RaftMsg::Tick event at regular `interval`.
@@ -28,23 +28,28 @@ where C: RaftTypeConfig
     enabled: Arc<AtomicBool>,
 }
 
-pub(crate) struct TickHandle {
+pub(crate) struct TickHandle<C>
+where C: RaftTypeConfig
+{
     enabled: Arc<AtomicBool>,
-    join_handle: JoinHandle<()>,
+    join_handle: <C::AsyncRuntime as AsyncRuntime>::JoinHandle<()>,
 }
 
 impl<C> Tick<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn spawn(interval: Duration, tx: mpsc::UnboundedSender<Notify<C>>, enabled: bool) -> TickHandle {
+    pub(crate) fn spawn(interval: Duration, tx: mpsc::UnboundedSender<Notify<C>>, enabled: bool) -> TickHandle<C> {
         let enabled = Arc::new(AtomicBool::from(enabled));
         let this = Self {
             interval,
             enabled: enabled.clone(),
             tx,
         };
-        let join_handle =
-            tokio::spawn(this.tick_loop().instrument(tracing::span!(parent: &Span::current(), Level::DEBUG, "tick")));
+        let join_handle = C::AsyncRuntime::spawn(this.tick_loop().instrument(tracing::span!(
+            parent: &Span::current(),
+            Level::DEBUG,
+            "tick"
+        )));
         TickHandle { enabled, join_handle }
     }
 
@@ -71,12 +76,14 @@ where C: RaftTypeConfig
     }
 }
 
-impl TickHandle {
+impl<C> TickHandle<C>
+where C: RaftTypeConfig
+{
     pub(crate) fn enable(&self, enabled: bool) {
         self.enabled.store(enabled, Ordering::Relaxed);
     }
 
     pub(crate) async fn shutdown(&self) {
-        self.join_handle.abort();
+        C::AsyncRuntime::abort(&self.join_handle);
     }
 }

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -51,6 +51,7 @@ mod vote;
 #[cfg(feature = "compat")] pub mod compat;
 #[cfg(feature = "compat-07")] pub use or07;
 
+pub mod async_runtime;
 pub mod entry;
 pub mod error;
 pub mod log_id;
@@ -84,6 +85,8 @@ pub use network::RPCTypes;
 pub use network::RaftNetwork;
 pub use network::RaftNetworkFactory;
 
+pub use crate::async_runtime::AsyncRuntime;
+pub use crate::async_runtime::Tokio;
 pub use crate::change_members::ChangeMembers;
 pub use crate::config::Config;
 pub use crate::config::ConfigError;

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -52,6 +52,7 @@ use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::AppData;
 use crate::AppDataResponse;
+use crate::AsyncRuntime;
 use crate::ChangeMembers;
 use crate::LogId;
 use crate::LogIdOptionExt;
@@ -105,6 +106,9 @@ pub trait RaftTypeConfig:
     /// See the [storage chapter of the guide](https://datafuselabs.github.io/openraft/getting-started.html#implement-raftstorage)
     /// for details on where and how this is used.
     type SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + Send + Sync + Unpin + 'static;
+
+    /// Asynchronous runtime type.
+    type AsyncRuntime: AsyncRuntime;
 }
 
 /// Define types for a Raft type configuration.
@@ -159,7 +163,7 @@ where
     id: C::NodeId,
     config: Arc<Config>,
     runtime_config: Arc<RuntimeConfig>,
-    tick_handle: TickHandle,
+    tick_handle: TickHandle<C>,
     tx_api: mpsc::UnboundedSender<RaftMsg<C, N, LS>>,
     rx_metrics: watch::Receiver<RaftMetrics<C::NodeId, C::Node>>,
     // TODO(xp): it does not need to be a async mutex.

--- a/rocksstore-compat07/src/lib.rs
+++ b/rocksstore-compat07/src/lib.rs
@@ -52,6 +52,7 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
+use openraft::Tokio;
 use openraft::Vote;
 use rocksdb::ColumnFamily;
 use rocksdb::ColumnFamilyDescriptor;
@@ -66,7 +67,7 @@ pub type RocksNodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration for `MemStore`.
     pub TypeConfig: D = RocksRequest, R = RocksResponse, NodeId = RocksNodeId, Node = EmptyNode,
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>
+    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = Tokio
 );
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/rocksstore/src/lib.rs
+++ b/rocksstore/src/lib.rs
@@ -32,6 +32,7 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
+use openraft::Tokio;
 use openraft::Vote;
 use rocksdb::ColumnFamily;
 use rocksdb::ColumnFamilyDescriptor;
@@ -46,7 +47,7 @@ pub type RocksNodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration for `MemStore`.
     pub TypeConfig: D = RocksRequest, R = RocksResponse, NodeId = RocksNodeId, Node = BasicNode,
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>
+    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = Tokio
 );
 
 /**

--- a/sledstore/src/lib.rs
+++ b/sledstore/src/lib.rs
@@ -31,6 +31,7 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
+use openraft::Tokio;
 use openraft::Vote;
 use serde::Deserialize;
 use serde::Serialize;
@@ -41,7 +42,7 @@ pub type ExampleNodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
     pub TypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId, Node = BasicNode,
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>
+    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = Tokio
 );
 
 /**


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

## Summary

This PR addresses #741 and it includes,

1. `AsyncRuntime` trait.

This generalizes the interface between `openraft` and `tokio`.

2. Add `AsyncRuntime` type parameter to `RaftTypeConfig`.

Users can specify an asynchronous runtime via `RaftTypeConfig::AsyncRuntime`.

3. Default `tokio` adaptor.

Implement `AsyncRuntime` for the `tokio` asynchronous runtime.

## Note

@drmingdrmer @schreter 

This only abstracts `tokio::task::spawn`, `tokio::task::JoinHandle` just to showcase how the final version of the API changes would look like. So, what do you think of those API changes? Any feedback is welcome :-)

**Checklist**

- [ o ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ o ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ x ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/866)
<!-- Reviewable:end -->
