### PR TITLE
Fix: Remove implementation of `Instant` for `std::time::Instant`

### DIFF
--- a/openraft/src/instant.rs
+++ b/openraft/src/instant.rs
@@ -43,10 +43,3 @@ impl Instant for tokio::time::Instant {
         tokio::time::Instant::now()
     }
 }
-
-impl Instant for std::time::Instant {
-    #[inline]
-    fn now() -> Self {
-        Self::now()
-    }
-}


### PR DESCRIPTION
The crate providing async runtime is responsible to provide an `Instant` implementation, not `openraft`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1001)
<!-- Reviewable:end -->
