### PR TITLE
Change: `Raft::begin_receiving_snapshot()` return only `Fatal` error.

### DIFF
--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::error::CheckIsLeaderError;
 use crate::error::ClientWriteError;
-use crate::error::HigherVote;
 use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::raft::AppendEntriesRequest;
@@ -76,7 +75,7 @@ where C: RaftTypeConfig
     /// It does not check [`Vote`] because it is a read operation
     /// and does not break raft protocol.
     BeginReceivingSnapshot {
-        tx: ResultSender<C, Box<SnapshotDataOf<C>>, HigherVote<C::NodeId>>,
+        tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>,
     },
 
     ClientWriteRequest {

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -3,7 +3,7 @@ use std::fmt::Formatter;
 
 use crate::core::raft_msg::ResultSender;
 use crate::display_ext::DisplaySlice;
-use crate::error::HigherVote;
+use crate::error::Infallible;
 use crate::log_id::RaftLogId;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::RaftTypeConfig;
@@ -59,7 +59,7 @@ where C: RaftTypeConfig
         Command::new(payload)
     }
 
-    pub(crate) fn begin_receiving_snapshot(tx: ResultSender<C, Box<SnapshotDataOf<C>>, HigherVote<C::NodeId>>) -> Self {
+    pub(crate) fn begin_receiving_snapshot(tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>) -> Self {
         let payload = CommandPayload::BeginReceivingSnapshot { tx };
         Command::new(payload)
     }
@@ -95,7 +95,7 @@ where C: RaftTypeConfig
     },
 
     BeginReceivingSnapshot {
-        tx: ResultSender<C, Box<SnapshotDataOf<C>>, HigherVote<C::NodeId>>,
+        tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>,
     },
 
     InstallFullSnapshot {

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -24,7 +24,7 @@ use crate::engine::EngineOutput;
 use crate::engine::Respond;
 use crate::entry::RaftPayload;
 use crate::error::ForwardToLeader;
-use crate::error::HigherVote;
+use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::error::NotAllowed;
 use crate::error::NotInMembers;
@@ -487,10 +487,7 @@ where C: RaftTypeConfig
 
     /// Install a completely received snapshot on a follower.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn handle_begin_receiving_snapshot(
-        &mut self,
-        tx: ResultSender<C, Box<SnapshotDataOf<C>>, HigherVote<C::NodeId>>,
-    ) {
+    pub(crate) fn handle_begin_receiving_snapshot(&mut self, tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>) {
         tracing::info!("{}", func_name!());
         self.output.push_command(Command::from(sm::Command::begin_receiving_snapshot(tx)));
     }


### PR DESCRIPTION

## Changelog

##### Change: `Raft::begin_receiving_snapshot()` return only `Fatal` error.

The returning error should be `RaftError<_, Infallible>`
instead of `RaftError<_, HigherVote>`: it does not return `HigherVote`
error anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1038)
<!-- Reviewable:end -->
