### PR TITLE
Fixup: raft-kv-metastore example, Arc<Store>::purge_logs_upto issues wrong debug message

### DIFF
--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -216,7 +216,7 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn purge_logs_upto(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
-        tracing::debug!("delete_log: [{:?}, +oo)", log_id);
+        tracing::debug!("delete_log: (-oo, {:?}]", log_id);
 
         {
             let mut ld = self.last_purged_log_id.write().await;


### PR DESCRIPTION
purge_logs_upto is purging (-oo, log_id], not [log_id, +oo).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/914)
<!-- Reviewable:end -->
