### PR TITLE
Fix: AsyncReadExt::read_buf() only reads at most 2MB per call

### DIFF
--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -645,12 +645,20 @@ where
 
         let mut offset = 0;
         let end = snapshot.snapshot.seek(SeekFrom::End(0)).await.sto_res(err_x)?;
-        let mut buf = Vec::with_capacity(self.config.snapshot_max_chunk_size as usize);
 
         loop {
             // Build the RPC.
             snapshot.snapshot.seek(SeekFrom::Start(offset)).await.sto_res(err_x)?;
-            let n_read = snapshot.snapshot.read_buf(&mut buf).await.sto_res(err_x)?;
+
+            let mut buf = Vec::with_capacity(self.config.snapshot_max_chunk_size as usize);
+            while buf.capacity() > buf.len() {
+                let n = snapshot.snapshot.read_buf(&mut buf).await.sto_res(err_x)?;
+                if n == 0 {
+                    break;
+                }
+            }
+
+            let n_read = buf.len();
 
             let leader_time = <C::AsyncRuntime as AsyncRuntime>::Instant::now();
 
@@ -659,10 +667,9 @@ where
                 vote: self.session_id.vote,
                 meta: snapshot.meta.clone(),
                 offset,
-                data: Vec::from(&buf[..n_read]),
+                data: buf,
                 done,
             };
-            buf.clear();
 
             // Send the RPC over to the target.
             tracing::debug!(


### PR DESCRIPTION

## Changelog

##### Fix: AsyncReadExt::read_buf() only reads at most 2MB per call

When streaming a snapshot chunk, it should repeatly `read_buf()` until
`snapshot_max_chunk_size` is full or read EOF.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/925)
<!-- Reviewable:end -->
