### PR TITLE
Feature: add `Raft::ensure_linearizable()` to ensure linearizable read

### DIFF
--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -39,7 +39,7 @@ pub async fn read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl R
 
 #[post("/consistent_read")]
 pub async fn consistent_read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl Responder> {
-    let ret = app.raft.is_leader().await;
+    let ret = app.raft.ensure_linearizable().await;
 
     match ret {
         Ok(_) => {

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -43,7 +43,7 @@ async fn read(mut req: Request<Arc<App>>) -> tide::Result {
 }
 
 async fn consistent_read(mut req: Request<Arc<App>>) -> tide::Result {
-    let ret = req.state().raft.is_leader().await;
+    let ret = req.state().raft.ensure_linearizable().await;
 
     match ret {
         Ok(_) => {

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -74,8 +74,14 @@ pub type MemNodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for `MemStore`.
-    pub TypeConfig: D = ClientRequest, R = ClientResponse, NodeId = MemNodeId, Node = (),
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = TokioRuntime
+    pub TypeConfig:
+        D = ClientRequest,
+        R = ClientResponse,
+        NodeId = MemNodeId,
+        Node = (),
+        Entry = Entry<TypeConfig>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime
 );
 
 /// The application snapshot type which the `MemStore` works with.

--- a/openraft/src/docs/protocol/mod.rs
+++ b/openraft/src/docs/protocol/mod.rs
@@ -1,5 +1,9 @@
 //! The protocol used by Openraft to replicate data.
 
+pub mod read {
+    #![doc = include_str!("read.md")]
+}
+
 pub mod replication {
     #![doc = include_str!("replication.md")]
 

--- a/openraft/src/docs/protocol/read.md
+++ b/openraft/src/docs/protocol/read.md
@@ -1,0 +1,74 @@
+# Read Operations
+
+Read operations within a Raft cluster are guaranteed to be linearizable.
+
+This ensures that for any two read operations,
+`A` and `B`, if `B` occurs after `A` by wall clock time,
+then `B` will observe the same state as `A` or any subsequent state changes made by `A`,
+regardless of which node within the cluster each operation is performed on.
+
+In Openraft `read_index` is the same as the `read_index` in the original raft paper.
+Openraft also use `read_log_id` instead of `read_index`.
+
+## Ensuring linearizability
+
+To ensure linearizability, read operations must perform a [`get_read_log_id()`] operation on the leader before proceeding.
+
+This method confirms that this node is the leader at the time of invocation by sending heartbeats to a quorum of followers, and returns `(read_log_id, last_applied_log_id)`:
+- `read_log_id` represents the log id up to which the state machine should apply to ensure a
+  linearizable read,
+- `last_applied_log_id` is the last applied log id.
+
+The caller then wait for `last_applied_log_id` to catch up `read_log_id`, which can be done by subscribing to [`Raft::metrics`],
+and at last, proceed with the state machine read.
+
+The above steps are encapsulated in the [`ensure_linearizable()`] method.
+
+## Examples
+
+```ignore
+my_raft.ensure_linearizable().await?;
+proceed_with_state_machine_read();
+```
+
+The above snippet does the same as the following:
+
+```ignore
+let (read_log_id, applied) = self.get_read_log_id().await?;
+
+if read_log_id.index() > applied.index() {
+    self.wait(None).applied_index_at_least(read_log_id.index(), "").await?
+}
+
+proceed_with_state_machine_read();
+```
+
+The comparison `read_log_id > applied_log_id` would also be valid in the above example.
+
+
+## Ensuring Linearizability with `read_log_id`
+
+The `read_log_id` is determined as the maximum of the `last_committed_log_id` and the
+log id of the first log entry in the current leader's term (the "blank" log entry).
+
+Assumes another earlier read operation reads from state machine with up to log id `A`.
+Since the leader has all committed entries up to its initial blank log entry,
+we have: `read_log_id >= A`.
+
+When the `last_applied_log_id` meets or exceeds `read_log_id`,
+the state machine contains all state upto `A`. Therefore, a linearizable read is assured
+when `last_applied_log_id >= read_log_id`.
+
+
+## Ensuring Linearizability with `read_index`
+
+And it is also legal by comparing `last_applied_log_id.index() >= read_log_id.index()`
+due to the guarantee that committed logs will not be lost.
+
+Since a previous read could only have observed committed logs, and `read_log_id.index()` is
+at least as large as any committed log, once `last_applied_log_id.index() >= read_log_id.index()`, the state machine is assured to reflect all entries seen by any past read.
+
+
+[`ensure_linearizable()`]: crate::Raft::ensure_linearizable
+[`get_read_log_id()`]: crate::Raft::get_read_log_id
+[`Raft::metrics`]: crate::Raft::metrics

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -269,7 +269,6 @@ impl<NID: NodeId> LogIdList<NID> {
     /// Get the log id at the specified index.
     ///
     /// It will return `last_purged_log_id` if index is at the last purged index.
-    #[allow(dead_code)]
     pub(crate) fn get(&self, index: u64) -> Option<LogId<NID>> {
         let res = self.key_log_ids.binary_search_by(|log_id| log_id.index.cmp(&index));
 
@@ -285,17 +284,34 @@ impl<NID: NodeId> LogIdList<NID> {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn first(&self) -> Option<&LogId<NID>> {
         self.key_log_ids.first()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn last(&self) -> Option<&LogId<NID>> {
         self.key_log_ids.last()
     }
 
     pub(crate) fn key_log_ids(&self) -> &[LogId<NID>] {
         &self.key_log_ids
+    }
+
+    /// Returns key log ids appended by the last leader.
+    ///
+    /// Note that the 0-th log does not belong to any leader(but a membership log to initialize a
+    /// cluster) but this method does not differentiate between them.
+    pub(crate) fn by_last_leader(&self) -> &[LogId<NID>] {
+        let ks = &self.key_log_ids;
+        let l = ks.len();
+        if l < 2 {
+            return ks;
+        }
+
+        // There are at most two(adjacent) key log ids with the same leader_id
+        if ks[l - 1].leader_id() == ks[l - 2].leader_id() {
+            &ks[l - 2..]
+        } else {
+            &ks[l - 1..]
+        }
     }
 }

--- a/openraft/src/engine/tests/log_id_list_test.rs
+++ b/openraft/src/engine/tests/log_id_list_test.rs
@@ -1,4 +1,5 @@
 use crate::engine::LogIdList;
+use crate::testing::log_id;
 
 #[test]
 fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
@@ -350,4 +351,28 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
 
     Ok(())
 }
-use crate::testing::log_id;
+
+#[test]
+fn test_log_id_list_by_last_leader() -> anyhow::Result<()> {
+    // len == 0
+    let ids = LogIdList::<u64>::default();
+    assert_eq!(ids.by_last_leader(), &[]);
+
+    // len == 1
+    let ids = LogIdList::<u64>::new([log_id(1, 1, 1)]);
+    assert_eq!(&[log_id(1, 1, 1)], ids.by_last_leader());
+
+    // len == 2, the last leader has only one log
+    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
+    assert_eq!(&[log_id(3, 1, 3)], ids.by_last_leader());
+
+    // len == 2, the last leader has two logs
+    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
+    assert_eq!(&[log_id(1, 1, 1), log_id(1, 1, 3)], ids.by_last_leader());
+
+    // len > 2, the last leader has only more than one logs
+    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
+    assert_eq!(&[log_id(7, 1, 8), log_id(7, 1, 10)], ids.by_last_leader());
+
+    Ok(())
+}

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -32,6 +32,7 @@ mod tests {
     mod accepted_test;
     mod forward_to_leader_test;
     mod log_state_reader_test;
+    mod read_log_id_test;
     mod validate_test;
 }
 
@@ -40,6 +41,7 @@ pub(crate) use log_state_reader::LogStateReader;
 pub use membership_state::MembershipState;
 pub(crate) use vote_state_reader::VoteStateReader;
 
+use crate::display_ext::DisplayOptionExt;
 pub(crate) use crate::raft_state::snapshot_streaming::StreamingState;
 
 /// A struct used to represent the raft state which a Raft node needs.
@@ -217,6 +219,29 @@ where
     /// Return the last updated time of the vote.
     pub fn vote_last_modified(&self) -> Option<I> {
         self.vote.utime()
+    }
+
+    /// Get the log id for a linearizable read.
+    ///
+    /// See: [Read Operation](crate::docs::protocol::read)
+    pub(crate) fn get_read_log_id(&self) -> Option<&LogId<NID>> {
+        // Get the first known log id appended by the last leader.
+        // - This log may not be committed.
+        // - The leader blank log may have been purged and this could be the last purged log id.
+        // - There must be such an entry, which is guaranteed by `Engine::establish_leader()`.
+        let leader_first = self.log_ids.by_last_leader().first();
+
+        debug_assert_eq!(
+            leader_first.map(|log_id| *log_id.committed_leader_id()),
+            self.vote_ref().committed_leader_id(),
+            "leader_first must belong to a leader of current vote: leader_first: {}, vote.committed_leader_id: {}",
+            leader_first.map(|log_id| log_id.committed_leader_id()).display(),
+            self.vote_ref().committed_leader_id().display(),
+        );
+
+        let committed = self.committed();
+
+        std::cmp::max(leader_first, committed)
     }
 
     /// Return the accepted last log id of the current leader.

--- a/openraft/src/raft_state/tests/read_log_id_test.rs
+++ b/openraft/src/raft_state/tests/read_log_id_test.rs
@@ -1,0 +1,40 @@
+use crate::engine::LogIdList;
+use crate::utime::UTime;
+use crate::CommittedLeaderId;
+use crate::LogId;
+use crate::RaftState;
+use crate::TokioInstant;
+use crate::Vote;
+
+fn log_id(term: u64, index: u64) -> LogId<u64> {
+    LogId::<u64> {
+        leader_id: CommittedLeaderId::new(term, 0),
+        index,
+    }
+}
+
+#[test]
+fn test_raft_state_get_read_log_id() -> anyhow::Result<()> {
+    let log_ids = || LogIdList::new(vec![log_id(1, 1), log_id(3, 4), log_id(3, 6)]);
+    {
+        let rs = RaftState::<u64, (), TokioInstant> {
+            vote: UTime::without_utime(Vote::new_committed(3, 0)),
+            log_ids: log_ids(),
+            committed: Some(log_id(2, 1)),
+            ..Default::default()
+        };
+
+        assert_eq!(Some(log_id(3, 4)), rs.get_read_log_id().copied());
+    }
+
+    {
+        let rs = RaftState::<u64, (), TokioInstant> {
+            vote: UTime::without_utime(Vote::new_committed(3, 0)),
+            log_ids: log_ids(),
+            committed: Some(log_id(3, 5)),
+            ..Default::default()
+        };
+        assert_eq!(Some(log_id(3, 5)), rs.get_read_log_id().copied());
+    }
+    Ok(())
+}

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -86,4 +86,10 @@ pub(crate) mod alias {
     pub(crate) type InstantOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Instant;
     pub(crate) type TimeoutErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::TimeoutError;
     pub(crate) type TimeoutOf<C, R, F> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Timeout<R, F>;
+
+    // Usually used types
+    pub(crate) type LogIdOf<C> = crate::LogId<NodeIdOf<C>>;
+    pub(crate) type VoteOf<C> = crate::Vote<NodeIdOf<C>>;
+    pub(crate) type LeaderIdOf<C> = crate::LeaderId<NodeIdOf<C>>;
+    pub(crate) type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<NodeIdOf<C>>;
 }

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -1,10 +1,17 @@
 use std::sync::Arc;
+use std::time::Duration;
 
+use anyerror::AnyError;
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::error::NetworkError;
+use openraft::error::RPCError;
 use openraft::Config;
+use openraft::LogIdOptionExt;
+use openraft::RPCTypes;
 
 use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RPCRequest;
 use crate::fixtures::RaftRouter;
 
 /// Client read tests.
@@ -12,8 +19,8 @@ use crate::fixtures::RaftRouter;
 /// What does this test do?
 ///
 /// - create a stable 3-node cluster.
-/// - call the is_leader interface on the leader, and assert success.
-/// - call the is_leader interface on the followers, and assert failure.
+/// - call the ensure_linearizable interface on the leader, and assert success.
+/// - call the ensure_linearizable interface on the followers, and assert failure.
 #[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
 async fn client_reads() -> Result<()> {
     let config = Arc::new(
@@ -25,35 +32,155 @@ async fn client_reads() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    // This test is sensitive to network delay.
+    // This test is sensitive to network delay. Thus skip the network delay test
     router.network_send_delay(0);
 
     tracing::info!("--- initializing cluster");
     let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
-    // Get the ID of the leader, and assert that is_leader succeeds.
+    // Get the ID of the leader, and assert that ensure_linearizable succeeds.
     let leader = router.leader().expect("leader not found");
     assert_eq!(leader, 0, "expected leader to be node 0, got {}", leader);
     router
-        .is_leader(leader)
+        .ensure_linearizable(leader)
         .await
-        .unwrap_or_else(|_| panic!("expected is_leader to succeed for cluster leader {}", leader));
+        .unwrap_or_else(|_| panic!("ensure_linearizable to succeed for cluster leader {}", leader));
 
-    router.is_leader(1).await.expect_err("expected is_leader on follower node 1 to fail");
-    router.is_leader(2).await.expect_err("expected is_leader on follower node 2 to fail");
+    router.ensure_linearizable(1).await.expect_err("ensure_linearizable on follower node 1 to fail");
+    router.ensure_linearizable(2).await.expect_err("ensure_linearizable on follower node 2 to fail");
 
-    tracing::info!(log_index, "--- isolate node 1 then is_leader should work");
+    tracing::info!(log_index, "--- isolate node 1 then ensure_linearizable should work");
 
     router.set_network_error(1, true);
-    router.is_leader(leader).await?;
+    router.ensure_linearizable(leader).await?;
 
-    tracing::info!(log_index, "--- isolate node 2 then is_leader should fail");
+    tracing::info!(log_index, "--- isolate node 2 then ensure_linearizable should fail");
 
     router.set_network_error(2, true);
-    let rst = router.is_leader(leader).await;
-    tracing::debug!(?rst, "is_leader with majority down");
+    let rst = router.ensure_linearizable(leader).await;
+    tracing::debug!(?rst, "ensure_linearizable with majority down");
 
     assert!(rst.is_err());
 
     Ok(())
+}
+
+/// - A leader that has not yet committed any log entries returns leader initialization log id(blank
+///   log id).
+/// - Return the last committed log id if the leader has committed any log entries.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn get_read_log_id() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            heartbeat_interval: 100,
+            election_timeout_min: 101,
+            election_timeout_max: 102,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
+
+    // Blocks append-entries to node 0, but let heartbeat pass.
+    let block_to_n0 = |_router: &_, req, _id, target| {
+        if target == 0 {
+            match req {
+                RPCRequest::AppendEntries(a) => {
+                    // Heartbeat is not blocked.
+                    if a.entries.is_empty() {
+                        return Ok(());
+                    }
+                }
+                _ => {
+                    unreachable!();
+                }
+            }
+
+            // Block append-entries to block commit.
+            let any_err = AnyError::error("block append-entries to node 0");
+            Err(RPCError::Network(NetworkError::new(&any_err)))
+        } else {
+            Ok(())
+        }
+    };
+
+    tracing::info!("--- block append-entries to node 0");
+    router.set_rpc_pre_hook(RPCTypes::AppendEntries, block_to_n0);
+
+    // Expire current leader
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    tracing::info!("--- let node 1 to become leader, append a blank log");
+    let n1 = router.get_raft_handle(&1).unwrap();
+    n1.trigger().elect().await?;
+
+    tracing::info!(log_index = log_index, "--- node 1 appends blank log but can not commit");
+    {
+        let res = n1.wait(timeout()).applied_index_at_least(Some(log_index + 1), "blank log can not commit").await;
+        assert!(res.is_err());
+    }
+
+    let blank_log_index = log_index + 1;
+
+    tracing::info!("--- get_read_log_id returns blank log id");
+    {
+        let (read_log_id, applied) = n1.get_read_log_id().await?;
+        assert_eq!(
+            read_log_id.index(),
+            Some(blank_log_index),
+            "read-log-id is the blank log"
+        );
+        assert_eq!(applied.index(), Some(log_index));
+    }
+
+    tracing::info!("--- stop blocking, write another log, get_read_log_id returns last log id");
+    {
+        router.rpc_pre_hook(RPCTypes::AppendEntries, None);
+
+        n1.wait(timeout()).applied_index(Some(log_index + 1), "commit blank log").await?;
+        log_index += 1;
+
+        log_index += router.client_request_many(1, "foo", 1).await?;
+
+        let (read_log_id, applied) = n1.get_read_log_id().await?;
+        assert_eq!(read_log_id.index(), Some(log_index), "read-log-id is the committed log");
+        assert_eq!(applied.index(), Some(log_index));
+    }
+
+    let last_committed = log_index;
+
+    tracing::info!(
+        "--- block append again, write 1 log that wont commit, get_read_log_id returns last committed log id"
+    );
+    {
+        router.set_rpc_pre_hook(RPCTypes::AppendEntries, block_to_n0);
+
+        let r = router.clone();
+        tokio::spawn(async move {
+            // This will block for ever
+            let _x = r.client_request_many(1, "foo", 1).await;
+        });
+
+        log_index += 1;
+        n1.wait(timeout()).log_index(Some(log_index), "log appended, but not committed").await?;
+
+        let (read_log_id, _applied) = n1.get_read_log_id().await?;
+        assert_eq!(
+            read_log_id.index(),
+            Some(last_committed),
+            "read-log-id is the committed log"
+        );
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(200))
 }

--- a/tests/tests/membership/t10_single_node.rs
+++ b/tests/tests/membership/t10_single_node.rs
@@ -48,7 +48,7 @@ async fn single_node() -> Result<()> {
         .await?;
 
     // Read some data from the single node cluster.
-    router.is_leader(0).await?;
+    router.ensure_linearizable(0).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Changelog

##### Feature: add `Raft::ensure_linearizable()` to ensure linearizable read

The `Raft::is_leader()` method does not fully ensure linearizable read
operations and is deprecated in this version. Instead, applications
should use the `Raft::ensure_linearizable()` method to guarantee
linearizability.

Under the hood, `Raft::ensure_linearizable()` obtains a `ReadIndex` from
`RaftCore` if it remains the leader, and blocks until the state
machine applies up to the `ReadIndex`. This process ensures that the
application observes all state visible to a preceding read operation.

- Fix: #965

Upgrade tip:

Replace `Raft::is_leader()` with `Raft::ensure_linearizable()`.

This PR implements the very basic requirement proposed in:
- #262

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/964)
<!-- Reviewable:end -->
