### PR TITLE
Feature: add `Wait::voter_ids()` and deprecate `Wait::members()`

### DIFF
--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -99,7 +99,7 @@ async fn test_wait() -> anyhow::Result<()> {
             let rst = tx.send(update);
             assert!(rst.is_ok());
         });
-        let got = w.members(btreeset![1, 2], "members").await?;
+        let got = w.voter_ids([1, 2], "members").await?;
         h.await?;
 
         assert_eq!(

--- a/tests/tests/append_entries/t11_append_updates_membership.rs
+++ b/tests/tests/append_entries/t11_append_updates_membership.rs
@@ -68,7 +68,7 @@ async fn append_updates_membership() -> Result<()> {
         assert!(resp.is_success());
         assert!(!resp.is_conflict());
 
-        r0.wait(timeout()).members(btreeset! {1,2,3,4}, "append-entries update membership").await?;
+        r0.wait(timeout()).voter_ids([1, 2, 3, 4], "append-entries update membership").await?;
     }
 
     tracing::info!("--- delete inconsistent logs update membership");
@@ -84,7 +84,7 @@ async fn append_updates_membership() -> Result<()> {
         assert!(resp.is_success());
         assert!(!resp.is_conflict());
 
-        r0.wait(timeout()).members(btreeset! {1,2}, "deleting inconsistent logs updates membership").await?;
+        r0.wait(timeout()).voter_ids([1, 2], "deleting inconsistent logs updates membership").await?;
     }
 
     Ok(())

--- a/tests/tests/snapshot_streaming/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
+++ b/tests/tests/snapshot_streaming/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
@@ -52,7 +52,7 @@ async fn snapshot_to_unreachable_node_should_not_block() -> Result<()> {
     );
     {
         n0.change_membership(btreeset! {0}, true).await?;
-        n0.wait(timeout()).members(btreeset! {0}, "change membership to {{0}}").await?;
+        n0.wait(timeout()).voter_ids([0], "change membership to {{0}}").await?;
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Feature: add `Wait::voter_ids()` and deprecate `Wait::members()`

Membership in Openraft now contains voters and learners, a simple
`members` is not clear about what to assert.
In this PR we add a new method `Wait::voter_ids()` to wait for
membership to become containing the expected voter ids and deprecated
`Wait::members()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/961)
<!-- Reviewable:end -->
