### PR TITLE
Fix: Split serde bound for `RaftError` into serialize and deserialize

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -27,7 +27,8 @@ use crate::Vote;
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(bound = "E:serde::Serialize + for <'d> serde::Deserialize<'d>")
+    serde(bound(serialize = "E: serde::Serialize")),
+    serde(bound(deserialize = "E: for <'d> serde::Deserialize<'d>"))
 )]
 pub enum RaftError<NID, E = Infallible>
 where NID: NodeId


### PR DESCRIPTION
While implementing a struct that has a generic `RaftError<E>` as a field, I ran into some issues with trait bounds because `RaftError` does not make a distinction between the serde `Serialize` and `Deserialize` bounds. The consequence is that any `impl` block that requires my struct to be `Serialize` will require `E` to *both* be `Serialize` and `DeserializeOwned`, which is not necessary. This PR splits the two bounds. 

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/991)
<!-- Reviewable:end -->
