### PR TITLE
Improve: Use `Unreachable` error in `examples/raft-kv-rocksdb`

### DIFF
--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -43,7 +43,7 @@ impl Network {
         tracing::debug!("client is created for: {}", url);
 
         let resp = client.post(url).json(&req).send().await.map_err(|e| {
-            // If the error is a connection error, we return Unreachable so that connection isn't retried
+            // If the error is a connection error, we return `Unreachable` so that connection isn't retried
             // immediately.
             if e.is_connect() {
                 return openraft::error::RPCError::Unreachable(Unreachable::new(&e));

--- a/examples/raft-kv-rocksdb/src/client.rs
+++ b/examples/raft-kv-rocksdb/src/client.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
 use openraft::error::RemoteError;
+use openraft::error::Unreachable;
 use openraft::RaftMetrics;
 use openraft::TryAsRef;
 use reqwest::Client;
@@ -143,7 +144,13 @@ impl ExampleClient {
         }
         .send()
         .await
-        .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        .map_err(|e| {
+            if e.is_connect() {
+                // `Unreachable` informs the caller to backoff for a short while to avoid error log flush.
+                return RPCError::Unreachable(Unreachable::new(&e));
+            }
+            RPCError::Network(NetworkError::new(&e))
+        })?;
 
         let res: Result<Resp, Err> = resp.json().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         println!(


### PR DESCRIPTION

## Changelog

##### Improve: Use `Unreachable` error in `examples/raft-kv-rocksdb`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1065)
<!-- Reviewable:end -->
