### PR TITLE
Refactor: storage implementation should use `OptionalSend, OptionalSync` instead of `Send, Sync`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -18,6 +18,8 @@ use openraft::storage::Snapshot;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogId;
 use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
@@ -100,7 +102,7 @@ impl StateMachineStore {
 }
 
 impl RaftLogReader<TypeConfig> for Arc<LogStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> Result<Vec<Entry<TypeConfig>>, StorageError<NodeId>> {

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -14,6 +14,8 @@ use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
@@ -101,7 +103,7 @@ pub struct LogStore {
 }
 
 impl RaftLogReader<TypeConfig> for Arc<LogStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> Result<Vec<Entry<TypeConfig>>, StorageError<NodeId>> {

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -20,6 +20,7 @@ use openraft::ErrorSubject;
 use openraft::ErrorVerb;
 use openraft::LogId;
 use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::SnapshotMeta;
@@ -368,7 +369,7 @@ impl LogStore {
 }
 
 impl RaftLogReader<TypeConfig> for LogStore {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> StorageResult<Vec<Entry<TypeConfig>>> {

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -18,6 +18,8 @@ use openraft::storage::Snapshot;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogId;
 use openraft::RaftStorage;
 use openraft::RaftTypeConfig;
@@ -205,7 +207,7 @@ impl Default for MemStore {
 }
 
 impl RaftLogReader<TypeConfig> for Arc<MemStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> Result<Vec<Entry<TypeConfig>>, StorageError<MemNodeId>> {
@@ -390,7 +392,7 @@ impl RaftStorage<TypeConfig> for Arc<MemStore> {
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
     async fn append_to_log<I>(&mut self, entries: I) -> Result<(), StorageError<MemNodeId>>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
+    where I: IntoIterator<Item = Entry<TypeConfig>> + OptionalSend {
         let mut log = self.log.write().await;
         for entry in entries {
             let s =

--- a/rocksstore-compat07/src/lib.rs
+++ b/rocksstore-compat07/src/lib.rs
@@ -42,6 +42,8 @@ use openraft::ErrorSubject;
 use openraft::ErrorVerb;
 use openraft::LogId;
 use openraft::LogState;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftStorage;
@@ -368,7 +370,7 @@ impl RocksStore {
 }
 
 impl RaftLogReader<TypeConfig> for Arc<RocksStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> StorageResult<Vec<Entry<TypeConfig>>> {
@@ -507,7 +509,7 @@ impl RaftStorage<TypeConfig> for Arc<RocksStore> {
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
     async fn append_to_log<I>(&mut self, entries: I) -> StorageResult<()>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
+    where I: IntoIterator<Item = Entry<TypeConfig>> + OptionalSend {
         for entry in entries {
             let id = id_to_bin(entry.log_id.index);
             assert_eq!(bin_to_id(&id), entry.log_id.index);

--- a/rocksstore/src/lib.rs
+++ b/rocksstore/src/lib.rs
@@ -23,6 +23,8 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::ErrorVerb;
 use openraft::LogId;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftStorage;
@@ -338,7 +340,7 @@ impl RocksStore {
 }
 
 impl RaftLogReader<TypeConfig> for Arc<RocksStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> StorageResult<Vec<Entry<TypeConfig>>> {
@@ -455,7 +457,7 @@ impl RaftStorage<TypeConfig> for Arc<RocksStore> {
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
     async fn append_to_log<I>(&mut self, entries: I) -> StorageResult<()>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
+    where I: IntoIterator<Item = Entry<TypeConfig>> + OptionalSend {
         for entry in entries {
             let id = id_to_bin(entry.log_id.index);
             assert_eq!(bin_to_id(&id), entry.log_id.index);

--- a/sledstore/src/lib.rs
+++ b/sledstore/src/lib.rs
@@ -21,6 +21,8 @@ use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogId;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
@@ -384,7 +386,7 @@ impl SledStore {
 }
 
 impl RaftLogReader<TypeConfig> for Arc<SledStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> StorageResult<Vec<Entry<TypeConfig>>> {
@@ -505,7 +507,7 @@ impl RaftStorage<TypeConfig> for Arc<SledStore> {
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
     async fn append_to_log<I>(&mut self, entries: I) -> StorageResult<()>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
+    where I: IntoIterator<Item = Entry<TypeConfig>> + OptionalSend {
         let logs_tree = logs(&self.db);
         let mut batch = sled::Batch::default();
         for entry in entries {

--- a/stores/rocksstore-v2/src/lib.rs
+++ b/stores/rocksstore-v2/src/lib.rs
@@ -29,6 +29,8 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::ErrorVerb;
 use openraft::LogId;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
 use openraft::RaftLogId;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
@@ -231,7 +233,7 @@ impl RocksLogStore {
 }
 
 impl RaftLogReader<TypeConfig> for RocksLogStore {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + Send + Sync>(
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
     ) -> StorageResult<Vec<Entry<TypeConfig>>> {


### PR DESCRIPTION

## Changelog

##### Refactor: storage implementation should use `OptionalSend, OptionalSync` instead of `Send, Sync`