### PR TITLE
Chore: print first and last log id when unexpected logs are returned while replicating

### DIFF
--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -49,6 +49,7 @@ use crate::Instant;
 use crate::LogId;
 use crate::MessageSummary;
 use crate::NodeId;
+use crate::RaftLogId;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::StorageIOError;
@@ -294,10 +295,12 @@ where
             debug_assert_eq!(
                 logs.len(),
                 (end - start) as usize,
-                "expect logs {}..{} but got only {} entries",
+                "expect logs {}..{} but got only {} entries, first: {}, last: {}",
                 start,
                 end,
-                logs.len()
+                logs.len(),
+                logs.first().map(|ent| ent.get_log_id()).display(),
+                logs.last().map(|ent| ent.get_log_id()).display()
             );
             logs
         };


### PR DESCRIPTION

## Changelog

##### Chore: print first and last log id when unexpected logs are returned while replicating

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/907)
<!-- Reviewable:end -->
