### PR TITLE
Feature: save committed log id

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1583,6 +1583,7 @@ where
                 ref already_committed,
                 ref upto,
             } => {
+                self.log_store.save_committed(Some(*upto)).await?;
                 self.apply_to_state_machine(seq, already_committed.next_index(), upto.index).await?;
             }
             Command::Replicate { req, target } => {

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -154,6 +154,7 @@ where C: RaftTypeConfig
 
             Command::StateMachine { .. }              => CommandKind::StateMachine,
             // Apply is firstly handled by RaftCore, then forwarded to state machine worker.
+            // TODO: Apply also write `committed` to log-store, which should be run in CommandKind::Log
             Command::Apply { .. }                     => CommandKind::Main,
         }
     }
@@ -168,6 +169,7 @@ where C: RaftTypeConfig
             Command::AppendEntry { .. }               => None,
             Command::AppendInputEntries { .. }        => None,
             Command::ReplicateCommitted { .. }        => None,
+            // TODO: Apply also write `committed` to log-store, which should be run in CommandKind::Log
             Command::Apply { .. }                     => None,
             Command::Replicate { .. }                 => None,
             Command::RebuildReplicationStreams { .. } => None,

--- a/openraft/src/storage/adapter.rs
+++ b/openraft/src/storage/adapter.rs
@@ -138,6 +138,14 @@ where
         S::read_vote(self.storage_mut().await.deref_mut()).await
     }
 
+    async fn save_committed(&mut self, committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C::NodeId>> {
+        S::save_committed(self.storage_mut().await.deref_mut(), committed).await
+    }
+
+    async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C::NodeId>> {
+        S::read_committed(self.storage_mut().await.deref_mut()).await
+    }
+
     async fn get_log_reader(&mut self) -> Self::LogReader {
         S::get_log_reader(self.storage_mut().await.deref_mut()).await
     }

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -208,6 +208,33 @@ where C: RaftTypeConfig
 
     async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>>;
 
+    /// Saves the last committed log id to storage.
+    ///
+    /// # Optional feature
+    ///
+    /// If the state machine flushes state to disk before returning from `apply()`,
+    /// then the application does not need to implement this method.
+    ///
+    /// Otherwise, i.e., the state machine just relies on periodical snapshot to persist state to
+    /// disk:
+    ///
+    /// - If the `committed` log id is saved, the state machine will be recovered to the state
+    ///   corresponding to this `committed` log id upon system startup, i.e., the state at the point
+    ///   when the committed log id was applied.
+    ///
+    /// - If the `committed` log id is not saved, Openraft will just recover the state machine to
+    ///   the state of the last snapshot taken.
+    async fn save_committed(&mut self, _committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C::NodeId>> {
+        // By default `committed` log id is not saved
+        Ok(())
+    }
+
+    /// Return the last saved committed log id by [`Self::save_committed`].
+    async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C::NodeId>> {
+        // By default `committed` log id is not saved and this method just return None.
+        Ok(None)
+    }
+
     // --- Log
 
     /// Returns the last deleted log id and the last log id.

--- a/openraft/src/storage/v2.rs
+++ b/openraft/src/storage/v2.rs
@@ -77,6 +77,33 @@ where C: RaftTypeConfig
     /// Return the last saved vote by [`Self::save_vote`].
     async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>>;
 
+    /// Saves the last committed log id to storage.
+    ///
+    /// # Optional feature
+    ///
+    /// If the state machine flushes state to disk before returning from `apply()`,
+    /// then the application does not need to implement this method.
+    ///
+    /// Otherwise, i.e., the state machine just relies on periodical snapshot to persist state to
+    /// disk:
+    ///
+    /// - If the `committed` log id is saved, the state machine will be recovered to the state
+    ///   corresponding to this `committed` log id upon system startup, i.e., the state at the point
+    ///   when the committed log id was applied.
+    ///
+    /// - If the `committed` log id is not saved, Openraft will just recover the state machine to
+    ///   the state of the last snapshot taken.
+    async fn save_committed(&mut self, _committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C::NodeId>> {
+        // By default `committed` log id is not saved
+        Ok(())
+    }
+
+    /// Return the last saved committed log id by [`Self::save_committed`].
+    async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C::NodeId>> {
+        // By default `committed` log id is not saved and this method just return None.
+        Ok(None)
+    }
+
     /// Append log entries and call the `callback` once logs are persisted on disk.
     ///
     /// It should returns immediately after saving the input log entries in memory, and calls the

--- a/tests/tests/log_store/main.rs
+++ b/tests/tests/log_store/main.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(feature = "bt", feature(error_generic_member_access))]
+#![cfg_attr(feature = "bt", feature(provide_any))]
+
+#[macro_use]
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+// The number indicate the preferred running order for these case.
+// The later tests may depend on the earlier ones.
+
+mod t10_save_committed;

--- a/tests/tests/log_store/t10_save_committed.rs
+++ b/tests/tests/log_store/t10_save_committed.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::storage::RaftLogStorage;
+use openraft::testing::log_id;
+use openraft::Config;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Before applying log, write `committed` log id to log store.
+#[async_entry::test(worker_threads = 4, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn write_committed_log_id_to_log_store() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    log_index += router.client_request_many(0, "0", 10).await?;
+
+    for i in [0, 1, 2] {
+        router.wait(&i, timeout()).log(Some(log_index), "write logs").await?;
+    }
+
+    for id in [0, 1, 2] {
+        let (_, mut ls, _) = router.remove_node(id).unwrap();
+        let committed = ls.read_committed().await?;
+        assert_eq!(Some(log_id(1, 0, log_index)), committed, "node-{} committed", id);
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
+}


### PR DESCRIPTION
## Changelog

##### Feature: save committed log id

- **Wrote committed log id to storage**
  Save the committed log id to storage before Raft apply log entries. This can
  recover state machine to the state corresponding to the committed log id upon
  system startup.

- **Re-applied log entries after startup**
  If the last applied log id is smaller than the committed log id saved in
  storage, re-apply log entries from the next index of last applied log id to the
  committed log id.

Version 1 storage API `RaftStorage` and Version 2 storage API
`RaftLogStorage` both add API `save_committed()` and `read_committed()`
to support saving/reading committed log id.

These two new API are optional and provides default dummy
implementation, an application does not need any modifications if it does
not need this feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/897)
<!-- Reviewable:end -->
