### PR TITLE
Fix: The last leader in a cluster should step down

### DIFF
--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -20,6 +20,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
     let config = Arc::new(
         Config {
             heartbeat_interval: 200,
+            enable_elect: false,
             election_timeout_min: 1000,
             election_timeout_max: 1001,
             ..Default::default()

--- a/tests/tests/elect/main.rs
+++ b/tests/tests/elect/main.rs
@@ -9,3 +9,4 @@ mod fixtures;
 
 mod t10_elect_compare_last_log;
 mod t11_elect_seize_leadership;
+mod t50_last_leader_expire;

--- a/tests/tests/elect/t50_last_leader_expire.rs
+++ b/tests/tests/elect/t50_last_leader_expire.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::AsyncRuntime;
+use openraft::Config;
+use openraft::RaftTypeConfig;
+use openraft::ServerState;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// The leader leader should expire and re-elect,
+/// even when the leader is the last live node in a cluster.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn last_leader_expire() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up cluster of 1 node");
+    let log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- shutdown node-1");
+    let (n1, _sto, _sm) = router.remove_node(1).unwrap();
+    n1.shutdown().await?;
+
+    tracing::info!(log_index, "--- ");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        let last_modify = n0.with_raft_state(|st| st.vote_last_modified()).await?;
+        let last_modify = last_modify.unwrap();
+        let now = <<TypeConfig as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::Instant::now();
+        println!(
+            "last_modify: {:?}, now: {:?}, {:?}",
+            last_modify,
+            now,
+            now - last_modify
+        );
+    }
+
+    tracing::info!(log_index, "--- node-0 should expire leader lease and step down");
+    {
+        router.wait(&0, timeout()).metrics(|m| m.current_leader.is_none(), "node-0 step down").await?;
+        router.wait(&0, timeout()).metrics(|m| m.state != ServerState::Leader, "node-0 step down").await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2_000))
+}

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -66,7 +66,7 @@ use openraft_memstore::IntoMemClientRequest;
 use openraft_memstore::MemLogStore as LogStoreInner;
 use openraft_memstore::MemNodeId;
 use openraft_memstore::MemStateMachine as SMInner;
-use openraft_memstore::TypeConfig;
+pub use openraft_memstore::TypeConfig;
 use openraft_memstore::TypeConfig as MemConfig;
 #[allow(unused_imports)] use pretty_assertions::assert_eq;
 #[allow(unused_imports)] use pretty_assertions::assert_ne;


### PR DESCRIPTION

## Changelog

##### Fix: The last leader in a cluster should step down

When the leader's leader lease expires, it should step down and start
another round of election.

Before this commit, if the leader is the last node in a cluster, this
last leader won't step down automatically, until it received a request
with higher vote from other nodes.

In this commit, the leader checks its lease to decide whether it is
still a valid leader.

Thanks to @pfwang80s for reporting this issue!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1056)
<!-- Reviewable:end -->
