### PR TITLE
Improve: IntoIterator::IntoIter should be Send

### DIFF
--- a/examples/raft-kv-memstore/test-cluster.sh
+++ b/examples/raft-kv-memstore/test-cluster.sh
@@ -42,6 +42,7 @@ rpc() {
 }
 
 export RUST_LOG=trace
+export RUST_BACKTRACE=full
 
 echo "Killing all running raft-key-value"
 

--- a/examples/raft-kv-rocksdb/test-cluster.sh
+++ b/examples/raft-kv-rocksdb/test-cluster.sh
@@ -43,6 +43,7 @@ rpc() {
 }
 
 export RUST_LOG=trace
+export RUST_BACKTRACE=full
 bin=./target/debug/raft-key-value-rocks
 
 echo "Killing all running raft-key-value-rocks and cleaning up old data"

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -638,6 +638,7 @@ where
     ) -> Result<(), StorageError<C::NodeId>>
     where
         I: IntoIterator<Item = C::Entry> + Send,
+        I::IntoIter: Send,
     {
         tracing::debug!("append_to_log");
 

--- a/openraft/src/storage/v2.rs
+++ b/openraft/src/storage/v2.rs
@@ -85,7 +85,9 @@ where C: RaftTypeConfig
     /// - There must not be a **hole** in logs. Because Raft only examine the last log id to ensure
     ///   correctness.
     async fn append<I>(&mut self, entries: I, callback: LogFlushed<C::NodeId>) -> Result<(), StorageError<C::NodeId>>
-    where I: IntoIterator<Item = C::Entry> + Send;
+    where
+        I: IntoIterator<Item = C::Entry> + Send,
+        I::IntoIter: Send;
 
     /// Truncate logs since `log_id`, inclusive
     ///
@@ -155,7 +157,9 @@ where C: RaftTypeConfig
     ///   persist state on disk. But every snapshot has to be persistent. And when starting up the
     ///   application, the state machine should be rebuilt from the last snapshot.
     async fn apply<I>(&mut self, entries: I) -> Result<Vec<C::R>, StorageError<C::NodeId>>
-    where I: IntoIterator<Item = C::Entry> + Send;
+    where
+        I: IntoIterator<Item = C::Entry> + Send,
+        I::IntoIter: Send;
 
     /// Get the snapshot builder for the state machine.
     ///

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -1132,6 +1132,7 @@ where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
     I: IntoIterator<Item = C::Entry> + Send,
+    I::IntoIter: Send,
 {
     sm.apply(entries).await?;
     Ok(())


### PR DESCRIPTION

## Changelog

##### Improve: IntoIterator::IntoIter should be Send

The `RaftStateMachine::apply()` and `RaftLogStorage::append_to_log()`
method contains a `Send` bound on the `IntoIterator` passed to it.
However, the actual iterator returned from `IntoIterator` doesn't have
it. Thus, it's impossible to iterate across awaits in the
implementation.

The correct API should be:

```
async fn apply<I>(&mut self, entries: I) -> Result<...>
where
    I: IntoIterator<Item = C::Entry> + Send,
    I::IntoIter: Send;
```

Thanks to [schreter](https://github.com/schreter)

- Fix: #860


##### Chore: enable backtrace for example application

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/868)
<!-- Reviewable:end -->
