### PR TITLE
Chore: update discord channel link without expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 
 - [Openraft FAQ](https://datafuselabs.github.io/openraft/faq) explains some common questions.
 
-- 🙌 Questions? Join the [Discord channel](https://discord.gg/JsaUQyAnkE) or start a [discussion](https://github.com/datafuselabs/openraft/discussions/new).
+- 🙌 Questions? Join the [Discord channel](https://discord.gg/ZKw3WG7FQ9) or start a [discussion](https://github.com/datafuselabs/openraft/discussions/new).
 
 - Openraft is derived from [async-raft](https://docs.rs/crate/async-raft/latest) with several bugs fixed: [Fixed bugs](https://github.com/datafuselabs/openraft/blob/main/derived-from-async-raft.md).
 


### PR DESCRIPTION

## Changelog

##### Chore: update discord channel link without expiration

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/921)
<!-- Reviewable:end -->
