### PR TITLE
Refactor: add defensive check to state machine replies

### DIFF
--- a/openraft/src/core/sm/mod.rs
+++ b/openraft/src/core/sm/mod.rs
@@ -191,7 +191,17 @@ where
             .map(|e| ApplyingEntry::new(*e.get_log_id(), e.get_membership().cloned()))
             .collect::<Vec<_>>();
 
+        let n_entries = applying_entries.len();
+
         let apply_results = self.state_machine.apply(entries).await?;
+
+        let n_replies = apply_results.len();
+
+        debug_assert_eq!(
+            n_entries, n_replies,
+            "n_entries: {} should equal n_replies: {}",
+            n_entries, n_replies
+        );
 
         let resp = ApplyResult {
             since,


### PR DESCRIPTION

## Changelog

##### Refactor: add defensive check to state machine replies

When implementing the `RaftStateMachine::apply` method, if the user
fails to return a number of replies that corresponds to the number of
input entries, OpenRaft will panic, often without providing helpful
diagnostic information.

To address this issue, this commit introduces an assertion immediately
after the `apply()` method returns its replies. This assertion checks
that the quantity of replies is equal to the number of input entries,
 ensuring consistency.

Additionally, new test cases focusing on the `apply()` method have been
added into the test suites provided by OpenRaft, enhancing the
robustness of the implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/972)
<!-- Reviewable:end -->
