### PR TITLE
Feature: `Raft::config()` returns a ref to Config this raft node uses

### DIFF
--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -276,6 +276,11 @@ where C: RaftTypeConfig
         RuntimeConfigHandle::new(self.inner.as_ref())
     }
 
+    /// Return the config of this Raft node.
+    pub fn config(&self) -> &Arc<Config> {
+        &self.inner.config
+    }
+
     /// Return a handle to manually trigger raft actions, such as elect or build snapshot.
     ///
     /// Example:

--- a/tests/tests/management/main.rs
+++ b/tests/tests/management/main.rs
@@ -1,0 +1,10 @@
+#![cfg_attr(feature = "bt", feature(error_generic_member_access))]
+
+#[macro_use]
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+// The number indicate the preferred running order for these case.
+// The later tests may depend on the earlier ones.
+
+mod t10_raft_config;

--- a/tests/tests/management/t10_raft_config.rs
+++ b/tests/tests/management/t10_raft_config.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Get config via [`Raft::config`](openraft::Raft::config)
+#[async_entry::test(worker_threads = 4, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn raft_config() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            election_timeout_min: 123,
+            election_timeout_max: 124,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- get config");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        let c = n0.config();
+
+        #[allow(clippy::bool_assert_comparison)]
+        {
+            assert_eq!(c.enable_tick, false);
+        }
+        assert_eq!(c.election_timeout_min, 123);
+        assert_eq!(c.election_timeout_max, 124);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### Feature: `Raft::config()` returns a ref to Config this raft node uses

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1057)
<!-- Reviewable:end -->
