### PR TITLE
Doc: do not enable `singlethreaded` for docs.rs; fix typos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 
 </div>
 
-🪵🪵🪵 Raft is not yet good enough.
 This project intends to improve raft as the next-generation consensus protocol for distributed data storage systems (SQL, NoSQL, KV, Streaming, Graph ... or maybe something more exotic).
 
 Currently, openraft is the consensus engine of meta-service cluster in [databend](https://github.com/datafuselabs/databend).
@@ -31,6 +30,7 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 - 🙌 **Questions**?
     - Join the [Discord channel](https://discord.gg/ZKw3WG7FQ9),
     - or start a [Discussion](https://github.com/datafuselabs/openraft/discussions/new),
+    - or Join [Feishu(飞书) group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=d20l9084-6d36-4470-bac5-4bad7378d003),
     - or join our wechat group: `drmingdrmer`.
 
 - Openraft is derived from [async-raft](https://docs.rs/crate/async-raft/latest) with several bugs fixed: [Fixed bugs](https://github.com/datafuselabs/openraft/blob/main/derived-from-async-raft.md).
@@ -57,7 +57,12 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 ## Versions
 
 - **Branch main** has been under active development.
-    The main branch is for the [release-0.9](https://github.com/datafuselabs/openraft/tree/release-0.9).
+    The main branch is for the [release-0.10](https://github.com/datafuselabs/openraft/tree/release-0.10).
+
+- **Branch [release-0.9](https://github.com/datafuselabs/openraft/tree/release-0.9)**:
+  Latest: ( [v0.9.0](https://github.com/datafuselabs/openraft/tree/v0.9.0) | [Change log](https://github.com/datafuselabs/openraft/blob/release-0.9/change-log.md#v090) );
+  Upgrade guide: ⬆️  [0.8 to 0.9](https://docs.rs/openraft/0.9.0/openraft/docs/upgrade_guide/upgrade_08_09/index.html);
+  `release-0.9` **Won't** accept new features but only bug fixes.
 
 - **Branch [release-0.8](https://github.com/datafuselabs/openraft/tree/release-0.8)**:
   Latest: ( [v0.8.8](https://github.com/datafuselabs/openraft/tree/v0.8.8) | [Change log](https://github.com/datafuselabs/openraft/blob/release-0.8/change-log.md#v088) );
@@ -121,25 +126,24 @@ For benchmark detail, go to the [./cluster_benchmark](./cluster_benchmark) folde
 - ✅ **Log Compaction**(snapshot of state machine): by policy or manully([`trigger_snapshot()`]).
 - ✅ **Snapshot replication**.
 - ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/latest/openraft/docs/cluster_control/dynamic_membership/index.html)
+- ✅ **Linearizable read**: [`ensure_linearizable()`][].
 - ⛔️ **Wont support**: Single-step config change.  <!-- TODO: explain why -->
-- ✅ Toggle heartbeat: [`enable_heartbeat`][].
-- ✅ Toggle election: [`enable_elect`][].
+- ✅ Toggle heartbeat / election: [`enable_heartbeat`][] / [`enable_elect`][].
+- ✅ Trigger snapshot / election manually: [`trigger_snapshot()`][] / [`trigger_elect()`][].
 - ✅ Purge log by policy or manually: [`purge_log()`][].
-
-<!--
-TODO: 0.9
-- ✅ Linearizable read.
--->
 
 
 # Who use it
 
+- [Databend](https://github.com/datafuselabs/databend)
+- [CnosDB](https://github.com/cnosdb/cnosdb)
 - [yuyang0/rrqlite](https://github.com/yuyang0/rrqlite)
 - [raymondshe/matchengine-raft](https://github.com/raymondshe/matchengine-raft)
 
 # Contributing
 
-Check out the [CONTRIBUTING.md](https://github.com/datafuselabs/openraft/blob/main/CONTRIBUTING.md) guide for more details on getting started with contributing to this project.
+Check out the [CONTRIBUTING.md](https://github.com/datafuselabs/openraft/blob/main/CONTRIBUTING.md)
+guide for more details on getting started with contributing to this project.
 
 ## Contributors
 
@@ -151,7 +155,9 @@ Made with [contributors-img](https://contrib.rocks).
 
 # License
 
-Openraft is licensed under the terms of the [MIT License](https://en.wikipedia.org/wiki/MIT_License#License_terms) or the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0), at your choosing.
+Openraft is licensed under the terms of the [MIT License](https://en.wikipedia.org/wiki/MIT_License#License_terms)
+or the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0), at your choosing.
+
 
 [`change_membership()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.change_membership
 [`add_learner()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.add_learner
@@ -160,14 +166,6 @@ Openraft is licensed under the terms of the [MIT License](https://en.wikipedia.o
 [`enable_heartbeat`]: https://docs.rs/openraft/latest/openraft/struct.Config.html#structfield.enable_heartbeat
 [`enable_elect`]: https://docs.rs/openraft/latest/openraft/struct.Config.html#structfield.enable_elect
 
-
-<!-- TODO: update these API when 0.9 is published: -->
-
 [`trigger_elect()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.trigger_elect
 [`trigger_snapshot()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.trigger_snapshot
-
-<!--
-TODO: enable when 0.9 is published:
-
-[`ensure_linearizable()`]: xx
--->
+[`ensure_linearizable()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.ensure_linearizable

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -115,8 +115,21 @@ tracing-log = [ "tracing/log" ]
 
 [package.metadata.docs.rs]
 
-# Enable this flag to show all types/mods, including the feature enabled ones on docs.rs
-all-features = true
+# Enable these feature flags to show all types/mods,
+# including the feature enabled ones on docs.rs
+features = [
+    "bt",
+    "compat",
+    "generic-snapshot-data",
+    "loosen-follower-log-revert",
+    "serde",
+    "storage-v2",
+    "tracing-log",
+]
+
+# Do not use this to enable all features:
+# "singlethreaded" makes `Raft<C>` a `!Send`, which confuses users.
+# all-features = true
 
 # Sort modules by appearance order for crate `docs`.
 # https://doc.rust-lang.org/rustdoc/unstable-features.html#--sort-modules-by-appearance-control-how-items-on-module-pages-are-sorted

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -4,7 +4,7 @@ mod external_request;
 mod message;
 mod raft_inner;
 mod runtime_config_handle;
-mod trigger;
+pub mod trigger;
 
 use std::collections::BTreeMap;
 
@@ -60,7 +60,7 @@ use crate::metrics::Wait;
 use crate::metrics::WaitError;
 use crate::network::RaftNetworkFactory;
 use crate::raft::raft_inner::RaftInner;
-use crate::raft::runtime_config_handle::RuntimeConfigHandle;
+pub use crate::raft::runtime_config_handle::RuntimeConfigHandle;
 use crate::raft::trigger::Trigger;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
@@ -89,7 +89,7 @@ use crate::Vote;
 /// Example:
 /// ```ignore
 /// openraft::declare_raft_types!(
-///    pub Config:
+///    pub TypeConfig:
 ///        D            = ClientRequest,
 ///        R            = ClientResponse,
 ///        NodeId       = u64,

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -25,7 +25,7 @@ use crate::OptionalSync;
 /// Example:
 /// ```ignore
 /// openraft::declare_raft_types!(
-///    pub Config:
+///    pub TypeConfig:
 ///        D            = ClientRequest,
 ///        R            = ClientResponse,
 ///        NodeId       = u64,


### PR DESCRIPTION

## Changelog

##### Doc: do not enable `singlethreaded` for docs.rs; fix typos


##### Refactor: RuntimeConfigHandler should be public


##### BumpVer: 0.9.1


##### Refactor: Trigger should be public


##### Doc: Update README for 0.9

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1047)
<!-- Reviewable:end -->
