### PR TITLE
Feature: add `Wait::eq()` and `ge()` to await a metics

### DIFF
--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -1,0 +1,83 @@
+use std::cmp::Ordering;
+
+use crate::metrics::metric_display::MetricDisplay;
+use crate::LogId;
+use crate::LogIdOptionExt;
+use crate::Node;
+use crate::NodeId;
+use crate::RaftMetrics;
+use crate::Vote;
+
+/// A metric entry of a Raft node.
+///
+/// This is used to specify which metric to observe.
+#[derive(Debug)]
+pub enum Metric<NID>
+where NID: NodeId
+{
+    Term(u64),
+    Vote(Vote<NID>),
+    LastLogIndex(Option<u64>),
+    Applied(Option<LogId<NID>>),
+    AppliedIndex(Option<u64>),
+    Snapshot(Option<LogId<NID>>),
+    Purged(Option<LogId<NID>>),
+}
+
+impl<NID> Metric<NID>
+where NID: NodeId
+{
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Metric::Term(_) => "term",
+            Metric::Vote(_) => "vote",
+            Metric::LastLogIndex(_) => "last_log_index",
+            Metric::Applied(_) => "applied",
+            Metric::AppliedIndex(_) => "applied_index",
+            Metric::Snapshot(_) => "snapshot",
+            Metric::Purged(_) => "purged",
+        }
+    }
+
+    pub(crate) fn value(&self) -> MetricDisplay<'_, NID> {
+        MetricDisplay { metric: self }
+    }
+}
+
+/// Metric can be compared with RaftMetrics by comparing the corresponding field of RaftMetrics.
+impl<NID, N> PartialEq<Metric<NID>> for RaftMetrics<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn eq(&self, other: &Metric<NID>) -> bool {
+        match other {
+            Metric::Term(v) => self.current_term == *v,
+            Metric::Vote(v) => &self.vote == v,
+            Metric::LastLogIndex(v) => self.last_log_index == *v,
+            Metric::Applied(v) => &self.last_applied == v,
+            Metric::AppliedIndex(v) => self.last_applied.index() == *v,
+            Metric::Snapshot(v) => &self.snapshot == v,
+            Metric::Purged(v) => &self.purged == v,
+        }
+    }
+}
+
+/// Metric can be compared with RaftMetrics by comparing the corresponding field of RaftMetrics.
+impl<NID, N> PartialOrd<Metric<NID>> for RaftMetrics<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    fn partial_cmp(&self, other: &Metric<NID>) -> Option<Ordering> {
+        match other {
+            Metric::Term(v) => Some(self.current_term.cmp(v)),
+            Metric::Vote(v) => self.vote.partial_cmp(v),
+            Metric::LastLogIndex(v) => Some(self.last_log_index.cmp(v)),
+            Metric::Applied(v) => Some(self.last_applied.cmp(v)),
+            Metric::AppliedIndex(v) => Some(self.last_applied.index().cmp(v)),
+            Metric::Snapshot(v) => Some(self.snapshot.cmp(v)),
+            Metric::Purged(v) => Some(self.purged.cmp(v)),
+        }
+    }
+}

--- a/openraft/src/metrics/metric_display.rs
+++ b/openraft/src/metrics/metric_display.rs
@@ -1,0 +1,29 @@
+use std::fmt;
+use std::fmt::Formatter;
+
+use crate::display_ext::DisplayOption;
+use crate::metrics::Metric;
+use crate::NodeId;
+
+/// Display the value of a metric.
+pub(crate) struct MetricDisplay<'a, NID>
+where NID: NodeId
+{
+    pub(crate) metric: &'a Metric<NID>,
+}
+
+impl<'a, NID> fmt::Display for MetricDisplay<'a, NID>
+where NID: NodeId
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.metric {
+            Metric::Term(v) => write!(f, "{}", v),
+            Metric::Vote(v) => write!(f, "{}", v),
+            Metric::LastLogIndex(v) => write!(f, "{}", DisplayOption(v)),
+            Metric::Applied(v) => write!(f, "{}", DisplayOption(v)),
+            Metric::AppliedIndex(v) => write!(f, "{}", DisplayOption(v)),
+            Metric::Snapshot(v) => write!(f, "{}", DisplayOption(v)),
+            Metric::Purged(v) => write!(f, "{}", DisplayOption(v)),
+        }
+    }
+}

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -27,16 +27,21 @@
 //! not every change of the state.
 //! Because internally, `watch::channel()` only stores one last state.
 
+mod metric;
 mod raft_metrics;
 mod wait;
 
+mod metric_display;
+mod wait_condition;
 #[cfg(test)] mod wait_test;
 
 use std::collections::BTreeMap;
 
+pub use metric::Metric;
 pub use raft_metrics::RaftMetrics;
 pub use wait::Wait;
 pub use wait::WaitError;
+pub(crate) use wait_condition::Condition;
 
 use crate::LogId;
 

--- a/openraft/src/metrics/wait_condition.rs
+++ b/openraft/src/metrics/wait_condition.rs
@@ -1,0 +1,57 @@
+use std::fmt;
+
+use crate::metrics::metric_display::MetricDisplay;
+use crate::metrics::Metric;
+use crate::NodeId;
+
+/// A condition that the application wait for.
+#[derive(Debug)]
+pub(crate) enum Condition<NID>
+where NID: NodeId
+{
+    GE(Metric<NID>),
+    EQ(Metric<NID>),
+}
+
+impl<NID> Condition<NID>
+where NID: NodeId
+{
+    /// Build a new condition which the application will await to meet or exceed.
+    pub(crate) fn ge(v: Metric<NID>) -> Self {
+        Self::GE(v)
+    }
+
+    /// Build a new condition which the application will await to meet.
+    pub(crate) fn eq(v: Metric<NID>) -> Self {
+        Self::EQ(v)
+    }
+
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Condition::GE(v) => v.name(),
+            Condition::EQ(v) => v.name(),
+        }
+    }
+
+    pub(crate) fn op(&self) -> &'static str {
+        match self {
+            Condition::GE(_) => ">=",
+            Condition::EQ(_) => "==",
+        }
+    }
+
+    pub(crate) fn value(&self) -> MetricDisplay<'_, NID> {
+        match self {
+            Condition::GE(v) => v.value(),
+            Condition::EQ(v) => v.value(),
+        }
+    }
+}
+
+impl<NID> fmt::Display for Condition<NID>
+where NID: NodeId
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}{}", self.name(), self.op(), self.value())
+    }
+}


### PR DESCRIPTION

## Changelog

##### Feature: add `Wait::eq()` and `ge()` to await a metics

`Wait` does not need many method for each metric. In this commit, it
provides method `eq()` and `ge()` to specify waiting condition in a
general way. The metric to await is specified by `Metric` as the first
argument.

```rust
my_raft.wait(None).ge(Metric::Term(2), "").await?
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/967)
<!-- Reviewable:end -->
