### PR TITLE
Chore: update license syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Advanced Raft consensus"
 documentation = "https://docs.rs/openraft"
 homepage = "https://github.com/datafuselabs/openraft"
 keywords = ["raft", "consensus"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 

--- a/cluster_benchmark/Cargo.toml
+++ b/cluster_benchmark/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 categories = ["algorithms", "asynchronous", "data-structures"]
 homepage = "https://github.com/datafuselabs/openraft"
 keywords = ["raft", "consensus"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 [dependencies]

--- a/examples/raft-kv-memstore/Cargo.toml
+++ b/examples/raft-kv-memstore/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["algorithms", "asynchronous", "data-structures"]
 description = "An example distributed key-value store built upon `openraft`."
 homepage = "https://github.com/datafuselabs/openraft"
 keywords = ["raft", "consensus"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 [[bin]]

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "asynchronous", "data-structures"]
 description = "An example distributed key-value store built upon `openraft`."
 homepage = "https://github.com/datafuselabs/openraft"
 keywords = ["raft", "consensus"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 [[bin]]

--- a/stores/rocksstore-v2/Cargo.toml
+++ b/stores/rocksstore-v2/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 categories = ["algorithms", "asynchronous", "data-structures"]
 homepage = "https://github.com/datafuselabs/openraft"
 keywords = ["raft", "consensus"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION

## Changelog

##### Chore: update license syntax

Make `license` field follow the SPDX 2.1 standard:
https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields