### PR TITLE
Feature: add ChangeMembers::SetNodes

### DIFF
--- a/openraft/src/change_members.rs
+++ b/openraft/src/change_members.rs
@@ -26,7 +26,22 @@ pub enum ChangeMembers<NID: NodeId, N: Node> {
     ReplaceAllVoters(BTreeSet<NID>),
 
     /// Add nodes to membership, as learners.
+    ///
+    /// it **WONT** replace existing node.
+    ///
+    /// Prefer using this variant instead of `SetNodes` whenever possible, as `AddNodes` ensures
+    /// safety, whereas incorrect usage of `SetNodes` can result in a brain split.
+    /// See: [Update-Node](`crate::docs::cluster_control::dynamic_membership#update-node`)
     AddNodes(BTreeMap<NID, N>),
+
+    /// Add or replace nodes in membership config.
+    ///
+    /// it **WILL** replace existing node.
+    ///
+    /// Prefer using `AddNodes` instead of `SetNodes` whenever possible, as `AddNodes` ensures
+    /// safety, whereas incorrect usage of `SetNodes` can result in a brain split.
+    /// See: [Update-Node](`crate::docs::cluster_control::dynamic_membership#update-node`)
+    SetNodes(BTreeMap<NID, N>),
 
     /// Remove nodes from membership.
     ///

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -321,6 +321,12 @@ where
                 }
                 self
             }
+            ChangeMembers::SetNodes(set_nodes) => {
+                for (node_id, node) in set_nodes.into_iter() {
+                    self.nodes.insert(node_id, node);
+                }
+                self
+            }
             ChangeMembers::RemoveNodes(remove_node_ids) => {
                 for node_id in remove_node_ids.iter() {
                     self.nodes.remove(node_id);
@@ -512,6 +518,23 @@ mod tests {
                 Ok(Membership::<u64, ()> {
                     configs: vec![btreeset! {1,2}],
                     nodes: btreemap! {1=>(),2=>(),3=>(), 4=>()}
+                }),
+                res
+            );
+        }
+
+        // SetNodes: Ok
+        {
+            let m = || Membership::<u64, u64> {
+                configs: vec![btreeset! {1,2}],
+                nodes: btreemap! {1=>1,2=>2,3=>3},
+            };
+
+            let res = m().change(ChangeMembers::SetNodes(btreemap! {3=>30, 4=>40}), false);
+            assert_eq!(
+                Ok(Membership::<u64, u64> {
+                    configs: vec![btreeset! {1,2}],
+                    nodes: btreemap! {1=>1,2=>2,3=>30, 4=>40}
                 }),
                 res
             );

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -155,6 +155,30 @@ fn test_membership_add_learner() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_membership_update_nodes() -> anyhow::Result<()> {
+    let node = |s: &str| TestNode {
+        addr: s.to_string(),
+        data: Default::default(),
+    };
+
+    let m_1_2 = Membership::<u64, TestNode>::new_unchecked(
+        vec![btreeset! {1}, btreeset! {2}],
+        btreemap! {1=>node("1"), 2=>node("2")},
+    );
+
+    let m_1_2_3 = m_1_2.change(ChangeMembers::SetNodes(btreemap! {2=>node("20"), 3=>node("30")}), true)?;
+    assert_eq!(
+        Membership::<u64, TestNode>::new_unchecked(
+            vec![btreeset! {1}, btreeset! {2}],
+            btreemap! {1=>node("1"), 2=>node("20"), 3=>node("30")}
+        ),
+        m_1_2_3
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_membership_extend_nodes() -> anyhow::Result<()> {
     let node = |s: &str| TestNode {
         addr: s.to_string(),

--- a/tests/tests/membership/t20_change_membership.rs
+++ b/tests/tests/membership/t20_change_membership.rs
@@ -12,7 +12,7 @@ use openraft::ServerState;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
-/// When a change-membership log is committed, the membership_state should be updated.
+/// When a change-membership log is committed, the `RaftState.membership_state` should be updated.
 #[async_entry::test(worker_threads = 3, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn update_membership_state() -> anyhow::Result<()> {
     let config = Arc::new(


### PR DESCRIPTION

## Changelog

##### Feature: add ChangeMembers::SetNodes

During dynamic cluster changes, we sometimes need to update an existing
node, for example changing its network address.

Adding `SetNodes` variant to `ChangeMembers` allows replacing an
existing node directly.
However, this also carries risk of creating a split brain scenario if
used incorrectly.

- Fix: #875

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/876)
<!-- Reviewable:end -->
