### PR TITLE
Fixup: do not call Tick::shutdown if it is already shutdown

### DIFF
--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -46,6 +46,9 @@ where C: RaftTypeConfig
 {
     /// Signal the tick loop to stop, without waiting for it to stop.
     fn drop(&mut self) {
+        if self.shutdown.lock().unwrap().is_none() {
+            return;
+        }
         let _ = self.shutdown();
     }
 }


### PR DESCRIPTION

## Changelog

##### Fixup: do not call Tick::shutdown if it is already shutdown

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1015)
<!-- Reviewable:end -->
