### PR TITLE
Refactor: pre-hook callback within tests/fixtures

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,6 +24,7 @@ openraft-memstore  = { path="../memstore" }
 anyerror           = { workspace = true }
 anyhow             = { workspace = true }
 async-entry        = { workspace = true }
+derive_more        = { workspace = true }
 futures            = { workspace = true }
 lazy_static        = { workspace = true }
 maplit             = { workspace = true }

--- a/tests/tests/replication/t50_append_entries_backoff.rs
+++ b/tests/tests/replication/t50_append_entries_backoff.rs
@@ -35,17 +35,14 @@ async fn append_entries_backoff() -> Result<()> {
 
     tracing::info!(log_index, "--- set node 2 to unreachable, and write 10 entries");
     {
-        router.set_rpc_pre_hook(
-            RPCTypes::AppendEntries,
-            Some(Box::new(|_router, _t, _id, target| {
-                if target == 2 {
-                    let any_err = AnyError::error("unreachable");
-                    Err(RPCError::Unreachable(Unreachable::new(&any_err)))
-                } else {
-                    Ok(())
-                }
-            })),
-        );
+        router.set_rpc_pre_hook(RPCTypes::AppendEntries, |_router, _req, _id, target| {
+            if target == 2 {
+                let any_err = AnyError::error("unreachable");
+                Err(RPCError::Unreachable(Unreachable::new(&any_err)))
+            } else {
+                Ok(())
+            }
+        });
         // The above is equivalent to the following:
         // router.set_unreachable(2, true);
 


### PR DESCRIPTION

## Changelog

##### Refactor: pre-hook callback within tests/fixtures

Simplify the API to set pre-hook callback.

The first argument is changed from `RPCTypes` to real RPC data, enabling
the hook callback to interact directly with the RPC request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/949)
<!-- Reviewable:end -->
