### PR TITLE
Fix: avoid panic with "loosen-follower-log-revert" enabled

### DIFF
--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -466,7 +466,22 @@ where
             func_name!()
         );
 
-        debug_assert!(self.matching <= new_matching);
+        if cfg!(feature = "loosen-follower-log-revert") {
+            if self.matching > new_matching {
+                tracing::warn!(
+                "follower log is reverted from {} to {}; with 'loosen-follower-log-revert' enabled, this is allowed",
+                self.matching.display(),
+                new_matching.display(),
+            );
+            }
+        } else {
+            debug_assert!(
+                self.matching <= new_matching,
+                "follower log is reverted from {} to {}",
+                self.matching.display(),
+                new_matching.display(),
+            );
+        }
 
         self.matching = new_matching;
 

--- a/tests/tests/replication/t60_feature_loosen_follower_log_revert.rs
+++ b/tests/tests/replication/t60_feature_loosen_follower_log_revert.rs
@@ -17,6 +17,8 @@ async fn feature_loosen_follower_log_revert() -> Result<()> {
         Config {
             enable_tick: false,
             enable_heartbeat: false,
+            // Make sure the replication is done in more than one steps
+            max_payload_entries: 1,
             ..Default::default()
         }
         .validate()?,


### PR DESCRIPTION

## Changelog

##### Fix: avoid panic with "loosen-follower-log-revert" enabled

Problem:

When "loosen-follower-log-revert" enabled, and a follower log gets
reverted, e.g., all raft-logs are removed from that follower, the leader
encounters a panic due to a `debug_assert()`.

Solution:

- Disable the assertion when this feature is enabled.

- The test `feature_loosen_follower_log_revert` is also revised to reveal this
  bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/937)
<!-- Reviewable:end -->
