### PR TITLE
Refactor: extract singlethreaded store to example/memstore

### DIFF
--- a/examples/memstore/src/lib.rs
+++ b/examples/memstore/src/lib.rs
@@ -3,3 +3,4 @@
 mod log_store;
 
 pub use log_store::LogStore;
+pub use log_store::LogStoreNoSend;

--- a/examples/raft-kv-memstore-singlethreaded/Cargo.toml
+++ b/examples/raft-kv-memstore-singlethreaded/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 [dependencies]
+memstore = { path = "../memstore", features = [] }
 openraft = { path = "../../openraft", features = ["serde", "storage-v2", "singlethreaded"] }
 
 clap = { version = "4.1.11", features = ["derive", "env"] }

--- a/examples/raft-kv-memstore-singlethreaded/src/lib.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/lib.rs
@@ -100,7 +100,7 @@ pub async fn start_raft(node_id: NodeId, router: Router) -> std::io::Result<()> 
     let config = Arc::new(config.validate().unwrap());
 
     // Create a instance of where the Raft logs will be stored.
-    let log_store = Rc::new(LogStore::default());
+    let log_store = LogStore::default();
 
     // Create a instance of where the state machine data will be stored.
     let state_machine_store = Rc::new(StateMachineStore::default());


### PR DESCRIPTION

## Changelog

##### Refactor: extract singlethreaded store to example/memstore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1024)
<!-- Reviewable:end -->
