### PR TITLE
Feature: add `RaftMetrics::millis_since_quorum_ack`

### DIFF
--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -84,6 +84,7 @@ where C: RaftTypeConfig
     ///
     /// Note: This method does not check last-log-id. handle-vote-request has to deal with
     /// last-log-id itself.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn update_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), RejectVoteRequest<C::NodeId>> {
         // Partial ord compare:
         // Vote does not has to be total ord.
@@ -137,7 +138,11 @@ where C: RaftTypeConfig
     pub(crate) fn become_leading(&mut self) {
         if let Some(l) = self.internal_server_state.leading_mut() {
             if l.vote.leader_id() == self.state.vote_ref().leader_id() {
-                // Vote still belongs to the same leader. Just updating vote is enough.
+                tracing::debug!(
+                    "vote still belongs to the same leader. Just updating vote is enough: node-{}, {}",
+                    self.config.id,
+                    self.state.vote_ref()
+                );
                 l.vote = *self.state.vote_ref();
                 self.server_state_handler().update_server_state_if_changed();
                 return;

--- a/openraft/src/instant.rs
+++ b/openraft/src/instant.rs
@@ -35,6 +35,18 @@ pub trait Instant:
 {
     /// Return the current instant.
     fn now() -> Self;
+
+    /// Return the amount of time since the instant.
+    ///
+    /// The returned duration is guaranteed to be non-negative.
+    fn elapsed(&self) -> Duration {
+        let now = Self::now();
+        if now > *self {
+            now - *self
+        } else {
+            Duration::from_secs(0)
+        }
+    }
 }
 
 pub type TokioInstant = tokio::time::Instant;

--- a/openraft/src/leader/leader.rs
+++ b/openraft/src/leader/leader.rs
@@ -107,8 +107,7 @@ where
     /// Note that the leader may not be in the QuorumSet at all.
     /// In such a case, the update operation will be just ignored,
     /// and the quorum-acked-time is totally determined by remove voters.
-    #[allow(dead_code)]
-    pub(crate) fn quorum_acked_time(&mut self) -> Option<I> {
+    pub(crate) fn last_quorum_acked_time(&mut self) -> Option<I> {
         // For `Leading`, the vote is always the leader's vote.
         // Thus vote.voted_for() is this node.
 
@@ -142,7 +141,7 @@ mod tests {
     use crate::Vote;
 
     #[test]
-    fn test_leading_quorum_acked_time_leader_is_voter() {
+    fn test_leading_last_quorum_acked_time_leader_is_voter() {
         let mut leading = Leading::<u64, Vec<u64>, InstantOf<UTConfig>>::new(
             Vote::new_committed(2, 1),
             vec![1, 2, 3],
@@ -153,12 +152,12 @@ mod tests {
         let now1 = InstantOf::<UTConfig>::now();
 
         let _t2 = leading.clock_progress.increase_to(&2, Some(now1));
-        let t1 = leading.quorum_acked_time();
+        let t1 = leading.last_quorum_acked_time();
         assert_eq!(Some(now1), t1, "n1(leader) and n2 acked, t1 > t2");
     }
 
     #[test]
-    fn test_leading_quorum_acked_time_leader_is_learner() {
+    fn test_leading_last_quorum_acked_time_leader_is_learner() {
         let mut leading = Leading::<u64, Vec<u64>, InstantOf<UTConfig>>::new(
             Vote::new_committed(2, 4),
             vec![1, 2, 3],
@@ -168,17 +167,17 @@ mod tests {
 
         let t2 = InstantOf::<UTConfig>::now();
         let _ = leading.clock_progress.increase_to(&2, Some(t2));
-        let t = leading.quorum_acked_time();
+        let t = leading.last_quorum_acked_time();
         assert!(t.is_none(), "n1(leader+learner) does not count in quorum");
 
         let t3 = InstantOf::<UTConfig>::now();
         let _ = leading.clock_progress.increase_to(&3, Some(t3));
-        let t = leading.quorum_acked_time();
+        let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");
     }
 
     #[test]
-    fn test_leading_quorum_acked_time_leader_is_not_member() {
+    fn test_leading_last_quorum_acked_time_leader_is_not_member() {
         let mut leading = Leading::<u64, Vec<u64>, InstantOf<UTConfig>>::new(
             Vote::new_committed(2, 5),
             vec![1, 2, 3],
@@ -188,12 +187,12 @@ mod tests {
 
         let t2 = InstantOf::<UTConfig>::now();
         let _ = leading.clock_progress.increase_to(&2, Some(t2));
-        let t = leading.quorum_acked_time();
+        let t = leading.last_quorum_acked_time();
         assert!(t.is_none(), "n1(leader+learner) does not count in quorum");
 
         let t3 = InstantOf::<UTConfig>::now();
         let _ = leading.clock_progress.increase_to(&3, Some(t3));
-        let t = leading.quorum_acked_time();
+        let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");
     }
 }

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -259,6 +259,7 @@ where C: RaftTypeConfig {
         purged: None,
 
         current_leader: None,
+        millis_since_quorum_ack: None,
         membership_config: Arc::new(StoredMembership::new(None, Membership::new(vec![btreeset! {}], None))),
 
         snapshot: None,

--- a/tests/tests/metrics/main.rs
+++ b/tests/tests/metrics/main.rs
@@ -8,6 +8,7 @@ mod fixtures;
 // The later tests may depend on the earlier ones.
 
 mod t10_current_leader;
+mod t10_leader_last_ack;
 mod t10_purged;
 mod t10_server_metrics_and_data_metrics;
 mod t20_metrics_state_machine_consistency;

--- a/tests/tests/metrics/t10_leader_last_ack.rs
+++ b/tests/tests/metrics/t10_leader_last_ack.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::AsyncRuntime;
+use openraft::Config;
+use openraft::RaftTypeConfig;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Get the last timestamp when a leader is acknowledged by a quorum,
+/// from RaftMetrics and RaftServerMetrics.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn leader_last_ack_3_nodes() -> Result<()> {
+    let heartbeat_interval = 50; // ms
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            heartbeat_interval,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let millis = n0.metrics().borrow().millis_since_quorum_ack;
+    assert!(millis >= Some(0));
+
+    {
+        let millis = n0.data_metrics().borrow().millis_since_quorum_ack;
+        assert!(millis >= Some(0));
+    }
+
+    tracing::info!(log_index, "--- sleep 500 ms, the `millis` should extend");
+    {
+        <<TypeConfig as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::sleep(Duration::from_millis(500)).await;
+
+        let greater = n0.metrics().borrow().millis_since_quorum_ack;
+        println!("greater: {:?}", greater);
+        assert!(greater > millis);
+        assert!(
+            greater > Some(500 - heartbeat_interval * 2),
+            "it extends, but may be smaller because the tick interval is 50 ms"
+        );
+    }
+
+    let n0 = router.get_raft_handle(&0)?;
+
+    tracing::info!(log_index, "--- heartbeat; millis_since_quorum_ack refreshes");
+    {
+        n0.trigger().heartbeat().await?;
+        n0.wait(timeout())
+            .metrics(
+                |x| x.millis_since_quorum_ack < Some(100),
+                "millis_since_quorum_ack refreshed",
+            )
+            .await?;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- sleep and heartbeat again; millis_since_quorum_ack refreshes"
+    );
+    {
+        <<TypeConfig as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::sleep(Duration::from_millis(500)).await;
+
+        n0.trigger().heartbeat().await?;
+
+        n0.wait(timeout())
+            .metrics(
+                |x| x.millis_since_quorum_ack < Some(100),
+                "millis_since_quorum_ack refreshed again",
+            )
+            .await?;
+    }
+
+    tracing::info!(log_index, "--- remove node 1 and node 2");
+    {
+        router.remove_node(1);
+        router.remove_node(2);
+    }
+
+    tracing::info!(
+        log_index,
+        "--- sleep and heartbeat again; millis_since_quorum_ack does not refresh"
+    );
+    {
+        <<TypeConfig as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::sleep(Duration::from_millis(500)).await;
+
+        n0.trigger().heartbeat().await?;
+
+        let got = n0
+            .wait(timeout())
+            .metrics(
+                |x| x.millis_since_quorum_ack < Some(100),
+                "millis_since_quorum_ack refreshed again",
+            )
+            .await;
+        assert!(got.is_err(), "millis_since_quorum_ack does not refresh");
+    }
+
+    Ok(())
+}
+
+/// Get the last timestamp when a leader is acknowledged by a quorum,
+/// from RaftMetrics and RaftServerMetrics.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn leader_last_ack_1_node() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+    let _ = log_index;
+
+    let n0 = router.get_raft_handle(&0)?;
+
+    let millis = n0.metrics().borrow().millis_since_quorum_ack;
+    assert_eq!(millis, Some(0), "it is always acked for single leader");
+
+    {
+        let millis = n0.data_metrics().borrow().millis_since_quorum_ack;
+        assert_eq!(millis, Some(0), "it is always acked for single leader");
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(500))
+}


### PR DESCRIPTION

## Changelog

##### Feature: add `RaftMetrics::millis_since_quorum_ack`

`RaftMetrics::millis_since_quorum_ack` is the interval in milliseconds
since the last timestamp a quorum acknowledged.

This duration is used by the application to assess the likelihood that
the leader has lost synchronization with the cluster.
A longer duration without acknowledgment may suggest a higher
probability of the leader being partitioned from the cluster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1062)
<!-- Reviewable:end -->
