### PR TITLE
Change: Consolidate `RaftMetrics` type parameters into `C`

### DIFF
--- a/examples/raft-kv-memstore-generic-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/api.rs
@@ -14,6 +14,7 @@ use crate::decode;
 use crate::encode;
 use crate::typ;
 use crate::NodeId;
+use crate::TypeConfig;
 
 pub async fn write(app: &mut App, req: String) -> String {
     let res = app.raft.client_write(decode(&req)).await;
@@ -99,6 +100,6 @@ pub async fn init(app: &mut App) -> String {
 pub async fn metrics(app: &mut App) -> String {
     let metrics = app.raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<NodeId, BasicNode>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<TypeConfig>, Infallible> = Ok(metrics);
     encode(res)
 }

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
@@ -58,7 +58,7 @@ pub mod typ {
     pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
     pub type StreamingError<E> = openraft::error::StreamingError<TypeConfig, E>;
 
-    pub type RaftMetrics = openraft::RaftMetrics<NodeId, BasicNode>;
+    pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 
     pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
     pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
@@ -14,6 +14,7 @@ use crate::decode;
 use crate::encode;
 use crate::typ;
 use crate::NodeId;
+use crate::TypeConfig;
 
 pub async fn write(app: &mut App, req: String) -> String {
     let res = app.raft.client_write(decode(&req)).await;
@@ -99,6 +100,6 @@ pub async fn init(app: &mut App) -> String {
 pub async fn metrics(app: &mut App) -> String {
     let metrics = app.raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<NodeId, BasicNode>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<TypeConfig>, Infallible> = Ok(metrics);
     encode(res)
 }

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -57,7 +57,7 @@ pub mod typ {
     pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
     pub type StreamingError<E> = openraft::error::StreamingError<TypeConfig, E>;
 
-    pub type RaftMetrics = openraft::RaftMetrics<NodeId, BasicNode>;
+    pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 
     pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
     pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;

--- a/examples/raft-kv-memstore-singlethreaded/src/api.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/api.rs
@@ -13,6 +13,7 @@ use crate::app::App;
 use crate::decode;
 use crate::encode;
 use crate::NodeId;
+use crate::TypeConfig;
 
 pub async fn write(app: &mut App, req: String) -> String {
     let res = app.raft.client_write(decode(&req)).await;
@@ -88,6 +89,6 @@ pub async fn init(app: &mut App) -> String {
 pub async fn metrics(app: &mut App) -> String {
     let metrics = app.raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<NodeId, BasicNode>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<TypeConfig>, Infallible> = Ok(metrics);
     encode(res)
 }

--- a/examples/raft-kv-memstore-singlethreaded/src/lib.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/lib.rs
@@ -70,7 +70,7 @@ pub mod typ {
     pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<NodeId, E>;
     pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
 
-    pub type RaftMetrics = openraft::RaftMetrics<NodeId, BasicNode>;
+    pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 
     pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
     pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;

--- a/examples/raft-kv-memstore/src/client.rs
+++ b/examples/raft-kv-memstore/src/client.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use openraft::error::ForwardToLeader;
 use openraft::error::NetworkError;
 use openraft::error::RemoteError;
-use openraft::BasicNode;
 use openraft::RaftMetrics;
 use openraft::TryAsRef;
 use serde::de::DeserializeOwned;
@@ -17,6 +16,7 @@ use tokio::time::timeout;
 use crate::typ;
 use crate::NodeId;
 use crate::Request;
+use crate::TypeConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Empty {}
@@ -103,7 +103,7 @@ impl ExampleClient {
     /// Metrics contains various information about the cluster, such as current leader,
     /// membership config, replication status etc.
     /// See [`RaftMetrics`].
-    pub async fn metrics(&self) -> Result<RaftMetrics<NodeId, BasicNode>, typ::RPCError> {
+    pub async fn metrics(&self) -> Result<RaftMetrics<TypeConfig>, typ::RPCError> {
         self.do_send_rpc_to_leader("metrics", None::<&()>).await
     }
 

--- a/examples/raft-kv-memstore/src/network/management.rs
+++ b/examples/raft-kv-memstore/src/network/management.rs
@@ -12,6 +12,7 @@ use openraft::RaftMetrics;
 
 use crate::app::App;
 use crate::NodeId;
+use crate::TypeConfig;
 
 // --- Cluster management
 
@@ -49,6 +50,6 @@ pub async fn init(app: Data<App>) -> actix_web::Result<impl Responder> {
 pub async fn metrics(app: Data<App>) -> actix_web::Result<impl Responder> {
     let metrics = app.raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<NodeId, BasicNode>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<TypeConfig>, Infallible> = Ok(metrics);
     Ok(Json(res))
 }

--- a/examples/raft-kv-rocksdb/src/client.rs
+++ b/examples/raft-kv-rocksdb/src/client.rs
@@ -16,6 +16,7 @@ use crate::typ;
 use crate::Node;
 use crate::NodeId;
 use crate::Request;
+use crate::TypeConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Empty {}
@@ -102,7 +103,7 @@ impl ExampleClient {
     /// Metrics contains various information about the cluster, such as current leader,
     /// membership config, replication status etc.
     /// See [`RaftMetrics`].
-    pub async fn metrics(&self) -> Result<RaftMetrics<NodeId, Node>, typ::RPCError> {
+    pub async fn metrics(&self) -> Result<RaftMetrics<TypeConfig>, typ::RPCError> {
         self.do_send_rpc_to_leader("cluster/metrics", None::<&()>).await
     }
 

--- a/examples/raft-kv-rocksdb/src/network/management.rs
+++ b/examples/raft-kv-rocksdb/src/network/management.rs
@@ -13,6 +13,7 @@ use crate::app::App;
 use crate::Node;
 use crate::NodeId;
 use crate::Server;
+use crate::TypeConfig;
 
 // --- Cluster management
 
@@ -60,6 +61,6 @@ async fn init(req: Request<Arc<App>>) -> tide::Result {
 async fn metrics(req: Request<Arc<App>>) -> tide::Result {
     let metrics = req.state().raft.metrics().borrow().clone();
 
-    let res: Result<RaftMetrics<NodeId, Node>, Infallible> = Ok(metrics);
+    let res: Result<RaftMetrics<TypeConfig>, Infallible> = Ok(metrics);
     Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
 }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -196,9 +196,9 @@ where
     /// A Receiver to receive callback from other components.
     pub(crate) rx_notify: mpsc::UnboundedReceiver<Notify<C>>,
 
-    pub(crate) tx_metrics: watch::Sender<RaftMetrics<C::NodeId, C::Node>>,
-    pub(crate) tx_data_metrics: watch::Sender<RaftDataMetrics<C::NodeId>>,
-    pub(crate) tx_server_metrics: watch::Sender<RaftServerMetrics<C::NodeId, C::Node>>,
+    pub(crate) tx_metrics: watch::Sender<RaftMetrics<C>>,
+    pub(crate) tx_data_metrics: watch::Sender<RaftDataMetrics<C>>,
+    pub(crate) tx_server_metrics: watch::Sender<RaftServerMetrics<C>>,
 
     pub(crate) command_state: CommandState,
 

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -48,7 +48,7 @@ mod tests {
     mod startup_test;
     mod trigger_purge_log_test;
 }
-#[cfg(test)] mod testing;
+#[cfg(test)] pub(crate) mod testing;
 
 pub(crate) use command::Command;
 pub(crate) use command::Condition;

--- a/openraft/src/metrics/metric_display.rs
+++ b/openraft/src/metrics/metric_display.rs
@@ -3,17 +3,17 @@ use std::fmt::Formatter;
 
 use crate::display_ext::DisplayOption;
 use crate::metrics::Metric;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// Display the value of a metric.
-pub(crate) struct MetricDisplay<'a, NID>
-where NID: NodeId
+pub(crate) struct MetricDisplay<'a, C>
+where C: RaftTypeConfig
 {
-    pub(crate) metric: &'a Metric<NID>,
+    pub(crate) metric: &'a Metric<C>,
 }
 
-impl<'a, NID> fmt::Display for MetricDisplay<'a, NID>
-where NID: NodeId
+impl<'a, C> fmt::Display for MetricDisplay<'a, C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.metric {

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -5,25 +5,20 @@ use crate::core::ServerState;
 use crate::display_ext::DisplayOption;
 use crate::error::Fatal;
 use crate::metrics::ReplicationMetrics;
-use crate::node::Node;
 use crate::summary::MessageSummary;
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::StoredMembership;
 use crate::Vote;
 
 /// A set of metrics describing the current state of a Raft node.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct RaftMetrics<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    pub running_state: Result<(), Fatal<NID>>,
+pub struct RaftMetrics<C: RaftTypeConfig> {
+    pub running_state: Result<(), Fatal<C::NodeId>>,
 
     /// The ID of the Raft node.
-    pub id: NID,
+    pub id: C::NodeId,
 
     // ---
     // --- data ---
@@ -32,23 +27,23 @@ where
     pub current_term: u64,
 
     /// The last accepted vote.
-    pub vote: Vote<NID>,
+    pub vote: Vote<C::NodeId>,
 
     /// The last log index has been appended to this Raft node's log.
     pub last_log_index: Option<u64>,
 
     /// The last log index has been applied to this Raft node's state machine.
-    pub last_applied: Option<LogId<NID>>,
+    pub last_applied: Option<LogId<C::NodeId>>,
 
     /// The id of the last log included in snapshot.
     /// If there is no snapshot, it is (0,0).
-    pub snapshot: Option<LogId<NID>>,
+    pub snapshot: Option<LogId<C::NodeId>>,
 
     /// The last log id that has purged from storage, inclusive.
     ///
     /// `purged` is also the first log id Openraft knows, although the corresponding log entry has
     /// already been deleted.
-    pub purged: Option<LogId<NID>>,
+    pub purged: Option<LogId<C::NodeId>>,
 
     // ---
     // --- cluster ---
@@ -57,22 +52,20 @@ where
     pub state: ServerState,
 
     /// The current cluster leader.
-    pub current_leader: Option<NID>,
+    pub current_leader: Option<C::NodeId>,
 
     /// The current membership config of the cluster.
-    pub membership_config: Arc<StoredMembership<NID, N>>,
+    pub membership_config: Arc<StoredMembership<C::NodeId, C::Node>>,
 
     // ---
     // --- replication ---
     // ---
     /// The replication states. It is Some() only when this node is leader.
-    pub replication: Option<ReplicationMetrics<NID>>,
+    pub replication: Option<ReplicationMetrics<C::NodeId>>,
 }
 
-impl<NID, N> fmt::Display for RaftMetrics<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> fmt::Display for RaftMetrics<C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Metrics{{")?;
@@ -106,22 +99,18 @@ where
         Ok(())
     }
 }
-impl<NID, N> MessageSummary<RaftMetrics<NID, N>> for RaftMetrics<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> MessageSummary<RaftMetrics<C>> for RaftMetrics<C>
+where C: RaftTypeConfig
 {
     fn summary(&self) -> String {
         self.to_string()
     }
 }
 
-impl<NID, N> RaftMetrics<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> RaftMetrics<C>
+where C: RaftTypeConfig
 {
-    pub fn new_initial(id: NID) -> Self {
+    pub fn new_initial(id: C::NodeId) -> Self {
         Self {
             running_state: Ok(()),
             id,
@@ -144,18 +133,16 @@ where
 /// Subset of RaftMetrics, only include data-related metrics
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct RaftDataMetrics<NID>
-where NID: NodeId
-{
-    pub last_log: Option<LogId<NID>>,
-    pub last_applied: Option<LogId<NID>>,
-    pub snapshot: Option<LogId<NID>>,
-    pub purged: Option<LogId<NID>>,
-    pub replication: Option<ReplicationMetrics<NID>>,
+pub struct RaftDataMetrics<C: RaftTypeConfig> {
+    pub last_log: Option<LogId<C::NodeId>>,
+    pub last_applied: Option<LogId<C::NodeId>>,
+    pub snapshot: Option<LogId<C::NodeId>>,
+    pub purged: Option<LogId<C::NodeId>>,
+    pub replication: Option<ReplicationMetrics<C::NodeId>>,
 }
 
-impl<NID> fmt::Display for RaftDataMetrics<NID>
-where NID: NodeId
+impl<C> fmt::Display for RaftDataMetrics<C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DataMetrics{{")?;
@@ -178,8 +165,8 @@ where NID: NodeId
     }
 }
 
-impl<NID> MessageSummary<RaftDataMetrics<NID>> for RaftDataMetrics<NID>
-where NID: NodeId
+impl<C> MessageSummary<RaftDataMetrics<C>> for RaftDataMetrics<C>
+where C: RaftTypeConfig
 {
     fn summary(&self) -> String {
         self.to_string()
@@ -189,22 +176,16 @@ where NID: NodeId
 /// Subset of RaftMetrics, only include server-related metrics
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct RaftServerMetrics<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
-    pub id: NID,
-    pub vote: Vote<NID>,
+pub struct RaftServerMetrics<C: RaftTypeConfig> {
+    pub id: C::NodeId,
+    pub vote: Vote<C::NodeId>,
     pub state: ServerState,
-    pub current_leader: Option<NID>,
-    pub membership_config: Arc<StoredMembership<NID, N>>,
+    pub current_leader: Option<C::NodeId>,
+    pub membership_config: Arc<StoredMembership<C::NodeId, C::Node>>,
 }
 
-impl<NID, N> fmt::Display for RaftServerMetrics<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> fmt::Display for RaftServerMetrics<C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ServerMetrics{{")?;
@@ -224,10 +205,8 @@ where
     }
 }
 
-impl<NID, N> MessageSummary<RaftServerMetrics<NID, N>> for RaftServerMetrics<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> MessageSummary<RaftServerMetrics<C>> for RaftServerMetrics<C>
+where C: RaftTypeConfig
 {
     fn summary(&self) -> String {
         self.to_string()

--- a/openraft/src/metrics/wait_condition.rs
+++ b/openraft/src/metrics/wait_condition.rs
@@ -2,27 +2,27 @@ use std::fmt;
 
 use crate::metrics::metric_display::MetricDisplay;
 use crate::metrics::Metric;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// A condition that the application wait for.
 #[derive(Debug)]
-pub(crate) enum Condition<NID>
-where NID: NodeId
+pub(crate) enum Condition<C>
+where C: RaftTypeConfig
 {
-    GE(Metric<NID>),
-    EQ(Metric<NID>),
+    GE(Metric<C>),
+    EQ(Metric<C>),
 }
 
-impl<NID> Condition<NID>
-where NID: NodeId
+impl<C> Condition<C>
+where C: RaftTypeConfig
 {
     /// Build a new condition which the application will await to meet or exceed.
-    pub(crate) fn ge(v: Metric<NID>) -> Self {
+    pub(crate) fn ge(v: Metric<C>) -> Self {
         Self::GE(v)
     }
 
     /// Build a new condition which the application will await to meet.
-    pub(crate) fn eq(v: Metric<NID>) -> Self {
+    pub(crate) fn eq(v: Metric<C>) -> Self {
         Self::EQ(v)
     }
 
@@ -40,7 +40,7 @@ where NID: NodeId
         }
     }
 
-    pub(crate) fn value(&self) -> MetricDisplay<'_, NID> {
+    pub(crate) fn value(&self) -> MetricDisplay<'_, C> {
         match self {
             Condition::GE(v) => v.value(),
             Condition::EQ(v) => v.value(),
@@ -48,8 +48,8 @@ where NID: NodeId
     }
 }
 
-impl<NID> fmt::Display for Condition<NID>
-where NID: NodeId
+impl<C> fmt::Display for Condition<C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}{}{}", self.name(), self.op(), self.value())

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -7,18 +7,18 @@ use tokio::sync::watch;
 use tokio::time::sleep;
 
 use crate::core::ServerState;
+use crate::engine::testing::UTConfig;
 use crate::log_id::LogIdOptionExt;
 use crate::metrics::Wait;
 use crate::metrics::WaitError;
 use crate::testing::log_id;
+use crate::type_config::alias::NodeIdOf;
 use crate::vote::CommittedLeaderId;
 use crate::LogId;
 use crate::Membership;
-use crate::Node;
-use crate::NodeId;
 use crate::RaftMetrics;
+use crate::RaftTypeConfig;
 use crate::StoredMembership;
-use crate::TokioRuntime;
 use crate::Vote;
 
 /// Test wait for different state changes
@@ -26,7 +26,7 @@ use crate::Vote;
 async fn test_wait() -> anyhow::Result<()> {
     {
         // wait for leader
-        let (init, w, tx) = init_wait_test::<u64, ()>();
+        let (init, w, tx) = init_wait_test::<UTConfig>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -42,7 +42,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for applied log
-        let (init, w, tx) = init_wait_test::<u64, ()>();
+        let (init, w, tx) = init_wait_test::<UTConfig>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -70,7 +70,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for state
-        let (init, w, tx) = init_wait_test::<u64, ()>();
+        let (init, w, tx) = init_wait_test::<UTConfig>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -87,7 +87,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // wait for members
-        let (init, w, tx) = init_wait_test::<u64, ()>();
+        let (init, w, tx) = init_wait_test::<UTConfig>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -110,7 +110,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     tracing::info!("--- wait for snapshot, Ok");
     {
-        let (init, w, tx) = init_wait_test::<u64, ()>();
+        let (init, w, tx) = init_wait_test::<UTConfig>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -127,7 +127,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     tracing::info!("--- wait for snapshot, only index matches");
     {
-        let (init, w, tx) = init_wait_test::<u64, ()>();
+        let (init, w, tx) = init_wait_test::<UTConfig>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(10)).await;
@@ -152,7 +152,7 @@ async fn test_wait() -> anyhow::Result<()> {
 
     {
         // timeout
-        let (_init, w, _tx) = init_wait_test::<u64, ()>();
+        let (_init, w, _tx) = init_wait_test::<UTConfig>();
 
         let h = tokio::spawn(async move {
             sleep(Duration::from_millis(200)).await;
@@ -176,7 +176,7 @@ async fn test_wait() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_wait_log_index() -> anyhow::Result<()> {
     // wait for applied log
-    let (init, w, tx) = init_wait_test::<u64, ()>();
+    let (init, w, tx) = init_wait_test::<UTConfig>();
 
     let h = tokio::spawn(async move {
         sleep(Duration::from_millis(10)).await;
@@ -203,7 +203,7 @@ async fn test_wait_log_index() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_wait_vote() -> anyhow::Result<()> {
-    let (init, w, tx) = init_wait_test::<u64, ()>();
+    let (init, w, tx) = init_wait_test::<UTConfig>();
 
     let h = tokio::spawn(async move {
         sleep(Duration::from_millis(10)).await;
@@ -226,7 +226,7 @@ async fn test_wait_vote() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_wait_purged() -> anyhow::Result<()> {
-    let (init, w, tx) = init_wait_test::<u64, ()>();
+    let (init, w, tx) = init_wait_test::<UTConfig>();
 
     let h = tokio::spawn(async move {
         sleep(Duration::from_millis(10)).await;
@@ -242,22 +242,15 @@ async fn test_wait_purged() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(crate) type InitResult<NID, N> = (
-    RaftMetrics<NID, N>,
-    Wait<NID, N, TokioRuntime>,
-    watch::Sender<RaftMetrics<NID, N>>,
-);
+pub(crate) type InitResult<C> = (RaftMetrics<C>, Wait<C>, watch::Sender<RaftMetrics<C>>);
 
 /// Build a initial state for testing of Wait:
 /// Returns init metrics, Wait, and the tx to send an updated metrics.
-fn init_wait_test<NID, N>() -> InitResult<NID, N>
-where
-    NID: NodeId,
-    N: Node,
-{
+fn init_wait_test<C>() -> InitResult<C>
+where C: RaftTypeConfig {
     let init = RaftMetrics {
         running_state: Ok(()),
-        id: NID::default(),
+        id: NodeIdOf::<C>::default(),
         state: ServerState::Learner,
         current_term: 0,
         vote: Vote::default(),
@@ -275,7 +268,6 @@ where
     let w = Wait {
         timeout: Duration::from_millis(100),
         rx,
-        _phantom: std::marker::PhantomData,
     };
 
     (init, w, tx)

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -13,7 +13,6 @@ pub(crate) use self::external_request::BoxCoreFn;
 pub(in crate::raft) mod core_state;
 
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -668,7 +667,7 @@ where C: RaftTypeConfig
     /// Returns Err() if it should keep waiting.
     fn check_replication_upto_date(
         &self,
-        metrics: &RaftMetrics<C::NodeId, C::Node>,
+        metrics: &RaftMetrics<C>,
         node_id: C::NodeId,
         membership_log_id: Option<LogId<C::NodeId>>,
     ) -> Result<Option<LogId<C::NodeId>>, ()> {
@@ -856,17 +855,17 @@ where C: RaftTypeConfig
     }
 
     /// Get a handle to the metrics channel.
-    pub fn metrics(&self) -> watch::Receiver<RaftMetrics<C::NodeId, C::Node>> {
+    pub fn metrics(&self) -> watch::Receiver<RaftMetrics<C>> {
         self.inner.rx_metrics.clone()
     }
 
     /// Get a handle to the data metrics channel.
-    pub fn data_metrics(&self) -> watch::Receiver<RaftDataMetrics<C::NodeId>> {
+    pub fn data_metrics(&self) -> watch::Receiver<RaftDataMetrics<C>> {
         self.inner.rx_data_metrics.clone()
     }
 
     /// Get a handle to the server metrics channel.
-    pub fn server_metrics(&self) -> watch::Receiver<RaftServerMetrics<C::NodeId, C::Node>> {
+    pub fn server_metrics(&self) -> watch::Receiver<RaftServerMetrics<C>> {
         self.inner.rx_server_metrics.clone()
     }
 
@@ -890,7 +889,7 @@ where C: RaftTypeConfig
     /// // wait for raft state to become a follower
     /// r.wait(None).state(State::Follower, "state").await?;
     /// ```
-    pub fn wait(&self, timeout: Option<Duration>) -> Wait<C::NodeId, C::Node, C::AsyncRuntime> {
+    pub fn wait(&self, timeout: Option<Duration>) -> Wait<C> {
         let timeout = match timeout {
             Some(t) => t,
             None => Duration::from_secs(86400 * 365 * 100),
@@ -898,7 +897,6 @@ where C: RaftTypeConfig
         Wait {
             timeout,
             rx: self.inner.rx_metrics.clone(),
-            _phantom: PhantomData,
         }
     }
 

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -34,9 +34,9 @@ where C: RaftTypeConfig
     pub(in crate::raft) runtime_config: Arc<RuntimeConfig>,
     pub(in crate::raft) tick_handle: TickHandle<C>,
     pub(in crate::raft) tx_api: mpsc::UnboundedSender<RaftMsg<C>>,
-    pub(in crate::raft) rx_metrics: watch::Receiver<RaftMetrics<C::NodeId, C::Node>>,
-    pub(in crate::raft) rx_data_metrics: watch::Receiver<RaftDataMetrics<C::NodeId>>,
-    pub(in crate::raft) rx_server_metrics: watch::Receiver<RaftServerMetrics<C::NodeId, C::Node>>,
+    pub(in crate::raft) rx_metrics: watch::Receiver<RaftMetrics<C>>,
+    pub(in crate::raft) rx_data_metrics: watch::Receiver<RaftDataMetrics<C>>,
+    pub(in crate::raft) rx_server_metrics: watch::Receiver<RaftServerMetrics<C>>,
 
     // TODO(xp): it does not need to be a async mutex.
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
## Changelog

##### Change: Consolidate `RaftMetrics` type parameters into `C`

The `RaftMetrics` type, along with related metric types, previously used
separate type parameters (`NID`, `N`) which have now been replaced with
a single generic parameter `C` bound by `RaftTypeConfig`. This
modification simplifies the type signatures and usage.

Upgrade tip:

To adapt to this change, update the metric-related type parameters from
separate `NID` and `N` to the single generic `C` constrained by
`RaftTypeConfig`:

```rust
RaftMetrics<NID, N>         --> RaftMetrics<C>
RaftDataMetrics<NID>        --> RaftDataMetrics<C>
RaftServerMetrics<NID, NID> --> RaftServerMetrics<C>
Metric<NID>                 --> Metric<C>
Wait<NID, N, A>             --> Wait<C>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1058)
<!-- Reviewable:end -->
