### PR TITLE
Feature: Enable feature-flag `type-alias` to use type shortcuts

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -72,6 +72,10 @@ serde = ["dep:serde"]
 # This feature is disabled by default.
 single-term-leader = []
 
+# Enable this feature to use `openraft::alias::*` type shortcuts.
+# The type shortcuts are not stable and may be changed in the future.
+type-alias = []
+
 # Provide basic compatible types
 compat = []
 

--- a/openraft/src/docs/feature_flags/feature-flags-toc.md
+++ b/openraft/src/docs/feature_flags/feature-flags-toc.md
@@ -7,3 +7,4 @@
 - [feature-flag `single-term-leader`](#feature-flag-single-term-leader)
 - [feature-flag `singlethreaded`](#feature-flag-singlethreaded)
 - [feature-flag `tracing-log`](#feature-flag-tracing-log)
+- [feature-flag `type-alias`](#feature-flag-type-alias)

--- a/openraft/src/docs/feature_flags/feature-flags.md
+++ b/openraft/src/docs/feature_flags/feature-flags.md
@@ -87,3 +87,24 @@ See: [tracing doc: emitting-log-records](https://docs.rs/tracing/latest/tracing/
 
 [`RaftNetwork::full_snapshot()`]: crate::network::RaftNetwork::full_snapshot
 [`RaftNetwork::install_snapshot()`]: crate::network::RaftNetwork::install_snapshot
+
+
+## feature-flag `type-alias`
+
+Enable this feature to use type shortcuts defined in `openraft::alias::*`
+
+For example:
+```rust,ignore
+use openraft::alias::SnapshotDataOf;
+
+struct MyTypeConfig;
+impl RaftTypeconfig For MyTypeConfig { /*...*/ }
+
+// The following two lines are equivalent:
+let snapshot_data: SnapshotDataOf<MyTypeConfig>;
+let snapshot_data: <MyTypeConfig as RaftTypeConfig>::SnapshotData;
+```
+
+Note that the type shortcuts are not stable and may be changed in the future.
+It is also a good idea to copy the type shortcuts to your own codebase if you
+want to use them.

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -72,6 +72,7 @@ pub use network::RPCTypes;
 pub use network::RaftNetwork;
 pub use network::RaftNetworkFactory;
 pub use openraft_macros::add_async_trait;
+#[cfg(feature = "type-alias")] pub use type_config::alias;
 pub use type_config::RaftTypeConfig;
 
 pub use crate::async_runtime::AsyncRuntime;

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -74,30 +74,30 @@ pub trait RaftTypeConfig:
 }
 
 #[allow(dead_code)]
-pub(crate) mod alias {
+pub mod alias {
     //! Type alias for types used in `RaftTypeConfig`.
 
-    pub(crate) type DOf<C> = <C as crate::RaftTypeConfig>::D;
-    pub(crate) type ROf<C> = <C as crate::RaftTypeConfig>::R;
-    pub(crate) type NodeIdOf<C> = <C as crate::RaftTypeConfig>::NodeId;
-    pub(crate) type NodeOf<C> = <C as crate::RaftTypeConfig>::Node;
-    pub(crate) type EntryOf<C> = <C as crate::RaftTypeConfig>::Entry;
-    pub(crate) type SnapshotDataOf<C> = <C as crate::RaftTypeConfig>::SnapshotData;
-    pub(crate) type AsyncRuntimeOf<C> = <C as crate::RaftTypeConfig>::AsyncRuntime;
+    pub type DOf<C> = <C as crate::RaftTypeConfig>::D;
+    pub type ROf<C> = <C as crate::RaftTypeConfig>::R;
+    pub type NodeIdOf<C> = <C as crate::RaftTypeConfig>::NodeId;
+    pub type NodeOf<C> = <C as crate::RaftTypeConfig>::Node;
+    pub type EntryOf<C> = <C as crate::RaftTypeConfig>::Entry;
+    pub type SnapshotDataOf<C> = <C as crate::RaftTypeConfig>::SnapshotData;
+    pub type AsyncRuntimeOf<C> = <C as crate::RaftTypeConfig>::AsyncRuntime;
 
-    pub(crate) type JoinErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::JoinError;
-    pub(crate) type JoinHandleOf<C, T> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::JoinHandle<T>;
-    pub(crate) type SleepOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Sleep;
-    pub(crate) type InstantOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Instant;
-    pub(crate) type TimeoutErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::TimeoutError;
-    pub(crate) type TimeoutOf<C, R, F> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Timeout<R, F>;
-    pub(crate) type OneshotSenderOf<C, T> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::OneshotSender<T>;
-    pub(crate) type OneshotReceiverErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::OneshotReceiverError;
-    pub(crate) type OneshotReceiverOf<C, T> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::OneshotReceiver<T>;
+    pub type JoinErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::JoinError;
+    pub type JoinHandleOf<C, T> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::JoinHandle<T>;
+    pub type SleepOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Sleep;
+    pub type InstantOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Instant;
+    pub type TimeoutErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::TimeoutError;
+    pub type TimeoutOf<C, R, F> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::Timeout<R, F>;
+    pub type OneshotSenderOf<C, T> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::OneshotSender<T>;
+    pub type OneshotReceiverErrorOf<C> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::OneshotReceiverError;
+    pub type OneshotReceiverOf<C, T> = <AsyncRuntimeOf<C> as crate::AsyncRuntime>::OneshotReceiver<T>;
 
     // Usually used types
-    pub(crate) type LogIdOf<C> = crate::LogId<NodeIdOf<C>>;
-    pub(crate) type VoteOf<C> = crate::Vote<NodeIdOf<C>>;
-    pub(crate) type LeaderIdOf<C> = crate::LeaderId<NodeIdOf<C>>;
-    pub(crate) type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<NodeIdOf<C>>;
+    pub type LogIdOf<C> = crate::LogId<NodeIdOf<C>>;
+    pub type VoteOf<C> = crate::Vote<NodeIdOf<C>>;
+    pub type LeaderIdOf<C> = crate::LeaderId<NodeIdOf<C>>;
+    pub type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<NodeIdOf<C>>;
 }


### PR DESCRIPTION

## Changelog

##### Feature: Enable feature-flag `type-alias` to use type shortcuts

For example:

```rust,ignore
use openraft::alias::SnapshotDataOf;

struct MyTypeConfig;
impl RaftTypeconfig For MyTypeConfig { /*...*/ }

// The following two lines are equivalent:
let snapshot_data: SnapshotDataOf<MyTypeConfig>;
let snapshot_data: <MyTypeConfig as RaftTypeConfig>::SnapshotData;
```

Note that the type shortcuts are not stable and may be changed in the future.
It is also a good idea to copy the type shortcuts to your own codebase if you
want to use them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1063)
<!-- Reviewable:end -->
