### PR TITLE
Change: remove deprecated RaftNetwork methods without `option` argument

### DIFF
--- a/examples/raft-kv-memstore-generic-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/network.rs
@@ -37,9 +37,10 @@ impl RaftNetworkFactory<TypeConfig> for Router {
 }
 
 impl RaftNetwork<TypeConfig> for Connection {
-    async fn send_append_entries(
+    async fn append_entries(
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
         let resp = self
             .router
@@ -65,7 +66,11 @@ impl RaftNetwork<TypeConfig> for Connection {
         Ok(resp)
     }
 
-    async fn send_vote(&mut self, req: VoteRequest<NodeId>) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    async fn vote(
+        &mut self,
+        req: VoteRequest<NodeId>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/vote", req)

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
@@ -37,9 +37,10 @@ impl RaftNetworkFactory<TypeConfig> for Router {
 }
 
 impl RaftNetwork<TypeConfig> for Connection {
-    async fn send_append_entries(
+    async fn append_entries(
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
         let resp = self
             .router
@@ -65,7 +66,11 @@ impl RaftNetwork<TypeConfig> for Connection {
         Ok(resp)
     }
 
-    async fn send_vote(&mut self, req: VoteRequest<NodeId>) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    async fn vote(
+        &mut self,
+        req: VoteRequest<NodeId>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/vote", req)

--- a/examples/raft-kv-memstore-singlethreaded/src/network.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/network.rs
@@ -1,5 +1,6 @@
 use openraft::error::InstallSnapshotError;
 use openraft::error::RemoteError;
+use openraft::network::RPCOption;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
 use openraft::raft::InstallSnapshotRequest;
@@ -32,9 +33,10 @@ impl RaftNetworkFactory<TypeConfig> for Router {
 }
 
 impl RaftNetwork<TypeConfig> for Connection {
-    async fn send_append_entries(
+    async fn append_entries(
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
         let resp = self
             .router
@@ -44,9 +46,10 @@ impl RaftNetwork<TypeConfig> for Connection {
         Ok(resp)
     }
 
-    async fn send_install_snapshot(
+    async fn install_snapshot(
         &mut self,
         req: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<NodeId>, typ::RPCError<InstallSnapshotError>> {
         let resp = self
             .router
@@ -56,7 +59,11 @@ impl RaftNetwork<TypeConfig> for Connection {
         Ok(resp)
     }
 
-    async fn send_vote(&mut self, req: VoteRequest<NodeId>) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    async fn vote(
+        &mut self,
+        req: VoteRequest<NodeId>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/vote", req)

--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -1,6 +1,7 @@
 use openraft::error::InstallSnapshotError;
 use openraft::error::NetworkError;
 use openraft::error::RemoteError;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -77,21 +78,27 @@ pub struct NetworkConnection {
 }
 
 impl RaftNetwork<TypeConfig> for NetworkConnection {
-    async fn send_append_entries(
+    async fn append_entries(
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-append", req).await
     }
 
-    async fn send_install_snapshot(
+    async fn install_snapshot(
         &mut self,
         req: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<NodeId>, typ::RPCError<InstallSnapshotError>> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-snapshot", req).await
     }
 
-    async fn send_vote(&mut self, req: VoteRequest<NodeId>) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    async fn vote(
+        &mut self,
+        req: VoteRequest<NodeId>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-vote", req).await
     }
 }

--- a/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft_network_impl.rs
@@ -6,6 +6,7 @@ use openraft::error::NetworkError;
 use openraft::error::RPCError;
 use openraft::error::RaftError;
 use openraft::error::RemoteError;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -99,7 +100,7 @@ fn to_error<E: std::error::Error + 'static + Clone>(e: toy_rpc::Error, target: N
 // 99  |       ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId>>>
 // {
 //     |  ___________________________________________________________________________________________^
-// 100 | |         tracing::debug!(req = debug(&req), "send_append_entries");
+// 100 | |         tracing::debug!(req = debug(&req), "append_entries");
 // 101 | |
 // 102 | |         let c = self.c().await?;
 // ...   |
@@ -112,11 +113,12 @@ fn to_error<E: std::error::Error + 'static + Clone>(e: toy_rpc::Error, target: N
 #[allow(clippy::blocks_in_conditions)]
 impl RaftNetwork<TypeConfig> for NetworkConnection {
     #[tracing::instrument(level = "debug", skip_all, err(Debug))]
-    async fn send_append_entries(
+    async fn append_entries(
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId>>> {
-        tracing::debug!(req = debug(&req), "send_append_entries");
+        tracing::debug!(req = debug(&req), "append_entries");
 
         let c = self.c().await?;
         tracing::debug!("got connection");
@@ -128,20 +130,22 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     }
 
     #[tracing::instrument(level = "debug", skip_all, err(Debug))]
-    async fn send_install_snapshot(
+    async fn install_snapshot(
         &mut self,
         req: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId, InstallSnapshotError>>> {
-        tracing::debug!(req = debug(&req), "send_install_snapshot");
+        tracing::debug!(req = debug(&req), "install_snapshot");
         self.c().await?.raft().snapshot(req).await.map_err(|e| to_error(e, self.target))
     }
 
     #[tracing::instrument(level = "debug", skip_all, err(Debug))]
-    async fn send_vote(
+    async fn vote(
         &mut self,
         req: VoteRequest<NodeId>,
+        _option: RPCOption,
     ) -> Result<VoteResponse<NodeId>, RPCError<NodeId, Node, RaftError<NodeId>>> {
-        tracing::debug!(req = debug(&req), "send_vote");
+        tracing::debug!(req = debug(&req), "vote");
         self.c().await?.raft().vote(req).await.map_err(|e| to_error(e, self.target))
     }
 }

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -240,7 +240,7 @@ where
     Closed(#[from] ReplicationClosed),
 
     // TODO(xp): two sub type: StorageError / TransportError
-    // TODO(xp): a sub error for just send_append_entries()
+    // TODO(xp): a sub error for just append_entries()
     #[error(transparent)]
     StorageError(#[from] StorageError<NID>),
 

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -53,11 +53,11 @@ impl<C: RaftTypeConfig> MessageSummary<AppendEntriesRequest<C>> for AppendEntrie
 
 /// The response to an `AppendEntriesRequest`.
 ///
-/// [`RaftNetwork::send_append_entries`] returns this type only when received an RPC reply.
+/// [`RaftNetwork::append_entries`] returns this type only when received an RPC reply.
 /// Otherwise it should return [`RPCError`].
 ///
 /// [`RPCError`]: crate::error::RPCError
-/// [`RaftNetwork::send_append_entries`]: crate::network::RaftNetwork::send_append_entries
+/// [`RaftNetwork::append_entries`]: crate::network::RaftNetwork::append_entries
 #[derive(Debug)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
@@ -67,7 +67,7 @@ pub enum AppendEntriesResponse<NID: NodeId> {
 
     /// Successfully sent the first portion of log entries.
     ///
-    /// [`RaftNetwork::send_append_entries`] can return a partial success.
+    /// [`RaftNetwork::append_entries`] can return a partial success.
     /// For example, it tries to send log entries `[1-2..3-10]`, the application is allowed to send
     /// just `[1-2..1-3]` and return `PartialSuccess(1-3)`,
     ///
@@ -75,12 +75,12 @@ pub enum AppendEntriesResponse<NID: NodeId> {
     ///
     /// The returned matching log id must be **greater than or equal to** the first log
     /// id([`AppendEntriesRequest::prev_log_id`]) of the entries to send. If no RPC reply is
-    /// received, [`RaftNetwork::send_append_entries`] must return an [`RPCError`] to inform
+    /// received, [`RaftNetwork::append_entries`] must return an [`RPCError`] to inform
     /// Openraft that the first log id([`AppendEntriesRequest::prev_log_id`]) may not match on
     /// the remote target node.
     ///
     /// [`RPCError`]: crate::error::RPCError
-    /// [`RaftNetwork::send_append_entries`]: crate::network::RaftNetwork::send_append_entries
+    /// [`RaftNetwork::append_entries`]: crate::network::RaftNetwork::append_entries
     PartialSuccess(Option<LogId<NID>>),
 
     /// The first log id([`AppendEntriesRequest::prev_log_id`]) of the entries to send does not

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -32,6 +32,7 @@ use openraft::error::RaftError;
 use openraft::error::RemoteError;
 use openraft::error::Unreachable;
 use openraft::metrics::Wait;
+use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
@@ -985,9 +986,10 @@ pub struct RaftRouterNetwork {
 
 impl RaftNetwork<MemConfig> for RaftRouterNetwork {
     /// Send an AppendEntries RPC to the target Raft node (§5).
-    async fn send_append_entries(
+    async fn append_entries(
         &mut self,
         mut rpc: AppendEntriesRequest<MemConfig>,
+        _option: RPCOption,
     ) -> Result<AppendEntriesResponse<MemNodeId>, RPCError<MemNodeId, (), RaftError<MemNodeId>>> {
         let from_id = rpc.vote.leader_id().voted_for().unwrap();
 
@@ -1048,9 +1050,10 @@ impl RaftNetwork<MemConfig> for RaftRouterNetwork {
     }
 
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
-    async fn send_install_snapshot(
+    async fn install_snapshot(
         &mut self,
         rpc: InstallSnapshotRequest<MemConfig>,
+        _option: RPCOption,
     ) -> Result<InstallSnapshotResponse<MemNodeId>, RPCError<MemNodeId, (), RaftError<MemNodeId, InstallSnapshotError>>>
     {
         let from_id = rpc.vote.leader_id().voted_for().unwrap();
@@ -1069,9 +1072,10 @@ impl RaftNetwork<MemConfig> for RaftRouterNetwork {
     }
 
     /// Send a RequestVote RPC to the target Raft node (§5).
-    async fn send_vote(
+    async fn vote(
         &mut self,
         rpc: VoteRequest<MemNodeId>,
+        _option: RPCOption,
     ) -> Result<VoteResponse<MemNodeId>, RPCError<MemNodeId, (), RaftError<MemNodeId>>> {
         let from_id = rpc.vote.leader_id().voted_for().unwrap();
 

--- a/tests/tests/replication/t10_append_entries_partial_success.rs
+++ b/tests/tests/replication/t10_append_entries_partial_success.rs
@@ -8,7 +8,7 @@ use openraft::Config;
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
 
-/// RaftNetwork::send_append_entries can return a partial success.
+/// RaftNetwork::append_entries can return a partial success.
 /// For example, it tries to send log entries `[1-2..2-10]`, the application is allowed to send just
 /// `[1-2..1-3]` and return `PartialSuccess(1-3)`.
 #[async_entry::test(worker_threads = 4, init = "init_default_ut_tracing()", tracing_span = "debug")]


### PR DESCRIPTION

## Changelog

##### Change: remove deprecated RaftNetwork methods without `option` argument

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1028)
<!-- Reviewable:end -->
