### PR TITLE
Change: Consolidate `SnapshotMeta`,  type parameters into `C`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -52,7 +52,7 @@ openraft::declare_raft_types!(
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, ()>,
+    pub meta: SnapshotMeta<TypeConfig>,
     pub data: Vec<u8>,
 }
 
@@ -285,7 +285,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, ()>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         let new_snapshot = StoredSnapshot {

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
@@ -48,7 +48,7 @@ pub mod typ {
     pub type Raft = openraft::Raft<TypeConfig>;
 
     pub type Vote = openraft::Vote<NodeId>;
-    pub type SnapshotMeta = openraft::SnapshotMeta<NodeId, BasicNode>;
+    pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
     pub type SnapshotData = <TypeConfig as openraft::RaftTypeConfig>::SnapshotData;
     pub type Snapshot = openraft::Snapshot<TypeConfig>;
 

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
@@ -44,7 +44,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Box<typ::SnapshotData>,
@@ -176,7 +176,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!("install snapshot");

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -47,7 +47,7 @@ pub mod typ {
     pub type Raft = openraft::Raft<TypeConfig>;
 
     pub type Vote = openraft::Vote<NodeId>;
-    pub type SnapshotMeta = openraft::SnapshotMeta<NodeId, BasicNode>;
+    pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
     pub type SnapshotData = <TypeConfig as openraft::RaftTypeConfig>::SnapshotData;
     pub type Snapshot = openraft::Snapshot<TypeConfig>;
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -47,7 +47,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Box<typ::SnapshotData>,
@@ -197,7 +197,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!("install snapshot");

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -74,7 +74,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -230,7 +230,7 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!(

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -51,7 +51,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -183,7 +183,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!(

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -68,7 +68,7 @@ pub struct Response {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, Node>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -249,7 +249,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
 
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, Node>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotData>,
     ) -> Result<(), StorageError<NodeId>> {
         let new_snapshot = StoredSnapshot {

--- a/openraft/src/core/sm/response.rs
+++ b/openraft/src/core/sm/response.rs
@@ -10,12 +10,12 @@ pub(crate) enum Response<C>
 where C: RaftTypeConfig
 {
     /// Build a snapshot, it returns result via the universal RaftCore response channel.
-    BuildSnapshot(SnapshotMeta<C::NodeId, C::Node>),
+    BuildSnapshot(SnapshotMeta<C>),
 
     /// When finishing installing a snapshot.
     ///
     /// It does not return any value to RaftCore.
-    InstallSnapshot(Option<SnapshotMeta<C::NodeId, C::Node>>),
+    InstallSnapshot(Option<SnapshotMeta<C>>),
 
     /// Send back applied result to RaftCore.
     Apply(ApplyResult<C>),

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -522,7 +522,7 @@ where C: RaftTypeConfig
     /// - Engine only keeps the snapshot meta with the greatest last-log-id;
     /// - and a snapshot smaller than last-committed is not allowed to be installed.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn finish_building_snapshot(&mut self, meta: SnapshotMeta<C::NodeId, C::Node>) {
+    pub(crate) fn finish_building_snapshot(&mut self, meta: SnapshotMeta<C>) {
         tracing::info!(snapshot_meta = display(&meta), "{}", func_name!());
 
         self.state.io_state_mut().set_building_snapshot(false);

--- a/openraft/src/engine/handler/snapshot_handler/mod.rs
+++ b/openraft/src/engine/handler/snapshot_handler/mod.rs
@@ -49,7 +49,7 @@ where C: RaftTypeConfig
     ///
     /// [`RaftStateMachine`]: crate::storage::RaftStateMachine
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_snapshot(&mut self, meta: SnapshotMeta<C::NodeId, C::Node>) -> bool {
+    pub(crate) fn update_snapshot(&mut self, meta: SnapshotMeta<C>) -> bool {
         tracing::info!("update_snapshot: {:?}", meta);
 
         if meta.last_log_id <= self.state.snapshot_last_log_id().copied() {

--- a/openraft/src/raft/message/install_snapshot.rs
+++ b/openraft/src/raft/message/install_snapshot.rs
@@ -14,7 +14,7 @@ pub struct InstallSnapshotRequest<C: RaftTypeConfig> {
     pub vote: Vote<C::NodeId>,
 
     /// Metadata of a snapshot: snapshot_id, last_log_ed membership etc.
-    pub meta: SnapshotMeta<C::NodeId, C::Node>,
+    pub meta: SnapshotMeta<C>,
 
     /// The byte offset where this chunk of data is positioned in the snapshot file.
     pub offset: u64,

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -70,7 +70,7 @@ where C: RaftTypeConfig
     pub membership_state: MembershipState<C::NodeId, C::Node>,
 
     /// The metadata of the last snapshot.
-    pub snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+    pub snapshot_meta: SnapshotMeta<C>,
 
     // --
     // -- volatile fields: they are not persisted.

--- a/openraft/src/replication/callbacks.rs
+++ b/openraft/src/replication/callbacks.rs
@@ -20,7 +20,7 @@ pub(crate) struct SnapshotCallback<C: RaftTypeConfig> {
     pub(crate) start_time: InstantOf<C>,
 
     /// Meta data of the snapshot to be replicated.
-    pub(crate) snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+    pub(crate) snapshot_meta: SnapshotMeta<C>,
 
     /// The result of the snapshot replication.
     pub(crate) result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
@@ -29,7 +29,7 @@ pub(crate) struct SnapshotCallback<C: RaftTypeConfig> {
 impl<C: RaftTypeConfig> SnapshotCallback<C> {
     pub(in crate::replication) fn new(
         start_time: InstantOf<C>,
-        snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+        snapshot_meta: SnapshotMeta<C>,
         result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
     ) -> Self {
         Self {

--- a/openraft/src/replication/request.rs
+++ b/openraft/src/replication/request.rs
@@ -150,7 +150,7 @@ where C: RaftTypeConfig
     pub(crate) fn new_snapshot_callback(
         request_id: RequestId,
         start_time: InstantOf<C>,
-        snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+        snapshot_meta: SnapshotMeta<C>,
         result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
     ) -> Self {
         Self::SnapshotCallback(DataWithId::new(

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -19,13 +19,11 @@ pub use v2::RaftLogStorageExt;
 pub use v2::RaftStateMachine;
 
 use crate::display_ext::DisplayOption;
-use crate::node::Node;
 use crate::raft_types::SnapshotId;
 pub use crate::storage::callback::LogApplied;
 pub use crate::storage::callback::LogFlushed;
 use crate::LogId;
 use crate::MessageSummary;
-use crate::NodeId;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftTypeConfig;
@@ -34,16 +32,14 @@ use crate::StoredMembership;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct SnapshotMeta<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+pub struct SnapshotMeta<C>
+where C: RaftTypeConfig
 {
     /// Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: Option<LogId<NID>>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 
     /// The last applied membership config.
-    pub last_membership: StoredMembership<NID, N>,
+    pub last_membership: StoredMembership<C::NodeId, C::Node>,
 
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be
@@ -51,10 +47,8 @@ where
     pub snapshot_id: SnapshotId,
 }
 
-impl<NID, N> fmt::Display for SnapshotMeta<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> fmt::Display for SnapshotMeta<C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -67,22 +61,18 @@ where
     }
 }
 
-impl<NID, N> MessageSummary<SnapshotMeta<NID, N>> for SnapshotMeta<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> MessageSummary<SnapshotMeta<C>> for SnapshotMeta<C>
+where C: RaftTypeConfig
 {
     fn summary(&self) -> String {
         self.to_string()
     }
 }
 
-impl<NID, N> SnapshotMeta<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+impl<C> SnapshotMeta<C>
+where C: RaftTypeConfig
 {
-    pub fn signature(&self) -> SnapshotSignature<NID> {
+    pub fn signature(&self) -> SnapshotSignature<C::NodeId> {
         SnapshotSignature {
             last_log_id: self.last_log_id,
             last_membership_log_id: *self.last_membership.log_id(),
@@ -90,8 +80,8 @@ where
         }
     }
 
-    /// Returns a ref to the id of the last log that is included in this snasphot.
-    pub fn last_log_id(&self) -> Option<&LogId<NID>> {
+    /// Returns a ref to the id of the last log that is included in this snapshot.
+    pub fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
         self.last_log_id.as_ref()
     }
 }
@@ -102,7 +92,7 @@ pub struct Snapshot<C>
 where C: RaftTypeConfig
 {
     /// metadata of a snapshot
-    pub meta: SnapshotMeta<C::NodeId, C::Node>,
+    pub meta: SnapshotMeta<C>,
 
     /// A read handle to the associated snapshot.
     pub snapshot: Box<C::SnapshotData>,
@@ -112,7 +102,7 @@ impl<C> Snapshot<C>
 where C: RaftTypeConfig
 {
     #[allow(dead_code)]
-    pub(crate) fn new(meta: SnapshotMeta<C::NodeId, C::Node>, snapshot: Box<C::SnapshotData>) -> Self {
+    pub(crate) fn new(meta: SnapshotMeta<C>, snapshot: Box<C::SnapshotData>) -> Self {
         Self { meta, snapshot }
     }
 }

--- a/openraft/src/storage/v2.rs
+++ b/openraft/src/storage/v2.rs
@@ -221,7 +221,7 @@ where C: RaftTypeConfig
     /// snapshot.
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<C::NodeId, C::Node>,
+        meta: &SnapshotMeta<C>,
         snapshot: Box<C::SnapshotData>,
     ) -> Result<(), StorageError<C::NodeId>>;
 

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -89,7 +89,7 @@ openraft::declare_raft_types!(
 /// The application snapshot type which the `MemStore` works with.
 #[derive(Debug)]
 pub struct MemStoreSnapshot {
-    pub meta: SnapshotMeta<MemNodeId, ()>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -484,7 +484,7 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<MemNodeId, ()>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<MemNodeId>> {
         tracing::info!(

--- a/stores/rocksstore/src/lib.rs
+++ b/stores/rocksstore/src/lib.rs
@@ -89,7 +89,7 @@ pub struct RocksResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RocksSnapshot {
-    pub meta: SnapshotMeta<RocksNodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -459,7 +459,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
 
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<RocksNodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<RocksNodeId>> {
         tracing::info!(

--- a/stores/sledstore/src/lib.rs
+++ b/stores/sledstore/src/lib.rs
@@ -79,7 +79,7 @@ pub struct ExampleResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ExampleSnapshot {
-    pub meta: SnapshotMeta<ExampleNodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -641,7 +641,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<ExampleNodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<ExampleNodeId>> {
         tracing::info!(


### PR DESCRIPTION

## Changelog

##### Change: Consolidate `SnapshotMeta`,  type parameters into `C`

Upgrade tip:

To adapt to this change, update type parameters with the single generic `C` constrained by `RaftTypeConfig`:

```rust,ignore
SnapshotMeta<NID, N> --> SnapshotMeta<C>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1075)
<!-- Reviewable:end -->
