### PR TITLE
Feature: permit follower log to revert to earlier state with `--features loosen-follower-log-revert`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -321,6 +321,9 @@ jobs:
           - toolchain: "nightly"
             features: "single-term-leader"
 
+          - toolchain: "nightly"
+            features: "loosen-follower-log-revert"
+
 
     steps:
       - name: Setup | Checkout

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -87,6 +87,12 @@ storage-v2 = []
 # Disallows applications to share a raft instance with multiple threads.
 singlethreaded = ["macros/singlethreaded"]
 
+
+# Permit the follower's log to roll back to an earlier state without causing the leader to panic.
+# Although log state reversion is typically seen as a bug, enabling it can be useful for testing or other special scenarios.
+# For instance, in an even numbere nodes cluster, erasing a node's data and then rebooting it(log reverts to empty) will not result in data loss.
+loosen-follower-log-revert = []
+
 # default = ["single-term-leader"]
 
 [package.metadata.docs.rs]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -39,3 +39,4 @@ tracing-subscriber = { workspace = true }
 
 bt = ["openraft/bt"]
 single-term-leader = ["openraft/single-term-leader"]
+loosen-follower-log-revert = ["openraft/loosen-follower-log-revert"]

--- a/tests/tests/README.md
+++ b/tests/tests/README.md
@@ -11,7 +11,7 @@ integration tests to a separate crate.
 
 A test file name starts with `t[\d\d]_`, where `\d\d` is the test case number indicating priority.
 
-- `t00`: no used.
+- `t00`: not used.
 - `t10`: basic behaviors.
 - `t20`: life cycle test cases. 
 - `t30`: special cases for an API. 

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -8,3 +8,5 @@ mod fixtures;
 mod t10_append_entries_partial_success;
 mod t50_append_entries_backoff;
 mod t50_append_entries_backoff_rejoin;
+#[cfg(feature = "loosen-follower-log-revert")]
+mod t60_feature_loosen_follower_log_revert;

--- a/tests/tests/replication/t60_feature_loosen_follower_log_revert.rs
+++ b/tests/tests/replication/t60_feature_loosen_follower_log_revert.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft_memstore::MemStore;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RPCType;
+use crate::fixtures::RaftRouter;
+
+/// With "--features loosen-follower-log-revert", the leader allows follower to revert its log to an
+/// earlier state.
+#[async_entry::test(worker_threads = 4, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn feature_loosen_follower_log_revert() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
+
+    tracing::info!(log_index, "--- write 10 logs");
+    {
+        log_index += router.client_request_many(0, "0", 10).await?;
+        for i in [0, 1, 2, 3] {
+            router.wait(&i, timeout()).log(Some(log_index), format!("{} writes", 10)).await?;
+        }
+    }
+
+    let (_raft, ls, sm) = router.remove_node(3).unwrap();
+    {
+        let mut sto = ls.storage_mut().await;
+        *sto = Arc::new(MemStore::new());
+    }
+    router.new_raft_node_with_sto(3, ls, sm).await;
+    router.add_learner(0, 3).await?;
+    log_index += 1; // add learner
+
+    tracing::info!(log_index, "--- write another 10 logs, leader should not panic");
+    {
+        log_index += router.client_request_many(0, "0", 10).await?;
+        for i in [0, 1] {
+            router.wait(&i, timeout()).log(Some(log_index), format!("{} writes", 10)).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### Feature: permit follower log to revert to earlier state with `--features loosen-follower-log-revert`

Add a new feature `loosen-follower-log-revert`, to permit the follower's
log to roll back to an earlier state without causing the leader to
panic.

Although log state reversion is typically seen as a bug, enabling it can
be useful for testing or in some special scenarios.
For instance, in an even number nodes cluster, erasing a node's data
and then rebooting it(log reverts to empty) will not result in data
loss.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/902)
<!-- Reviewable:end -->
