### PR TITLE
Change: remove `N, LS` from `Raft<C, N, LS, _>`

### DIFF
--- a/cluster_benchmark/tests/benchmark/network.rs
+++ b/cluster_benchmark/tests/benchmark/network.rs
@@ -29,7 +29,7 @@ use crate::store::NodeId;
 use crate::store::StateMachineStore;
 use crate::store::TypeConfig as MemConfig;
 
-pub type BenchRaft = Raft<MemConfig, Router, Arc<LogStore>, Arc<StateMachineStore>>;
+pub type BenchRaft = Raft<MemConfig>;
 
 #[derive(Clone)]
 pub struct Router {

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -37,7 +37,7 @@ openraft::declare_raft_types!(
 
 pub type LogStore = Adaptor<TypeConfig, Arc<Store>>;
 pub type StateMachineStore = Adaptor<TypeConfig, Arc<Store>>;
-pub type Raft = openraft::Raft<TypeConfig, Network, LogStore, StateMachineStore>;
+pub type Raft = openraft::Raft<TypeConfig>;
 
 pub mod typ {
     use openraft::BasicNode;

--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -47,7 +47,7 @@ openraft::declare_raft_types!(
 
 pub type LogStore = Adaptor<TypeConfig, Arc<Store>>;
 pub type StateMachineStore = Adaptor<TypeConfig, Arc<Store>>;
-pub type ExampleRaft = openraft::Raft<TypeConfig, Network, LogStore, StateMachineStore>;
+pub type ExampleRaft = openraft::Raft<TypeConfig>;
 
 type Server = tide::Server<Arc<App>>;
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -186,8 +186,8 @@ where
     pub(crate) leader_data: Option<LeaderData<C>>,
 
     #[allow(dead_code)]
-    pub(crate) tx_api: mpsc::UnboundedSender<RaftMsg<C, N, LS>>,
-    pub(crate) rx_api: mpsc::UnboundedReceiver<RaftMsg<C, N, LS>>,
+    pub(crate) tx_api: mpsc::UnboundedSender<RaftMsg<C>>,
+    pub(crate) rx_api: mpsc::UnboundedReceiver<RaftMsg<C>>,
 
     /// A Sender to send callback by other components to [`RaftCore`], when an action is finished,
     /// such as flushing log to disk, or applying log entries to state machine.
@@ -1063,7 +1063,7 @@ where
 
     // TODO: Make this method non-async. It does not need to run any async command in it.
     #[tracing::instrument(level = "debug", skip(self, msg), fields(state = debug(self.engine.state.server_state), id=display(self.id)))]
-    pub(crate) async fn handle_api_msg(&mut self, msg: RaftMsg<C, N, LS>) {
+    pub(crate) async fn handle_api_msg(&mut self, msg: RaftMsg<C>) {
         tracing::debug!("recv from rx_api: {}", msg.summary());
 
         match msg {
@@ -1120,7 +1120,7 @@ where
                 self.change_membership(changes, retain, tx);
             }
             RaftMsg::ExternalRequest { req } => {
-                req(&self.engine.state, &mut self.log_store, &mut self.network);
+                req(&self.engine.state);
             }
             RaftMsg::ExternalCommand { cmd } => {
                 tracing::info!(cmd = debug(&cmd), "received RaftMsg::ExternalCommand: {}", func_name!());

--- a/openraft/src/raft/external_request.rs
+++ b/openraft/src/raft/external_request.rs
@@ -1,0 +1,9 @@
+//! Defines API for application to send request to access Raft core.
+
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::NodeIdOf;
+use crate::type_config::alias::NodeOf;
+use crate::RaftState;
+
+/// Boxed trait object for external request function run in `RaftCore` task.
+pub(crate) type BoxCoreFn<C> = Box<dyn FnOnce(&RaftState<NodeIdOf<C>, NodeOf<C>, InstantOf<C>>) + Send + 'static>;

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -12,26 +12,21 @@ use crate::core::raft_msg::RaftMsg;
 use crate::core::TickHandle;
 use crate::error::Fatal;
 use crate::raft::core_state::CoreState;
-use crate::storage::RaftLogStorage;
 use crate::AsyncRuntime;
 use crate::Config;
 use crate::RaftMetrics;
-use crate::RaftNetworkFactory;
 use crate::RaftTypeConfig;
 
 /// RaftInner is the internal handle and provides internally used APIs to communicate with
 /// `RaftCore`.
-pub(in crate::raft) struct RaftInner<C, N, LS>
-where
-    C: RaftTypeConfig,
-    N: RaftNetworkFactory<C>,
-    LS: RaftLogStorage<C>,
+pub(in crate::raft) struct RaftInner<C>
+where C: RaftTypeConfig
 {
     pub(in crate::raft) id: C::NodeId,
     pub(in crate::raft) config: Arc<Config>,
     pub(in crate::raft) runtime_config: Arc<RuntimeConfig>,
     pub(in crate::raft) tick_handle: TickHandle<C>,
-    pub(in crate::raft) tx_api: mpsc::UnboundedSender<RaftMsg<C, N, LS>>,
+    pub(in crate::raft) tx_api: mpsc::UnboundedSender<RaftMsg<C>>,
     pub(in crate::raft) rx_metrics: watch::Receiver<RaftMetrics<C::NodeId, C::Node>>,
 
     // TODO(xp): it does not need to be a async mutex.
@@ -40,11 +35,8 @@ where
     pub(in crate::raft) core_state: Mutex<CoreState<C::NodeId, C::AsyncRuntime>>,
 }
 
-impl<C, N, LS> RaftInner<C, N, LS>
-where
-    C: RaftTypeConfig,
-    N: RaftNetworkFactory<C>,
-    LS: RaftLogStorage<C>,
+impl<C> RaftInner<C>
+where C: RaftTypeConfig
 {
     /// Send an [`ExternalCommand`] to RaftCore to execute in the `RaftCore` thread.
     ///

--- a/openraft/src/raft/runtime_config_handle.rs
+++ b/openraft/src/raft/runtime_config_handle.rs
@@ -3,30 +3,22 @@
 use std::sync::atomic::Ordering;
 
 use crate::raft::RaftInner;
-use crate::storage::RaftLogStorage;
-use crate::RaftNetworkFactory;
 use crate::RaftTypeConfig;
 
 /// RuntimeConfigHandle is an interface to update runtime config.
 ///
 /// These config are mainly designed for testing purpose and special use cases.
 /// Usually you don't need to change runtime config.
-pub struct RuntimeConfigHandle<'r, C, N, LS>
-where
-    C: RaftTypeConfig,
-    N: RaftNetworkFactory<C>,
-    LS: RaftLogStorage<C>,
+pub struct RuntimeConfigHandle<'r, C>
+where C: RaftTypeConfig
 {
-    raft_inner: &'r RaftInner<C, N, LS>,
+    raft_inner: &'r RaftInner<C>,
 }
 
-impl<'r, C, N, LS> RuntimeConfigHandle<'r, C, N, LS>
-where
-    C: RaftTypeConfig,
-    N: RaftNetworkFactory<C>,
-    LS: RaftLogStorage<C>,
+impl<'r, C> RuntimeConfigHandle<'r, C>
+where C: RaftTypeConfig
 {
-    pub(in crate::raft) fn new(raft_inner: &'r RaftInner<C, N, LS>) -> Self {
+    pub(in crate::raft) fn new(raft_inner: &'r RaftInner<C>) -> Self {
         Self { raft_inner }
     }
 

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -3,27 +3,19 @@
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::error::Fatal;
 use crate::raft::RaftInner;
-use crate::storage::RaftLogStorage;
-use crate::RaftNetworkFactory;
 use crate::RaftTypeConfig;
 
 /// Trigger is an interface to trigger an action to RaftCore by external caller.
-pub struct Trigger<'r, C, N, LS>
-where
-    C: RaftTypeConfig,
-    N: RaftNetworkFactory<C>,
-    LS: RaftLogStorage<C>,
+pub struct Trigger<'r, C>
+where C: RaftTypeConfig
 {
-    raft_inner: &'r RaftInner<C, N, LS>,
+    raft_inner: &'r RaftInner<C>,
 }
 
-impl<'r, C, N, LS> Trigger<'r, C, N, LS>
-where
-    C: RaftTypeConfig,
-    N: RaftNetworkFactory<C>,
-    LS: RaftLogStorage<C>,
+impl<'r, C> Trigger<'r, C>
+where C: RaftTypeConfig
 {
-    pub(in crate::raft) fn new(raft_inner: &'r RaftInner<C, N, LS>) -> Self {
+    pub(in crate::raft) fn new(raft_inner: &'r RaftInner<C>) -> Self {
         Self { raft_inner }
     }
 

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -67,3 +67,23 @@ pub trait RaftTypeConfig:
     /// Asynchronous runtime type.
     type AsyncRuntime: AsyncRuntime;
 }
+
+#[allow(dead_code)]
+pub(crate) mod alias {
+    //! Type alias for types used in `RaftTypeConfig`.
+
+    pub(crate) type DOf<C> = <C as crate::RaftTypeConfig>::D;
+    pub(crate) type ROf<C> = <C as crate::RaftTypeConfig>::R;
+    pub(crate) type NodeIdOf<C> = <C as crate::RaftTypeConfig>::NodeId;
+    pub(crate) type NodeOf<C> = <C as crate::RaftTypeConfig>::Node;
+    pub(crate) type EntryOf<C> = <C as crate::RaftTypeConfig>::Entry;
+    pub(crate) type SnapshotDataOf<C> = <C as crate::RaftTypeConfig>::SnapshotData;
+    pub(crate) type AsyncRuntimeOf<C> = <C as crate::RaftTypeConfig>::AsyncRuntime;
+
+    pub(crate) type JoinErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::JoinError;
+    pub(crate) type JoinHandleOf<C, T> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::JoinHandle<T>;
+    pub(crate) type SleepOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Sleep;
+    pub(crate) type InstantOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Instant;
+    pub(crate) type TimeoutErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::TimeoutError;
+    pub(crate) type TimeoutOf<C, R, F> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Timeout<R, F>;
+}

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -78,7 +78,7 @@ async fn append_sees_higher_vote() -> Result<()> {
             .state(ServerState::Follower, "node-0 becomes follower due to a higher vote")
             .await?;
 
-        router.external_request(0, |st, _, _| {
+        router.external_request(0, |st| {
             assert_eq!(&Vote::new(10, 1), st.vote_ref(), "higher vote is stored");
         });
     }

--- a/tests/tests/append_entries/t60_enable_heartbeat.rs
+++ b/tests/tests/append_entries/t60_enable_heartbeat.rs
@@ -41,7 +41,7 @@ async fn enable_heartbeat() -> Result<()> {
                 .await?;
 
             // leader lease is extended.
-            router.external_request(node_id, move |state, _store, _net| {
+            router.external_request(node_id, move |state| {
                 assert!(state.vote_last_modified() > Some(now));
             });
         }

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -38,7 +38,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
     {
         let m = vote_modified_time.clone();
 
-        router.external_request(1, move |state, _store, _net| {
+        router.external_request(1, move |state| {
             let mut l = m.lock().unwrap();
             *l = state.vote_last_modified();
             assert!(state.vote_last_modified() > Some(now));
@@ -49,7 +49,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
 
         let m = vote_modified_time.clone();
 
-        router.external_request(1, move |state, _store, _net| {
+        router.external_request(1, move |state| {
             let l = m.lock().unwrap();
             assert!(state.vote_last_modified() > Some(now));
             assert!(state.vote_last_modified() > *l);

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -72,7 +72,7 @@ pub type MemLogStore = Adaptor<MemConfig, Arc<MemStore>>;
 pub type MemStateMachine = Adaptor<MemConfig, Arc<MemStore>>;
 
 /// A concrete Raft type used during testing.
-pub type MemRaft = Raft<MemConfig, TypedRaftRouter, MemLogStore, MemStateMachine>;
+pub type MemRaft = Raft<MemConfig>;
 
 pub fn init_default_ut_tracing() {
     static START: Once = Once::new();
@@ -280,7 +280,7 @@ impl TypedRaftRouter {
         // (since they are awaited).
         #[allow(clippy::single_element_loop)]
         for node in [0] {
-            self.external_request(node, |s, _sto, _net| {
+            self.external_request(node, |s| {
                 assert_eq!(s.server_state, ServerState::Learner);
             });
         }
@@ -637,9 +637,7 @@ impl TypedRaftRouter {
     }
 
     /// Send external request to the particular node.
-    pub fn external_request<
-        F: FnOnce(&RaftState<MemNodeId, (), TokioInstant>, &mut MemLogStore, &mut TypedRaftRouter) + Send + 'static,
-    >(
+    pub fn external_request<F: FnOnce(&RaftState<MemNodeId, (), TokioInstant>) + Send + 'static>(
         &self,
         target: MemNodeId,
         req: F,

--- a/tests/tests/life_cycle/t10_initialization.rs
+++ b/tests/tests/life_cycle/t10_initialization.rs
@@ -69,7 +69,7 @@ async fn initialization() -> anyhow::Result<()> {
     // before other requests in the Raft core API queue, which definitely are executed
     // (since they are awaited).
     for node in [0, 1, 2] {
-        router.external_request(node, |s, _sto, _net| {
+        router.external_request(node, |s| {
             assert_eq!(s.server_state, ServerState::Learner);
         });
     }
@@ -88,7 +88,7 @@ async fn initialization() -> anyhow::Result<()> {
 
     tracing::info!(log_index, "--- check membership state");
     for node_id in [0, 1, 2] {
-        router.external_request(node_id, move |s, _sto, _net| {
+        router.external_request(node_id, move |s| {
             let want = EffectiveMembership::new(
                 Some(LogId::new(CommittedLeaderId::new(0, 0), 0)),
                 Membership::new(vec![btreeset! {0,1,2}], None),
@@ -147,7 +147,7 @@ async fn initialization() -> anyhow::Result<()> {
     let mut follower_count = 0;
     for node in [0, 1, 2] {
         let (tx, rx) = oneshot::channel();
-        router.external_request(node, |s, _sm, _net| tx.send(s.server_state).unwrap());
+        router.external_request(node, |s| tx.send(s.server_state).unwrap());
         match rx.await.unwrap() {
             ServerState::Leader => {
                 assert!(!found_leader);
@@ -176,7 +176,7 @@ async fn initialize_err_target_not_include_target() -> anyhow::Result<()> {
     router.new_raft_node(1).await;
 
     for node in [0, 1] {
-        router.external_request(node, |s, _sto, _net| {
+        router.external_request(node, |s| {
             assert_eq!(s.server_state, ServerState::Learner);
         });
     }
@@ -210,7 +210,7 @@ async fn initialize_err_not_allowed() -> anyhow::Result<()> {
     router.new_raft_node(0).await;
 
     for node in [0] {
-        router.external_request(node, |s, _sto, _net| {
+        router.external_request(node, |s| {
             assert_eq!(s.server_state, ServerState::Learner);
         });
     }

--- a/tests/tests/life_cycle/t11_shutdown.rs
+++ b/tests/tests/life_cycle/t11_shutdown.rs
@@ -55,7 +55,7 @@ async fn return_error_after_panic() -> Result<()> {
 
     tracing::info!(log_index, "--- panic the RaftCore");
     {
-        router.external_request(0, |_s, _sto, _net| {
+        router.external_request(0, |_s| {
             panic!("foo");
         });
     }

--- a/tests/tests/membership/t20_change_membership.rs
+++ b/tests/tests/membership/t20_change_membership.rs
@@ -36,7 +36,7 @@ async fn update_membership_state() -> anyhow::Result<()> {
 
         for node_id in [0, 1, 2, 3, 4] {
             router.wait(&node_id, timeout()).log(Some(log_index), "change-membership log applied").await?;
-            router.external_request(node_id, move |st, _, _| {
+            router.external_request(node_id, move |st| {
                 tracing::debug!("--- got state: {:?}", st);
                 assert_eq!(st.membership_state.committed().log_id().index(), Some(log_index));
                 assert_eq!(st.membership_state.effective().log_id().index(), Some(log_index));


### PR DESCRIPTION

## Changelog

##### Change: remove `N, LS` from `Raft<C, N, LS, _>`

- `Raft<C, ..>`: is a control handle of `RaftCore` and it does not directly
  rely on `N: RaftNetworkFactory` and `LS: RaftLogStorage`.
  Thus these two type should not be part of `Raft`.

  In this commit, we remove `N, LS` from `Raft<C, N, LS, SM>`,
  `RaftInner<C, N, LS>` and `RaftMsg<C, N, LS>`.
  Type `N, LS` now is only used by `Raft::new()` which needs these two
  types to create `RaftCore`.

- `Raft::external_request()`: Another change is the signature of the
  `Fn` passed to `Raft::external_request()` changes from
  `FnOnce(&RaftState, &mut LS, &mut N)` to `FnOnce(&RaftState)`.

- Fix: the `FnOnce` passed to `Raft::external_request()` should always
  be `Send`, unoptionally. Because it is used to send from `Raft` to
  `RaftCore`.

- Fix: #939

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/940)
<!-- Reviewable:end -->
