### PR TITLE
Refactor: add examples/memstore to implement LogStore for other example applications

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -404,6 +404,7 @@ jobs:
           - "stable"
           - "nightly"
         example:
+          - "memstore"
           - "raft-kv-memstore"
           - "raft-kv-memstore-generic-snapshot-data"
           - "raft-kv-memstore-singlethreaded"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,12 @@ members = [
     "tests",
     "rocksstore",
     "rocksstore-compat07",
-    "sledstore"]
+    "sledstore",
+]
 exclude = [
     "cluster_benchmark",
     "stores/rocksstore-v2",
+    "examples/memstore",
     "examples/raft-kv-memstore",
     "examples/raft-kv-memstore-singlethreaded",
     "examples/raft-kv-memstore-generic-snapshot-data",

--- a/examples/memstore/Cargo.toml
+++ b/examples/memstore/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "memstore"
+version = "0.1.0"
+readme = "README.md"
+
+edition = "2021"
+authors = [
+    "drdr xp <drdr.xp@gmail.com>",
+]
+categories = ["algorithms", "asynchronous", "data-structures"]
+description = "An example in-memory storage for `openraft`."
+homepage = "https://github.com/datafuselabs/openraft"
+keywords = ["raft", "consensus"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/datafuselabs/openraft"
+
+[dependencies]
+openraft = { path = "../../openraft", features = ["serde", "storage-v2"] }
+
+tokio = { version = "1.0", default-features = false, features = ["sync"] }
+
+[features]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/examples/memstore/README.md
+++ b/examples/memstore/README.md
@@ -1,0 +1,8 @@
+# memstore
+
+This is a simple in-memory implementation of `RaftLogStore`.
+Other example Raft based applications use this crate as a component to store raft logs. 
+
+TODO:
+
+- [ ] Add `RaftStateMachine`

--- a/examples/memstore/src/lib.rs
+++ b/examples/memstore/src/lib.rs
@@ -1,0 +1,5 @@
+//! Provide storage layer implementation for examples.
+
+mod log_store;
+
+pub use log_store::LogStore;

--- a/examples/memstore/src/log_store.rs
+++ b/examples/memstore/src/log_store.rs
@@ -1,0 +1,217 @@
+//! Provide `LogStore`, which is a in-memory implementation of `RaftLogStore` for demostration
+//! purpose only.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use openraft::storage::LogFlushed;
+use openraft::LogId;
+use openraft::LogState;
+use openraft::RaftLogId;
+use openraft::RaftTypeConfig;
+use openraft::StorageError;
+use openraft::Vote;
+use tokio::sync::Mutex;
+
+/// RaftLogStore implementation with a in-memory storage
+#[derive(Clone, Debug, Default)]
+pub struct LogStore<C: RaftTypeConfig> {
+    inner: Arc<Mutex<LogStoreInner<C>>>,
+}
+
+#[derive(Debug)]
+pub struct LogStoreInner<C: RaftTypeConfig> {
+    /// The last purged log id.
+    last_purged_log_id: Option<LogId<C::NodeId>>,
+
+    /// The Raft log.
+    log: BTreeMap<u64, C::Entry>,
+
+    /// The commit log id.
+    committed: Option<LogId<C::NodeId>>,
+
+    /// The current granted vote.
+    vote: Option<Vote<C::NodeId>>,
+}
+
+impl<C: RaftTypeConfig> Default for LogStoreInner<C> {
+    fn default() -> Self {
+        Self {
+            last_purged_log_id: None,
+            log: BTreeMap::new(),
+            committed: None,
+            vote: None,
+        }
+    }
+}
+
+impl<C: RaftTypeConfig> LogStoreInner<C> {
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>>
+    where
+        C::Entry: Clone,
+    {
+        let response = self.log.range(range.clone()).map(|(_, val)| val.clone()).collect::<Vec<_>>();
+        Ok(response)
+    }
+
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>> {
+        let last = self.log.iter().next_back().map(|(_, ent)| *ent.get_log_id());
+
+        let last_purged = self.last_purged_log_id;
+
+        let last = match last {
+            None => last_purged,
+            Some(x) => Some(x),
+        };
+
+        Ok(LogState {
+            last_purged_log_id: last_purged,
+            last_log_id: last,
+        })
+    }
+
+    async fn save_committed(&mut self, committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C::NodeId>> {
+        self.committed = committed;
+        Ok(())
+    }
+
+    async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C::NodeId>> {
+        Ok(self.committed)
+    }
+
+    async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+        self.vote = Some(*vote);
+        Ok(())
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>> {
+        Ok(self.vote)
+    }
+
+    async fn append<I>(&mut self, entries: I, callback: LogFlushed<C::NodeId>) -> Result<(), StorageError<C::NodeId>>
+    where I: IntoIterator<Item = C::Entry> {
+        // Simple implementation that calls the flush-before-return `append_to_log`.
+        for entry in entries {
+            self.log.insert(entry.get_log_id().index, entry);
+        }
+        callback.log_io_completed(Ok(()));
+
+        Ok(())
+    }
+
+    async fn truncate(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+        let keys = self.log.range(log_id.index..).map(|(k, _v)| *k).collect::<Vec<_>>();
+        for key in keys {
+            self.log.remove(&key);
+        }
+
+        Ok(())
+    }
+
+    async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+        {
+            let ld = &mut self.last_purged_log_id;
+            assert!(*ld <= Some(log_id));
+            *ld = Some(log_id);
+        }
+
+        {
+            let keys = self.log.range(..=log_id.index).map(|(k, _v)| *k).collect::<Vec<_>>();
+            for key in keys {
+                self.log.remove(&key);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+mod impl_log_store {
+    use std::fmt::Debug;
+    use std::ops::RangeBounds;
+
+    use openraft::storage::LogFlushed;
+    use openraft::storage::RaftLogStorage;
+    use openraft::LogId;
+    use openraft::LogState;
+    use openraft::RaftLogReader;
+    use openraft::RaftTypeConfig;
+    use openraft::StorageError;
+    use openraft::Vote;
+
+    use crate::log_store::LogStore;
+
+    impl<C: RaftTypeConfig> RaftLogReader<C> for LogStore<C>
+    where C::Entry: Clone
+    {
+        async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug>(
+            &mut self,
+            range: RB,
+        ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.try_get_log_entries(range).await
+        }
+    }
+
+    impl<C: RaftTypeConfig> RaftLogStorage<C> for LogStore<C>
+    where C::Entry: Clone
+    {
+        type LogReader = Self;
+
+        async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.get_log_state().await
+        }
+
+        async fn save_committed(&mut self, committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.save_committed(committed).await
+        }
+
+        async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.read_committed().await
+        }
+
+        async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.save_vote(vote).await
+        }
+
+        async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.read_vote().await
+        }
+
+        async fn append<I>(
+            &mut self,
+            entries: I,
+            callback: LogFlushed<C::NodeId>,
+        ) -> Result<(), StorageError<C::NodeId>>
+        where
+            I: IntoIterator<Item = C::Entry>,
+        {
+            let mut inner = self.inner.lock().await;
+            inner.append(entries, callback).await
+        }
+
+        async fn truncate(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.truncate(log_id).await
+        }
+
+        async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C::NodeId>> {
+            let mut inner = self.inner.lock().await;
+            inner.purge(log_id).await
+        }
+
+        async fn get_log_reader(&mut self) -> Self::LogReader {
+            self.clone()
+        }
+    }
+}

--- a/examples/memstore/test-cluster.sh
+++ b/examples/memstore/test-cluster.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "No shell test script for memstore"

--- a/examples/raft-kv-memstore-generic-snapshot-data/Cargo.toml
+++ b/examples/raft-kv-memstore-generic-snapshot-data/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 [dependencies]
+memstore = { path = "../memstore", features = [] }
 openraft = { path = "../../openraft", features = ["serde", "storage-v2", "generic-snapshot-data"] }
 
 clap = { version = "4.1.11", features = ["derive", "env"] }

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
@@ -91,7 +91,7 @@ pub async fn new_raft(node_id: NodeId, router: Router) -> (typ::Raft, App) {
     let config = Arc::new(config.validate().unwrap());
 
     // Create a instance of where the Raft logs will be stored.
-    let log_store = Arc::new(LogStore::default());
+    let log_store = LogStore::default();
 
     // Create a instance of where the state machine data will be stored.
     let state_machine_store = Arc::new(StateMachineStore::default());

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
@@ -1,31 +1,27 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use openraft::storage::LogFlushed;
-use openraft::storage::LogState;
-use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
-use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StoredMembership;
-use openraft::Vote;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::typ;
 use crate::NodeId;
 use crate::TypeConfig;
+
+pub type LogStore = memstore::LogStore<TypeConfig>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
@@ -78,30 +74,6 @@ pub struct StateMachineStore {
 
     /// The last received snapshot.
     current_snapshot: Mutex<Option<StoredSnapshot>>,
-}
-
-#[derive(Debug, Default)]
-pub struct LogStore {
-    last_purged_log_id: Mutex<Option<LogId<NodeId>>>,
-
-    /// The Raft log.
-    log: Mutex<BTreeMap<u64, Entry<TypeConfig>>>,
-
-    committed: Mutex<Option<LogId<NodeId>>>,
-
-    /// The current granted vote.
-    vote: Mutex<Option<Vote<NodeId>>>,
-}
-
-impl RaftLogReader<TypeConfig> for Arc<LogStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug>(
-        &mut self,
-        range: RB,
-    ) -> Result<Vec<Entry<TypeConfig>>, StorageError<NodeId>> {
-        let log = self.log.lock().unwrap();
-        let response = log.range(range.clone()).map(|(_, val)| val.clone()).collect::<Vec<_>>();
-        Ok(response)
-    }
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
@@ -244,101 +216,6 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
-        self.clone()
-    }
-}
-
-impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
-    type LogReader = Self;
-
-    async fn get_log_state(&mut self) -> Result<LogState<TypeConfig>, StorageError<NodeId>> {
-        let log = self.log.lock().unwrap();
-        let last = log.iter().next_back().map(|(_, ent)| ent.log_id);
-
-        let last_purged = *self.last_purged_log_id.lock().unwrap();
-
-        let last = match last {
-            None => last_purged,
-            Some(x) => Some(x),
-        };
-
-        Ok(LogState {
-            last_purged_log_id: last_purged,
-            last_log_id: last,
-        })
-    }
-
-    async fn save_committed(&mut self, committed: Option<LogId<NodeId>>) -> Result<(), StorageError<NodeId>> {
-        let mut c = self.committed.lock().unwrap();
-        *c = committed;
-        Ok(())
-    }
-
-    async fn read_committed(&mut self) -> Result<Option<LogId<NodeId>>, StorageError<NodeId>> {
-        let committed = self.committed.lock().unwrap();
-        Ok(*committed)
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<NodeId>> {
-        let mut v = self.vote.lock().unwrap();
-        *v = Some(*vote);
-        Ok(())
-    }
-
-    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<NodeId>> {
-        Ok(*self.vote.lock().unwrap())
-    }
-
-    #[tracing::instrument(level = "trace", skip(self, entries, callback))]
-    async fn append<I>(&mut self, entries: I, callback: LogFlushed<NodeId>) -> Result<(), StorageError<NodeId>>
-    where I: IntoIterator<Item = Entry<TypeConfig>> {
-        // Simple implementation that calls the flush-before-return `append_to_log`.
-        let mut log = self.log.lock().unwrap();
-        for entry in entries {
-            log.insert(entry.log_id.index, entry);
-        }
-        callback.log_io_completed(Ok(()));
-
-        Ok(())
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn truncate(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
-        tracing::debug!("delete_log: [{:?}, +oo)", log_id);
-
-        let mut log = self.log.lock().unwrap();
-        let keys = log.range(log_id.index..).map(|(k, _v)| *k).collect::<Vec<_>>();
-        for key in keys {
-            log.remove(&key);
-        }
-
-        Ok(())
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
-        tracing::debug!("delete_log: (-oo, {:?}]", log_id);
-
-        {
-            let mut ld = self.last_purged_log_id.lock().unwrap();
-            assert!(*ld <= Some(log_id));
-            *ld = Some(log_id);
-        }
-
-        {
-            let mut log = self.log.lock().unwrap();
-
-            let keys = log.range(..=log_id.index).map(|(k, _v)| *k).collect::<Vec<_>>();
-            for key in keys {
-                log.remove(&key);
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn get_log_reader(&mut self) -> Self::LogReader {
         self.clone()
     }
 }

--- a/examples/raft-kv-memstore/Cargo.toml
+++ b/examples/raft-kv-memstore/Cargo.toml
@@ -20,6 +20,7 @@ name = "raft-key-value"
 path = "src/bin/main.rs"
 
 [dependencies]
+memstore = { path = "../memstore", features = [] }
 openraft = { path = "../../openraft", features = ["serde", "storage-v2"] }
 
 actix-web = "4.0.0-rc.2"

--- a/examples/raft-kv-memstore/src/app.rs
+++ b/examples/raft-kv-memstore/src/app.rs
@@ -11,7 +11,7 @@ pub struct App {
     pub id: NodeId,
     pub addr: String,
     pub raft: Raft,
-    pub log_store: Arc<LogStore>,
+    pub log_store: LogStore,
     pub state_machine_store: Arc<StateMachineStore>,
     pub config: Arc<openraft::Config>,
 }

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -66,7 +66,7 @@ pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std:
     let config = Arc::new(config.validate().unwrap());
 
     // Create a instance of where the Raft logs will be stored.
-    let log_store = Arc::new(LogStore::default());
+    let log_store = LogStore::default();
     // Create a instance of where the Raft data will be stored.
     let state_machine_store = Arc::new(StateMachineStore::default());
 

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -1,34 +1,29 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::io::Cursor;
-use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use openraft::storage::LogFlushed;
-use openraft::storage::LogState;
-use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
-use openraft::OptionalSend;
-use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
-use openraft::Vote;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::RwLock;
 
 use crate::NodeId;
 use crate::TypeConfig;
+
+pub type LogStore = memstore::LogStore<TypeConfig>;
 
 /**
  * Here you will set the types of request that will interact with the raft nodes.
@@ -86,30 +81,6 @@ pub struct StateMachineStore {
 
     /// The last received snapshot.
     current_snapshot: RwLock<Option<StoredSnapshot>>,
-}
-
-#[derive(Debug, Default)]
-pub struct LogStore {
-    last_purged_log_id: RwLock<Option<LogId<NodeId>>>,
-
-    /// The Raft log.
-    log: RwLock<BTreeMap<u64, Entry<TypeConfig>>>,
-
-    committed: RwLock<Option<LogId<NodeId>>>,
-
-    /// The current granted vote.
-    vote: RwLock<Option<Vote<NodeId>>>,
-}
-
-impl RaftLogReader<TypeConfig> for Arc<LogStore> {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
-        &mut self,
-        range: RB,
-    ) -> Result<Vec<Entry<TypeConfig>>, StorageError<NodeId>> {
-        let log = self.log.read().await;
-        let response = log.range(range.clone()).map(|(_, val)| val.clone()).collect::<Vec<_>>();
-        Ok(response)
-    }
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
@@ -256,101 +227,6 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
-        self.clone()
-    }
-}
-
-impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
-    type LogReader = Self;
-
-    async fn get_log_state(&mut self) -> Result<LogState<TypeConfig>, StorageError<NodeId>> {
-        let log = self.log.read().await;
-        let last = log.iter().next_back().map(|(_, ent)| ent.log_id);
-
-        let last_purged = *self.last_purged_log_id.read().await;
-
-        let last = match last {
-            None => last_purged,
-            Some(x) => Some(x),
-        };
-
-        Ok(LogState {
-            last_purged_log_id: last_purged,
-            last_log_id: last,
-        })
-    }
-
-    async fn save_committed(&mut self, committed: Option<LogId<NodeId>>) -> Result<(), StorageError<NodeId>> {
-        let mut c = self.committed.write().await;
-        *c = committed;
-        Ok(())
-    }
-
-    async fn read_committed(&mut self) -> Result<Option<LogId<NodeId>>, StorageError<NodeId>> {
-        let committed = self.committed.read().await;
-        Ok(*committed)
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<NodeId>> {
-        let mut v = self.vote.write().await;
-        *v = Some(*vote);
-        Ok(())
-    }
-
-    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<NodeId>> {
-        Ok(*self.vote.read().await)
-    }
-
-    #[tracing::instrument(level = "trace", skip(self, entries, callback))]
-    async fn append<I>(&mut self, entries: I, callback: LogFlushed<NodeId>) -> Result<(), StorageError<NodeId>>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
-        // Simple implementation that calls the flush-before-return `append_to_log`.
-        let mut log = self.log.write().await;
-        for entry in entries {
-            log.insert(entry.log_id.index, entry);
-        }
-        callback.log_io_completed(Ok(()));
-
-        Ok(())
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn truncate(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
-        tracing::debug!("delete_log: [{:?}, +oo)", log_id);
-
-        let mut log = self.log.write().await;
-        let keys = log.range(log_id.index..).map(|(k, _v)| *k).collect::<Vec<_>>();
-        for key in keys {
-            log.remove(&key);
-        }
-
-        Ok(())
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
-        tracing::debug!("delete_log: (-oo, {:?}]", log_id);
-
-        {
-            let mut ld = self.last_purged_log_id.write().await;
-            assert!(*ld <= Some(log_id));
-            *ld = Some(log_id);
-        }
-
-        {
-            let mut log = self.log.write().await;
-
-            let keys = log.range(..=log_id.index).map(|(k, _v)| *k).collect::<Vec<_>>();
-            for key in keys {
-                log.remove(&key);
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn get_log_reader(&mut self) -> Self::LogReader {
         self.clone()
     }
 }

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -106,7 +106,7 @@ pub use crate::raft_types::SnapshotSegmentId;
 pub use crate::storage::LogState;
 pub use crate::storage::RaftLogReader;
 pub use crate::storage::RaftSnapshotBuilder;
-pub use crate::storage::RaftStorage;
+#[cfg(not(feature = "storage-v2"))] pub use crate::storage::RaftStorage;
 pub use crate::storage::Snapshot;
 pub use crate::storage::SnapshotMeta;
 pub use crate::storage::StorageHelper;


### PR DESCRIPTION

## Changelog

##### Refactor: add examples/memstore to implement LogStore for other example applications

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1022)
<!-- Reviewable:end -->
