### PR TITLE
Refactor: fix handling of non-voter leader

### DIFF
--- a/openraft/src/docs/data/vote.md
+++ b/openraft/src/docs/data/vote.md
@@ -41,7 +41,7 @@ The only difference between these two modes is the definition of `LeaderId`, and
 See: [`leader-id`].
 
 
-## Vote defines the server state
+## Vote and Membership define the server state
 
 In the default mode, the `Vote` defines the server state(leader, candidate, follower or learner).
 A server state has a unique corresponding `vote`, thus `vote` can be used to identify different server
@@ -55,17 +55,27 @@ new membership log is replicated to a follower or learner.
 
 E.g.:
 
-- A vote `(term=1, node_id=2, committed=false)` is in a candidate state for
-  node-2.
+- Node-2 with vote `(term=1, node_id=2, committed=true)`:
+  - is a leader if it is **present** in config, either a voter or non-voter.
+  - is a learner if it is **absent** in config.
 
-- A vote `(term=1, node_id=2, committed=true)` is in a leader state for
-  node-2.
+- Node-2 with vote `(term=1, node_id=2, committed=false)`:
+  - is a candidate if it is **present** in config, either a voter or non-voter.
+  - is a learner if it is **absent** in config.
 
-- A vote `(term=1, node_id=2, committed=false|true)` is in a follower/learner
-  state for node-3.
+- Node-3 with vote `(term=1, node_id=99, committed=false|true)`:
+  - is a follower if it is a **voter** in config,
+  - is a learner if it is a **non-voter** or **absent** in config.
 
-- A vote `(term=1, node_id=1, committed=false|true)` is in another different
-  follower/learner state for node-3.
+For node-2:
+
+| vote \ membership                     | Voter     | Non-voter | Absent  |
+|---------------------------------------|-----------|-----------|---------|
+| (term=1, node_id=2, committed=true)   | leader    | leader    | learner |
+| (term=1, node_id=2, committed=false)  | candidate | candidate | learner |
+| (term=1, node_id=99, committed=true)  | follower  | learner   | learner |
+| (term=1, node_id=99, committed=false) | follower  | learner   | learner |
+
 
 
 [`Vote`]: `crate::vote::Vote`

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -95,7 +95,6 @@ where C: RaftTypeConfig
         }
     }
 
-    // TODO: test it
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn startup(&mut self) {
         // Allows starting up as a leader.
@@ -517,10 +516,7 @@ where C: RaftTypeConfig
 
         #[allow(clippy::collapsible_if)]
         if em.log_id().as_ref() <= self.state.committed() {
-            if !em.is_voter(&self.config.id) && self.state.is_leading(&self.config.id) {
-                tracing::debug!("leader {} is stepping down", self.config.id);
-                self.vote_handler().become_following();
-            }
+            self.vote_handler().update_internal_server_state();
         }
     }
 

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -38,7 +38,7 @@ fn m1_2() -> Membership<u64, ()> {
 }
 
 fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], btreeset! {1,2,3})
 }
 
 fn eng() -> Engine<UTConfig> {

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -23,7 +23,7 @@ fn m01() -> Membership<u64, ()> {
 }
 
 fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+    Membership::<u64, ()>::new(vec![btreeset! {2,3}], btreeset! {1,2,3})
 }
 
 fn eng() -> Engine<UTConfig> {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -124,7 +124,7 @@ where C: RaftTypeConfig
 
     /// Enter leading or following state by checking `vote`.
     pub(crate) fn update_internal_server_state(&mut self) {
-        if self.state.vote_ref().leader_id().voted_for() == Some(self.config.id) {
+        if self.state.is_leading(&self.config.id) {
             self.become_leading();
         } else {
             self.become_following();

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -172,6 +172,11 @@ where
     N: Node,
     NID: NodeId,
 {
+    /// Return true if the given node id is an either voter or learner.
+    pub(crate) fn contains(&self, node_id: &NID) -> bool {
+        self.nodes.contains_key(node_id)
+    }
+
     /// Check if the given `NodeId` exists and is a voter.
     pub(crate) fn is_voter(&self, node_id: &NID) -> bool {
         for c in self.configs.iter() {

--- a/openraft/src/raft/message/client_write.rs
+++ b/openraft/src/raft/message/client_write.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 
-use crate::AppDataResponse;
 use crate::LogId;
 use crate::Membership;
 use crate::MessageSummary;
@@ -10,7 +9,7 @@ use crate::RaftTypeConfig;
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "C::R: AppDataResponse")
+    serde(bound = "C::R: crate::AppDataResponse")
 )]
 pub struct ClientWriteResponse<C: RaftTypeConfig> {
     /// The id of the log that is applied.

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -77,6 +77,12 @@ where
         Self { committed, effective }
     }
 
+    /// Return true if the given node id is an either voter or learner.
+    pub(crate) fn contains(&self, id: &NID) -> bool {
+        self.effective.membership().contains(id)
+    }
+
+    /// Check if the given `NodeId` exists and is a voter.
     pub(crate) fn is_voter(&self, id: &NID) -> bool {
         self.effective.membership().is_voter(id)
     }

--- a/tests/tests/life_cycle/main.rs
+++ b/tests/tests/life_cycle/main.rs
@@ -13,3 +13,4 @@ mod t50_follower_restart_does_not_interrupt;
 mod t50_single_follower_restart;
 mod t50_single_leader_restart_re_apply_logs;
 mod t90_issue_607_single_restart;
+mod t90_issue_920_non_voter_leader_restart;

--- a/tests/tests/life_cycle/t90_issue_920_non_voter_leader_restart.rs
+++ b/tests/tests/life_cycle/t90_issue_920_non_voter_leader_restart.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::storage::RaftLogStorage;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::Vote;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Special case: A leader that is not a member(neither a voter or non-voter) should be started too,
+/// as a learner.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn issue_920_non_member_leader_restart() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    let (mut log_store, sm) = router.new_store();
+    // Set committed vote that believes node 0 is the leader.
+    log_store.save_vote(&Vote::new_committed(1, 0)).await?;
+    router.new_raft_node_with_sto(0, log_store, sm).await;
+
+    router
+        .wait(&0, timeout())
+        .state(ServerState::Learner, "node 0 becomes learner when startup")
+        .await?;
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
+}


### PR DESCRIPTION

## Changelog

##### Refactor: fix handling of non-voter leader

Openraft does not require Leader/Candidate to be a voter.
Before this commit, Openraft's handling of non-voter leader is
inconsistent:

For a node that has a vote proposed by this node and is committed, and is not a voter:

- [`calc_server_state()`](https://github.com/datafuselabs/openraft/blob/97254a31c673e52429ee7187de96fd2ea2a5ce98/openraft/src/raft_state/mod.rs#L323) returns `Learner`.
- But [`is_leader()`](https://github.com/datafuselabs/openraft/blob/97254a31c673e52429ee7187de96fd2ea2a5ce98/openraft/src/raft_state/mod.rs#L353) returns true.

Since this commit,
`calc_server_state()` and `is_leader()` returns consistent result according to the following table:

For node-2:

- Node-2 with vote `(term=1, node_id=2, committed=true)`:
  - is a leader if it is **present** in config, either a voter or non-voter.
  - is a learner if it is **absent** in config.

- Node-2 with vote `(term=1, node_id=2, committed=false)`:
  - is a candidate if it is **present** in config, either a voter or non-voter.
  - is a learner if it is **absent** in config.

- Node-3 with vote `(term=1, node_id=99, committed=false|true)`:
  - is a follower if it is a **voter** in config,
  - is a learner if it is a **non-voter** or **absent** in config.

| vote \ membership                     | Voter     | Non-voter | Absent  |
|---------------------------------------|-----------|-----------|---------|
| (term=1, node_id=2, committed=true)   | leader    | leader    | learner |
| (term=1, node_id=2, committed=false)  | candidate | candidate | learner |
| (term=1, node_id=99, committed=true)  | follower  | learner   | learner |
| (term=1, node_id=99, committed=false) | follower  | learner   | learner |

- Fix: #920

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/924)
<!-- Reviewable:end -->
