### PR TITLE
Chore: move entries in declare_raft_types into multiple lines

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -40,8 +40,14 @@ pub struct ClientResponse {}
 pub type NodeId = u64;
 
 openraft::declare_raft_types!(
-    pub TypeConfig: D = ClientRequest, R = ClientResponse, NodeId = NodeId, Node = (),
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = TokioRuntime
+    pub TypeConfig:
+        D = ClientRequest,
+        R = ClientResponse,
+        NodeId = NodeId,
+        Node = (),
+        Entry = Entry<TypeConfig>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime
 );
 
 #[derive(Debug)]
@@ -224,14 +230,8 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    async fn append<I>(
-        &mut self,
-        entries: I,
-        callback: LogFlushed<TypeConfig>,
-    ) -> Result<(), StorageError<NodeId>>
-    where
-        I: IntoIterator<Item = Entry<TypeConfig>> + Send,
-    {
+    async fn append<I>(&mut self, entries: I, callback: LogFlushed<TypeConfig>) -> Result<(), StorageError<NodeId>>
+    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
         {
             let mut log = self.log.write().await;
             log.extend(entries.into_iter().map(|entry| (entry.get_log_id().index, entry)));

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -29,8 +29,14 @@ pub type NodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
-    pub TypeConfig: D = Request, R = Response, NodeId = NodeId, Node = BasicNode,
-    Entry = openraft::Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = TokioRuntime
+    pub TypeConfig:
+        D = Request,
+        R = Response,
+        NodeId = NodeId,
+        Node = BasicNode,
+        Entry = openraft::Entry<TypeConfig>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime
 );
 
 pub type LogStore = store::LogStore;

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -36,7 +36,7 @@ openraft::declare_raft_types!(
         Node = BasicNode,
         Entry = openraft::Entry<TypeConfig>,
         SnapshotData = Cursor<Vec<u8>>,
-        AsyncRuntime = TokioRuntime
+        AsyncRuntime = TokioRuntime,
 );
 
 pub type LogStore = store::LogStore;

--- a/openraft/src/docs/upgrade_guide/upgrade-v08-v09.md
+++ b/openraft/src/docs/upgrade_guide/upgrade-v08-v09.md
@@ -36,12 +36,28 @@ The first step for upgrading is to adapt the changes in the API.
 Follow the following steps to update your application to pass compilation with v0.9.
 
 - Implementation of `RaftLogReader::get_log_state()` is moved to `RaftLogReader::get_log_state()`.
+
 - Generic types parameters `N, LS, SM` are removed from `Raft<C, N, LS, SM>`.
+
 - `RaftNetwork::send_xxx()` methods are removed, and should be replaced with `RaftNetwork::xxx()`:
   - `RaftNetwork::send_append_entries()` to `RaftNetwork::append_entries()`;
   - `RaftNetwork::send_vote()` to `RaftNetwork::vote()`;
   - `RaftNetwork::send_install_snapshot()` to `RaftNetwork::install_snapshot()`;
 
+- `asycn` traits in Openraft are declared with [`#[openraft-macros::add_async_trait]`][`openraft-macros`] attribute since 0.9.
+  `#[async_trait::async_trait]` are no longer needed when implementing `async` trait.
+
+  For example, upgrade 0.8 async-trait implementation 
+  ```ignore
+  #[async_trait::async_trait]
+  impl RaftNetwork<TypeConfig> for MyNetwork {}
+  ```
+  
+  to 
+
+  ```ignore
+  impl RaftNetwork<TypeConfig> for MyNetwork {}
+  ```
 
 ## Upgrade `RaftTypeConfig`
 
@@ -188,5 +204,6 @@ To use arbitrary snapshot data, the application needs to:
 [`generic-snapshot-data`]:       `crate::docs::feature_flags#feature-flag-generic-snapshot-data`
 [`tracing-log`]:                 `crate::docs::feature_flags#feature-flag-tracing-log`
 
+[`openraft-macros`]: https://docs.rs/openraft-macros/latest/openraft_macros/
 [`tokio`]: https://tokio.rs/ 
 [`monoio`]: https://github.com/bytedance/monoio

--- a/openraft/src/docs/upgrade_guide/upgrade-v08-v09.md
+++ b/openraft/src/docs/upgrade_guide/upgrade-v08-v09.md
@@ -30,6 +30,19 @@
     - [`generic-snapshot-data`][]: Remove `AsyncRead + AsyncWrite` bound from snapshot data. Let application define its own snapshot data transfer.
 
 
+## Upgrade for API changes 
+
+The first step for upgrading is to adapt the changes in the API.
+Follow the following steps to update your application to pass compilation with v0.9.
+
+- Implementation of `RaftLogReader::get_log_state()` is moved to `RaftLogReader::get_log_state()`.
+- Generic types parameters `N, LS, SM` are removed from `Raft<C, N, LS, SM>`.
+- `RaftNetwork::send_xxx()` methods are removed, and should be replaced with `RaftNetwork::xxx()`:
+  - `RaftNetwork::send_append_entries()` to `RaftNetwork::append_entries()`;
+  - `RaftNetwork::send_vote()` to `RaftNetwork::vote()`;
+  - `RaftNetwork::send_install_snapshot()` to `RaftNetwork::install_snapshot()`;
+
+
 ## Upgrade `RaftTypeConfig`
 
 - Add `AsyncRuntime` to `RaftTypeConfig` to specify the async runtime to use.

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -101,7 +101,7 @@ use crate::Vote;
 /// ```
 #[macro_export]
 macro_rules! declare_raft_types {
-    ( $(#[$outer:meta])* $visibility:vis $id:ident: $($(#[$inner:meta])* $type_id:ident = $type:ty),+ ) => {
+    ( $(#[$outer:meta])* $visibility:vis $id:ident: $($(#[$inner:meta])* $type_id:ident = $type:ty),+ $(,)? ) => {
         $(#[$outer])*
         #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/rocksstore/src/lib.rs
+++ b/rocksstore/src/lib.rs
@@ -46,8 +46,14 @@ pub type RocksNodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for `MemStore`.
-    pub TypeConfig: D = RocksRequest, R = RocksResponse, NodeId = RocksNodeId, Node = BasicNode,
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = TokioRuntime
+    pub TypeConfig:
+        D = RocksRequest,
+        R = RocksResponse,
+        NodeId = RocksNodeId,
+        Node = BasicNode,
+        Entry = Entry<TypeConfig>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime
 );
 
 /**

--- a/sledstore/src/lib.rs
+++ b/sledstore/src/lib.rs
@@ -41,8 +41,14 @@ pub type ExampleNodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
-    pub TypeConfig: D = ExampleRequest, R = ExampleResponse, NodeId = ExampleNodeId, Node = BasicNode,
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = TokioRuntime
+    pub TypeConfig:
+        D = ExampleRequest,
+        R = ExampleResponse,
+        NodeId = ExampleNodeId,
+        Node = BasicNode,
+        Entry = Entry<TypeConfig>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime
 );
 
 /**

--- a/stores/rocksstore-v2/src/lib.rs
+++ b/stores/rocksstore-v2/src/lib.rs
@@ -53,8 +53,14 @@ pub type RocksNodeId = u64;
 
 openraft::declare_raft_types!(
     /// Declare the type configuration.
-    pub TypeConfig: D = RocksRequest, R = RocksResponse, NodeId = RocksNodeId, Node = BasicNode,
-    Entry = Entry<TypeConfig>, SnapshotData = Cursor<Vec<u8>>, AsyncRuntime = TokioRuntime
+    pub TypeConfig:
+        D = RocksRequest,
+        R = RocksResponse,
+        NodeId = RocksNodeId,
+        Node = BasicNode,
+        Entry = Entry<TypeConfig>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime
 );
 
 /**


### PR DESCRIPTION

## Changelog

##### Chore: move entries in declare_raft_types into multiple lines

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1048)
<!-- Reviewable:end -->
