### PR TITLE
Chore: increase timeout for example application. It tends to timeout in a CI

### DIFF
--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -93,7 +93,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Wait for server to start up.
-    async_std::task::sleep(Duration::from_millis(500)).await;
+    async_std::task::sleep(Duration::from_millis(1_000)).await;
 
     // --- Create a client to the first node, as a control handle to the cluster.
 
@@ -172,7 +172,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
 
     // --- Wait for a while to let the replication get done.
 
-    async_std::task::sleep(Duration::from_millis(200)).await;
+    async_std::task::sleep(Duration::from_millis(500)).await;
 
     // --- Read it on every node.
 
@@ -200,7 +200,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
         })
         .await?;
 
-    async_std::task::sleep(Duration::from_millis(200)).await;
+    async_std::task::sleep(Duration::from_millis(500)).await;
 
     // --- Read it on every node.
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### Chore: increase timeout for example application. It tends to timeout in a CI

## Changelog







## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/926)
<!-- Reviewable:end -->
