### PR TITLE
Refactor: even when `generic-snapshot-data` is enabled, the old chunked transport be still available

### DIFF
--- a/openraft/src/network/mod.rs
+++ b/openraft/src/network/mod.rs
@@ -5,7 +5,8 @@ mod factory;
 #[allow(clippy::module_inception)] mod network;
 mod rpc_option;
 mod rpc_type;
-#[cfg(not(feature = "generic-snapshot-data"))] pub(crate) mod stream_snapshot;
+
+pub mod snapshot_transport;
 
 pub use backoff::Backoff;
 pub use factory::RaftNetworkFactory;

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -44,8 +44,7 @@ where C: RaftTypeConfig
     pub(in crate::raft) core_state: Mutex<CoreState<C::NodeId, C::AsyncRuntime>>,
 
     /// The ongoing snapshot transmission.
-    #[cfg(not(feature = "generic-snapshot-data"))]
-    pub(in crate::raft) snapshot: Mutex<Option<crate::network::stream_snapshot::Streaming<C>>>,
+    pub(in crate::raft) snapshot: Mutex<Option<crate::network::snapshot_transport::Streaming<C>>>,
 }
 
 impl<C> RaftInner<C>


### PR DESCRIPTION

## Changelog

##### Refactor: even when `generic-snapshot-data` is enabled, the old chunked transport be still available

If `generic-snapshot-data` is enabled, the old chunk based transport
such as `RaftNetwork::install_snapshot()` for sending and
`Raft::install_snapshot()` for receiving should be still be available
but just deprecated.
This way the application can upgrade Openraft without modification,
except several `#[allow(deprecated)]` attributes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1036)
<!-- Reviewable:end -->
