### PR TITLE
Chore: make case append_to_log more rigorous

### DIFF
--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -936,13 +936,13 @@ where
 
         store.purge(log_id_0(0, 0)).await?;
 
-        append(&mut store, [blank_ent_0::<C>(2, 10)]).await?;
+        append(&mut store, [blank_ent_0::<C>(2, 11)]).await?;
 
         let l = store.try_get_log_entries(0..).await?.len();
         let last = store.try_get_log_entries(0..).await?.into_iter().last().unwrap();
 
-        assert_eq!(l, 10, "expected 10 entries to exist in the log");
-        assert_eq!(*last.get_log_id(), log_id_0(2, 10), "unexpected log id");
+        assert_eq!(l, 11, "expected 11 entries to exist in the log");
+        assert_eq!(*last.get_log_id(), log_id_0(2, 11), "unexpected log id");
         Ok(())
     }
 


### PR DESCRIPTION
In case append_to_log, two entries with index = 10 were appended to log, purging will fail if we choose stream-like log store instead of map-like, and it will never happen in the real world.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/952)
<!-- Reviewable:end -->
