### PR TITLE
Refactor: use type alias to simplify types

### DIFF
--- a/cluster_benchmark/Cargo.toml
+++ b/cluster_benchmark/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/datafuselabs/openraft"
 [dependencies]
 
 [dev-dependencies]
-openraft           = { path="../openraft", version = "0.10.0", features = ["serde"] }
+openraft           = { path="../openraft", version = "0.10.0", features = ["serde", "type-alias"] }
 
 anyhow = "1.0.63"
 maplit = "1.0.2"

--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::LogFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogReader;
@@ -20,7 +21,6 @@ use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::OptionalSend;
 use openraft::RaftLogId;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
@@ -278,9 +278,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -288,7 +286,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<NodeId, ()>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         let new_snapshot = StoredSnapshot {
             meta: meta.clone(),

--- a/examples/memstore/Cargo.toml
+++ b/examples/memstore/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 [dependencies]
-openraft = { path = "../../openraft", features = ["serde"] }
+openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 
 tokio = { version = "1.0", default-features = false, features = ["sync"] }
 

--- a/examples/raft-kv-memstore-generic-snapshot-data/Cargo.toml
+++ b/examples/raft-kv-memstore-generic-snapshot-data/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/datafuselabs/openraft"
 
 [dependencies]
 memstore = { path = "../memstore", features = [] }
-openraft = { path = "../../openraft", features = ["serde", "generic-snapshot-data"] }
+openraft = { path = "../../openraft", features = ["serde", "generic-snapshot-data", "type-alias"] }
 
 clap = { version = "4.1.11", features = ["derive", "env"] }
 reqwest = { version = "0.11.9", features = ["json"] }

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::BasicNode;
@@ -10,7 +11,6 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::RaftSnapshotBuilder;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StoredMembership;
@@ -169,9 +169,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
         Ok(Box::default())
     }
 
@@ -179,7 +177,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<NodeId, BasicNode>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!("install snapshot");
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/datafuselabs/openraft"
 
 [dependencies]
 memstore = { path = "../memstore", features = [] }
-openraft = { path = "../../openraft", features = ["serde", "generic-snapshot-data"] }
+openraft = { path = "../../openraft", features = ["serde", "generic-snapshot-data", "type-alias"] }
 
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use opendal::Operator;
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::BasicNode;
@@ -11,7 +12,6 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::RaftSnapshotBuilder;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StoredMembership;
@@ -190,9 +190,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
         Ok(Box::default())
     }
 
@@ -200,7 +198,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<NodeId, BasicNode>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!("install snapshot");
 

--- a/examples/raft-kv-memstore-singlethreaded/Cargo.toml
+++ b/examples/raft-kv-memstore-singlethreaded/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/datafuselabs/openraft"
 
 [dependencies]
-openraft = { path = "../../openraft", features = ["serde", "singlethreaded"] }
+openraft = { path = "../../openraft", features = ["serde", "singlethreaded", "type-alias"] }
 
 clap = { version = "4.1.11", features = ["derive", "env"] }
 reqwest = { version = "0.11.9", features = ["json"] }

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::rc::Rc;
 
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::LogFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogStorage;
@@ -17,7 +18,6 @@ use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
@@ -223,9 +223,7 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -233,7 +231,7 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<NodeId, BasicNode>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },

--- a/examples/raft-kv-memstore/Cargo.toml
+++ b/examples/raft-kv-memstore/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/bin/main.rs"
 
 [dependencies]
 memstore = { path = "../memstore", features = [] }
-openraft = { path = "../../openraft", features = ["serde"] }
+openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 
 actix-web = "4.0.0-rc.2"
 clap = { version = "4.1.11", features = ["derive", "env"] }

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -4,6 +4,7 @@ use std::io::Cursor;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::BasicNode;
@@ -11,7 +12,6 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::RaftSnapshotBuilder;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
@@ -176,9 +176,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -186,7 +184,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<NodeId, BasicNode>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -21,7 +21,7 @@ name = "raft-key-value-rocks"
 path = "src/bin/main.rs"
 
 [dependencies]
-openraft = { path = "../../openraft", features = ["serde"] }
+openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 
 tokio = { version = "1.35.1", features = ["full"] }
 byteorder = "1.4.3"

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -550,13 +550,6 @@ where
             replication: replication.clone(),
         };
 
-        tracing::debug!("report_metrics: {}", m.summary());
-        let res = self.tx_metrics.send(m);
-
-        if let Err(err) = res {
-            tracing::error!(error=%err, id=display(self.id), "error reporting metrics");
-        }
-
         let data_metrics = RaftDataMetrics {
             last_log: st.last_log_id().copied(),
             last_applied: st.io_applied().copied(),
@@ -565,13 +558,6 @@ where
             millis_since_quorum_ack,
             replication,
         };
-        self.tx_data_metrics.send_if_modified(|metrix| {
-            if data_metrics.ne(metrix) {
-                *metrix = data_metrics.clone();
-                return true;
-            }
-            false
-        });
 
         let server_metrics = RaftServerMetrics {
             id: self.id,
@@ -580,6 +566,20 @@ where
             current_leader,
             membership_config,
         };
+
+        // Start to send metrics
+        // `RaftMetrics` is sent last, because `Wait` only examines `RaftMetrics`
+        // but not `RaftDataMetrics` and `RaftServerMetrics`.
+        // Thus if `RaftMetrics` change is perceived, the other two should have been updated.
+
+        self.tx_data_metrics.send_if_modified(|metrix| {
+            if data_metrics.ne(metrix) {
+                *metrix = data_metrics.clone();
+                return true;
+            }
+            false
+        });
+
         self.tx_server_metrics.send_if_modified(|metrix| {
             if server_metrics.ne(metrix) {
                 *metrix = server_metrics.clone();
@@ -587,6 +587,13 @@ where
             }
             false
         });
+
+        tracing::debug!("report_metrics: {}", m.summary());
+        let res = self.tx_metrics.send(m);
+
+        if let Err(err) = res {
+            tracing::error!(error=%err, id=display(self.id), "error reporting metrics");
+        }
     }
 
     /// Handle the admin command `initialize`.

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -12,13 +12,12 @@ use crate::raft::ClientWriteResponse;
 use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
-use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::NodeIdOf;
 use crate::type_config::alias::NodeOf;
+use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::SnapshotDataOf;
-use crate::AsyncRuntime;
 use crate::ChangeMembers;
 use crate::MessageSummary;
 use crate::RaftTypeConfig;
@@ -30,8 +29,7 @@ pub(crate) mod external_command;
 /// A oneshot TX to send result from `RaftCore` to external caller, e.g. `Raft::append_entries`.
 pub(crate) type ResultSender<C, T, E = Infallible> = OneshotSenderOf<C, Result<T, E>>;
 
-pub(crate) type ResultReceiver<C, T, E = Infallible> =
-    <AsyncRuntimeOf<C> as AsyncRuntime>::OneshotReceiver<Result<T, E>>;
+pub(crate) type ResultReceiver<C, T, E = Infallible> = OneshotReceiverOf<C, Result<T, E>>;
 
 /// TX for Vote Response
 pub(crate) type VoteTx<C> = ResultSender<C, VoteResponse<NodeIdOf<C>>>;

--- a/openraft/src/core/sm/mod.rs
+++ b/openraft/src/core/sm/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use response::Response;
 
 use crate::core::notify::Notify;
 use crate::core::raft_msg::ResultSender;
+use crate::type_config::alias::JoinHandleOf;
 
 /// State machine worker handle for sending command to it.
 pub(crate) struct Handle<C>
@@ -37,7 +38,7 @@ where C: RaftTypeConfig
 {
     cmd_tx: mpsc::UnboundedSender<Command<C>>,
     #[allow(dead_code)]
-    join_handle: <C::AsyncRuntime as AsyncRuntime>::JoinHandle<()>,
+    join_handle: JoinHandleOf<C, ()>,
 }
 
 impl<C> Handle<C>
@@ -81,7 +82,7 @@ where
         Handle { cmd_tx, join_handle }
     }
 
-    fn do_spawn(mut self) -> <C::AsyncRuntime as AsyncRuntime>::JoinHandle<()> {
+    fn do_spawn(mut self) -> JoinHandleOf<C, ()> {
         C::AsyncRuntime::spawn(async move {
             let res = self.worker_loop().await;
 

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -12,7 +12,7 @@ use crate::engine::EngineOutput;
 use crate::entry::RaftPayload;
 use crate::error::RejectAppendEntries;
 use crate::raft_state::LogStateReader;
-use crate::AsyncRuntime;
+use crate::type_config::alias::InstantOf;
 use crate::EffectiveMembership;
 use crate::LogId;
 use crate::LogIdOptionExt;
@@ -37,7 +37,7 @@ pub(crate) struct FollowingHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
-    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>,
+    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -7,7 +7,7 @@ use crate::engine::EngineOutput;
 use crate::entry::RaftPayload;
 use crate::internal_server_state::LeaderQuorumSet;
 use crate::leader::Leading;
-use crate::AsyncRuntime;
+use crate::type_config::alias::InstantOf;
 use crate::RaftLogId;
 use crate::RaftState;
 use crate::RaftTypeConfig;
@@ -24,9 +24,8 @@ pub(crate) struct LeaderHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
-    pub(crate) leader:
-        &'x mut Leading<C::NodeId, LeaderQuorumSet<C::NodeId>, <C::AsyncRuntime as AsyncRuntime>::Instant>,
-    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>,
+    pub(crate) leader: &'x mut Leading<C::NodeId, LeaderQuorumSet<C::NodeId>, InstantOf<C>>,
+    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -3,7 +3,7 @@ use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::raft_state::LogStateReader;
 use crate::summary::MessageSummary;
-use crate::AsyncRuntime;
+use crate::type_config::alias::InstantOf;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftState;
@@ -17,7 +17,7 @@ pub(crate) struct LogHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
-    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>,
+    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -1,7 +1,7 @@
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
-use crate::AsyncRuntime;
+use crate::type_config::alias::InstantOf;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::ServerState;
@@ -13,7 +13,7 @@ pub(crate) struct ServerStateHandler<'st, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'st EngineConfig<C::NodeId>,
-    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>,
+    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
     pub(crate) output: &'st mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/snapshot_handler/mod.rs
+++ b/openraft/src/engine/handler/snapshot_handler/mod.rs
@@ -5,7 +5,7 @@ use crate::engine::Command;
 use crate::engine::EngineOutput;
 use crate::raft_state::LogStateReader;
 use crate::summary::MessageSummary;
-use crate::AsyncRuntime;
+use crate::type_config::alias::InstantOf;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::SnapshotMeta;
@@ -17,7 +17,7 @@ use crate::SnapshotMeta;
 pub(crate) struct SnapshotHandler<'st, 'out, C>
 where C: RaftTypeConfig
 {
-    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>,
+    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
     pub(crate) output: &'out mut EngineOutput<C>,
 }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -64,6 +64,8 @@ use crate::raft::trigger::Trigger;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::type_config::alias::AsyncRuntimeOf;
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::AsyncRuntime;
 use crate::ChangeMembers;
@@ -809,9 +811,7 @@ where C: RaftTypeConfig
     /// ```
     pub async fn with_raft_state<F, V>(&self, func: F) -> Result<V, Fatal<C::NodeId>>
     where
-        F: FnOnce(&RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>) -> V
-            + OptionalSend
-            + 'static,
+        F: FnOnce(&RaftState<C::NodeId, C::Node, InstantOf<C>>) -> V + OptionalSend + 'static,
         V: OptionalSend + 'static,
     {
         let (tx, rx) = C::AsyncRuntime::oneshot();
@@ -848,8 +848,7 @@ where C: RaftTypeConfig
     /// If the API channel is already closed (Raft is in shutdown), then the request functor is
     /// destroyed right away and not called at all.
     pub fn external_request<F>(&self, req: F)
-    where F: FnOnce(&RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>) + OptionalSend + 'static
-    {
+    where F: FnOnce(&RaftState<C::NodeId, C::Node, InstantOf<C>>) + OptionalSend + 'static {
         let req: BoxCoreFn<C> = Box::new(req);
         let _ignore_error = self.inner.tx_api.send(RaftMsg::ExternalCoreRequest { req });
     }
@@ -903,7 +902,7 @@ where C: RaftTypeConfig
     /// Shutdown this Raft node.
     ///
     /// It sends a shutdown signal and waits until `RaftCore` returns.
-    pub async fn shutdown(&self) -> Result<(), <C::AsyncRuntime as AsyncRuntime>::JoinError> {
+    pub async fn shutdown(&self) -> Result<(), JoinErrorOf<C>> {
         if let Some(tx) = self.inner.tx_shutdown.lock().await.take() {
             // A failure to send means the RaftCore is already shutdown. Continue to check the task
             // return value.

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -16,6 +16,7 @@ use crate::error::RaftError;
 use crate::metrics::RaftDataMetrics;
 use crate::metrics::RaftServerMetrics;
 use crate::raft::core_state::CoreState;
+use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::AsyncRuntime;
 use crate::Config;
@@ -55,7 +56,7 @@ where C: RaftTypeConfig
     pub(crate) async fn call_core<T, E>(
         &self,
         mes: RaftMsg<C>,
-        rx: <C::AsyncRuntime as AsyncRuntime>::OneshotReceiver<Result<T, E>>,
+        rx: OneshotReceiverOf<C, Result<T, E>>,
     ) -> Result<T, RaftError<C::NodeId, E>>
     where
         E: Debug + OptionalSend,

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -1,7 +1,7 @@
 use crate::replication::request_id::RequestId;
 use crate::replication::ReplicationSessionId;
+use crate::type_config::alias::InstantOf;
 use crate::utime::UTime;
-use crate::AsyncRuntime;
 use crate::LogId;
 use crate::MessageSummary;
 use crate::NodeId;
@@ -33,7 +33,7 @@ where C: RaftTypeConfig
         /// the target node.
         ///
         /// The result also track the time when this request is sent.
-        result: Result<UTime<ReplicationResult<C::NodeId>, <C::AsyncRuntime as AsyncRuntime>::Instant>, String>,
+        result: Result<UTime<ReplicationResult<C::NodeId>, InstantOf<C>>, String>,
 
         /// In which session this message is sent.
         ///

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -10,8 +10,8 @@ use crate::raft_state::LogIOId;
 use crate::storage::RaftLogReaderExt;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
+use crate::type_config::alias::InstantOf;
 use crate::utime::UTime;
-use crate::AsyncRuntime;
 use crate::EffectiveMembership;
 use crate::Instant;
 use crate::LogIdOptionExt;
@@ -61,8 +61,7 @@ where
     /// state from stable storage.
     pub async fn get_initial_state(
         &mut self,
-    ) -> Result<RaftState<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>, StorageError<C::NodeId>>
-    {
+    ) -> Result<RaftState<C::NodeId, C::Node, InstantOf<C>>, StorageError<C::NodeId>> {
         let vote = self.log_store.read_vote().await?;
         let vote = vote.unwrap_or_default();
 
@@ -152,7 +151,7 @@ where
             last_purged_log_id,
         );
 
-        let now = <C::AsyncRuntime as AsyncRuntime>::Instant::now();
+        let now = InstantOf::<C>::now();
 
         Ok(RaftState {
             committed: last_applied,

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -19,6 +19,8 @@ use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::storage::StorageHelper;
 use crate::testing::StoreBuilder;
+use crate::type_config::alias::AsyncRuntimeOf;
+use crate::type_config::alias::InstantOf;
 use crate::vote::CommittedLeaderId;
 use crate::AsyncRuntime;
 use crate::LogId;
@@ -341,7 +343,7 @@ where
 
     pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
-        let mut want = RaftState::<C::NodeId, C::Node, <C::AsyncRuntime as AsyncRuntime>::Instant>::default();
+        let mut want = RaftState::<C::NodeId, C::Node, InstantOf<C>>::default();
         want.vote.update(initial.vote.utime().unwrap(), Vote::default());
 
         assert_eq!(want, initial, "uninitialized state");
@@ -1170,7 +1172,7 @@ where
     let entries = entries.into_iter().collect::<Vec<_>>();
     let last_log_id = *entries.last().unwrap().get_log_id();
 
-    let (tx, rx) = <C::AsyncRuntime as AsyncRuntime>::oneshot();
+    let (tx, rx) = AsyncRuntimeOf::<C>::oneshot();
 
     let cb = LogFlushed::new(Some(last_log_id), tx);
 

--- a/stores/memstore/Cargo.toml
+++ b/stores/memstore/Cargo.toml
@@ -14,7 +14,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path= "../../openraft", version = "0.10.0", features=["serde"] }
+openraft = { path= "../../openraft", version = "0.10.0", features=["serde", "type-alias"] }
 
 serde           = { workspace = true }
 serde_json      = { workspace = true }

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -11,6 +11,7 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::LogFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogReader;
@@ -23,7 +24,6 @@ use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::OptionalSend;
 use openraft::RaftLogId;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
@@ -477,9 +477,7 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<MemNodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<MemNodeId>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -487,7 +485,7 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<MemNodeId, ()>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<MemNodeId>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },

--- a/stores/rocksstore/Cargo.toml
+++ b/stores/rocksstore/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/datafuselabs/openraft"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openraft = { path= "../../openraft", version = "0.10.0", features=["serde"] }
+openraft = { path= "../../openraft", version = "0.10.0", features=["serde", "type-alias"] }
 
 rocksdb = "0.20.1"
 rand = "*"

--- a/stores/rocksstore/src/lib.rs
+++ b/stores/rocksstore/src/lib.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use byteorder::BigEndian;
 use byteorder::ReadBytesExt;
 use byteorder::WriteBytesExt;
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::LogFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogStorage;
@@ -33,7 +34,6 @@ use openraft::OptionalSend;
 use openraft::RaftLogId;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
@@ -453,16 +453,14 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         self.clone()
     }
 
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<RocksNodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<RocksNodeId>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<RocksNodeId, BasicNode>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<RocksNodeId>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },

--- a/stores/sledstore/Cargo.toml
+++ b/stores/sledstore/Cargo.toml
@@ -14,7 +14,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path= "../../openraft", version = "0.10.0", features=["serde"] }
+openraft = { path= "../../openraft", version = "0.10.0", features=["serde", "type-alias"] }
 
 sled = "0.34.7"
 byteorder = "1.4.3"

--- a/stores/sledstore/src/lib.rs
+++ b/stores/sledstore/src/lib.rs
@@ -14,6 +14,7 @@ use async_std::sync::RwLock;
 use byteorder::BigEndian;
 use byteorder::ByteOrder;
 use byteorder::ReadBytesExt;
+use openraft::alias::SnapshotDataOf;
 use openraft::storage::LogFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogStorage;
@@ -28,7 +29,6 @@ use openraft::OptionalSend;
 use openraft::RaftLogId;
 use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
-use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
@@ -634,7 +634,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn begin_receiving_snapshot(
         &mut self,
-    ) -> Result<Box<<TypeConfig as RaftTypeConfig>::SnapshotData>, StorageError<ExampleNodeId>> {
+    ) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<ExampleNodeId>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -642,7 +642,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<ExampleNodeId, BasicNode>,
-        snapshot: Box<<TypeConfig as RaftTypeConfig>::SnapshotData>,
+        snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<ExampleNodeId>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,7 @@ repository    = { workspace = true }
 [dependencies]
 
 [dev-dependencies]
-openraft           = { path="../openraft", version = "0.10.0" }
+openraft           = { path="../openraft", version = "0.10.0", features=["type-alias"] }
 openraft-memstore  = { path= "../stores/memstore" }
 
 anyerror           = { workspace = true }

--- a/tests/tests/append_entries/t60_enable_heartbeat.rs
+++ b/tests/tests/append_entries/t60_enable_heartbeat.rs
@@ -3,9 +3,11 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::alias::InstantOf;
 use openraft::AsyncRuntime;
 use openraft::Config;
 use openraft::TokioRuntime;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::init_default_ut_tracing;
 use crate::fixtures::RaftRouter;
@@ -30,7 +32,7 @@ async fn enable_heartbeat() -> Result<()> {
     node0.runtime_config().heartbeat(true);
 
     for _i in 0..3 {
-        let now = <TokioRuntime as AsyncRuntime>::Instant::now();
+        let now = InstantOf::<TypeConfig>::now();
         TokioRuntime::sleep(Duration::from_millis(500)).await;
 
         for node_id in [1, 2, 3] {

--- a/tests/tests/membership/t11_add_learner.rs
+++ b/tests/tests/membership/t11_add_learner.rs
@@ -181,6 +181,8 @@ async fn add_learner_with_set_nodes() -> Result<()> {
         let raft = router.get_raft_handle(&0)?;
         raft.change_membership(ChangeMembers::SetNodes(btreemap! {2=>(), 4=>()}), true).await?;
 
+        // TODO: Flaky: there is chance that the log is committed but metrics is not updated.
+        //       Because metrics is updated in the next loop in the `runtime_loop`
         let metrics = router.get_raft_handle(&0)?.metrics().borrow().clone();
         let node_ids = metrics.membership_config.membership().nodes().map(|x| *x.0).collect::<Vec<_>>();
         assert_eq!(vec![0, 1, 2, 4], node_ids);

--- a/tests/tests/membership/t11_add_learner.rs
+++ b/tests/tests/membership/t11_add_learner.rs
@@ -181,11 +181,13 @@ async fn add_learner_with_set_nodes() -> Result<()> {
         let raft = router.get_raft_handle(&0)?;
         raft.change_membership(ChangeMembers::SetNodes(btreemap! {2=>(), 4=>()}), true).await?;
 
-        // TODO: Flaky: there is chance that the log is committed but metrics is not updated.
-        //       Because metrics is updated in the next loop in the `runtime_loop`
-        let metrics = router.get_raft_handle(&0)?.metrics().borrow().clone();
-        let node_ids = metrics.membership_config.membership().nodes().map(|x| *x.0).collect::<Vec<_>>();
-        assert_eq!(vec![0, 1, 2, 4], node_ids);
+        router
+            .wait(&0, timeout())
+            .metrics(
+                |m| m.membership_config.membership().nodes().map(|x| *x.0).collect::<Vec<_>>() == vec![0, 1, 2, 4],
+                "set node 2 and 4",
+            )
+            .await?;
     }
 
     Ok(())

--- a/tests/tests/metrics/t10_leader_last_ack.rs
+++ b/tests/tests/metrics/t10_leader_last_ack.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::alias::AsyncRuntimeOf;
 use openraft::AsyncRuntime;
 use openraft::Config;
-use openraft::RaftTypeConfig;
 use openraft_memstore::TypeConfig;
 
 use crate::fixtures::init_default_ut_tracing;
@@ -41,7 +41,7 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
 
     tracing::info!(log_index, "--- sleep 500 ms, the `millis` should extend");
     {
-        <<TypeConfig as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::sleep(Duration::from_millis(500)).await;
+        AsyncRuntimeOf::<TypeConfig>::sleep(Duration::from_millis(500)).await;
 
         let greater = n0.metrics().borrow().millis_since_quorum_ack;
         println!("greater: {:?}", greater);
@@ -70,7 +70,7 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
         "--- sleep and heartbeat again; millis_since_quorum_ack refreshes"
     );
     {
-        <<TypeConfig as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::sleep(Duration::from_millis(500)).await;
+        AsyncRuntimeOf::<TypeConfig>::sleep(Duration::from_millis(500)).await;
 
         n0.trigger().heartbeat().await?;
 
@@ -93,7 +93,7 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
         "--- sleep and heartbeat again; millis_since_quorum_ack does not refresh"
     );
     {
-        <<TypeConfig as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::sleep(Duration::from_millis(500)).await;
+        AsyncRuntimeOf::<TypeConfig>::sleep(Duration::from_millis(500)).await;
 
         n0.trigger().heartbeat().await?;
 

--- a/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
+++ b/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
@@ -43,6 +44,8 @@ async fn server_metrics_and_data_metrics() -> Result<()> {
     tracing::info!(log_index, "--- write {} logs", n);
     log_index += router.client_request_many(0, "foo", n).await?;
 
+    router.wait(&0, timeout()).applied_index(Some(log_index), "applied log index").await?;
+
     let last_log_index = data_metrics.borrow().last_log.unwrap_or_default().index;
     assert_eq!(last_log_index, log_index, "last_log_index should be {:?}", log_index);
 
@@ -57,4 +60,8 @@ async fn server_metrics_and_data_metrics() -> Result<()> {
         server_metrics_2
     );
     Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(500))
 }


### PR DESCRIPTION

## Changelog

##### Refactor: use type alias to simplify types

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1064)
<!-- Reviewable:end -->
