### PR TITLE
Chore: internal refactor replication::Data

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -82,6 +82,7 @@ use crate::storage::LogFlushed;
 use crate::storage::RaftLogReaderExt;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
+use crate::type_config::alias::InstantOf;
 use crate::utime::UTime;
 use crate::AsyncRuntime;
 use crate::ChangeMembers;
@@ -1419,7 +1420,7 @@ where
         &mut self,
         target: C::NodeId,
         id: u64,
-        result: Result<UTime<ReplicationResult<C::NodeId>, <C::AsyncRuntime as AsyncRuntime>::Instant>, String>,
+        result: Result<UTime<ReplicationResult<C::NodeId>, InstantOf<C>>, String>,
     ) {
         tracing::debug!(
             target = display(target),

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -352,30 +352,7 @@ where
                 Ok(None)
             }
             AppendEntriesResponse::PartialSuccess(matching) => {
-                debug_assert!(
-                    matching <= log_id_range.last_log_id,
-                    "matching ({}) should be <= last_log_id ({})",
-                    matching.display(),
-                    log_id_range.last_log_id.display()
-                );
-                debug_assert!(
-                    matching.index() <= log_id_range.last_log_id.index(),
-                    "matching.index ({}) should be <= last_log_id.index ({})",
-                    matching.index().display(),
-                    log_id_range.last_log_id.index().display()
-                );
-                debug_assert!(
-                    matching >= log_id_range.prev_log_id,
-                    "matching ({}) should be >= prev_log_id ({})",
-                    matching.display(),
-                    log_id_range.prev_log_id.display()
-                );
-                debug_assert!(
-                    matching.index() >= log_id_range.prev_log_id.index(),
-                    "matching.index ({}) should be >= prev_log_id.index ({})",
-                    matching.index().display(),
-                    log_id_range.prev_log_id.index().display()
-                );
+                Self::debug_assert_partial_success(&log_id_range, &matching);
 
                 self.update_matching(request_id, leader_time, matching);
                 if matching < log_id_range.last_log_id {
@@ -763,6 +740,34 @@ where
             // Check raft channel to ensure we are staying up-to-date, then loop.
             self.try_drain_events().await?;
         }
+    }
+
+    /// Check if partial success result(`matching`) is valid for a given log range to send.
+    fn debug_assert_partial_success(to_send: &LogIdRange<C::NodeId>, matching: &Option<LogId<C::LogId>>) {
+        debug_assert!(
+            matching <= to_send.last_log_id,
+            "matching ({}) should be <= last_log_id ({})",
+            matching.display(),
+            to_send.last_log_id.display()
+        );
+        debug_assert!(
+            matching.index() <= to_send.last_log_id.index(),
+            "matching.index ({}) should be <= last_log_id.index ({})",
+            matching.index().display(),
+            to_send.last_log_id.index().display()
+        );
+        debug_assert!(
+            matching >= to_send.prev_log_id,
+            "matching ({}) should be >= prev_log_id ({})",
+            matching.display(),
+            to_send.prev_log_id.display()
+        );
+        debug_assert!(
+            matching.index() >= to_send.prev_log_id.index(),
+            "matching.index ({}) should be >= prev_log_id.index ({})",
+            matching.index().display(),
+            to_send.prev_log_id.index().display()
+        );
     }
 }
 


### PR DESCRIPTION

## Changelog

##### Chore: internal refactor replication::Data

Make `replication::Data` a enum, and enable using its variants `Logs(l)`
and `Snapshot(s)` directly.


##### Chore: simplify usage of C::AsyncRuntime in replication/mod.rs


##### Chore: move partial success checking to separate function

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/944)
<!-- Reviewable:end -->
