### PR TITLE
Change: RaftLogReaderExt::get_log_id() should not return last-purged-id

### DIFF
--- a/openraft/src/storage/log_store_ext.rs
+++ b/openraft/src/storage/log_store_ext.rs
@@ -5,7 +5,6 @@ use macros::add_async_trait;
 
 use crate::defensive::check_range_matches_entries;
 use crate::LogId;
-use crate::LogIdOptionExt;
 use crate::RaftLogId;
 use crate::RaftLogReader;
 use crate::RaftTypeConfig;
@@ -40,12 +39,6 @@ where C: RaftTypeConfig
 
     /// Get the log id of the entry at `index`.
     async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C::NodeId>> {
-        let st = self.get_log_state().await?;
-
-        if Some(log_index) == st.last_purged_log_id.index() {
-            return Ok(st.last_purged_log_id.unwrap());
-        }
-
         let entries = self.get_log_entries(log_index..=log_index).await?;
 
         Ok(*entries[0].get_log_id())

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -708,14 +708,17 @@ where
         let res = store.get_log_id(0).await;
         assert!(res.is_err());
 
-        let res = store.get_log_id(11).await;
+        let res = store.get_log_id(3).await;
         assert!(res.is_err());
-
-        let res = store.get_log_id(3).await?;
-        assert_eq!(log_id_0(1, 3), res);
 
         let res = store.get_log_id(4).await?;
         assert_eq!(log_id_0(1, 4), res);
+
+        let res = store.get_log_id(10).await?;
+        assert_eq!(log_id_0(1, 10), res);
+
+        let res = store.get_log_id(11).await;
+        assert!(res.is_err());
 
         Ok(())
     }


### PR DESCRIPTION

## Changelog

##### Change: RaftLogReaderExt::get_log_id() should not return last-purged-id

`get_log_id()` should only return present log id,
and should not be responsible to return id of an already purged log
entry, which introduce unnecessary complexity.

Upgrade tip:

An RaftStorage implementation should have already maintained the
last-purge-log-id. Avoid getting it via `RaftLogReaderExt::get_log_id()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/892)
<!-- Reviewable:end -->
