### PR TITLE
Fix: Ensure heartbeat results are returned to `RaftCore`

### DIFF
--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -7,6 +7,7 @@ use std::fmt::Formatter;
 use validit::Validate;
 
 use crate::log_id_range::LogIdRange;
+use crate::replication::request_id::RequestId;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::MessageSummary;
@@ -112,11 +113,11 @@ impl<NID: NodeId> Inflight<NID> {
         }
     }
 
-    pub(crate) fn is_my_id(&self, res_id: u64) -> bool {
+    pub(crate) fn is_my_id(&self, res_id: RequestId) -> bool {
         match self {
             Inflight::None => false,
-            Inflight::Logs { id, .. } => *id == res_id,
-            Inflight::Snapshot { id, .. } => *id == res_id,
+            Inflight::Logs { id, .. } => RequestId::AppendEntries { id: *id } == res_id,
+            Inflight::Snapshot { id, .. } => RequestId::Snapshot { id: *id } == res_id,
         }
     }
 

--- a/openraft/src/replication/request_id.rs
+++ b/openraft/src/replication/request_id.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+
+/// The request id of a replication action.
+///
+/// HeartBeat has not payload and does not need a request id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RequestId {
+    HeartBeat,
+    AppendEntries { id: u64 },
+    Snapshot { id: u64 },
+}
+
+impl RequestId {
+    pub(crate) fn new_heartbeat() -> Self {
+        Self::HeartBeat
+    }
+
+    pub(crate) fn new_append_entries(id: u64) -> Self {
+        Self::AppendEntries { id }
+    }
+
+    pub(crate) fn new_snapshot(id: u64) -> Self {
+        Self::Snapshot { id }
+    }
+
+    pub(crate) fn request_id(&self) -> Option<u64> {
+        match self {
+            Self::HeartBeat => None,
+            Self::AppendEntries { id } => Some(*id),
+            Self::Snapshot { id } => Some(*id),
+        }
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HeartBeat => write!(f, "HeartBeat"),
+            Self::AppendEntries { id } => write!(f, "AppendEntries({})", id),
+            Self::Snapshot { id } => write!(f, "Snapshot({})", id),
+        }
+    }
+}

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -1,3 +1,4 @@
+use crate::replication::request_id::RequestId;
 use crate::replication::ReplicationSessionId;
 use crate::utime::UTime;
 use crate::AsyncRuntime;
@@ -22,9 +23,7 @@ where C: RaftTypeConfig
         target: C::NodeId,
 
         /// The id of the subject that submit this replication action.
-        ///
-        /// It is only used for debugging purpose.
-        request_id: u64,
+        request_id: RequestId,
 
         /// The request by this leader has been successfully handled by the target node,
         /// or an error in string.


### PR DESCRIPTION

## Changelog

##### Fix: Ensure heartbeat results are returned to `RaftCore`

Previously, the heartbeat results were not sent back to
`RaftCore`, which requires these results to calculate the **last
timestamp acknowledged by a quorum**.

This commit resolves the issue by ensuring that the heartbeat RPC
results are sent back to `RaftCore`, allowing it to correctly update the
**last timestamp acknowledged by a quorum**.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1061)
<!-- Reviewable:end -->
