### PR TITLE
Fix: End `tick_loop()` when the receiver is gone.

### DIFF
--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -66,8 +66,9 @@ where C: RaftTypeConfig
             }
 
             let send_res = self.tx.send(Notify::Tick { i });
-            if let Err(e) = send_res {
-                tracing::info!("Tick fails to send, receiving end quit: {e}");
+            if let Err(_e) = send_res {
+                tracing::info!("Stopping tick_loop(), main loop terminated");
+                break;
             } else {
                 tracing::debug!("Tick sent: {}", i)
             }


### PR DESCRIPTION
Currently, `tick_loop()` would keep printing the trace message every tick even when the receiver (Raft main loop) is gone in this form:

`INFO openraft::core::tick: .../tick.rs:70: Tick fails to send, receiving end quit: channel closed`

If the tick message fails to send, then terminate the loop, since every future message will fail to send as well.

Also adjust the trace message to better describe what happened.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/930)
<!-- Reviewable:end -->
