### PR TITLE
Improve: impl Clone for Raft does not require Clone for its type parameters

### DIFF
--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -190,7 +190,6 @@ where
 /// `shutdown` method should be called on this type to await the shutdown of the node. If the parent
 /// application needs to shutdown the Raft node for any reason, calling `shutdown` will do the
 /// trick.
-#[derive(Clone)]
 pub struct Raft<C, N, LS, SM>
 where
     C: RaftTypeConfig,
@@ -200,6 +199,21 @@ where
 {
     inner: Arc<RaftInner<C, N, LS>>,
     _phantom: PhantomData<SM>,
+}
+
+impl<C, N, LS, SM> Clone for Raft<C, N, LS, SM>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkFactory<C>,
+    LS: RaftLogStorage<C>,
+    SM: RaftStateMachine<C>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<C, N, LS, SM> Raft<C, N, LS, SM>


### PR DESCRIPTION

## Changelog

##### Improve: impl Clone for Raft does not require Clone for its type parameters

Thanks to [xDarksome](https://github.com/xDarksome)

- Fix: #870

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/872)
<!-- Reviewable:end -->
