### PR TITLE
Feature: add `Raft::install_complete_snapshot()` to install a snapshot

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1134,6 +1134,9 @@ where
 
                 self.handle_install_snapshot_request(rpc, tx);
             }
+            RaftMsg::InstallCompleteSnapshot { vote, snapshot, tx } => {
+                self.engine.handle_install_complete_snapshot(vote, snapshot, tx);
+            }
             RaftMsg::CheckIsLeaderRequest { tx } => {
                 if self.engine.state.is_leader(&self.engine.config.id) {
                     self.handle_check_is_leader_request(tx).await;

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -22,6 +22,8 @@ use crate::type_config::alias::NodeOf;
 use crate::ChangeMembers;
 use crate::MessageSummary;
 use crate::RaftTypeConfig;
+use crate::Snapshot;
+use crate::Vote;
 
 pub(crate) mod external_command;
 
@@ -65,6 +67,12 @@ where C: RaftTypeConfig
     InstallSnapshot {
         rpc: InstallSnapshotRequest<C>,
         tx: InstallSnapshotTx<C::NodeId>,
+    },
+
+    InstallCompleteSnapshot {
+        vote: Vote<C::NodeId>,
+        snapshot: Snapshot<C>,
+        tx: ResultSender<InstallSnapshotResponse<C::NodeId>>,
     },
 
     ClientWriteRequest {
@@ -113,6 +121,9 @@ where C: RaftTypeConfig
             }
             RaftMsg::InstallSnapshot { rpc, .. } => {
                 format!("InstallSnapshot: {}", rpc.summary())
+            }
+            RaftMsg::InstallCompleteSnapshot { vote, snapshot, .. } => {
+                format!("InstallCompleteSnapshot: vote: {}, snapshot: {}", vote, snapshot)
             }
             RaftMsg::ClientWriteRequest { .. } => "ClientWriteRequest".to_string(),
             RaftMsg::CheckIsLeaderRequest { .. } => "CheckIsLeaderRequest".to_string(),

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -74,6 +74,11 @@ where C: RaftTypeConfig
         Command::new(payload)
     }
 
+    pub(crate) fn install_complete_snapshot(snapshot: Snapshot<C>) -> Self {
+        let payload = CommandPayload::InstallCompleteSnapshot { snapshot };
+        Command::new(payload)
+    }
+
     pub(crate) fn cancel_snapshot(snapshot_meta: SnapshotMeta<C::NodeId, C::Node>) -> Self {
         let payload = CommandPayload::FinalizeSnapshot {
             install: false,
@@ -103,14 +108,18 @@ where C: RaftTypeConfig
     BuildSnapshot,
 
     /// Get the latest built snapshot.
-    GetSnapshot { tx: ResultSender<Option<Snapshot<C>>> },
+    GetSnapshot {
+        tx: ResultSender<Option<Snapshot<C>>>,
+    },
 
     /// Receive a chunk of snapshot.
     ///
     /// If it is the final chunk, the snapshot stream will be closed and saved.
     ///
     /// Installing a snapshot includes two steps: ReceiveSnapshotChunk and FinalizeSnapshot.
-    ReceiveSnapshotChunk { req: InstallSnapshotRequest<C> },
+    ReceiveSnapshotChunk {
+        req: InstallSnapshotRequest<C>,
+    },
 
     /// After receiving all chunks, finalize the snapshot by installing it or discarding it,
     /// if the snapshot is stale(the snapshot last log id is smaller than the local committed).
@@ -120,8 +129,14 @@ where C: RaftTypeConfig
         snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
     },
 
+    InstallCompleteSnapshot {
+        snapshot: Snapshot<C>,
+    },
+
     /// Apply the log entries to the state machine.
-    Apply { entries: Vec<C::Entry> },
+    Apply {
+        entries: Vec<C::Entry>,
+    },
 }
 
 impl<C> Debug for CommandPayload<C>
@@ -136,6 +151,9 @@ where C: RaftTypeConfig
             }
             CommandPayload::FinalizeSnapshot { install, snapshot_meta } => {
                 write!(f, "FinalizeSnapshot: install:{} {:?}", install, snapshot_meta)
+            }
+            CommandPayload::InstallCompleteSnapshot { snapshot } => {
+                write!(f, "InstallCompleteSnapshot: meta: {:?}", snapshot.meta)
             }
             CommandPayload::Apply { entries } => write!(f, "Apply: {}", DisplaySlice::<_>(entries)),
         }

--- a/openraft/src/core/sm/mod.rs
+++ b/openraft/src/core/sm/mod.rs
@@ -166,6 +166,17 @@ where
                     let res = CommandResult::new(cmd.seq, Ok(Response::InstallSnapshot(resp)));
                     let _ = self.resp_tx.send(Notify::sm(res));
                 }
+                CommandPayload::InstallCompleteSnapshot { snapshot } => {
+                    tracing::info!("{}: install complete snapshot", func_name!());
+
+                    let meta = snapshot.meta.clone();
+                    self.state_machine.install_snapshot(&meta, snapshot.snapshot).await?;
+
+                    tracing::info!("Done install complete snapshot, meta: {}", meta);
+
+                    let res = CommandResult::new(cmd.seq, Ok(Response::InstallSnapshot(Some(meta))));
+                    let _ = self.resp_tx.send(Notify::sm(res));
+                }
                 CommandPayload::Apply { entries } => {
                     let resp = self.apply(entries).await?;
                     let res = CommandResult::new(cmd.seq, Ok(Response::Apply(resp)));

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -229,6 +229,7 @@ where
     AppendEntries(ValueSender<Result<AppendEntriesResponse<NID>, Infallible>>),
     ReceiveSnapshotChunk(ValueSender<Result<(), InstallSnapshotError>>),
     InstallSnapshot(ValueSender<Result<InstallSnapshotResponse<NID>, InstallSnapshotError>>),
+    InstallCompleteSnapshot(ValueSender<Result<InstallSnapshotResponse<NID>, Infallible>>),
     Initialize(ValueSender<Result<(), InitializeError<NID, N>>>),
 }
 
@@ -251,6 +252,7 @@ where
             Respond::AppendEntries(x) => x.send(),
             Respond::ReceiveSnapshotChunk(x) => x.send(),
             Respond::InstallSnapshot(x) => x.send(),
+            Respond::InstallCompleteSnapshot(x) => x.send(),
             Respond::Initialize(x) => x.send(),
         }
     }

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -99,7 +99,7 @@ where
 }
 
 /// The data associated with the current snapshot.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Snapshot<C>
 where C: RaftTypeConfig
 {
@@ -115,6 +115,14 @@ where C: RaftTypeConfig
 {
     pub(crate) fn new(meta: SnapshotMeta<C::NodeId, C::Node>, snapshot: Box<C::SnapshotData>) -> Self {
         Self { meta, snapshot }
+    }
+}
+
+impl<C> fmt::Display for Snapshot<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Snapshot{{meta: {}}}", self.meta)
     }
 }
 

--- a/tests/tests/client_api/main.rs
+++ b/tests/tests/client_api/main.rs
@@ -11,6 +11,7 @@ mod t10_client_writes;
 mod t11_client_reads;
 mod t12_trigger_purge_log;
 mod t13_get_snapshot;
+mod t13_install_complete_snapshot;
 mod t13_trigger_snapshot;
 mod t16_with_raft_state;
 mod t50_lagging_network_write;

--- a/tests/tests/client_api/t13_install_complete_snapshot.rs
+++ b/tests/tests/client_api/t13_install_complete_snapshot.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::testing::log_id;
+use openraft::Config;
+use openraft::Vote;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn install_complete_snapshot() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- isolate node 2 so that it can receive snapshot");
+    router.set_unreachable(2, true);
+
+    tracing::info!(log_index, "--- write to make node-0,1 have more logs");
+    {
+        log_index += router.client_request_many(0, "foo", 3).await?;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "write more log").await?;
+        router.wait(&1, timeout()).applied_index(Some(log_index), "write more log").await?;
+    }
+
+    let snap;
+
+    tracing::info!(log_index, "--- trigger and get snapshot from node-0");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.trigger().snapshot().await?;
+
+        router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "node-1 snapshot").await?;
+
+        snap = n0.get_snapshot().await?.unwrap();
+    }
+
+    tracing::info!(log_index, "--- fails to install snapshot with smaller vote");
+    {
+        let n1 = router.get_raft_handle(&1)?;
+
+        let resp = n1.install_complete_snapshot(Vote::new(0, 0), snap.clone()).await?;
+        assert_eq!(
+            Vote::new_committed(1, 0),
+            resp.vote,
+            "node-1 vote is higher, and is returned"
+        );
+        n1.with_raft_state(|state| {
+            assert_eq!(
+                None, state.snapshot_meta.last_log_id,
+                "node-1 snapshot is not installed"
+            );
+        })
+        .await?;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- no install snapshot on node-1 because of snapshot last log id equals committed"
+    );
+    {
+        let n1 = router.get_raft_handle(&1)?;
+
+        let resp = n1.install_complete_snapshot(Vote::new_committed(1, 0), snap.clone()).await?;
+        assert_eq!(Vote::new_committed(1, 0), resp.vote,);
+        n1.with_raft_state(move |state| {
+            assert_eq!(
+                None, state.snapshot_meta.last_log_id,
+                "node-1 snapshot is not installed"
+            );
+        })
+        .await?;
+    }
+
+    tracing::info!(log_index, "--- succeed to install snapshot on node-2 with higher vote");
+    {
+        let n2 = router.get_raft_handle(&2)?;
+
+        let resp = n2.install_complete_snapshot(Vote::new_committed(1, 0), snap.clone()).await?;
+        assert_eq!(Vote::new_committed(1, 0), resp.vote,);
+        n2.with_raft_state(move |state| {
+            assert_eq!(
+                Some(log_id(1, 0, log_index)),
+                state.snapshot_meta.last_log_id,
+                "node-1 snapshot is installed"
+            );
+        })
+        .await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### Feature: add `Raft::install_complete_snapshot()` to install a snapshot

Using this method, the application provides a full snapshot to
Openraft, which is then used to install and replace the state machine.
It is entirely the responsibility of the application to acquire a
snapshot through any means: be it in chunks, as a stream, or via shared
storage solutions like S3.

This method necessitates that the caller supplies a valid `Vote` to
confirm the legitimacy of the leader, mirroring the requirements of
other Raft protocol APIs such as `append_entries` and `vote`.

- Part of #606

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1002)
<!-- Reviewable:end -->
