### PR TITLE
Feature: `RaftNetwork::snapshot()` to send a complete snapshot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -355,7 +355,7 @@ jobs:
         with:
           name: tests-feature-test
           path: |
-            openraft/_log/
+            tests/_log/
 
   lint:
     name: lint

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -137,6 +137,10 @@ pub struct Config {
     ///
     /// It is disabled by default, by setting it to `0`.
     /// The timeout for sending every segment is `install_snapshot_timeout`.
+    #[deprecated(
+        since = "0.9.0",
+        note = "Sending snapshot by chunks is deprecated; Use `install_snapshot_timeout` instead"
+    )]
     #[clap(long, default_value = "0")]
     pub send_snapshot_timeout: u64,
 
@@ -258,7 +262,12 @@ impl Config {
     }
 
     /// Get the timeout for sending a non-last snapshot segment.
+    #[deprecated(
+        since = "0.9.0",
+        note = "Sending snapshot by chunks is deprecated; Use `install_snapshot_timeout()` instead"
+    )]
     pub fn send_snapshot_timeout(&self) -> Duration {
+        #[allow(deprecated)]
         if self.send_snapshot_timeout > 0 {
             Duration::from_millis(self.send_snapshot_timeout)
         } else {

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -68,7 +68,11 @@ fn test_build() -> anyhow::Result<()> {
     assert_eq!(10, config.election_timeout_min);
     assert_eq!(20, config.election_timeout_max);
     assert_eq!(5, config.heartbeat_interval);
-    assert_eq!(199, config.send_snapshot_timeout);
+
+    #[allow(deprecated)]
+    {
+        assert_eq!(199, config.send_snapshot_timeout);
+    }
     assert_eq!(200, config.install_snapshot_timeout);
     assert_eq!(201, config.max_payload_entries);
     assert_eq!(SnapshotPolicy::LogsSinceLast(202), config.snapshot_policy);
@@ -78,6 +82,7 @@ fn test_build() -> anyhow::Result<()> {
     assert_eq!(207, config.purge_batch_size);
 
     // Test config methods
+    #[allow(deprecated)]
     {
         let mut c = config;
         assert_eq!(Duration::from_millis(199), c.send_snapshot_timeout());

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -779,6 +779,7 @@ where
 
         let membership_log_id = self.engine.state.membership_state.effective().log_id();
         let network = self.network.new_client(target, target_node).await;
+        let snapshot_network = self.network.new_client(target, target_node).await;
 
         let session_id = ReplicationSessionId::new(*self.engine.state.vote_ref(), *membership_log_id);
 
@@ -789,6 +790,7 @@ where
             self.engine.state.committed().copied(),
             progress_entry.matching,
             network,
+            snapshot_network,
             self.log_store.get_log_reader().await,
             self.tx_notify.clone(),
             tracing::span!(parent: &self.span, Level::DEBUG, "replication", id=display(self.id), target=display(target)),

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -12,7 +12,7 @@ use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::BoxCoreFn;
 use crate::raft::ClientWriteResponse;
-use crate::raft::InstallSnapshotResponse;
+use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::type_config::alias::LogIdOf;
@@ -64,7 +64,7 @@ where C: RaftTypeConfig
     InstallCompleteSnapshot {
         vote: Vote<C::NodeId>,
         snapshot: Snapshot<C>,
-        tx: ResultSender<InstallSnapshotResponse<C::NodeId>>,
+        tx: ResultSender<SnapshotResponse<C::NodeId>>,
     },
 
     /// Begin receiving a snapshot from the leader.

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -11,6 +11,7 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::InstallSnapshotResponse;
+use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::LeaderId;
@@ -229,7 +230,7 @@ where
     AppendEntries(ValueSender<Result<AppendEntriesResponse<NID>, Infallible>>),
     ReceiveSnapshotChunk(ValueSender<Result<(), InstallSnapshotError>>),
     InstallSnapshot(ValueSender<Result<InstallSnapshotResponse<NID>, InstallSnapshotError>>),
-    InstallCompleteSnapshot(ValueSender<Result<InstallSnapshotResponse<NID>, Infallible>>),
+    InstallCompleteSnapshot(ValueSender<Result<SnapshotResponse<NID>, Infallible>>),
     Initialize(ValueSender<Result<(), InitializeError<NID, N>>>),
 }
 

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -170,7 +170,7 @@ where C: RaftTypeConfig
         let granted = *self
             .leader
             .clock_progress
-            .update(&node_id, Some(t))
+            .increase_to(&node_id, Some(t))
             .expect("it should always update existing progress");
 
         tracing::debug!(

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -1,5 +1,8 @@
 //! Error types exposed by this crate.
 
+mod replication_closed;
+mod streaming_error;
+
 use std::collections::BTreeSet;
 use std::error::Error;
 use std::fmt;
@@ -8,6 +11,8 @@ use std::time::Duration;
 
 use anyerror::AnyError;
 
+pub use self::replication_closed::ReplicationClosed;
+pub use self::streaming_error::StreamingError;
 use crate::network::RPCTypes;
 use crate::node::Node;
 use crate::raft::AppendEntriesResponse;
@@ -243,11 +248,6 @@ where
     RPCError(#[from] RPCError<NID, N, RaftError<NID, Infallible>>),
 }
 
-/// Error occurs when replication is closed.
-#[derive(Debug, thiserror::Error)]
-#[error("Replication is closed by RaftCore")]
-pub(crate) struct ReplicationClosed {}
-
 /// Error occurs when invoking a remote raft API.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 // NID already has serde bound.
@@ -322,6 +322,21 @@ impl<NID: NodeId, N: Node, T: Error> RemoteError<NID, N, T> {
             target,
             target_node: Some(node),
             source: e,
+        }
+    }
+}
+
+impl<NID, N, E> From<RemoteError<NID, N, Fatal<NID>>> for RemoteError<NID, N, RaftError<NID, E>>
+where
+    NID: NodeId,
+    N: Node,
+    E: Error,
+{
+    fn from(e: RemoteError<NID, N, Fatal<NID>>) -> Self {
+        RemoteError {
+            target: e.target,
+            target_node: e.target_node,
+            source: RaftError::Fatal(e.source),
         }
     }
 }

--- a/openraft/src/error/replication_closed.rs
+++ b/openraft/src/error/replication_closed.rs
@@ -1,0 +1,17 @@
+/// Replication is closed intentionally.
+///
+/// No further replication action should be taken.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[error("Replication is closed: {reason}")]
+pub struct ReplicationClosed {
+    reason: String,
+}
+
+impl ReplicationClosed {
+    pub fn new(reason: impl ToString) -> Self {
+        Self {
+            reason: reason.to_string(),
+        }
+    }
+}

--- a/openraft/src/error/streaming_error.rs
+++ b/openraft/src/error/streaming_error.rs
@@ -1,0 +1,72 @@
+use std::error::Error;
+
+use crate::error::NetworkError;
+use crate::error::RPCError;
+use crate::error::RaftError;
+use crate::error::RemoteError;
+use crate::error::ReplicationClosed;
+use crate::error::ReplicationError;
+use crate::error::Timeout;
+use crate::error::Unreachable;
+use crate::RaftTypeConfig;
+use crate::StorageError;
+
+/// Error occurred when streaming local data to a remote raft node.
+///
+/// Thus this error includes storage error, network error, and remote error.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(bound(serialize = "E: serde::Serialize")),
+    serde(bound(deserialize = "E: for <'d> serde::Deserialize<'d>"))
+)]
+pub enum StreamingError<C: RaftTypeConfig, E: Error> {
+    /// The replication stream is closed intentionally.
+    #[error(transparent)]
+    Closed(#[from] ReplicationClosed),
+
+    /// Storage error occurs when reading local data.
+    #[error(transparent)]
+    StorageError(#[from] StorageError<C::NodeId>),
+
+    /// Timeout when streaming data to remote node.
+    #[error(transparent)]
+    Timeout(#[from] Timeout<C::NodeId>),
+
+    /// The node is temporarily unreachable and should backoff before retrying.
+    #[error(transparent)]
+    Unreachable(#[from] Unreachable),
+
+    /// Failed to send the RPC request and should retry immediately.
+    #[error(transparent)]
+    Network(#[from] NetworkError),
+
+    /// Remote node returns an error.
+    #[error(transparent)]
+    RemoteError(#[from] RemoteError<C::NodeId, C::Node, E>),
+}
+
+impl<C: RaftTypeConfig, E> From<StreamingError<C, E>> for ReplicationError<C::NodeId, C::Node>
+where
+    E: Error,
+    RaftError<C::NodeId>: From<E>,
+{
+    fn from(e: StreamingError<C, E>) -> Self {
+        match e {
+            StreamingError::Closed(e) => ReplicationError::Closed(e),
+            StreamingError::StorageError(e) => ReplicationError::StorageError(e),
+            StreamingError::Timeout(e) => ReplicationError::RPCError(RPCError::Timeout(e)),
+            StreamingError::Unreachable(e) => ReplicationError::RPCError(RPCError::Unreachable(e)),
+            StreamingError::Network(e) => ReplicationError::RPCError(RPCError::Network(e)),
+            StreamingError::RemoteError(e) => {
+                let remote_err = RemoteError {
+                    target: e.target,
+                    target_node: e.target_node,
+                    source: RaftError::from(e.source),
+                };
+                ReplicationError::RPCError(RPCError::RemoteError(remote_err))
+            }
+        }
+    }
+}

--- a/openraft/src/membership/into_nodes.rs
+++ b/openraft/src/membership/into_nodes.rs
@@ -15,12 +15,12 @@ where
     N: Node,
     NID: NodeId,
 {
-    #[deprecated(note = "unused any more")]
+    #[deprecated(since = "0.8.4", note = "unused any more")]
     fn has_nodes(&self) -> bool {
         unimplemented!("has_nodes is deprecated")
     }
 
-    #[deprecated(note = "unused any more")]
+    #[deprecated(since = "0.8.4", note = "unused any more")]
     fn node_ids(&self) -> Vec<NID> {
         unimplemented!("node_ids is deprecated")
     }

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -130,7 +130,7 @@ where
     }
 
     /// Check to see if the config is currently in joint consensus.
-    #[deprecated(note = "use `get_joint_config().len() > 1` instead")]
+    #[deprecated(since = "0.8.4", note = "use `get_joint_config().len() > 1` instead")]
     pub fn is_in_joint_consensus(&self) -> bool {
         self.configs.len() > 1
     }

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -128,7 +128,7 @@ where
     }
 
     /// Wait until applied exactly `want_log`(inclusive) logs or timeout.
-    #[deprecated(note = "use `log_index()` and `applied_index()` instead, deprecated since 0.9.0")]
+    #[deprecated(since = "0.9.0", note = "use `log_index()` and `applied_index()` instead")]
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn log(&self, want_log_index: Option<u64>, msg: impl ToString) -> Result<RaftMetrics<NID, N>, WaitError> {
         self.eq(Metric::LastLogIndex(want_log_index), msg.to_string()).await?;
@@ -136,7 +136,10 @@ where
     }
 
     /// Wait until applied at least `want_log`(inclusive) logs or timeout.
-    #[deprecated(note = "use `log_index_at_least()` and `applied_index_at_least()` instead, deprecated since 0.9.0")]
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `log_index_at_least()` and `applied_index_at_least()` instead"
+    )]
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn log_at_least(
         &self,
@@ -195,7 +198,7 @@ where
     }
 
     /// Wait for `membership` to become the expected node id set or timeout.
-    #[deprecated(note = "use `voter_ids()` instead, deprecated since 0.9.0")]
+    #[deprecated(since = "0.9.0", note = "use `voter_ids()` instead")]
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn members(
         &self,

--- a/openraft/src/network/rpc_option.rs
+++ b/openraft/src/network/rpc_option.rs
@@ -4,16 +4,23 @@ use std::time::Duration;
 /// networking behaviors.
 ///
 /// [`RaftNetwork`]: `crate::network::RaftNetwork`
+#[derive(Clone, Debug)]
 pub struct RPCOption {
     /// The expected time-to-last for an RPC.
     ///
     /// The caller will cancel an RPC if it takes longer than this duration.
     hard_ttl: Duration,
+
+    /// The size of the snapshot chunk.
+    pub(crate) snapshot_chunk_size: Option<usize>,
 }
 
 impl RPCOption {
     pub fn new(hard_ttl: Duration) -> Self {
-        Self { hard_ttl }
+        Self {
+            hard_ttl,
+            snapshot_chunk_size: None,
+        }
     }
 
     /// The moderate max interval an RPC should last for.
@@ -38,5 +45,10 @@ impl RPCOption {
     /// When exceeding this limit, the RPC will be dropped by Openraft at once.
     pub fn hard_ttl(&self) -> Duration {
         self.hard_ttl
+    }
+
+    /// Get the recommended size of the snapshot chunk for transport.
+    pub fn snapshot_chunk_size(&self) -> Option<usize> {
+        self.snapshot_chunk_size
     }
 }

--- a/openraft/src/network/stream_snapshot.rs
+++ b/openraft/src/network/stream_snapshot.rs
@@ -1,21 +1,54 @@
+use std::future::Future;
+use std::io::SeekFrom;
+use std::pin::Pin;
+use std::time::Duration;
+
+use futures::FutureExt;
 use macros::add_async_trait;
 use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
 use tokio::io::AsyncSeek;
+use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 
 use crate::core::snapshot_state::SnapshotRequestId;
 use crate::core::streaming_state::Streaming;
+use crate::error::Fatal;
+use crate::error::ReplicationClosed;
+use crate::error::StreamingError;
+use crate::network::RPCOption;
 use crate::raft::InstallSnapshotRequest;
+use crate::raft::SnapshotResponse;
+use crate::type_config::alias::AsyncRuntimeOf;
+use crate::AsyncRuntime;
+use crate::ErrorSubject;
+use crate::ErrorVerb;
 use crate::OptionalSend;
 use crate::OptionalSync;
+use crate::RaftNetwork;
 use crate::RaftTypeConfig;
 use crate::Snapshot;
 use crate::StorageError;
 use crate::StorageIOError;
+use crate::ToStorageResult;
+use crate::Vote;
 
 #[add_async_trait]
 pub(crate) trait SnapshotTransport<C: RaftTypeConfig> {
+    async fn send_snapshot<Net>(
+        _net: &mut Net,
+        _vote: Vote<C::NodeId>,
+        _snapshot: Snapshot<C>,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>
+    where
+        Net: RaftNetwork<C> + ?Sized,
+    {
+        unimplemented!("send_snapshot is only implemented with SnapshotData with AsyncRead + AsyncSeek ...")
+    }
+
     async fn receive_snapshot(
         _streaming: &mut Option<Streaming<C>>,
         _req: InstallSnapshotRequest<C>,
@@ -24,12 +57,116 @@ pub(crate) trait SnapshotTransport<C: RaftTypeConfig> {
     }
 }
 
-/// Receive snapshot by chunks.
+/// Send and Receive snapshot by chunks.
 pub(crate) struct Chunked {}
 
 impl<C: RaftTypeConfig> SnapshotTransport<C> for Chunked
 where C::SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + OptionalSend + OptionalSync + Unpin + 'static
 {
+    /// Stream snapshot by chunks.
+    ///
+    /// This function is for backward compatibility and provides a default implement for
+    /// `RaftNetwork::snapshot()` upon `RafNetwork::install_snapshot()`. This implementation
+    /// requires `SnapshotData` to be `AsyncRead + AsyncSeek`.
+    ///
+    /// The argument `vote` is the leader's vote which is used to check if the leader is still valid
+    /// by a follower.
+    ///
+    /// `cancel` is a future that is polled only by this function. It return Ready if the caller
+    /// decide to cancel this snapshot transmission.
+    async fn send_snapshot<Net>(
+        net: &mut Net,
+        vote: Vote<C::NodeId>,
+        mut snapshot: Snapshot<C>,
+        mut cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        option: RPCOption,
+    ) -> Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>
+    where
+        Net: RaftNetwork<C> + ?Sized,
+    {
+        let subject_verb = || (ErrorSubject::Snapshot(Some(snapshot.meta.signature())), ErrorVerb::Read);
+
+        let mut offset = 0;
+        let end = snapshot.snapshot.seek(SeekFrom::End(0)).await.sto_res(subject_verb)?;
+
+        loop {
+            // Safety: `cancel` is a future that is polled only by this function.
+            let c = unsafe { Pin::new_unchecked(&mut cancel) };
+
+            // If canceled, return at once
+            if let Some(err) = c.now_or_never() {
+                return Err(err.into());
+            }
+
+            // Sleep a short time otherwise in test environment it is a dead-loop that never
+            // yields.
+            // Because network implementation does not yield.
+            AsyncRuntimeOf::<C>::sleep(Duration::from_millis(10)).await;
+
+            snapshot.snapshot.seek(SeekFrom::Start(offset)).await.sto_res(subject_verb)?;
+
+            // Safe unwrap(): this function is called only by default implementation of
+            // `RaftNetwork::snapshot()` and it is always set.
+            let chunk_size = option.snapshot_chunk_size().unwrap();
+            let mut buf = Vec::with_capacity(chunk_size);
+            while buf.capacity() > buf.len() {
+                let n = snapshot.snapshot.read_buf(&mut buf).await.sto_res(subject_verb)?;
+                if n == 0 {
+                    break;
+                }
+            }
+
+            let n_read = buf.len();
+
+            let done = (offset + n_read as u64) == end;
+            let req = InstallSnapshotRequest {
+                vote,
+                meta: snapshot.meta.clone(),
+                offset,
+                data: buf,
+                done,
+            };
+
+            // Send the RPC over to the target.
+            tracing::debug!(
+                snapshot_size = req.data.len(),
+                req.offset,
+                end,
+                req.done,
+                "sending snapshot chunk"
+            );
+
+            #[allow(deprecated)]
+            let res = AsyncRuntimeOf::<C>::timeout(option.hard_ttl(), net.install_snapshot(req, option.clone())).await;
+
+            let resp = match res {
+                Ok(outer_res) => match outer_res {
+                    Ok(res) => res,
+                    Err(err) => {
+                        tracing::warn!(error=%err, "error sending InstallSnapshot RPC to target");
+                        continue;
+                    }
+                },
+                Err(err) => {
+                    tracing::warn!(error=%err, "timeout while sending InstallSnapshot RPC to target");
+                    continue;
+                }
+            };
+
+            if resp.vote > vote {
+                // Unfinished, return a response with a higher vote.
+                // The caller checks the vote and return a HigherVote error.
+                return Ok(SnapshotResponse::new(resp.vote));
+            }
+
+            if done {
+                return Ok(SnapshotResponse::new(resp.vote));
+            }
+
+            offset += n_read as u64;
+        }
+    }
+
     async fn receive_snapshot(
         streaming: &mut Option<Streaming<C>>,
         req: InstallSnapshotRequest<C>,

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -50,6 +50,18 @@ where
         self.update_with(id, |x| *x = value)
     }
 
+    /// Update the value if the new value is greater than the current value.
+    ///
+    /// It returns Err(committed) if the `id` is not found.
+    fn increase_to(&mut self, id: &ID, value: V) -> Result<&P, &P>
+    where V: PartialOrd {
+        self.update_with(id, |x| {
+            if value > *x {
+                *x = value;
+            }
+        })
+    }
+
     /// Try to get the value by `id`.
     fn try_get(&self, id: &ID) -> Option<&V>;
 

--- a/openraft/src/raft/message/install_snapshot.rs
+++ b/openraft/src/raft/message/install_snapshot.rs
@@ -54,3 +54,25 @@ impl<C: RaftTypeConfig> MessageSummary<InstallSnapshotRequest<C>> for InstallSna
 pub struct InstallSnapshotResponse<NID: NodeId> {
     pub vote: Vote<NID>,
 }
+
+/// The response to `Raft::install_complete_snapshot` API.
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+#[derive(derive_more::Display)]
+#[display(fmt = "SnapshotResponse{{vote:{}}}", vote)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub struct SnapshotResponse<NID: NodeId> {
+    pub vote: Vote<NID>,
+}
+
+impl<NID: NodeId> SnapshotResponse<NID> {
+    pub fn new(vote: Vote<NID>) -> Self {
+        Self { vote }
+    }
+}
+
+impl<NID: NodeId> From<SnapshotResponse<NID>> for InstallSnapshotResponse<NID> {
+    fn from(snap_resp: SnapshotResponse<NID>) -> Self {
+        Self { vote: snap_resp.vote }
+    }
+}

--- a/openraft/src/raft/message/mod.rs
+++ b/openraft/src/raft/message/mod.rs
@@ -14,5 +14,6 @@ pub use append_entries::AppendEntriesResponse;
 pub use client_write::ClientWriteResponse;
 pub use install_snapshot::InstallSnapshotRequest;
 pub use install_snapshot::InstallSnapshotResponse;
+pub use install_snapshot::SnapshotResponse;
 pub use vote::VoteRequest;
 pub use vote::VoteResponse;

--- a/openraft/src/replication/callbacks.rs
+++ b/openraft/src/replication/callbacks.rs
@@ -1,0 +1,58 @@
+//! Callbacks for ReplicationCore internal communication.
+use core::fmt;
+
+use crate::error::Fatal;
+use crate::error::StreamingError;
+use crate::raft::SnapshotResponse;
+use crate::type_config::alias::InstantOf;
+use crate::RaftTypeConfig;
+use crate::SnapshotMeta;
+
+/// Callback payload when a snapshot transmission finished, successfully or not.
+#[derive(Debug)]
+pub(crate) struct SnapshotCallback<C: RaftTypeConfig> {
+    // TODO: Remove `start_time`.
+    //       Because sending snapshot is a long lasting process,
+    //       we should not rely on the start time to extend leader lease.
+    /// The time when the snapshot replication started on leader.
+    ///
+    /// This time is used to extend lease of the leader on leader. like a heartbeat.
+    pub(crate) start_time: InstantOf<C>,
+
+    /// Meta data of the snapshot to be replicated.
+    pub(crate) snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+
+    /// The result of the snapshot replication.
+    pub(crate) result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
+}
+
+impl<C: RaftTypeConfig> SnapshotCallback<C> {
+    pub(in crate::replication) fn new(
+        start_time: InstantOf<C>,
+        snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+        result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
+    ) -> Self {
+        Self {
+            start_time,
+            snapshot_meta,
+            result,
+        }
+    }
+}
+
+impl<C: RaftTypeConfig> fmt::Display for SnapshotCallback<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SnapshotCallback {{ start_time: {:?}, snapshot_meta: {}, result:",
+            self.start_time, self.snapshot_meta
+        )?;
+
+        match &self.result {
+            Ok(resp) => write!(f, " Ok({})", resp)?,
+            Err(e) => write!(f, " Err({})", e)?,
+        };
+
+        write!(f, " }}",)
+    }
+}

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -1,11 +1,11 @@
 //! Replication stream.
 
+pub(crate) mod callbacks;
 pub(crate) mod hint;
 mod replication_session_id;
 pub(crate) mod request;
 pub(crate) mod response;
 
-use std::io::SeekFrom;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -17,10 +17,10 @@ use request::DataWithId;
 use request::Replicate;
 use response::ReplicationResult;
 pub(crate) use response::Response;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncSeekExt;
 use tokio::select;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 use tracing_futures::Instrument;
 
 use crate::config::Config;
@@ -45,7 +45,7 @@ use crate::network::RaftNetwork;
 use crate::network::RaftNetworkFactory;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
-use crate::raft::InstallSnapshotRequest;
+use crate::replication::callbacks::SnapshotCallback;
 use crate::replication::hint::ReplicationHint;
 use crate::storage::RaftLogReader;
 use crate::storage::RaftLogStorage;
@@ -55,8 +55,6 @@ use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinHandleOf;
 use crate::utime::UTime;
 use crate::AsyncRuntime;
-use crate::ErrorSubject;
-use crate::ErrorVerb;
 use crate::Instant;
 use crate::LogId;
 use crate::MessageSummary;
@@ -64,7 +62,7 @@ use crate::RaftLogId;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::StorageIOError;
-use crate::ToStorageResult;
+use crate::Vote;
 
 /// The handle to a spawned replication stream.
 pub(crate) struct ReplicationHandle<C>
@@ -98,11 +96,30 @@ where
     #[allow(clippy::type_complexity)]
     tx_raft_core: mpsc::UnboundedSender<Notify<C>>,
 
-    /// A channel for receiving events from the RaftCore.
-    rx_repl: mpsc::UnboundedReceiver<Replicate<C>>,
+    /// A channel for receiving events from the RaftCore and snapshot transmitting task.
+    rx_event: mpsc::UnboundedReceiver<Replicate<C>>,
 
-    /// The `RaftNetwork` interface.
+    /// A weak reference to the Sender for the separate sending-snapshot task to send callback.
+    ///
+    /// Because 1) ReplicationCore replies on the `close` event to shutdown.
+    /// 2) ReplicationCore holds this tx; It is made a weak so that when
+    /// RaftCore drops the only non-weak tx, the Receiver `rx_repl` will be closed.
+    weak_tx_event: mpsc::WeakUnboundedSender<Replicate<C>>,
+
+    /// The `RaftNetwork` interface for replicating logs and heartbeat.
     network: N::Network,
+
+    /// Another `RaftNetwork` specific for snapshot replication.
+    ///
+    /// Snapshot transmitting is a long running task, and is processed in a separate task.
+    snapshot_network: Arc<Mutex<N::Network>>,
+
+    /// The current snapshot replication state.
+    ///
+    /// It includes a cancel signaler and the join handle of the snapshot replication task.
+    /// When ReplicationCore is dropped, this Sender is dropped, the snapshot task will be notified
+    /// to quit.
+    snapshot_state: Option<(oneshot::Sender<()>, JoinHandleOf<C, ()>)>,
 
     /// The backoff policy if an [`Unreachable`](`crate::error::Unreachable`) error is returned.
     /// It will be reset to `None` when an successful response is received.
@@ -145,6 +162,7 @@ where
         committed: Option<LogId<C::NodeId>>,
         matching: Option<LogId<C::NodeId>>,
         network: N::Network,
+        snapshot_network: N::Network,
         log_reader: LS::LogReader,
         tx_raft_core: mpsc::UnboundedSender<Notify<C>>,
         span: tracing::Span,
@@ -158,26 +176,32 @@ where
         );
 
         // other component to ReplicationStream
-        let (tx_repl, rx_repl) = mpsc::unbounded_channel();
+        let (tx_event, rx_event) = mpsc::unbounded_channel();
 
         let this = Self {
             target,
             session_id,
             network,
+            snapshot_network: Arc::new(Mutex::new(snapshot_network)),
+            snapshot_state: None,
             backoff: None,
             log_reader,
             config,
             committed,
             matching,
             tx_raft_core,
-            rx_repl,
+            rx_event,
+            weak_tx_event: tx_event.downgrade(),
             next_action: None,
             entries_hint: Default::default(),
         };
 
         let join_handle = C::AsyncRuntime::spawn(this.main().instrument(span));
 
-        ReplicationHandle { join_handle, tx_repl }
+        ReplicationHandle {
+            join_handle,
+            tx_repl: tx_event,
+        }
     }
 
     #[tracing::instrument(level="debug", skip(self), fields(session=%self.session_id, target=display(self.target), cluster=%self.config.cluster_name))]
@@ -185,7 +209,7 @@ where
         loop {
             let action = self.next_action.take();
 
-            let mut repl_id = None;
+            let mut request_id = None;
             // Backup the log data for retrying.
             let mut log_data = None;
 
@@ -194,7 +218,7 @@ where
                 Some(d) => {
                     tracing::debug!(replication_data = display(&d), "{} send replication RPC", func_name!());
 
-                    repl_id = d.request_id();
+                    request_id = d.request_id();
 
                     match d {
                         Data::Heartbeat => {
@@ -210,6 +234,7 @@ where
                             self.send_log_entries(log).await
                         }
                         Data::Snapshot(snap) => self.stream_snapshot(snap).await,
+                        Data::SnapshotCallback(resp) => self.handle_snapshot_callback(resp),
                     }
                 }
             };
@@ -280,7 +305,7 @@ where
                             if retry {
                                 debug_assert!(self.next_action.is_some(), "next_action must be Some");
                             } else {
-                                self.send_progress_error(repl_id, err);
+                                self.send_progress_error(request_id, err);
                             }
                         }
                     };
@@ -587,7 +612,7 @@ where
             let sleep_duration = until - InstantOf::<C>::now();
             let sleep = C::AsyncRuntime::sleep(sleep_duration);
 
-            let recv = self.rx_repl.recv();
+            let recv = self.rx_event.recv();
 
             tracing::debug!("backoff timeout: {:?}", sleep_duration);
 
@@ -597,7 +622,7 @@ where
                     return Ok(());
                 }
                 recv_res = recv => {
-                    let event = recv_res.ok_or(ReplicationClosed{})?;
+                    let event = recv_res.ok_or(ReplicationClosed::new("RaftCore closed replication"))?;
                     self.process_event(event);
                 }
             }
@@ -614,7 +639,8 @@ where
         // If there is next action to run, do not block waiting for events,
         // instead, just try the best to drain all events.
         if self.next_action.is_none() {
-            let event = self.rx_repl.recv().await.ok_or(ReplicationClosed {})?;
+            let event =
+                self.rx_event.recv().await.ok_or(ReplicationClosed::new("rx_repl is closed in drain_event()"))?;
             self.process_event(event);
         }
 
@@ -633,17 +659,14 @@ where
         // There should NOT be more than one `Replicate::Data` event in the channel.
         // Looping it just collect all commit events and heartbeat events.
         loop {
-            let maybe_res = self.rx_repl.recv().now_or_never();
+            let maybe_res = self.rx_event.recv().now_or_never();
 
-            let recv_res = match maybe_res {
-                None => {
-                    // No more events in self.repl_rx
-                    return Ok(());
-                }
-                Some(x) => x,
+            let Some(recv_res) = maybe_res else {
+                // No more event found in self.repl_rx
+                return Ok(());
             };
 
-            let event = recv_res.ok_or(ReplicationClosed {})?;
+            let event = recv_res.ok_or(ReplicationClosed::new("rx_repl is closed in try_drain_event"))?;
 
             self.process_event(event);
         }
@@ -681,8 +704,27 @@ where
                 //       actions without waiting for the previous to finish.
                 debug_assert!(
                     !self.next_action.as_ref().map(|d| d.has_payload()).unwrap_or(false),
-                    "there can not be two actions with payload in flight"
+                    "there can not be two actions with payload in flight, curr: {}",
+                    self.next_action.as_ref().map(|d| d.to_string()).display()
                 );
+
+                if cfg!(debug_assertions) {
+                    match &d {
+                        Data::SnapshotCallback(_) => {
+                            debug_assert!(
+                                self.snapshot_state.is_some(),
+                                "snapshot state must be Some to receive callback"
+                            );
+                        }
+                        _ => {
+                            debug_assert!(
+                                self.snapshot_state.is_none(),
+                                "can not send other data while sending snapshot"
+                            );
+                        }
+                    }
+                }
+
                 self.next_action = Some(d);
             }
         }
@@ -712,7 +754,7 @@ where
             snapshot.as_ref().map(|x| &x.meta).summary()
         );
 
-        let mut snapshot = match snapshot {
+        let snapshot = match snapshot {
             None => {
                 let io_err = StorageIOError::read_snapshot(None, AnyError::error("snapshot not found"));
                 let sto_err = StorageError::IO { source: io_err };
@@ -721,113 +763,98 @@ where
             Some(x) => x,
         };
 
-        let err_x = || (ErrorSubject::Snapshot(Some(snapshot.meta.signature())), ErrorVerb::Read);
+        let mut option = RPCOption::new(self.config.install_snapshot_timeout());
+        option.snapshot_chunk_size = Some(self.config.snapshot_max_chunk_size as usize);
 
-        let mut offset = 0;
-        let end = snapshot.snapshot.seek(SeekFrom::End(0)).await.sto_res(err_x)?;
+        let (tx_cancel, rx_cancel) = oneshot::channel();
 
-        loop {
-            // Build the RPC.
-            snapshot.snapshot.seek(SeekFrom::Start(offset)).await.sto_res(err_x)?;
+        let jh = AsyncRuntimeOf::<C>::spawn(Self::send_snapshot(
+            request_id,
+            self.snapshot_network.clone(),
+            self.session_id.vote,
+            snapshot,
+            option,
+            rx_cancel,
+            self.weak_tx_event.clone(),
+        ));
 
-            let mut buf = Vec::with_capacity(self.config.snapshot_max_chunk_size as usize);
-            while buf.capacity() > buf.len() {
-                let n = snapshot.snapshot.read_buf(&mut buf).await.sto_res(err_x)?;
-                if n == 0 {
-                    break;
-                }
-            }
+        // When self.rx_event is dropped:
+        // 1) ReplicationCore will return from the main loop;
+        // 2) and tx_cancel is dropped;
+        // 3) and the snapshot task will be notified.
+        self.snapshot_state = Some((tx_cancel, jh));
+        Ok(None)
+    }
 
-            let n_read = buf.len();
+    async fn send_snapshot(
+        request_id: Option<u64>,
+        network: Arc<Mutex<N::Network>>,
+        vote: Vote<C::NodeId>,
+        snapshot: Snapshot<C>,
+        option: RPCOption,
+        cancel: oneshot::Receiver<()>,
+        weak_tx: mpsc::WeakUnboundedSender<Replicate<C>>,
+    ) {
+        let meta = snapshot.meta.clone();
 
-            let leader_time = InstantOf::<C>::now();
+        let mut net = network.lock().await;
 
-            let done = (offset + n_read as u64) == end;
-            let req = InstallSnapshotRequest {
-                vote: self.session_id.vote,
-                meta: snapshot.meta.clone(),
-                offset,
-                data: buf,
-                done,
-            };
+        let start_time = InstantOf::<C>::now();
 
-            // Send the RPC over to the target.
-            tracing::debug!(
-                snapshot_size = req.data.len(),
-                req.offset,
-                end,
-                req.done,
-                "sending snapshot chunk"
-            );
+        let cancel = async move {
+            let _ = cancel.await;
+            ReplicationClosed::new("ReplicationCore is dropped")
+        };
 
-            let snap_timeout = if done {
-                self.config.install_snapshot_timeout()
-            } else {
-                self.config.send_snapshot_timeout()
-            };
-
-            let option = RPCOption::new(snap_timeout);
-
-            let res = C::AsyncRuntime::timeout(snap_timeout, self.network.install_snapshot(req, option)).await;
-
-            let res = match res {
-                Ok(outer_res) => match outer_res {
-                    Ok(res) => res,
-                    Err(err) => {
-                        tracing::warn!(error=%err, "error sending InstallSnapshot RPC to target");
-
-                        // If sender is closed, return at once
-                        self.try_drain_events().await?;
-
-                        // Sleep a short time otherwise in test environment it is a dead-loop that
-                        // never yields. Because network implementation does
-                        // not yield.
-                        C::AsyncRuntime::sleep(Duration::from_millis(10)).await;
-                        continue;
-                    }
-                },
-                Err(err) => {
-                    // TODO(2): add backoff when Unreachable is returned
-                    tracing::warn!(error=%err, "timeout while sending InstallSnapshot RPC to target");
-
-                    // If sender is closed, return at once
-                    self.try_drain_events().await?;
-
-                    // Sleep a short time otherwise in test environment it is a dead-loop that never
-                    // yields. Because network implementation does not yield.
-                    C::AsyncRuntime::sleep(Duration::from_millis(10)).await;
-                    continue;
-                }
-            };
-
-            // Handle response conditions.
-            if res.vote > self.session_id.vote {
-                return Err(ReplicationError::HigherVote(HigherVote {
-                    higher: res.vote,
-                    mine: self.session_id.vote,
-                }));
-            }
-
-            // If we just sent the final chunk of the snapshot, then transition to lagging state.
-            if done {
-                tracing::debug!(
-                    "done install snapshot: snapshot last_log_id: {:?}, matching: {}",
-                    snapshot.meta.last_log_id,
-                    self.matching.summary(),
-                );
-
-                // TODO: update leader lease for every successfully sent chunk.
-                self.send_progress_matching(request_id, leader_time, snapshot.meta.last_log_id);
-
-                return Ok(None);
-            }
-
-            // Everything is good, so update offset for sending the next chunk.
-            offset += n_read as u64;
-
-            // Check raft channel to ensure we are staying up-to-date, then loop.
-            self.try_drain_events().await?;
+        let res = net.snapshot(vote, snapshot, cancel, option).await;
+        if let Err(e) = &res {
+            tracing::warn!(error = display(e), "failed to send snapshot");
         }
+
+        if let Some(tx_noty) = weak_tx.upgrade() {
+            let data = Data::new_snapshot_callback(request_id, start_time, meta, res);
+            let send_res = tx_noty.send(Replicate::new_data(data));
+            if send_res.is_err() {
+                tracing::warn!("weak_tx failed to send snapshot result to ReplicationCore");
+            }
+        } else {
+            tracing::warn!("weak_tx is dropped, no response is sent to ReplicationCore");
+        }
+    }
+
+    fn handle_snapshot_callback(
+        &mut self,
+        callback: DataWithId<SnapshotCallback<C>>,
+    ) -> Result<Option<Data<C>>, ReplicationError<C::NodeId, C::Node>> {
+        tracing::debug!(
+            request_id = debug(callback.request_id()),
+            response = display(callback.data()),
+            matching = display(self.matching.display()),
+            "handle_snapshot_response"
+        );
+
+        self.snapshot_state = None;
+
+        let request_id = callback.request_id();
+        let SnapshotCallback {
+            start_time,
+            result,
+            snapshot_meta,
+        } = callback.into_data();
+
+        let resp = result?;
+
+        // Handle response conditions.
+        if resp.vote > self.session_id.vote {
+            return Err(ReplicationError::HigherVote(HigherVote {
+                higher: resp.vote,
+                mine: self.session_id.vote,
+            }));
+        }
+
+        self.send_progress_matching(request_id, start_time, snapshot_meta.last_log_id);
+
+        Ok(None)
     }
 
     /// Update matching and build a return value for a successful append-entries RPC.

--- a/tests/tests/snapshot_streaming/t33_snapshot_delete_conflict_logs.rs
+++ b/tests/tests/snapshot_streaming/t33_snapshot_delete_conflict_logs.rs
@@ -157,6 +157,7 @@ async fn snapshot_delete_conflicting_logs() -> Result<()> {
 
         let option = RPCOption::new(Duration::from_millis(1_000));
 
+        #[allow(deprecated)]
         router.new_client(1, &()).await.install_snapshot(req, option).await?;
 
         tracing::info!(log_index, "--- DONE installing snapshot");


### PR DESCRIPTION
## Changelog
### Feature: `RaftNetwork::snapshot()` to send a complete snapshot

Add `RaftNetwork::snapshot()` to send a complete snapshot and move
sending snapshot by chunks out of ReplicationCore.

To enable a fully customizable implementation of snapshot transmission
tailored to the application's needs, this commit relocates the
chunk-by-chunk transmission logic from `ReplicationCore` to a new
sub mod, `crate::network::stream_snapshot`.

The `stream_snapshot` mod provides a default chunk-based snapshot
transmission mechanism, which can be overridden by creating a custom
implementation of the `RaftNetwork::snapshot()` method. As part of this
commit, `RaftNetwork::snapshot()` simply delegates to `stream_snapshot`.
Developers may use `stream_snapshot` as a reference when implementing
their own snapshot transmission strategy.

Snapshot transmission is internally divided into two distinct phases:

1. Upon request for snapshot transmission, `ReplicationCore` initiates a
   new task `RaftNetwork::snapshot()` dedicated to sending a complete
   `Snapshot`. This task should be able to be terminated gracefully by
   subscribing the `cancel` future.

2. Once the snapshot has been fully transmitted by
   `RaftNetwork::snapshot()`, the task signals an event back to
   `ReplicationCore`. Subsequently, `ReplicationCore` informs `RaftCore`
   of the event, allowing it to acknowledge the completion of the
   snapshot transmission.

Other changes:

- `ReplicationCore` has two `RaftNetwork`s, one for log replication and
  heartbeat, the other for snapshot only.

- `ReplicationClosed` becomes a public error for notifying the
  application implemented sender that a snapshot replication is
  canceled.

- `StreamingError` is introduced as a container of errors that may occur
  in application defined snapshot transmission, including local IO
  error, network errors, errors returned by remote peer and `ReplicationClosed`.

- The `SnapshotResponse` type is introduced to differentiate it from the
  `InstallSnapshotResponse`, which is used for chunk-based responses.

---

- Part of #606

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1009)
<!-- Reviewable:end -->
