### PR TITLE
Change: `Raft::begin_receiving_snapshot()` does not need to check `Vote`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1117,8 +1117,8 @@ where
 
                 self.handle_vote_request(rpc, tx);
             }
-            RaftMsg::BeginReceivingSnapshot { vote, tx } => {
-                self.engine.handle_begin_receiving_snapshot(vote, tx);
+            RaftMsg::BeginReceivingSnapshot { tx } => {
+                self.engine.handle_begin_receiving_snapshot(tx);
             }
             RaftMsg::InstallFullSnapshot { vote, snapshot, tx } => {
                 self.engine.handle_install_full_snapshot(vote, snapshot, tx);

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -71,11 +71,11 @@ where C: RaftTypeConfig
 
     /// Begin receiving a snapshot from the leader.
     ///
-    /// Returns a handle to a snapshot data ready for receiving if successful.
-    /// Otherwise, it is an error because of the `vote` is not GE the local `vote`, the local `vote`
-    /// will be returned in a Err
+    /// Returns a snapshot data handle for receiving data.
+    ///
+    /// It does not check [`Vote`] because it is a read operation
+    /// and does not break raft protocol.
     BeginReceivingSnapshot {
-        vote: Vote<C::NodeId>,
         tx: ResultSender<C, Box<SnapshotDataOf<C>>, HigherVote<C::NodeId>>,
     },
 
@@ -123,9 +123,7 @@ where C: RaftTypeConfig
             RaftMsg::RequestVote { rpc, .. } => {
                 format!("RequestVote: {}", rpc.summary())
             }
-            RaftMsg::BeginReceivingSnapshot { vote, .. } => {
-                format!("BeginReceivingSnapshot: vote: {}", vote)
-            }
+            RaftMsg::BeginReceivingSnapshot { .. } => "BeginReceivingSnapshot".to_string(),
             RaftMsg::InstallFullSnapshot { vote, snapshot, .. } => {
                 format!("InstallFullSnapshot: vote: {}, snapshot: {}", vote, snapshot)
             }

--- a/tests/tests/client_api/t13_begin_receiving_snapshot.rs
+++ b/tests/tests/client_api/t13_begin_receiving_snapshot.rs
@@ -2,9 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-use openraft::error::HigherVote;
 use openraft::Config;
-use openraft::Vote;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -35,24 +33,10 @@ async fn begin_receiving_snapshot() -> anyhow::Result<()> {
         router.wait(&1, timeout()).applied_index(Some(log_index), "write more log").await?;
     }
 
-    tracing::info!(log_index, "--- fails to execute with smaller vote");
-    {
-        let n1 = router.get_raft_handle(&1)?;
-
-        let res = n1.begin_receiving_snapshot(Vote::new(0, 0)).await;
-        assert_eq!(
-            HigherVote {
-                higher: Vote::new_committed(1, 0),
-                mine: Vote::new(0, 0),
-            },
-            res.unwrap_err().into_api_error().unwrap()
-        );
-    }
-
     tracing::info!(log_index, "--- got a snapshot data");
     {
         let n1 = router.get_raft_handle(&1)?;
-        let _resp = n1.begin_receiving_snapshot(Vote::new_committed(1, 0)).await?;
+        let _resp = n1.begin_receiving_snapshot().await?;
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Change: `Raft::begin_receiving_snapshot()` does not need to check `Vote`

Because `begin_receiving_snapshot` is a read operation and does not
break raft protocol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1037)
<!-- Reviewable:end -->
