### PR TITLE
Change: Consolidate `RaftEntry` and `RaftPayload` type parameters into `C`

### DIFF
--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -94,7 +94,7 @@ where C: RaftTypeConfig
     }
 }
 
-impl<C> RaftPayload<C::NodeId, C::Node> for Entry<C>
+impl<C> RaftPayload<C> for Entry<C>
 where C: RaftTypeConfig
 {
     fn is_blank(&self) -> bool {
@@ -118,7 +118,7 @@ where C: RaftTypeConfig
     }
 }
 
-impl<C> RaftEntry<C::NodeId, C::Node> for Entry<C>
+impl<C> RaftEntry<C> for Entry<C>
 where C: RaftTypeConfig
 {
     fn new_blank(log_id: LogId<C::NodeId>) -> Self {

--- a/openraft/src/entry/payload.rs
+++ b/openraft/src/entry/payload.rs
@@ -59,7 +59,7 @@ impl<C: RaftTypeConfig> MessageSummary<EntryPayload<C>> for EntryPayload<C> {
     }
 }
 
-impl<C: RaftTypeConfig> RaftPayload<C::NodeId, C::Node> for EntryPayload<C> {
+impl<C: RaftTypeConfig> RaftPayload<C> for EntryPayload<C> {
     fn is_blank(&self) -> bool {
         matches!(self, EntryPayload::Blank)
     }

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -4,41 +4,37 @@ use std::fmt::Display;
 use crate::log_id::RaftLogId;
 use crate::LogId;
 use crate::Membership;
-use crate::Node;
-use crate::NodeId;
 use crate::OptionalSend;
 use crate::OptionalSerde;
 use crate::OptionalSync;
+use crate::RaftTypeConfig;
 
 /// Defines operations on an entry payload.
-pub trait RaftPayload<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+pub trait RaftPayload<C>
+where C: RaftTypeConfig
 {
     /// Return `true` if the entry payload is blank.
     fn is_blank(&self) -> bool;
 
     /// Return `Some(&Membership)` if the entry payload is a membership payload.
-    fn get_membership(&self) -> Option<&Membership<NID, N>>;
+    fn get_membership(&self) -> Option<&Membership<C::NodeId, C::Node>>;
 }
 
 /// Defines operations on an entry.
-pub trait RaftEntry<NID, N>: RaftPayload<NID, N> + RaftLogId<NID>
+pub trait RaftEntry<C>: RaftPayload<C> + RaftLogId<C::NodeId>
 where
-    N: Node,
-    NID: NodeId,
+    C: RaftTypeConfig,
     Self: OptionalSerde + Debug + Display + OptionalSend + OptionalSync,
 {
     /// Create a new blank log entry.
     ///
     /// The returned instance must return `true` for `Self::is_blank()`.
-    fn new_blank(log_id: LogId<NID>) -> Self;
+    fn new_blank(log_id: LogId<C::NodeId>) -> Self;
 
     /// Create a new membership log entry.
     ///
     /// The returned instance must return `Some()` for `Self::get_membership()`.
-    fn new_membership(log_id: LogId<NID>, m: Membership<NID, N>) -> Self;
+    fn new_membership(log_id: LogId<C::NodeId>, m: Membership<C::NodeId, C::Node>) -> Self;
 }
 
 /// Build a raft log entry from app data.

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -383,7 +383,7 @@ where C: RaftTypeConfig
         self.is_leading(id) && self.vote.is_committed()
     }
 
-    pub(crate) fn assign_log_ids<'a, Ent: RaftEntry<C::NodeId, C::Node> + 'a>(
+    pub(crate) fn assign_log_ids<'a, Ent: RaftEntry<C> + 'a>(
         &mut self,
         entries: impl IntoIterator<Item = &'a mut Ent>,
     ) {

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -52,7 +52,7 @@ pub trait RaftTypeConfig:
     type Node: Node;
 
     /// Raft log entry, which can be built from an AppData.
-    type Entry: RaftEntry<Self::NodeId, Self::Node> + FromAppData<Self::D>;
+    type Entry: RaftEntry<Self> + FromAppData<Self::D>;
 
     /// Snapshot data for exposing a snapshot for reading & writing.
     ///


### PR DESCRIPTION

## Changelog

##### Change: Consolidate `RaftEntry` and `RaftPayload` type parameters into `C`

Upgrade tip:

To adapt to this change, update type parameters from separate `NID`,
`N` to the single generic `C` constrained by `RaftTypeConfig`:

```rust
RaftEntry<NID, N>   --> RaftEntry<C>
RaftPayload<NID, N> --> RaftPayload<C>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1072)
<!-- Reviewable:end -->
