### PR TITLE
Change: move get_log_state() from RaftLogReader to RaftStorage

### DIFF
--- a/openraft/src/compat/compat07.rs
+++ b/openraft/src/compat/compat07.rs
@@ -314,7 +314,7 @@ pub mod testing {
                 }
 
                 // get_log_state
-                let got = crate::RaftLogReader::get_log_state(&mut s8).await?;
+                let got = crate::RaftStorage::get_log_state(&mut s8).await?;
                 assert_eq!(
                     crate::LogState {
                         last_purged_log_id: Some(crate::LogId::new(crate::CommittedLeaderId::new(1, 0), 5)),

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -87,8 +87,8 @@ Follow the link to method document to see the details.
 | Kind       | [`RaftStorage`] method           | Return value                 | Description                           |
 |------------|----------------------------------|------------------------------|---------------------------------------|
 | Read log:  | [`get_log_reader()`]             | impl [`RaftLogReader`]       | get a read-only log reader            |
-|            |                                  | ↳ [`get_log_state()`]        | get first/last log id                 |
 |            |                                  | ↳ [`try_get_log_entries()`]  | get a range of logs                   |
+|            | [`get_log_state()`]              | [`LogState`]                 | get first/last log id                 |
 | Write log: | [`append_to_log()`]              | ()                           | append logs                           |
 | Write log: | [`delete_conflict_logs_since()`] | ()                           | delete logs `[index, +oo)`            |
 | Write log: | [`purge_logs_upto()`]            | ()                           | purge logs `(-oo, index]`             |
@@ -115,15 +115,15 @@ Most of the APIs are quite straightforward, except two indirect APIs:
     ```
 
     [`RaftLogReader`] defines the APIs to read logs, and is an also super trait of [`RaftStorage`] :
-    - [`get_log_state()`] get latest log state from the storage;
     - [`try_get_log_entries()`] get log entries in a range;
 
     ```ignore
     trait RaftLogReader<C: RaftTypeConfig> {
-        async fn get_log_state(&mut self) -> Result<LogState<C>, ...>;
         async fn try_get_log_entries<RB: RangeBounds<u64>>(&mut self, range: RB) -> Result<Vec<C::Entry>, ...>;
     }
     ```
+
+    And [`RaftStorage::get_log_state()`][`get_log_state()`] get latest log state from the storage;
 
 -   Build a snapshot from the local state machine needs to be done in two steps:
     - [`RaftStorage::get_snapshot_builder() -> Self::SnapshotBuilder`][`get_snapshot_builder()`],
@@ -357,12 +357,13 @@ Additionally, two test scripts for setting up a cluster are available:
 [`Entry`]:                          `crate::entry::Entry`
 [`docs::Vote`]:                     `crate::docs::data::Vote`
 [`Vote`]:                           `crate::vote::Vote`
+[`LogState`]:                       `crate::storage::LogState` 
 
 [`RaftLogReader`]:                  `crate::storage::RaftLogReader`
-[`get_log_state()`]:                `crate::storage::RaftLogReader::get_log_state`
 [`try_get_log_entries()`]:          `crate::storage::RaftLogReader::try_get_log_entries`
 
 [`RaftStorage`]:                    `crate::storage::RaftStorage`
+[`get_log_state()`]:                `crate::storage::RaftStorage::get_log_state`
 [`RaftStorage::LogReader`]:         `crate::storage::RaftStorage::LogReader`
 [`RaftStorage::SnapshotBuilder`]:   `crate::storage::RaftStorage::SnapshotBuilder`
 [`get_log_reader()`]:               `crate::storage::RaftStorage::get_log_reader`

--- a/openraft/src/storage/adapter.rs
+++ b/openraft/src/storage/adapter.rs
@@ -103,10 +103,6 @@ where
     C: RaftTypeConfig,
     S: RaftStorage<C>,
 {
-    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>> {
-        S::get_log_state(self.storage_mut().await.deref_mut()).await
-    }
-
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &mut self,
         range: RB,
@@ -129,6 +125,10 @@ where
     S: RaftStorage<C>,
 {
     type LogReader = S::LogReader;
+
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>> {
+        S::get_log_state(self.storage_mut().await.deref_mut()).await
+    }
 
     async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
         S::save_vote(self.storage_mut().await.deref_mut(), vote).await

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -141,15 +141,6 @@ pub struct LogState<C: RaftTypeConfig> {
 pub trait RaftLogReader<C>: Send + Sync + 'static
 where C: RaftTypeConfig
 {
-    /// Returns the last deleted log id and the last log id.
-    ///
-    /// The impl should not consider the applied log id in state machine.
-    /// The returned `last_log_id` could be the log id of the last present log entry, or the
-    /// `last_purged_log_id` if there is no entry at all.
-    // NOTE: This can be made into sync, provided all state machines will use atomic read or the
-    // like.
-    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>>;
-
     /// Get a series of log entries from storage.
     ///
     /// The start value is inclusive in the search and the stop value is non-inclusive: `[start,
@@ -218,6 +209,15 @@ where C: RaftTypeConfig
     async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>>;
 
     // --- Log
+
+    /// Returns the last deleted log id and the last log id.
+    ///
+    /// The impl should **not** consider the applied log id in state machine.
+    /// The returned `last_log_id` could be the log id of the last present log entry, or the
+    /// `last_purged_log_id` if there is no entry at all.
+    // NOTE: This can be made into sync, provided all state machines will use atomic read or the
+    // like.
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>>;
 
     /// Get the log reader.
     ///

--- a/openraft/src/storage/v2.rs
+++ b/openraft/src/storage/v2.rs
@@ -7,6 +7,7 @@ use macros::add_async_trait;
 use crate::storage::callback::LogFlushed;
 use crate::storage::v2::sealed::Sealed;
 use crate::LogId;
+use crate::LogState;
 use crate::OptionalSend;
 use crate::RaftLogReader;
 use crate::RaftSnapshotBuilder;
@@ -50,6 +51,15 @@ where C: RaftTypeConfig
     /// Log reader is used by multiple replication tasks, which read logs and send them to remote
     /// nodes.
     type LogReader: RaftLogReader<C>;
+
+    /// Returns the last deleted log id and the last log id.
+    ///
+    /// The impl should **not** consider the applied log id in state machine.
+    /// The returned `last_log_id` could be the log id of the last present log entry, or the
+    /// `last_purged_log_id` if there is no entry at all.
+    // NOTE: This can be made into sync, provided all state machines will use atomic read or the
+    // like.
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>>;
 
     /// Get the log reader.
     ///

--- a/rocksstore/src/lib.rs
+++ b/rocksstore/src/lib.rs
@@ -340,31 +340,6 @@ impl RocksStore {
 
 #[async_trait]
 impl RaftLogReader<TypeConfig> for Arc<RocksStore> {
-    async fn get_log_state(&mut self) -> StorageResult<LogState<TypeConfig>> {
-        let last = self.db.iterator_cf(self.cf_logs(), rocksdb::IteratorMode::End).next();
-
-        let last_log_id = match last {
-            None => None,
-            Some(res) => {
-                let (_log_index, entry_bytes) = res.map_err(read_logs_err)?;
-                let ent = serde_json::from_slice::<Entry<TypeConfig>>(&entry_bytes).map_err(read_logs_err)?;
-                Some(ent.log_id)
-            }
-        };
-
-        let last_purged_log_id = self.get_meta::<meta::LastPurged>()?;
-
-        let last_log_id = match last_log_id {
-            None => last_purged_log_id,
-            Some(x) => Some(x),
-        };
-
-        Ok(LogState {
-            last_purged_log_id,
-            last_log_id,
-        })
-    }
-
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &mut self,
         range: RB,
@@ -447,6 +422,31 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<RocksStore> {
 impl RaftStorage<TypeConfig> for Arc<RocksStore> {
     type LogReader = Self;
     type SnapshotBuilder = Self;
+
+    async fn get_log_state(&mut self) -> StorageResult<LogState<TypeConfig>> {
+        let last = self.db.iterator_cf(self.cf_logs(), rocksdb::IteratorMode::End).next();
+
+        let last_log_id = match last {
+            None => None,
+            Some(res) => {
+                let (_log_index, entry_bytes) = res.map_err(read_logs_err)?;
+                let ent = serde_json::from_slice::<Entry<TypeConfig>>(&entry_bytes).map_err(read_logs_err)?;
+                Some(ent.log_id)
+            }
+        };
+
+        let last_purged_log_id = self.get_meta::<meta::LastPurged>()?;
+
+        let last_log_id = match last_log_id {
+            None => last_purged_log_id,
+            Some(x) => Some(x),
+        };
+
+        Ok(LogState {
+            last_purged_log_id,
+            last_log_id,
+        })
+    }
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn save_vote(&mut self, vote: &Vote<RocksNodeId>) -> Result<(), StorageError<RocksNodeId>> {

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -48,7 +48,6 @@ use openraft::LogIdOptionExt;
 use openraft::MessageSummary;
 use openraft::Raft;
 use openraft::RaftLogId;
-use openraft::RaftLogReader;
 use openraft::RaftMetrics;
 use openraft::RaftState;
 use openraft::ServerState;

--- a/tests/tests/metrics/t10_purged.rs
+++ b/tests/tests/metrics/t10_purged.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::storage::RaftLogStorage;
 use openraft::testing::log_id;
 use openraft::Config;
-use openraft::RaftLogReader;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;

--- a/tests/tests/snapshot_streaming/t33_snapshot_delete_conflict_logs.rs
+++ b/tests/tests/snapshot_streaming/t33_snapshot_delete_conflict_logs.rs
@@ -21,7 +21,6 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::Membership;
-use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::ServerState;
 use openraft::SnapshotPolicy;


### PR DESCRIPTION

## Changelog

##### Change: move get_log_state() from RaftLogReader to RaftStorage

- Move the `get_log_state()` method from the `RaftLogReader` trait to
  the `RaftStorage` trait.

- For applications that enable the `storage-v2` feature,
  `get_log_state()` will be moved from `RaftLogReader` to
  `RaftLogStorage`.

- `get_log_state()` should only be called once when openraft starts up.
  Only the `ReplicationCore` uses `RaftLogReader`, and it does not need
  `get_log_state()`. The log entries to replicate are decided by
  `RaftCore`.

Upgrade tip:

Implement `get_log_state()` in the `RaftStorage` or `RaftLogStorage`
trait instead of `RaftLogReader`.

Refer to the changes in `rocksstore/src/lib.rs` in this commit for an
example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/893)
<!-- Reviewable:end -->
