### PR TITLE
Change: Consolidate `RaftState` type parameters into `C`

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -67,7 +67,7 @@ where C: RaftTypeConfig
     pub(crate) config: EngineConfig<C::NodeId>,
 
     /// The state of this raft node.
-    pub(crate) state: Valid<RaftState<C::NodeId, C::Node, InstantOf<C>>>,
+    pub(crate) state: Valid<RaftState<C>>,
 
     // TODO: add a Voting state as a container.
     /// Whether a greater log id is seen during election.
@@ -86,10 +86,7 @@ where C: RaftTypeConfig
 impl<C> Engine<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(
-        init_state: RaftState<C::NodeId, C::Node, InstantOf<C>>,
-        config: EngineConfig<C::NodeId>,
-    ) -> Self {
+    pub(crate) fn new(init_state: RaftState<C>, config: EngineConfig<C::NodeId>) -> Self {
         Self {
             config,
             state: Valid::new(init_state),

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -12,7 +12,6 @@ use crate::engine::EngineOutput;
 use crate::entry::RaftPayload;
 use crate::error::RejectAppendEntries;
 use crate::raft_state::LogStateReader;
-use crate::type_config::alias::InstantOf;
 use crate::EffectiveMembership;
 use crate::LogId;
 use crate::LogIdOptionExt;
@@ -37,7 +36,7 @@ pub(crate) struct FollowingHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
-    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
+    pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -25,7 +25,7 @@ where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
     pub(crate) leader: &'x mut Leading<C::NodeId, LeaderQuorumSet<C::NodeId>, InstantOf<C>>,
-    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
+    pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -3,7 +3,6 @@ use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::raft_state::LogStateReader;
 use crate::summary::MessageSummary;
-use crate::type_config::alias::InstantOf;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftState;
@@ -17,7 +16,7 @@ pub(crate) struct LogHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
-    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
+    pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -42,7 +42,7 @@ where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C::NodeId>,
     pub(crate) leader: &'x mut Leading<C::NodeId, LeaderQuorumSet<C::NodeId>, InstantOf<C>>,
-    pub(crate) state: &'x mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
+    pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -1,7 +1,6 @@
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
-use crate::type_config::alias::InstantOf;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::ServerState;
@@ -13,7 +12,7 @@ pub(crate) struct ServerStateHandler<'st, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'st EngineConfig<C::NodeId>,
-    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
+    pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'st mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/snapshot_handler/mod.rs
+++ b/openraft/src/engine/handler/snapshot_handler/mod.rs
@@ -5,7 +5,6 @@ use crate::engine::Command;
 use crate::engine::EngineOutput;
 use crate::raft_state::LogStateReader;
 use crate::summary::MessageSummary;
-use crate::type_config::alias::InstantOf;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::SnapshotMeta;
@@ -17,7 +16,7 @@ use crate::SnapshotMeta;
 pub(crate) struct SnapshotHandler<'st, 'out, C>
 where C: RaftTypeConfig
 {
-    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
+    pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'out mut EngineOutput<C>,
 }
 

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -29,7 +29,7 @@ pub(crate) struct VoteHandler<'st, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'st EngineConfig<C::NodeId>,
-    pub(crate) state: &'st mut RaftState<C::NodeId, C::Node, InstantOf<C>>,
+    pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'st mut EngineOutput<C>,
     pub(crate) internal_server_state: &'st mut InternalServerState<C::NodeId, InstantOf<C>>,
 }
@@ -56,7 +56,7 @@ where C: RaftTypeConfig
         T: Debug + Eq + OptionalSend,
         E: Debug + Eq + OptionalSend,
         Respond<C>: From<ValueSender<C, Result<T, E>>>,
-        F: Fn(&RaftState<C::NodeId, C::Node, InstantOf<C>>, RejectVoteRequest<C::NodeId>) -> Result<T, E>,
+        F: Fn(&RaftState<C>, RejectVoteRequest<C::NodeId>) -> Result<T, E>,
     {
         let vote_res = self.update_vote(vote);
 

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -1,18 +1,24 @@
 use std::io::Cursor;
 
+use crate::Node;
 use crate::RaftTypeConfig;
 use crate::TokioRuntime;
 
-/// Trivial Raft type config for Engine related unit test.
+/// Trivial Raft type config for Engine related unit tests,
+/// with an optional custom node type `N` for Node type.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub(crate) struct UTConfig {}
-impl RaftTypeConfig for UTConfig {
+pub(crate) struct UTConfig<N = ()> {
+    _p: std::marker::PhantomData<N>,
+}
+impl<N> RaftTypeConfig for UTConfig<N>
+where N: Node + Copy + Ord
+{
     type D = ();
     type R = ();
     type NodeId = u64;
-    type Node = ();
-    type Entry = crate::Entry<UTConfig>;
+    type Node = N;
+    type Entry = crate::Entry<Self>;
     type SnapshotData = Cursor<Vec<u8>>;
     type AsyncRuntime = TokioRuntime;
 }

--- a/openraft/src/raft/external_request.rs
+++ b/openraft/src/raft/external_request.rs
@@ -1,21 +1,15 @@
 //! Defines API for application to send request to access Raft core.
 
-use crate::type_config::alias::InstantOf;
-use crate::type_config::alias::NodeIdOf;
-use crate::type_config::alias::NodeOf;
 use crate::OptionalSend;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 
-pub trait BoxCoreFnInternal<C>: FnOnce(&RaftState<NodeIdOf<C>, NodeOf<C>, InstantOf<C>>) + OptionalSend
+pub trait BoxCoreFnInternal<C>: FnOnce(&RaftState<C>) + OptionalSend
 where C: RaftTypeConfig
 {
 }
 
-impl<C: RaftTypeConfig, T: FnOnce(&RaftState<NodeIdOf<C>, NodeOf<C>, InstantOf<C>>) + OptionalSend> BoxCoreFnInternal<C>
-    for T
-{
-}
+impl<C: RaftTypeConfig, T: FnOnce(&RaftState<C>) + OptionalSend> BoxCoreFnInternal<C> for T {}
 
 /// Boxed trait object for external request function run in `RaftCore` task.
 pub(crate) type BoxCoreFn<C> = Box<dyn BoxCoreFnInternal<C> + 'static>;

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -64,7 +64,6 @@ use crate::raft::trigger::Trigger;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::type_config::alias::AsyncRuntimeOf;
-use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::AsyncRuntime;
@@ -811,7 +810,7 @@ where C: RaftTypeConfig
     /// ```
     pub async fn with_raft_state<F, V>(&self, func: F) -> Result<V, Fatal<C::NodeId>>
     where
-        F: FnOnce(&RaftState<C::NodeId, C::Node, InstantOf<C>>) -> V + OptionalSend + 'static,
+        F: FnOnce(&RaftState<C>) -> V + OptionalSend + 'static,
         V: OptionalSend + 'static,
     {
         let (tx, rx) = C::AsyncRuntime::oneshot();
@@ -848,7 +847,7 @@ where C: RaftTypeConfig
     /// If the API channel is already closed (Raft is in shutdown), then the request functor is
     /// destroyed right away and not called at all.
     pub fn external_request<F>(&self, req: F)
-    where F: FnOnce(&RaftState<C::NodeId, C::Node, InstantOf<C>>) + OptionalSend + 'static {
+    where F: FnOnce(&RaftState<C>) + OptionalSend + 'static {
         let req: BoxCoreFn<C> = Box::new(req);
         let _ignore_error = self.inner.tx_api.send(RaftMsg::ExternalCoreRequest { req });
     }

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -7,12 +7,10 @@ use crate::engine::LogIdList;
 use crate::entry::RaftEntry;
 use crate::error::ForwardToLeader;
 use crate::log_id::RaftLogId;
-use crate::node::Node;
 use crate::utime::UTime;
-use crate::Instant;
 use crate::LogId;
 use crate::LogIdOptionExt;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::ServerState;
 use crate::SnapshotMeta;
 use crate::Vote;
@@ -43,18 +41,17 @@ pub(crate) use vote_state_reader::VoteStateReader;
 
 use crate::display_ext::DisplayOptionExt;
 pub(crate) use crate::raft_state::snapshot_streaming::StreamingState;
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::LogIdOf;
 
 /// A struct used to represent the raft state which a Raft node needs.
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
-pub struct RaftState<NID, N, I>
-where
-    NID: NodeId,
-    N: Node,
-    I: Instant,
+pub struct RaftState<C>
+where C: RaftTypeConfig
 {
     /// The vote state of this node.
-    pub(crate) vote: UTime<Vote<NID>, I>,
+    pub(crate) vote: UTime<Vote<C::NodeId>, InstantOf<C>>,
 
     /// The LogId of the last log committed(AKA applied) to the state machine.
     ///
@@ -62,18 +59,18 @@ where
     ///   of the leader.
     ///
     /// - A quorum could be a uniform quorum or joint quorum.
-    pub committed: Option<LogId<NID>>,
+    pub committed: Option<LogId<C::NodeId>>,
 
     pub(crate) purged_next: u64,
 
     /// All log ids this node has.
-    pub log_ids: LogIdList<NID>,
+    pub log_ids: LogIdList<C::NodeId>,
 
     /// The latest cluster membership configuration found, in log or in state machine.
-    pub membership_state: MembershipState<NID, N>,
+    pub membership_state: MembershipState<C::NodeId, C::Node>,
 
     /// The metadata of the last snapshot.
-    pub snapshot_meta: SnapshotMeta<NID, N>,
+    pub snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
 
     // --
     // -- volatile fields: they are not persisted.
@@ -81,9 +78,9 @@ where
     /// The state of a Raft node, such as Leader or Follower.
     pub server_state: ServerState,
 
-    pub(crate) accepted: Accepted<NID>,
+    pub(crate) accepted: Accepted<C::NodeId>,
 
-    pub(crate) io_state: IOState<NID>,
+    pub(crate) io_state: IOState<C::NodeId>,
 
     pub(crate) snapshot_streaming: Option<StreamingState>,
 
@@ -91,14 +88,11 @@ where
     ///
     /// If a log is in use by a replication task, the purge is postponed and is stored in this
     /// field.
-    pub(crate) purge_upto: Option<LogId<NID>>,
+    pub(crate) purge_upto: Option<LogId<C::NodeId>>,
 }
 
-impl<NID, N, I> Default for RaftState<NID, N, I>
-where
-    NID: NodeId,
-    N: Node,
-    I: Instant,
+impl<C> Default for RaftState<C>
+where C: RaftTypeConfig
 {
     fn default() -> Self {
         Self {
@@ -117,45 +111,42 @@ where
     }
 }
 
-impl<NID, N, I> LogStateReader<NID> for RaftState<NID, N, I>
-where
-    NID: NodeId,
-    N: Node,
-    I: Instant,
+impl<C> LogStateReader<C::NodeId> for RaftState<C>
+where C: RaftTypeConfig
 {
-    fn get_log_id(&self, index: u64) -> Option<LogId<NID>> {
+    fn get_log_id(&self, index: u64) -> Option<LogId<C::NodeId>> {
         self.log_ids.get(index)
     }
 
-    fn last_log_id(&self) -> Option<&LogId<NID>> {
+    fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
         self.log_ids.last()
     }
 
-    fn committed(&self) -> Option<&LogId<NID>> {
+    fn committed(&self) -> Option<&LogId<C::NodeId>> {
         self.committed.as_ref()
     }
 
-    fn io_applied(&self) -> Option<&LogId<NID>> {
+    fn io_applied(&self) -> Option<&LogId<C::NodeId>> {
         self.io_state.applied()
     }
 
-    fn io_snapshot_last_log_id(&self) -> Option<&LogId<NID>> {
+    fn io_snapshot_last_log_id(&self) -> Option<&LogId<C::NodeId>> {
         self.io_state.snapshot()
     }
 
-    fn io_purged(&self) -> Option<&LogId<NID>> {
+    fn io_purged(&self) -> Option<&LogId<C::NodeId>> {
         self.io_state.purged()
     }
 
-    fn snapshot_last_log_id(&self) -> Option<&LogId<NID>> {
+    fn snapshot_last_log_id(&self) -> Option<&LogId<C::NodeId>> {
         self.snapshot_meta.last_log_id.as_ref()
     }
 
-    fn purge_upto(&self) -> Option<&LogId<NID>> {
+    fn purge_upto(&self) -> Option<&LogId<C::NodeId>> {
         self.purge_upto.as_ref()
     }
 
-    fn last_purged_log_id(&self) -> Option<&LogId<NID>> {
+    fn last_purged_log_id(&self) -> Option<&LogId<C::NodeId>> {
         if self.purged_next == 0 {
             return None;
         }
@@ -163,22 +154,16 @@ where
     }
 }
 
-impl<NID, N, I> VoteStateReader<NID> for RaftState<NID, N, I>
-where
-    NID: NodeId,
-    N: Node,
-    I: Instant,
+impl<C> VoteStateReader<C::NodeId> for RaftState<C>
+where C: RaftTypeConfig
 {
-    fn vote_ref(&self) -> &Vote<NID> {
+    fn vote_ref(&self) -> &Vote<C::NodeId> {
         self.vote.deref()
     }
 }
 
-impl<NID, N, I> Validate for RaftState<NID, N, I>
-where
-    NID: NodeId,
-    N: Node,
-    I: Instant,
+impl<C> Validate for RaftState<C>
+where C: RaftTypeConfig
 {
     fn validate(&self) -> Result<(), Box<dyn Error>> {
         if self.purged_next == 0 {
@@ -205,26 +190,23 @@ where
     }
 }
 
-impl<NID, N, I> RaftState<NID, N, I>
-where
-    NID: NodeId,
-    N: Node,
-    I: Instant,
+impl<C> RaftState<C>
+where C: RaftTypeConfig
 {
     /// Get a reference to the current vote.
-    pub fn vote_ref(&self) -> &Vote<NID> {
+    pub fn vote_ref(&self) -> &Vote<C::NodeId> {
         self.vote.deref()
     }
 
     /// Return the last updated time of the vote.
-    pub fn vote_last_modified(&self) -> Option<I> {
+    pub fn vote_last_modified(&self) -> Option<InstantOf<C>> {
         self.vote.utime()
     }
 
     /// Get the log id for a linearizable read.
     ///
     /// See: [Read Operation](crate::docs::protocol::read)
-    pub(crate) fn get_read_log_id(&self) -> Option<&LogId<NID>> {
+    pub(crate) fn get_read_log_id(&self) -> Option<&LogId<C::NodeId>> {
         // Get the first known log id appended by the last leader.
         // - This log may not be committed.
         // - The leader blank log may have been purged and this could be the last purged log id.
@@ -245,12 +227,12 @@ where
     }
 
     /// Return the accepted last log id of the current leader.
-    pub(crate) fn accepted(&self) -> Option<&LogId<NID>> {
+    pub(crate) fn accepted(&self) -> Option<&LogId<C::NodeId>> {
         self.accepted.last_accepted_log_id(self.vote_ref().leader_id())
     }
 
     /// Update the accepted log id for the current leader.
-    pub(crate) fn update_accepted(&mut self, accepted: Option<LogId<NID>>) {
+    pub(crate) fn update_accepted(&mut self, accepted: Option<LogId<C::NodeId>>) {
         debug_assert!(
             self.vote_ref().is_committed(),
             "vote must be committed: {}",
@@ -271,18 +253,18 @@ where
     /// Append a list of `log_id`.
     ///
     /// The log ids in the input has to be continuous.
-    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: RaftLogId<NID> + 'a>(&mut self, new_log_ids: &[LID]) {
+    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: RaftLogId<C::NodeId> + 'a>(&mut self, new_log_ids: &[LID]) {
         self.log_ids.extend_from_same_leader(new_log_ids)
     }
 
-    pub(crate) fn extend_log_ids<'a, LID: RaftLogId<NID> + 'a>(&mut self, new_log_id: &[LID]) {
+    pub(crate) fn extend_log_ids<'a, LID: RaftLogId<C::NodeId> + 'a>(&mut self, new_log_id: &[LID]) {
         self.log_ids.extend(new_log_id)
     }
 
     /// Update field `committed` if the input is greater.
     /// If updated, it returns the previous value in a `Some()`.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_committed(&mut self, committed: &Option<LogId<NID>>) -> Option<Option<LogId<NID>>> {
+    pub(crate) fn update_committed(&mut self, committed: &Option<LogIdOf<C>>) -> Option<Option<LogIdOf<C>>> {
         if committed.as_ref() > self.committed() {
             let prev = self.committed().copied();
 
@@ -295,7 +277,7 @@ where
         }
     }
 
-    pub(crate) fn io_state_mut(&mut self) -> &mut IOState<NID> {
+    pub(crate) fn io_state_mut(&mut self) -> &mut IOState<C::NodeId> {
         &mut self.io_state
     }
 
@@ -309,14 +291,14 @@ where
     ///
     /// Usually, when a client request is handled, [`RaftState`] is updated and several IO command
     /// is enqueued. And when the IO commands are completed, [`IOState`] is updated.
-    pub(crate) fn io_state(&self) -> &IOState<NID> {
+    pub(crate) fn io_state(&self) -> &IOState<C::NodeId> {
         &self.io_state
     }
 
     /// Find the first entry in the input that does not exist on local raft-log,
     /// by comparing the log id.
     pub(crate) fn first_conflicting_index<Ent>(&self, entries: &[Ent]) -> usize
-    where Ent: RaftLogId<NID> {
+    where Ent: RaftLogId<C::NodeId> {
         let l = entries.len();
 
         for (i, ent) in entries.iter().enumerate() {
@@ -337,7 +319,7 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn purge_log(&mut self, upto: &LogId<NID>) {
+    pub(crate) fn purge_log(&mut self, upto: &LogIdOf<C>) {
         self.purged_next = upto.index + 1;
         self.log_ids.purge(upto);
     }
@@ -348,7 +330,7 @@ where
     ///
     /// [Determine Server State]: crate::docs::data::vote#vote-and-membership-define-the-server-state
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn calc_server_state(&self, id: &NID) -> ServerState {
+    pub(crate) fn calc_server_state(&self, id: &C::NodeId) -> ServerState {
         tracing::debug!(
             contains = display(self.membership_state.contains(id)),
             is_voter = display(self.is_voter(id)),
@@ -374,7 +356,7 @@ where
         }
     }
 
-    pub(crate) fn is_voter(&self, id: &NID) -> bool {
+    pub(crate) fn is_voter(&self, id: &C::NodeId) -> bool {
         self.membership_state.is_voter(id)
     }
 
@@ -385,7 +367,7 @@ where
     /// more details about determining the server state.
     ///
     /// [Determine Server State]: crate::docs::data::vote#vote-and-membership-define-the-server-state
-    pub(crate) fn is_leading(&self, id: &NID) -> bool {
+    pub(crate) fn is_leading(&self, id: &C::NodeId) -> bool {
         self.membership_state.contains(id) && self.vote.leader_id().voted_for().as_ref() == Some(id)
     }
 
@@ -397,11 +379,11 @@ where
     /// more details about determining the server state.
     ///
     /// [Determine Server State]: crate::docs::data::vote#vote-and-membership-define-the-server-state
-    pub(crate) fn is_leader(&self, id: &NID) -> bool {
+    pub(crate) fn is_leader(&self, id: &C::NodeId) -> bool {
         self.is_leading(id) && self.vote.is_committed()
     }
 
-    pub(crate) fn assign_log_ids<'a, Ent: RaftEntry<NID, N> + 'a>(
+    pub(crate) fn assign_log_ids<'a, Ent: RaftEntry<C::NodeId, C::Node> + 'a>(
         &mut self,
         entries: impl IntoIterator<Item = &'a mut Ent>,
     ) {
@@ -417,7 +399,7 @@ where
     }
 
     /// Build a ForwardToLeader error that contains the leader id and node it knows.
-    pub(crate) fn forward_to_leader(&self) -> ForwardToLeader<NID, N> {
+    pub(crate) fn forward_to_leader(&self) -> ForwardToLeader<C::NodeId, C::Node> {
         let vote = self.vote_ref();
 
         if vote.is_committed() {

--- a/openraft/src/raft_state/tests/forward_to_leader_test.rs
+++ b/openraft/src/raft_state/tests/forward_to_leader_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use maplit::btreemap;
 use maplit::btreeset;
 
+use crate::engine::testing::UTConfig;
 use crate::error::ForwardToLeader;
 use crate::utime::UTime;
 use crate::CommittedLeaderId;
@@ -27,7 +28,7 @@ fn m12() -> Membership<u64, ()> {
 
 #[test]
 fn test_forward_to_leader_vote_not_committed() {
-    let rs = RaftState {
+    let rs = RaftState::<UTConfig> {
         vote: UTime::new(TokioInstant::now(), Vote::new(1, 2)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -41,7 +42,7 @@ fn test_forward_to_leader_vote_not_committed() {
 
 #[test]
 fn test_forward_to_leader_not_a_member() {
-    let rs = RaftState {
+    let rs = RaftState::<UTConfig> {
         vote: UTime::new(TokioInstant::now(), Vote::new_committed(1, 3)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -57,7 +58,7 @@ fn test_forward_to_leader_not_a_member() {
 fn test_forward_to_leader_has_leader() {
     let m123 = || Membership::<u64, u64>::new(vec![btreeset! {1,2}], btreemap! {1=>4,2=>5,3=>6});
 
-    let rs = RaftState {
+    let rs = RaftState::<UTConfig<u64>> {
         vote: UTime::new(TokioInstant::now(), Vote::new_committed(1, 3)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),

--- a/openraft/src/raft_state/tests/log_state_reader_test.rs
+++ b/openraft/src/raft_state/tests/log_state_reader_test.rs
@@ -1,9 +1,9 @@
+use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
 use crate::CommittedLeaderId;
 use crate::LogId;
 use crate::RaftState;
-use crate::TokioInstant;
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
     LogId::<u64> {
@@ -16,7 +16,7 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
 fn test_raft_state_prev_log_id() -> anyhow::Result<()> {
     // There is log id at 0
     {
-        let rs = RaftState::<u64, (), TokioInstant> {
+        let rs = RaftState::<UTConfig> {
             log_ids: LogIdList::new(vec![log_id(0, 0), log_id(1, 1), log_id(3, 4)]),
             ..Default::default()
         };
@@ -29,7 +29,7 @@ fn test_raft_state_prev_log_id() -> anyhow::Result<()> {
 
     // There is no log id at 0
     {
-        let rs = RaftState::<u64, (), TokioInstant> {
+        let rs = RaftState::<UTConfig> {
             log_ids: LogIdList::new(vec![log_id(1, 1), log_id(3, 4)]),
             ..Default::default()
         };
@@ -45,7 +45,7 @@ fn test_raft_state_prev_log_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, (), TokioInstant>::default();
+    let rs = RaftState::<UTConfig>::default();
 
     assert!(!rs.has_log_id(&log_id(0, 0)));
 
@@ -54,7 +54,7 @@ fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         committed: Some(log_id(2, 1)),
         ..Default::default()
     };
@@ -68,7 +68,7 @@ fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         committed: Some(log_id(2, 1)),
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
@@ -88,20 +88,20 @@ fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_last_log_id() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![]),
         ..Default::default()
     };
 
     assert_eq!(None, rs.last_log_id());
 
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         ..Default::default()
     };
     assert_eq!(Some(&log_id(1, 2)), rs.last_log_id());
 
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
@@ -112,7 +112,7 @@ fn test_raft_state_last_log_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_purge_upto() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         purge_upto: Some(log_id(1, 2)),
         ..Default::default()
     };
@@ -124,21 +124,21 @@ fn test_raft_state_purge_upto() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![]),
         ..Default::default()
     };
 
     assert_eq!(None, rs.last_purged_log_id());
 
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![log_id(1, 2)]),
         purged_next: 3,
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());
 
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         purged_next: 3,
         ..Default::default()

--- a/openraft/src/raft_state/tests/read_log_id_test.rs
+++ b/openraft/src/raft_state/tests/read_log_id_test.rs
@@ -1,9 +1,9 @@
+use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::utime::UTime;
 use crate::CommittedLeaderId;
 use crate::LogId;
 use crate::RaftState;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -17,7 +17,7 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
 fn test_raft_state_get_read_log_id() -> anyhow::Result<()> {
     let log_ids = || LogIdList::new(vec![log_id(1, 1), log_id(3, 4), log_id(3, 6)]);
     {
-        let rs = RaftState::<u64, (), TokioInstant> {
+        let rs = RaftState::<UTConfig> {
             vote: UTime::without_utime(Vote::new_committed(3, 0)),
             log_ids: log_ids(),
             committed: Some(log_id(2, 1)),
@@ -28,7 +28,7 @@ fn test_raft_state_get_read_log_id() -> anyhow::Result<()> {
     }
 
     {
-        let rs = RaftState::<u64, (), TokioInstant> {
+        let rs = RaftState::<UTConfig> {
             vote: UTime::without_utime(Vote::new_committed(3, 0)),
             log_ids: log_ids(),
             committed: Some(log_id(3, 5)),

--- a/openraft/src/raft_state/tests/validate_test.rs
+++ b/openraft/src/raft_state/tests/validate_test.rs
@@ -1,11 +1,11 @@
 use validit::Validate;
 
+use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::CommittedLeaderId;
 use crate::LogId;
 use crate::RaftState;
 use crate::SnapshotMeta;
-use crate::TokioInstant;
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
     LogId::<u64> {
@@ -19,7 +19,7 @@ fn test_raft_state_validate_snapshot_is_none() -> anyhow::Result<()> {
     // Some app does not persist snapshot, when restarted, purged is not None but snapshot_last_log_id
     // is None. This is a valid state and should not emit error.
 
-    let rs = RaftState::<u64, (), TokioInstant> {
+    let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![log_id(1, 1), log_id(3, 4)]),
         purged_next: 2,
         purge_upto: Some(log_id(1, 1)),

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -59,9 +59,7 @@ where
     ///
     /// When the Raft node is first started, it will call this interface to fetch the last known
     /// state from stable storage.
-    pub async fn get_initial_state(
-        &mut self,
-    ) -> Result<RaftState<C::NodeId, C::Node, InstantOf<C>>, StorageError<C::NodeId>> {
+    pub async fn get_initial_state(&mut self) -> Result<RaftState<C>, StorageError<C::NodeId>> {
         let vote = self.log_store.read_vote().await?;
         let vote = vote.unwrap_or_default();
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -20,7 +20,6 @@ use crate::storage::RaftStateMachine;
 use crate::storage::StorageHelper;
 use crate::testing::StoreBuilder;
 use crate::type_config::alias::AsyncRuntimeOf;
-use crate::type_config::alias::InstantOf;
 use crate::vote::CommittedLeaderId;
 use crate::AsyncRuntime;
 use crate::LogId;
@@ -343,7 +342,7 @@ where
 
     pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
-        let mut want = RaftState::<C::NodeId, C::Node, InstantOf<C>>::default();
+        let mut want = RaftState::<C>::default();
         want.vote.update(initial.vote.utime().unwrap(), Vote::default());
 
         assert_eq!(want, initial, "uninitialized state");

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -57,7 +57,6 @@ use openraft::RaftMetrics;
 use openraft::RaftState;
 use openraft::RaftTypeConfig;
 use openraft::ServerState;
-use openraft::TokioInstant;
 use openraft::Vote;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::ClientResponse;
@@ -764,7 +763,7 @@ impl TypedRaftRouter {
     /// Send external request to the particular node.
     pub async fn with_raft_state<V, F>(&self, target: MemNodeId, func: F) -> Result<V, Fatal<MemNodeId>>
     where
-        F: FnOnce(&RaftState<MemNodeId, (), TokioInstant>) -> V + Send + 'static,
+        F: FnOnce(&RaftState<MemConfig>) -> V + Send + 'static,
         V: Send + 'static,
     {
         let r = self.get_raft_handle(&target).unwrap();
@@ -772,11 +771,7 @@ impl TypedRaftRouter {
     }
 
     /// Send external request to the particular node.
-    pub fn external_request<F: FnOnce(&RaftState<MemNodeId, (), TokioInstant>) + Send + 'static>(
-        &self,
-        target: MemNodeId,
-        req: F,
-    ) {
+    pub fn external_request<F: FnOnce(&RaftState<MemConfig>) + Send + 'static>(&self, target: MemNodeId, req: F) {
         let r = self.get_raft_handle(&target).unwrap();
         r.external_request(req)
     }


### PR DESCRIPTION

## Changelog

##### Change: Consolidate `RaftState` type parameters into `C`

The `RaftState` type, along with related metric types, previously used
separate type parameters (`NID`, `N`, `I`) which have now been replaced
with a single generic parameter `C` bound by `RaftTypeConfig`. This
modification simplifies the type signatures and usage.

Upgrade tip:

To adapt to this change, update the usage of `RaftState` type parameters
from separate `NID`, `N`, `I` to the single generic `C` constrained by
`RaftTypeConfig`:

```rust
RaftState<NID, N, I> --> RaftState<C>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1070)
<!-- Reviewable:end -->
