### PR TITLE
Feature: Add random number generator to `AsyncRuntime`

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -6,11 +6,11 @@ use std::time::Duration;
 
 use anyerror::AnyError;
 use clap::Parser;
-use rand::thread_rng;
 use rand::Rng;
 
 use crate::config::error::ConfigError;
 use crate::raft_state::LogStateReader;
+use crate::AsyncRuntime;
 use crate::LogIdOptionExt;
 use crate::NodeId;
 
@@ -248,8 +248,8 @@ impl Default for Config {
 
 impl Config {
     /// Generate a new random election timeout within the configured min & max.
-    pub fn new_rand_election_timeout(&self) -> u64 {
-        thread_rng().gen_range(self.election_timeout_min..self.election_timeout_max)
+    pub fn new_rand_election_timeout<RT: AsyncRuntime>(&self) -> u64 {
+        RT::thread_rng().gen_range(self.election_timeout_min..self.election_timeout_max)
     }
 
     /// Get the timeout for sending and installing the last snapshot segment.

--- a/openraft/src/engine/engine_config.rs
+++ b/openraft/src/engine/engine_config.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use crate::engine::time_state;
+use crate::AsyncRuntime;
 use crate::Config;
 use crate::NodeId;
 use crate::SnapshotPolicy;
@@ -41,8 +42,8 @@ impl<NID: NodeId> Default for EngineConfig<NID> {
 }
 
 impl<NID: NodeId> EngineConfig<NID> {
-    pub(crate) fn new(id: NID, config: &Config) -> Self {
-        let election_timeout = Duration::from_millis(config.new_rand_election_timeout());
+    pub(crate) fn new<RT: AsyncRuntime>(id: NID, config: &Config) -> Self {
+        let election_timeout = Duration::from_millis(config.new_rand_election_timeout::<RT>());
         Self {
             id,
             snapshot_policy: config.snapshot_policy.clone(),

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -196,7 +196,7 @@ where C: RaftTypeConfig
             cluster = display(&config.cluster_name)
         );
 
-        let eng_config = EngineConfig::new(id, config.as_ref());
+        let eng_config = EngineConfig::new::<C::AsyncRuntime>(id, config.as_ref());
 
         let state = {
             let mut helper = StorageHelper::new(&mut log_store, &mut state_machine);


### PR DESCRIPTION
Up to now, the `rand` crate was used directly to generate random numbers for `openraft`. However, this has some drawback when integrating with other async runtimes.

Expose the random number generator via `AsyncRuntime` abstraction and implement it by default via `rand::thread_rng()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/995)
<!-- Reviewable:end -->
