### PR TITLE
Refactor: make `macros` a public crate for publishing

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "macros"
+name = "openraft-macros"
 
 version       = { workspace = true }
 edition       = { workspace = true }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("lib_readme.md")]
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse2;
@@ -11,7 +13,7 @@ use syn::Type;
 
 /// This proc macro attribute optionally adds `Send` bounds to a trait.
 ///
-/// By default, `Send` bounds will be added to the trait and to the return bounds of any  async
+/// By default, `Send` bounds will be added to the trait and to the return bounds of any async
 /// functions defined withing the trait.
 ///
 /// If the `singlethreaded` feature is enabled, the trait definition remains the same without any
@@ -20,11 +22,19 @@ use syn::Type;
 /// # Example
 ///
 /// ```
-/// use macros::add_async_trait;
+/// use openraft_macros::add_async_trait;
 ///
 /// #[add_async_trait]
 /// trait MyTrait {
 ///     async fn my_method(&self) -> Result<(), String>;
+/// }
+/// ```
+///
+/// The above code will be transformed into:
+///
+/// ```ignore
+/// trait MyTrait {
+///     fn my_method(&self) -> impl Future<Output=Result<(), String>> + Send;
 /// }
 /// ```
 ///

--- a/macros/src/lib_readme.md
+++ b/macros/src/lib_readme.md
@@ -1,0 +1,20 @@
+Supporting utils for [Openraft](https://crates.io/crates/openraft).
+
+`#[add_async_trait]` adds `Send` bounds to an async trait.
+
+# Example
+
+```
+#[openraft_macros::add_async_trait]
+trait MyTrait {
+    async fn my_method(&self) -> Result<(), String>;
+}
+```
+
+The above code will be transformed into:
+
+```ignore
+trait MyTrait {
+    fn my_method(&self) -> impl Future<Output=Result<(), String>> + Send;
+}
+```

--- a/memstore/README.md
+++ b/memstore/README.md
@@ -1,5 +1,5 @@
 # openraft-memstore
 
-This is an in-memory example `RaftStorage` implementation based on [openraft-0.8](https://github.com/datafuselabs/openraft/tree/release-0.8).
+This is an in-memory example `RaftLogStorage` and `RaftStateMachine` implementation based on [openraft](https://github.com/datafuselabs/openraft/).
 
 This crate is built mainly for testing or demonstrating purpose.:)

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -13,6 +13,7 @@ keywords      = { workspace = true }
 license       = { workspace = true }
 repository    = { workspace = true }
 
+
 [dependencies]
 anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
@@ -20,7 +21,7 @@ byte-unit       = { workspace = true }
 clap            = { workspace = true }
 derive_more     = { workspace = true }
 futures         = { workspace = true }
-macros          = { path = "../macros" }
+openraft-macros = { path = "../macros", version = "0.9.0" }
 maplit          = { workspace = true }
 rand            = { workspace = true }
 serde           = { workspace = true, optional = true }
@@ -80,7 +81,7 @@ compat = []
 storage-v2 = []
 
 # Disallows applications to share a raft instance with multiple threads.
-singlethreaded = ["macros/singlethreaded"]
+singlethreaded = ["openraft-macros/singlethreaded"]
 
 
 # Permit the follower's log to roll back to an earlier state without causing the

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -68,10 +68,10 @@ mod try_as_ref;
 
 pub use anyerror;
 pub use anyerror::AnyError;
-pub use macros::add_async_trait;
 pub use network::RPCTypes;
 pub use network::RaftNetwork;
 pub use network::RaftNetworkFactory;
+pub use openraft_macros::add_async_trait;
 pub use type_config::RaftTypeConfig;
 
 pub use crate::async_runtime::AsyncRuntime;

--- a/openraft/src/network/factory.rs
+++ b/openraft/src/network/factory.rs
@@ -1,4 +1,4 @@
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 
 use crate::network::RaftNetwork;
 use crate::OptionalSend;

--- a/openraft/src/network/network.rs
+++ b/openraft/src/network/network.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::time::Duration;
 
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 
 use crate::error::Fatal;
 use crate::error::RPCError;

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -6,7 +6,7 @@ use std::io::SeekFrom;
 use std::time::Duration;
 
 use futures::FutureExt;
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWriteExt;

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -1,4 +1,4 @@
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 
 use crate::engine::Command;
 use crate::RaftTypeConfig;

--- a/openraft/src/storage/log_store_ext.rs
+++ b/openraft/src/storage/log_store_ext.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::ops::RangeBounds;
 
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 
 use crate::defensive::check_range_matches_entries;
 use crate::LogId;

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -14,7 +14,7 @@ use std::ops::RangeBounds;
 #[cfg(not(feature = "storage-v2"))] pub use adapter::Adaptor;
 pub use helper::StorageHelper;
 pub use log_store_ext::RaftLogReaderExt;
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 pub use snapshot_signature::SnapshotSignature;
 pub use v2::RaftLogStorage;
 pub use v2::RaftLogStorageExt;

--- a/openraft/src/storage/v2.rs
+++ b/openraft/src/storage/v2.rs
@@ -4,7 +4,7 @@
 
 mod raft_log_storage_ext;
 
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 pub use raft_log_storage_ext::RaftLogStorageExt;
 
 use crate::storage::callback::LogFlushed;

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -1,5 +1,5 @@
 use anyerror::AnyError;
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 
 use crate::storage::LogFlushed;
 use crate::storage::RaftLogStorage;

--- a/openraft/src/testing/store_builder.rs
+++ b/openraft/src/testing/store_builder.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "storage-v2"))] use std::future::Future;
 
-use macros::add_async_trait;
+use openraft_macros::add_async_trait;
 
 #[cfg(not(feature = "storage-v2"))] use crate::storage::Adaptor;
 use crate::storage::RaftLogStorage;


### PR DESCRIPTION

## Changelog

##### Refactor: make `macros` a public crate for publishing

`macros` is renamed to `openraft-macros` and will be published to
crates.io so that Openraft-0.9 that relies on it can be published.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1045)
<!-- Reviewable:end -->
