### PR TITLE
Feature: add Raft::get_snapshot() to get the last snapshot from state machine

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1183,6 +1183,13 @@ where
                         self.send_heartbeat("ExternalCommand");
                     }
                     ExternalCommand::Snapshot => self.trigger_snapshot(),
+                    ExternalCommand::GetSnapshot { tx } => {
+                        let cmd = sm::Command::get_snapshot(tx);
+                        let res = self.sm_handle.send(cmd);
+                        if let Err(e) = res {
+                            tracing::error!(error = display(e), "error sending GetSnapshot to sm worker");
+                        }
+                    }
                     ExternalCommand::PurgeLog { upto } => {
                         self.engine.trigger_purge_log(upto);
                     }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1163,7 +1163,7 @@ where
 
                 self.change_membership(changes, retain, tx);
             }
-            RaftMsg::ExternalRequest { req } => {
+            RaftMsg::ExternalCoreRequest { req } => {
                 req(&self.engine.state);
             }
             RaftMsg::ExternalCommand { cmd } => {

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -89,7 +89,7 @@ where C: RaftTypeConfig
         tx: ResultSender<ClientWriteResponse<C>, ClientWriteError<C::NodeId, C::Node>>,
     },
 
-    ExternalRequest {
+    ExternalCoreRequest {
         req: BoxCoreFn<C>,
     },
 
@@ -124,7 +124,7 @@ where C: RaftTypeConfig
             } => {
                 format!("ChangeMembership: members: {:?}, retain: {}", members, retain,)
             }
-            RaftMsg::ExternalRequest { .. } => "External Request".to_string(),
+            RaftMsg::ExternalCoreRequest { .. } => "External Request".to_string(),
             RaftMsg::ExternalCommand { cmd } => {
                 format!("ExternalCommand: {:?}", cmd)
             }

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -26,16 +26,18 @@ use crate::RaftTypeConfig;
 pub(crate) mod external_command;
 
 /// A oneshot TX to send result from `RaftCore` to external caller, e.g. `Raft::append_entries`.
-pub(crate) type ResultSender<T, E> = oneshot::Sender<Result<T, E>>;
+pub(crate) type ResultSender<T, E = Infallible> = oneshot::Sender<Result<T, E>>;
+
+pub(crate) type ResultReceiver<T, E = Infallible> = oneshot::Receiver<Result<T, E>>;
 
 /// TX for Install Snapshot Response
 pub(crate) type InstallSnapshotTx<NID> = ResultSender<InstallSnapshotResponse<NID>, InstallSnapshotError>;
 
 /// TX for Vote Response
-pub(crate) type VoteTx<NID> = ResultSender<VoteResponse<NID>, Infallible>;
+pub(crate) type VoteTx<NID> = ResultSender<VoteResponse<NID>>;
 
 /// TX for Append Entries Response
-pub(crate) type AppendEntriesTx<NID> = ResultSender<AppendEntriesResponse<NID>, Infallible>;
+pub(crate) type AppendEntriesTx<NID> = ResultSender<AppendEntriesResponse<NID>>;
 
 /// TX for Client Write Response
 pub(crate) type ClientWriteTx<C> = ResultSender<ClientWriteResponse<C>, ClientWriteError<NodeIdOf<C>, NodeOf<C>>>;
@@ -94,7 +96,7 @@ where C: RaftTypeConfig
     },
 
     ExternalCommand {
-        cmd: ExternalCommand,
+        cmd: ExternalCommand<C>,
     },
 }
 

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -1,8 +1,7 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use tokio::sync::oneshot;
-
+use crate::core::raft_msg::ResultSender;
 use crate::display_ext::DisplaySlice;
 use crate::log_id::RaftLogId;
 use crate::raft::InstallSnapshotRequest;
@@ -56,7 +55,7 @@ where C: RaftTypeConfig
         Command::new(payload)
     }
 
-    pub(crate) fn get_snapshot(tx: oneshot::Sender<Option<Snapshot<C>>>) -> Self {
+    pub(crate) fn get_snapshot(tx: ResultSender<Option<Snapshot<C>>>) -> Self {
         let payload = CommandPayload::GetSnapshot { tx };
         Command::new(payload)
     }
@@ -104,7 +103,7 @@ where C: RaftTypeConfig
     BuildSnapshot,
 
     /// Get the latest built snapshot.
-    GetSnapshot { tx: oneshot::Sender<Option<Snapshot<C>>> },
+    GetSnapshot { tx: ResultSender<Option<Snapshot<C>>> },
 
     /// Receive a chunk of snapshot.
     ///

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -822,7 +822,7 @@ where C: RaftTypeConfig
     pub fn external_request<F>(&self, req: F)
     where F: FnOnce(&RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>) + Send + 'static {
         let req: BoxCoreFn<C> = Box::new(req);
-        let _ignore_error = self.inner.tx_api.send(RaftMsg::ExternalRequest { req });
+        let _ignore_error = self.inner.tx_api.send(RaftMsg::ExternalCoreRequest { req });
     }
 
     /// Get a handle to the metrics channel.

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -37,6 +37,7 @@ use tracing::Level;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
 use crate::core::command_state::CommandState;
+use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::replication_lag;
 use crate::core::sm;
@@ -69,6 +70,7 @@ use crate::LogIdOptionExt;
 use crate::MessageSummary;
 use crate::RaftState;
 pub use crate::RaftTypeConfig;
+use crate::Snapshot;
 use crate::StorageHelper;
 
 /// Define types for a Raft type configuration.
@@ -344,6 +346,19 @@ where C: RaftTypeConfig
 
         let (tx, rx) = oneshot::channel();
         self.call_core(RaftMsg::RequestVote { rpc, tx }, rx).await
+    }
+
+    /// Get the latest snapshot from the state machine.
+    ///
+    /// It returns error only when `RaftCore` fails to serve the request, e.g., Encountering a
+    /// storage error or shutting down.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn get_snapshot(&self) -> Result<Option<Snapshot<C>>, RaftError<C::NodeId>> {
+        tracing::debug!("Raft::get_snapshot()");
+
+        let (tx, rx) = oneshot::channel();
+        let cmd = ExternalCommand::GetSnapshot { tx };
+        self.call_core(RaftMsg::ExternalCommand { cmd }, rx).await
     }
 
     /// Submit an InstallSnapshot RPC to this Raft node.

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -47,7 +47,7 @@ where C: RaftTypeConfig
     /// It returns at once.
     pub(in crate::raft) async fn send_external_command(
         &self,
-        cmd: ExternalCommand,
+        cmd: ExternalCommand<C>,
         cmd_desc: impl fmt::Display + Default,
     ) -> Result<(), Fatal<C::NodeId>> {
         let send_res = self.tx_api.send(RaftMsg::ExternalCommand { cmd });

--- a/openraft/src/replication/request.rs
+++ b/openraft/src/replication/request.rs
@@ -21,7 +21,7 @@ where C: RaftTypeConfig
         Self::Data(Data::new_logs(id, log_id_range))
     }
 
-    pub(crate) fn snapshot(id: Option<u64>, snapshot_rx: oneshot::Receiver<Option<Snapshot<C>>>) -> Self {
+    pub(crate) fn snapshot(id: Option<u64>, snapshot_rx: ResultReceiver<Option<Snapshot<C>>>) -> Self {
         Self::Data(Data::new_snapshot(id, snapshot_rx))
     }
 }
@@ -42,8 +42,7 @@ where C: RaftTypeConfig
     }
 }
 
-use tokio::sync::oneshot;
-
+use crate::core::raft_msg::ResultReceiver;
 use crate::display_ext::DisplayOptionExt;
 use crate::log_id_range::LogIdRange;
 use crate::LogId;
@@ -60,7 +59,7 @@ pub(crate) enum Data<C>
 where C: RaftTypeConfig
 {
     Logs(DataWithId<LogIdRange<C::NodeId>>),
-    Snapshot(DataWithId<oneshot::Receiver<Option<Snapshot<C>>>>),
+    Snapshot(DataWithId<ResultReceiver<Option<Snapshot<C>>>>),
 }
 
 impl<C> fmt::Debug for Data<C>
@@ -111,7 +110,7 @@ where C: RaftTypeConfig
         Self::Logs(DataWithId::new(request_id, log_id_range))
     }
 
-    pub(crate) fn new_snapshot(request_id: Option<u64>, snapshot_rx: oneshot::Receiver<Option<Snapshot<C>>>) -> Self {
+    pub(crate) fn new_snapshot(request_id: Option<u64>, snapshot_rx: ResultReceiver<Option<Snapshot<C>>>) -> Self {
         Self::Snapshot(DataWithId::new(request_id, snapshot_rx))
     }
 

--- a/tests/tests/client_api/main.rs
+++ b/tests/tests/client_api/main.rs
@@ -10,6 +10,7 @@ mod fixtures;
 mod t10_client_writes;
 mod t11_client_reads;
 mod t12_trigger_purge_log;
+mod t13_get_snapshot;
 mod t13_trigger_snapshot;
 mod t16_with_raft_state;
 mod t50_lagging_network_write;

--- a/tests/tests/client_api/t13_get_snapshot.rs
+++ b/tests/tests/client_api/t13_get_snapshot.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::testing::log_id;
+use openraft::Config;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Get snapshot with `Raft::get_snapshot()`
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn get_snapshot() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- get None snapshot for node-1");
+    {
+        let n1 = router.get_raft_handle(&1)?;
+
+        let curr_snap = n1.get_snapshot().await?;
+        assert!(curr_snap.is_none());
+    }
+
+    tracing::info!(log_index, "--- trigger and get snapshot for node-1");
+    {
+        let n1 = router.get_raft_handle(&1)?;
+        n1.trigger().snapshot().await?;
+
+        router.wait(&1, timeout()).snapshot(log_id(1, 0, log_index), "node-1 snapshot").await?;
+
+        let curr_snap = n1.get_snapshot().await?;
+        let snap = curr_snap.unwrap();
+        assert_eq!(snap.meta.last_log_id, Some(log_id(1, 0, log_index)));
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### Feature: add Raft::get_snapshot() to get the last snapshot from state machine


##### Chore: Rename RaftMsg::ExternalRequest to RaftMsg::ExternalCoreRequest

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1000)
<!-- Reviewable:end -->
