### PR TITLE
Feature: add 'singlethreaded' raft mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -271,7 +271,7 @@ jobs:
             features: "single-term-leader"
 
           - toolchain: "nightly"
-            features: "single-term-leader,serde"
+            features: "single-term-leader,serde,singlethreaded"
 
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - toolchain: "nightly"
-            features: "bench,serde,bt"
+            features: "bench,serde,bt,singlethreaded"
 
     steps:
       - name: Setup | Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ resolver = "2"
 members = [
     "openraft",
     "memstore",
+    "macros",
     "tests",
     "rocksstore",
     "rocksstore-compat07",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "macros"
+
+version       = { workspace = true }
+edition       = { workspace = true }
+authors       = { workspace = true }
+categories    = { workspace = true }
+description   = { workspace = true }
+documentation = { workspace = true }
+homepage      = { workspace = true }
+keywords      = { workspace = true }
+license       = { workspace = true }
+repository    = { workspace = true }
+
+[lib]
+proc-macro = true
+
+[features]
+
+# Passes `?Send` to `async_trait` to force affected tasks to be spawned in the current thread.
+singlethreaded = []
+

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,21 @@
+use proc_macro::TokenStream;
+
+/// This macro either emits `#[async_trait::async_trait]` or `#[asnc_trait::async_trait(?Send)]`
+/// based on the activated feature set.
+///
+/// This assumes that the `[async_trait](https://crates.io/crates/async-trait)` crate is imported
+/// as `async_trait`. If the `singlethreaded` feature is enabled, `?Send` is passed to
+/// `async_trait`, thereby forcing the affected asynchronous trait functions and methods to be run
+/// in the same thread.
+#[proc_macro_attribute]
+pub fn add_async_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    if cfg!(feature = "singlethreaded") {
+        let mut output = "#[async_trait::async_trait(?Send)]".parse::<TokenStream>().unwrap();
+        output.extend(item);
+        output
+    } else {
+        let mut output = "#[async_trait::async_trait]".parse::<TokenStream>().unwrap();
+        output.extend(item);
+        output
+    }
+}

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -20,6 +20,7 @@ anyhow          = { workspace = true, optional = true }
 byte-unit       = { workspace = true }
 derive_more     = { workspace = true }
 futures         = { workspace = true }
+macros          = { path = "../macros" }
 maplit          = { workspace = true }
 pin-utils       = { workspace = true }
 rand            = { workspace = true }
@@ -82,6 +83,9 @@ compat-07-testing = ["dep:tempfile", "anyhow", "dep:serde_json"]
 # See `openraft::storage::v2` for more details.
 # V2 API are unstable and may change in the future.
 storage-v2 = []
+
+# Disallows applications to share a raft instance with multiple threads.
+singlethreaded = ["macros/singlethreaded"]
 
 # default = ["single-term-leader"]
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -12,6 +12,7 @@ use anyerror::AnyError;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use futures::TryFutureExt;
+use macros::add_async_trait;
 use maplit::btreeset;
 use tokio::select;
 use tokio::sync::mpsc;
@@ -90,6 +91,7 @@ use crate::Membership;
 use crate::MessageSummary;
 use crate::Node;
 use crate::NodeId;
+use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::StorageIOError;
@@ -644,8 +646,8 @@ where
         last_log_id: LogId<C::NodeId>,
     ) -> Result<(), StorageError<C::NodeId>>
     where
-        I: IntoIterator<Item = C::Entry> + Send,
-        I::IntoIter: Send,
+        I: IntoIterator<Item = C::Entry> + OptionalSend,
+        I::IntoIter: OptionalSend,
     {
         tracing::debug!("append_to_log");
 
@@ -1470,7 +1472,7 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[add_async_trait]
 impl<C, N, LS, SM> RaftRuntime<C> for RaftCore<C, N, LS, SM>
 where
     C: RaftTypeConfig,

--- a/openraft/src/docs/feature_flags/feature-flags.md
+++ b/openraft/src/docs/feature_flags/feature-flags.md
@@ -24,3 +24,7 @@ By default openraft enables no features.
   This feature disables `Adapter`, which is for v1 storage to be used as v2.
   V2 storage separates log store and state machine store so that log IO and state machine IO can be parallelized naturally. 
   
+- `singlethreaded`: removes `Send` bounds from `AppData`, `AppDataResponse`, `RaftEntry`, and `SnapshotData` to force the
+  asynchronous runtime to spawn any tasks in the current thread.
+  This is for any single-threaded application that never allow a raft instance to be shared among multiple threads.
+  In order to use the feature, `AsyncRuntime::spawn` should invoke `tokio::task::spawn_local` or equivalents.

--- a/openraft/src/docs/feature_flags/feature-flags.md
+++ b/openraft/src/docs/feature_flags/feature-flags.md
@@ -26,5 +26,5 @@ By default openraft enables no features.
   
 - `singlethreaded`: removes `Send` bounds from `AppData`, `AppDataResponse`, `RaftEntry`, and `SnapshotData` to force the
   asynchronous runtime to spawn any tasks in the current thread.
-  This is for any single-threaded application that never allow a raft instance to be shared among multiple threads.
+  This is for any single-threaded application that never allows a raft instance to be shared among multiple threads.
   In order to use the feature, `AsyncRuntime::spawn` should invoke `tokio::task::spawn_local` or equivalents.

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -6,6 +6,7 @@ use crate::LogId;
 use crate::Membership;
 use crate::Node;
 use crate::NodeId;
+use crate::OptionalSend;
 use crate::OptionalSerde;
 
 /// Defines operations on an entry payload.
@@ -26,7 +27,7 @@ pub trait RaftEntry<NID, N>: RaftPayload<NID, N> + RaftLogId<NID>
 where
     N: Node,
     NID: NodeId,
-    Self: OptionalSerde + Debug + Display + Send + Sync,
+    Self: OptionalSerde + Debug + Display + OptionalSend + Sync,
 {
     /// Create a new blank log entry.
     ///

--- a/openraft/src/instant.rs
+++ b/openraft/src/instant.rs
@@ -40,3 +40,10 @@ impl Instant for tokio::time::Instant {
         tokio::time::Instant::now()
     }
 }
+
+impl Instant for std::time::Instant {
+    #[inline]
+    fn now() -> Self {
+        Self::now()
+    }
+}

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -85,6 +85,7 @@ mod try_as_ref;
 pub use anyerror;
 pub use anyerror::AnyError;
 pub use async_trait;
+pub use macros::add_async_trait;
 pub use network::RPCTypes;
 pub use network::RaftNetwork;
 pub use network::RaftNetworkFactory;

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -13,6 +13,7 @@ use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::MessageSummary;
 use crate::NodeId;
+use crate::OptionalSend;
 use crate::Vote;
 
 // Error variants related to metrics.
@@ -47,7 +48,7 @@ where
     /// Wait for metrics to satisfy some condition or timeout.
     #[tracing::instrument(level = "trace", skip(self, func), fields(msg=%msg.to_string()))]
     pub async fn metrics<T>(&self, func: T, msg: impl ToString) -> Result<RaftMetrics<NID, N>, WaitError>
-    where T: Fn(&RaftMetrics<NID, N>) -> bool + Send {
+    where T: Fn(&RaftMetrics<NID, N>) -> bool + OptionalSend {
         let timeout_at = A::Instant::now() + self.timeout;
 
         let mut rx = self.rx.clone();

--- a/openraft/src/network/factory.rs
+++ b/openraft/src/network/factory.rs
@@ -1,4 +1,4 @@
-use async_trait::async_trait;
+use macros::add_async_trait;
 
 use crate::network::RaftNetwork;
 use crate::RaftTypeConfig;
@@ -11,7 +11,7 @@ use crate::RaftTypeConfig;
 ///
 /// Typically, the network implementation as such will be hidden behind a `Box<T>` or `Arc<T>` and
 /// this interface implemented on the `Box<T>` or `Arc<T>`.
-#[async_trait]
+#[add_async_trait]
 pub trait RaftNetworkFactory<C>: Send + Sync + 'static
 where C: RaftTypeConfig
 {

--- a/openraft/src/network/network.rs
+++ b/openraft/src/network/network.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
+use macros::add_async_trait;
 
 use crate::error::InstallSnapshotError;
 use crate::error::RPCError;
@@ -13,6 +13,7 @@ use crate::raft::InstallSnapshotRequest;
 use crate::raft::InstallSnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
+use crate::OptionalSend;
 use crate::RaftTypeConfig;
 
 /// A trait defining the interface for a Raft network between cluster members.
@@ -34,8 +35,8 @@ use crate::RaftTypeConfig;
 ///   delegate to the old API.
 ///
 /// - Implementing the new APIs will disable the old APIs.
-#[async_trait]
-pub trait RaftNetwork<C>: Send + Sync + 'static
+#[add_async_trait]
+pub trait RaftNetwork<C>: OptionalSend + Sync + 'static
 where C: RaftTypeConfig
 {
     /// Send an AppendEntries RPC to the target.

--- a/openraft/src/raft.rs
+++ b/openraft/src/raft.rs
@@ -57,6 +57,7 @@ use crate::LogIdOptionExt;
 use crate::Membership;
 use crate::MessageSummary;
 use crate::NodeId;
+use crate::OptionalSend;
 use crate::RaftState;
 use crate::SnapshotMeta;
 use crate::StorageHelper;
@@ -103,7 +104,7 @@ pub trait RaftTypeConfig:
     ///
     /// See the [storage chapter of the guide](https://datafuselabs.github.io/openraft/getting-started.html#implement-raftstorage)
     /// for details on where and how this is used.
-    type SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + Send + Sync + Unpin + 'static;
+    type SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + OptionalSend + Sync + Unpin + 'static;
 
     /// Asynchronous runtime type.
     type AsyncRuntime: AsyncRuntime;

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -1,3 +1,5 @@
+use macros::add_async_trait;
+
 use crate::engine::Command;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -55,7 +57,7 @@ use crate::StorageError;
 /// ```
 ///
 /// TODO: add this diagram to guides/
-#[async_trait::async_trait]
+#[add_async_trait]
 pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// Run a command produced by the engine.
     ///

--- a/openraft/src/storage/log_store_ext.rs
+++ b/openraft/src/storage/log_store_ext.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::ops::RangeBounds;
 
-use async_trait::async_trait;
+use macros::add_async_trait;
 
 use crate::defensive::check_range_matches_entries;
 use crate::LogId;
@@ -11,7 +11,7 @@ use crate::RaftLogReader;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 
-#[async_trait]
+#[add_async_trait]
 pub trait RaftLogReaderExt<C>: RaftLogReader<C>
 where C: RaftTypeConfig
 {

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -27,6 +27,7 @@ use crate::AsyncRuntime;
 use crate::LogId;
 use crate::Membership;
 use crate::NodeId;
+use crate::OptionalSend;
 use crate::RaftSnapshotBuilder;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -1120,7 +1121,7 @@ where
     LS: RaftLogStorage<C>,
     SM: RaftStateMachine<C>,
     B: StoreBuilder<C, LS, SM, G>,
-    Fu: Future<Output = Result<Ret, StorageError<C::NodeId>>> + Send,
+    Fu: Future<Output = Result<Ret, StorageError<C::NodeId>>> + OptionalSend,
     TestFn: Fn(LS, SM) -> Fu + Sync + Send,
 {
     let (_g, store, sm) = builder.build().await?;
@@ -1132,8 +1133,8 @@ async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<(), StorageError<C::
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
-    I: IntoIterator<Item = C::Entry> + Send,
-    I::IntoIter: Send,
+    I: IntoIterator<Item = C::Entry> + OptionalSend,
+    I::IntoIter: OptionalSend,
 {
     sm.apply(entries).await?;
     Ok(())


### PR DESCRIPTION
- 'singlethreaded' compile-time feature gate.

The new feature gate forces the raft instance to be used by a single thread by not implementing `Send` for certain data structures and substituting calls to `tokio::spawn` with calls to `tokio::spawn_local` when using the `tokio` asynchronous runtime. In case the application wants to use a different type of asynchronous runtimes, the `spawn` method has to be appropriately implemented.

- Additional change included.

`openraft::Instant` is implemented for `std::time::Instant` to simplify the usage.

- Fix: [#862](https://github.com/datafuselabs/openraft/issues/862)

FYI: @schreter 

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/878)
<!-- Reviewable:end -->
