### PR TITLE
Change: Consolidate type parameters into `C`

### DIFF
--- a/cluster_benchmark/tests/benchmark/network.rs
+++ b/cluster_benchmark/tests/benchmark/network.rs
@@ -26,6 +26,7 @@ use openraft::Raft;
 use crate::store::LogStore;
 use crate::store::NodeId;
 use crate::store::StateMachineStore;
+use crate::store::TypeConfig;
 use crate::store::TypeConfig as MemConfig;
 
 pub type BenchRaft = Raft<MemConfig>;
@@ -100,7 +101,7 @@ impl RaftNetwork<MemConfig> for Network {
         &mut self,
         rpc: AppendEntriesRequest<MemConfig>,
         _option: RPCOption,
-    ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId>>> {
+    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<MemConfig, RaftError<MemConfig>>> {
         let resp = self.target_raft.append_entries(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
         Ok(resp)
     }
@@ -109,16 +110,17 @@ impl RaftNetwork<MemConfig> for Network {
         &mut self,
         rpc: InstallSnapshotRequest<MemConfig>,
         _option: RPCOption,
-    ) -> Result<InstallSnapshotResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId, InstallSnapshotError>>> {
+    ) -> Result<InstallSnapshotResponse<TypeConfig>, RPCError<MemConfig, RaftError<MemConfig, InstallSnapshotError>>>
+    {
         let resp = self.target_raft.install_snapshot(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
         Ok(resp)
     }
 
     async fn vote(
         &mut self,
-        rpc: VoteRequest<NodeId>,
+        rpc: VoteRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<VoteResponse<NodeId>, RPCError<NodeId, (), RaftError<NodeId>>> {
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<MemConfig, RaftError<MemConfig>>> {
         let resp = self.target_raft.vote(rpc).await.map_err(|e| RemoteError::new(self.target, e))?;
         Ok(resp)
     }

--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -52,14 +52,14 @@ openraft::declare_raft_types!(
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, ()>,
+    pub meta: SnapshotMeta<TypeConfig>,
     pub data: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct StateMachine {
     pub last_applied_log: Option<LogId<NodeId>>,
-    pub last_membership: StoredMembership<NodeId, ()>,
+    pub last_membership: StoredMembership<TypeConfig>,
 }
 
 pub struct LogStore {
@@ -250,7 +250,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
 impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, ()>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
         let sm = self.sm.read().await;
         Ok((sm.last_applied_log, sm.last_membership.clone()))
     }
@@ -285,7 +285,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, ()>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         let new_snapshot = StoredSnapshot {

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/api.rs
@@ -31,7 +31,7 @@ pub async fn read(app: &mut App, req: String) -> String {
             let state_machine = app.state_machine.state_machine.lock().unwrap();
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<NodeId, CheckIsLeaderError<NodeId, BasicNode>>> =
+            let res: Result<String, RaftError<TypeConfig, CheckIsLeaderError<TypeConfig>>> =
                 Ok(value.unwrap_or_default());
             res
         }

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
@@ -40,7 +40,6 @@ pub type LogStore = store::LogStore;
 pub type StateMachineStore = store::StateMachineStore;
 
 pub mod typ {
-    use openraft::BasicNode;
 
     use crate::NodeId;
     use crate::TypeConfig;
@@ -48,22 +47,22 @@ pub mod typ {
     pub type Raft = openraft::Raft<TypeConfig>;
 
     pub type Vote = openraft::Vote<NodeId>;
-    pub type SnapshotMeta = openraft::SnapshotMeta<NodeId, BasicNode>;
+    pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
     pub type SnapshotData = <TypeConfig as openraft::RaftTypeConfig>::SnapshotData;
     pub type Snapshot = openraft::Snapshot<TypeConfig>;
 
     pub type Infallible = openraft::error::Infallible;
-    pub type Fatal = openraft::error::Fatal<NodeId>;
-    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<NodeId, E>;
-    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
+    pub type Fatal = openraft::error::Fatal<TypeConfig>;
+    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<TypeConfig, E>;
+    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<TypeConfig, RaftError<E>>;
     pub type StreamingError<E> = openraft::error::StreamingError<TypeConfig, E>;
 
     pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 
-    pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
-    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;
-    pub type ForwardToLeader = openraft::error::ForwardToLeader<NodeId, BasicNode>;
-    pub type InitializeError = openraft::error::InitializeError<NodeId, BasicNode>;
+    pub type ClientWriteError = openraft::error::ClientWriteError<TypeConfig>;
+    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<TypeConfig>;
+    pub type ForwardToLeader = openraft::error::ForwardToLeader<TypeConfig>;
+    pub type InitializeError = openraft::error::InitializeError<TypeConfig>;
 
     pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 }

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/network.rs
@@ -41,7 +41,7 @@ impl RaftNetwork<TypeConfig> for Connection {
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
+    ) -> Result<AppendEntriesResponse<TypeConfig>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/append", req)
@@ -57,7 +57,7 @@ impl RaftNetwork<TypeConfig> for Connection {
         snapshot: Snapshot<TypeConfig>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
         _option: RPCOption,
-    ) -> Result<SnapshotResponse<NodeId>, typ::StreamingError<typ::Fatal>> {
+    ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError<typ::Fatal>> {
         let resp = self
             .router
             .send::<_, _, typ::Infallible>(self.target, "/raft/snapshot", (vote, snapshot.meta, snapshot.snapshot))
@@ -68,9 +68,9 @@ impl RaftNetwork<TypeConfig> for Connection {
 
     async fn vote(
         &mut self,
-        req: VoteRequest<NodeId>,
+        req: VoteRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    ) -> Result<VoteResponse<TypeConfig>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/vote", req)

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/store.rs
@@ -6,7 +6,6 @@ use std::sync::Mutex;
 use openraft::alias::SnapshotDataOf;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
-use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
@@ -44,7 +43,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Box<typ::SnapshotData>,
@@ -57,7 +56,7 @@ pub struct StoredSnapshot {
 pub struct StateMachineData {
     pub last_applied: Option<LogId<NodeId>>,
 
-    pub last_membership: StoredMembership<NodeId, BasicNode>,
+    pub last_membership: StoredMembership<TypeConfig>,
 
     /// Application data.
     pub data: BTreeMap<String, String>,
@@ -132,7 +131,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, BasicNode>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
@@ -176,7 +175,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!("install snapshot");

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
@@ -31,7 +31,7 @@ pub async fn read(app: &mut App, req: String) -> String {
             let state_machine = app.state_machine.state_machine.lock().unwrap();
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<NodeId, CheckIsLeaderError<NodeId, BasicNode>>> =
+            let res: Result<String, RaftError<TypeConfig, CheckIsLeaderError<TypeConfig>>> =
                 Ok(value.unwrap_or_default());
             res
         }

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -39,7 +39,6 @@ pub type LogStore = store::LogStore;
 pub type StateMachineStore = store::StateMachineStore;
 
 pub mod typ {
-    use openraft::BasicNode;
 
     use crate::NodeId;
     use crate::TypeConfig;
@@ -47,22 +46,22 @@ pub mod typ {
     pub type Raft = openraft::Raft<TypeConfig>;
 
     pub type Vote = openraft::Vote<NodeId>;
-    pub type SnapshotMeta = openraft::SnapshotMeta<NodeId, BasicNode>;
+    pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
     pub type SnapshotData = <TypeConfig as openraft::RaftTypeConfig>::SnapshotData;
     pub type Snapshot = openraft::Snapshot<TypeConfig>;
 
     pub type Infallible = openraft::error::Infallible;
-    pub type Fatal = openraft::error::Fatal<NodeId>;
-    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<NodeId, E>;
-    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
+    pub type Fatal = openraft::error::Fatal<TypeConfig>;
+    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<TypeConfig, E>;
+    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<TypeConfig, RaftError<E>>;
     pub type StreamingError<E> = openraft::error::StreamingError<TypeConfig, E>;
 
     pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 
-    pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
-    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;
-    pub type ForwardToLeader = openraft::error::ForwardToLeader<NodeId, BasicNode>;
-    pub type InitializeError = openraft::error::InitializeError<NodeId, BasicNode>;
+    pub type ClientWriteError = openraft::error::ClientWriteError<TypeConfig>;
+    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<TypeConfig>;
+    pub type ForwardToLeader = openraft::error::ForwardToLeader<TypeConfig>;
+    pub type InitializeError = openraft::error::InitializeError<TypeConfig>;
 
     pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 }

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
@@ -41,7 +41,7 @@ impl RaftNetwork<TypeConfig> for Connection {
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
+    ) -> Result<AppendEntriesResponse<TypeConfig>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/append", req)
@@ -57,7 +57,7 @@ impl RaftNetwork<TypeConfig> for Connection {
         snapshot: Snapshot<TypeConfig>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
         _option: RPCOption,
-    ) -> Result<SnapshotResponse<NodeId>, typ::StreamingError<typ::Fatal>> {
+    ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError<typ::Fatal>> {
         let resp = self
             .router
             .send::<_, _, typ::Infallible>(self.target, "/raft/snapshot", (vote, snapshot.meta, snapshot.snapshot))
@@ -68,9 +68,9 @@ impl RaftNetwork<TypeConfig> for Connection {
 
     async fn vote(
         &mut self,
-        req: VoteRequest<NodeId>,
+        req: VoteRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    ) -> Result<VoteResponse<TypeConfig>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/vote", req)

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -7,7 +7,6 @@ use opendal::Operator;
 use openraft::alias::SnapshotDataOf;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
-use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
@@ -47,7 +46,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Box<typ::SnapshotData>,
@@ -60,7 +59,7 @@ pub struct StoredSnapshot {
 pub struct StateMachineData {
     pub last_applied: Option<LogId<NodeId>>,
 
-    pub last_membership: StoredMembership<NodeId, BasicNode>,
+    pub last_membership: StoredMembership<TypeConfig>,
 
     /// Application data.
     pub data: BTreeMap<String, String>,
@@ -153,7 +152,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, BasicNode>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
@@ -197,7 +196,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!("install snapshot");

--- a/examples/raft-kv-memstore-singlethreaded/src/api.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/api.rs
@@ -30,7 +30,7 @@ pub async fn read(app: &mut App, req: String) -> String {
             let state_machine = app.state_machine.state_machine.borrow();
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<NodeId, CheckIsLeaderError<NodeId, BasicNode>>> =
+            let res: Result<String, RaftError<TypeConfig, CheckIsLeaderError<TypeConfig>>> =
                 Ok(value.unwrap_or_default());
             res
         }

--- a/examples/raft-kv-memstore-singlethreaded/src/lib.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/lib.rs
@@ -62,20 +62,18 @@ pub type StateMachineStore = store::StateMachineStore;
 pub type Raft = openraft::Raft<TypeConfig>;
 
 pub mod typ {
-    use openraft::BasicNode;
 
-    use crate::NodeId;
     use crate::TypeConfig;
 
-    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<NodeId, E>;
-    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
+    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<TypeConfig, E>;
+    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<TypeConfig, RaftError<E>>;
 
     pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 
-    pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
-    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;
-    pub type ForwardToLeader = openraft::error::ForwardToLeader<NodeId, BasicNode>;
-    pub type InitializeError = openraft::error::InitializeError<NodeId, BasicNode>;
+    pub type ClientWriteError = openraft::error::ClientWriteError<TypeConfig>;
+    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<TypeConfig>;
+    pub type ForwardToLeader = openraft::error::ForwardToLeader<TypeConfig>;
+    pub type InitializeError = openraft::error::InitializeError<TypeConfig>;
 
     pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 }

--- a/examples/raft-kv-memstore-singlethreaded/src/network.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/network.rs
@@ -37,7 +37,7 @@ impl RaftNetwork<TypeConfig> for Connection {
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
+    ) -> Result<AppendEntriesResponse<TypeConfig>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/append", req)
@@ -50,7 +50,7 @@ impl RaftNetwork<TypeConfig> for Connection {
         &mut self,
         req: InstallSnapshotRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<InstallSnapshotResponse<NodeId>, typ::RPCError<InstallSnapshotError>> {
+    ) -> Result<InstallSnapshotResponse<TypeConfig>, typ::RPCError<InstallSnapshotError>> {
         let resp = self
             .router
             .send(self.target, "/raft/snapshot", req)
@@ -61,9 +61,9 @@ impl RaftNetwork<TypeConfig> for Connection {
 
     async fn vote(
         &mut self,
-        req: VoteRequest<NodeId>,
+        req: VoteRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    ) -> Result<VoteResponse<TypeConfig>, typ::RPCError> {
         let resp = self
             .router
             .send(self.target, "/raft/vote", req)

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -12,7 +12,6 @@ use openraft::storage::LogState;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
-use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
@@ -74,7 +73,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -87,7 +86,7 @@ pub struct StoredSnapshot {
 pub struct StateMachineData {
     pub last_applied: Option<LogId<NodeId>>,
 
-    pub last_membership: StoredMembership<NodeId, BasicNode>,
+    pub last_membership: StoredMembership<TypeConfig>,
 
     /// Application data.
     pub data: BTreeMap<String, String>,
@@ -186,7 +185,7 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, BasicNode>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
         let state_machine = self.state_machine.borrow();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
@@ -230,7 +229,7 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!(

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -44,18 +44,16 @@ pub type StateMachineStore = store::StateMachineStore;
 pub type Raft = openraft::Raft<TypeConfig>;
 
 pub mod typ {
-    use openraft::BasicNode;
 
-    use crate::NodeId;
     use crate::TypeConfig;
 
-    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<NodeId, E>;
-    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<NodeId, BasicNode, RaftError<E>>;
+    pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<TypeConfig, E>;
+    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<TypeConfig, RaftError<E>>;
 
-    pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, BasicNode>;
-    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, BasicNode>;
-    pub type ForwardToLeader = openraft::error::ForwardToLeader<NodeId, BasicNode>;
-    pub type InitializeError = openraft::error::InitializeError<NodeId, BasicNode>;
+    pub type ClientWriteError = openraft::error::ClientWriteError<TypeConfig>;
+    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<TypeConfig>;
+    pub type ForwardToLeader = openraft::error::ForwardToLeader<TypeConfig>;
+    pub type InitializeError = openraft::error::InitializeError<TypeConfig>;
 
     pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 }

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -5,12 +5,11 @@ use actix_web::Responder;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
 use openraft::error::RaftError;
-use openraft::BasicNode;
 use web::Json;
 
 use crate::app::App;
 use crate::store::Request;
-use crate::NodeId;
+use crate::TypeConfig;
 
 /**
  * Application API
@@ -47,7 +46,7 @@ pub async fn consistent_read(app: Data<App>, req: Json<String>) -> actix_web::Re
             let key = req.0;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<NodeId, CheckIsLeaderError<NodeId, BasicNode>>> =
+            let res: Result<String, RaftError<TypeConfig, CheckIsLeaderError<TypeConfig>>> =
                 Ok(value.unwrap_or_default());
             Ok(Json(res))
         }

--- a/examples/raft-kv-memstore/src/network/raft.rs
+++ b/examples/raft-kv-memstore/src/network/raft.rs
@@ -7,13 +7,12 @@ use openraft::raft::InstallSnapshotRequest;
 use openraft::raft::VoteRequest;
 
 use crate::app::App;
-use crate::NodeId;
 use crate::TypeConfig;
 
 // --- Raft communication
 
 #[post("/raft-vote")]
-pub async fn vote(app: Data<App>, req: Json<VoteRequest<NodeId>>) -> actix_web::Result<impl Responder> {
+pub async fn vote(app: Data<App>, req: Json<VoteRequest<TypeConfig>>) -> actix_web::Result<impl Responder> {
     let res = app.raft.vote(req.0).await;
     Ok(Json(res))
 }

--- a/examples/raft-kv-memstore/src/network/raft_network_impl.rs
+++ b/examples/raft-kv-memstore/src/network/raft_network_impl.rs
@@ -28,7 +28,7 @@ impl Network {
         target_node: &BasicNode,
         uri: &str,
         req: Req,
-    ) -> Result<Resp, openraft::error::RPCError<NodeId, BasicNode, Err>>
+    ) -> Result<Resp, openraft::error::RPCError<TypeConfig, Err>>
     where
         Req: Serialize,
         Err: std::error::Error + DeserializeOwned,
@@ -85,7 +85,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
         &mut self,
         req: AppendEntriesRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<AppendEntriesResponse<NodeId>, typ::RPCError> {
+    ) -> Result<AppendEntriesResponse<TypeConfig>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-append", req).await
     }
 
@@ -93,15 +93,15 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
         &mut self,
         req: InstallSnapshotRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<InstallSnapshotResponse<NodeId>, typ::RPCError<InstallSnapshotError>> {
+    ) -> Result<InstallSnapshotResponse<TypeConfig>, typ::RPCError<InstallSnapshotError>> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-snapshot", req).await
     }
 
     async fn vote(
         &mut self,
-        req: VoteRequest<NodeId>,
+        req: VoteRequest<TypeConfig>,
         _option: RPCOption,
-    ) -> Result<VoteResponse<NodeId>, typ::RPCError> {
+    ) -> Result<VoteResponse<TypeConfig>, typ::RPCError> {
         self.owner.send_rpc(self.target, &self.target_node, "raft-vote", req).await
     }
 }

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -7,7 +7,6 @@ use std::sync::Mutex;
 use openraft::alias::SnapshotDataOf;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
-use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
@@ -51,7 +50,7 @@ pub struct Response {
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -64,7 +63,7 @@ pub struct StoredSnapshot {
 pub struct StateMachineData {
     pub last_applied_log: Option<LogId<NodeId>>,
 
-    pub last_membership: StoredMembership<NodeId, BasicNode>,
+    pub last_membership: StoredMembership<TypeConfig>,
 
     /// Application data.
     pub data: BTreeMap<String, String>,
@@ -139,7 +138,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, BasicNode>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
         let state_machine = self.state_machine.read().await;
         Ok((state_machine.last_applied_log, state_machine.last_membership.clone()))
     }
@@ -183,7 +182,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<NodeId>> {
         tracing::info!(

--- a/examples/raft-kv-rocksdb/src/client.rs
+++ b/examples/raft-kv-rocksdb/src/client.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::typ;
-use crate::Node;
 use crate::NodeId;
 use crate::Request;
 use crate::TypeConfig;
@@ -119,7 +118,7 @@ impl ExampleClient {
         &self,
         uri: &str,
         req: Option<&Req>,
-    ) -> Result<Resp, RPCError<NodeId, Node, Err>>
+    ) -> Result<Resp, RPCError<TypeConfig, Err>>
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,

--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -54,19 +54,17 @@ openraft::declare_raft_types!(
 pub mod typ {
     use openraft::error::Infallible;
 
-    use crate::Node;
-    use crate::NodeId;
     use crate::TypeConfig;
 
     pub type Entry = openraft::Entry<TypeConfig>;
 
-    pub type RaftError<E = Infallible> = openraft::error::RaftError<NodeId, E>;
-    pub type RPCError<E = Infallible> = openraft::error::RPCError<NodeId, Node, RaftError<E>>;
+    pub type RaftError<E = Infallible> = openraft::error::RaftError<TypeConfig, E>;
+    pub type RPCError<E = Infallible> = openraft::error::RPCError<TypeConfig, RaftError<E>>;
 
-    pub type ClientWriteError = openraft::error::ClientWriteError<NodeId, Node>;
-    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<NodeId, Node>;
-    pub type ForwardToLeader = openraft::error::ForwardToLeader<NodeId, Node>;
-    pub type InitializeError = openraft::error::InitializeError<NodeId, Node>;
+    pub type ClientWriteError = openraft::error::ClientWriteError<TypeConfig>;
+    pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<TypeConfig>;
+    pub type ForwardToLeader = openraft::error::ForwardToLeader<TypeConfig>;
+    pub type InitializeError = openraft::error::InitializeError<TypeConfig>;
 
     pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 }

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -8,9 +8,8 @@ use tide::Response;
 use tide::StatusCode;
 
 use crate::app::App;
-use crate::Node;
-use crate::NodeId;
 use crate::Server;
+use crate::TypeConfig;
 
 pub fn rest(app: &mut Server) {
     let mut api = app.at("/api");
@@ -52,7 +51,7 @@ async fn consistent_read(mut req: Request<Arc<App>>) -> tide::Result {
 
             let value = kvs.get(&key);
 
-            let res: Result<String, CheckIsLeaderError<NodeId, Node>> = Ok(value.cloned().unwrap_or_default());
+            let res: Result<String, CheckIsLeaderError<TypeConfig>> = Ok(value.cloned().unwrap_or_default());
             Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
         }
         e => Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&e)?).build()),

--- a/examples/raft-kv-rocksdb/src/network/raft.rs
+++ b/examples/raft-kv-rocksdb/src/network/raft.rs
@@ -23,7 +23,7 @@ impl Raft {
     }
 
     #[export_method]
-    pub async fn vote(&self, vote: VoteRequest<u64>) -> Result<VoteResponse<u64>, toy_rpc::Error> {
+    pub async fn vote(&self, vote: VoteRequest<TypeConfig>) -> Result<VoteResponse<TypeConfig>, toy_rpc::Error> {
         self.app.raft.vote(vote).await.map_err(|e| toy_rpc::Error::Internal(Box::new(e)))
     }
 
@@ -31,7 +31,7 @@ impl Raft {
     pub async fn append(
         &self,
         req: AppendEntriesRequest<TypeConfig>,
-    ) -> Result<AppendEntriesResponse<u64>, toy_rpc::Error> {
+    ) -> Result<AppendEntriesResponse<TypeConfig>, toy_rpc::Error> {
         tracing::debug!("handle append");
         self.app.raft.append_entries(req).await.map_err(|e| toy_rpc::Error::Internal(Box::new(e)))
     }
@@ -40,7 +40,7 @@ impl Raft {
     pub async fn snapshot(
         &self,
         req: InstallSnapshotRequest<TypeConfig>,
-    ) -> Result<InstallSnapshotResponse<u64>, toy_rpc::Error> {
+    ) -> Result<InstallSnapshotResponse<TypeConfig>, toy_rpc::Error> {
         self.app.raft.install_snapshot(req).await.map_err(|e| toy_rpc::Error::Internal(Box::new(e)))
     }
 }

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -37,7 +37,6 @@ use serde::Serialize;
 use tokio::sync::RwLock;
 
 use crate::typ;
-use crate::Node;
 use crate::NodeId;
 use crate::SnapshotData;
 use crate::TypeConfig;
@@ -68,7 +67,7 @@ pub struct Response {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StoredSnapshot {
-    pub meta: SnapshotMeta<NodeId, Node>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -92,7 +91,7 @@ pub struct StateMachineStore {
 pub struct StateMachineData {
     pub last_applied_log_id: Option<LogId<NodeId>>,
 
-    pub last_membership: StoredMembership<NodeId, Node>,
+    pub last_membership: StoredMembership<TypeConfig>,
 
     /// State built from applying the raft logs
     pub kvs: Arc<RwLock<BTreeMap<String, String>>>,
@@ -201,7 +200,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, Node>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
         Ok((self.data.last_applied_log_id, self.data.last_membership.clone()))
     }
 
@@ -249,7 +248,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
 
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<NodeId, Node>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotData>,
     ) -> Result<(), StorageError<NodeId>> {
         let new_snapshot = StoredSnapshot {

--- a/openraft/src/core/notify.rs
+++ b/openraft/src/core/notify.rs
@@ -11,7 +11,7 @@ where C: RaftTypeConfig
 {
     VoteResponse {
         target: C::NodeId,
-        resp: VoteResponse<C::NodeId>,
+        resp: VoteResponse<C>,
 
         /// The candidate that sent the vote request.
         ///

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -13,8 +13,6 @@ use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::type_config::alias::LogIdOf;
-use crate::type_config::alias::NodeIdOf;
-use crate::type_config::alias::NodeOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::SnapshotDataOf;
@@ -32,17 +30,16 @@ pub(crate) type ResultSender<C, T, E = Infallible> = OneshotSenderOf<C, Result<T
 pub(crate) type ResultReceiver<C, T, E = Infallible> = OneshotReceiverOf<C, Result<T, E>>;
 
 /// TX for Vote Response
-pub(crate) type VoteTx<C> = ResultSender<C, VoteResponse<NodeIdOf<C>>>;
+pub(crate) type VoteTx<C> = ResultSender<C, VoteResponse<C>>;
 
 /// TX for Append Entries Response
-pub(crate) type AppendEntriesTx<C> = ResultSender<C, AppendEntriesResponse<NodeIdOf<C>>>;
+pub(crate) type AppendEntriesTx<C> = ResultSender<C, AppendEntriesResponse<C>>;
 
 /// TX for Client Write Response
-pub(crate) type ClientWriteTx<C> = ResultSender<C, ClientWriteResponse<C>, ClientWriteError<NodeIdOf<C>, NodeOf<C>>>;
+pub(crate) type ClientWriteTx<C> = ResultSender<C, ClientWriteResponse<C>, ClientWriteError<C>>;
 
 /// TX for Linearizable Read Response
-pub(crate) type ClientReadTx<C> =
-    ResultSender<C, (Option<LogIdOf<C>>, Option<LogIdOf<C>>), CheckIsLeaderError<NodeIdOf<C>, NodeOf<C>>>;
+pub(crate) type ClientReadTx<C> = ResultSender<C, (Option<LogIdOf<C>>, Option<LogIdOf<C>>), CheckIsLeaderError<C>>;
 
 /// A message sent by application to the [`RaftCore`].
 ///
@@ -56,14 +53,14 @@ where C: RaftTypeConfig
     },
 
     RequestVote {
-        rpc: VoteRequest<C::NodeId>,
+        rpc: VoteRequest<C>,
         tx: VoteTx<C>,
     },
 
     InstallFullSnapshot {
         vote: Vote<C::NodeId>,
         snapshot: Snapshot<C>,
-        tx: ResultSender<C, SnapshotResponse<C::NodeId>>,
+        tx: ResultSender<C, SnapshotResponse<C>>,
     },
 
     /// Begin receiving a snapshot from the leader.
@@ -87,7 +84,7 @@ where C: RaftTypeConfig
 
     Initialize {
         members: BTreeMap<C::NodeId, C::Node>,
-        tx: ResultSender<C, (), InitializeError<C::NodeId, C::Node>>,
+        tx: ResultSender<C, (), InitializeError<C>>,
     },
 
     ChangeMembership {
@@ -97,7 +94,7 @@ where C: RaftTypeConfig
         /// config will be converted into learners, otherwise they will be removed.
         retain: bool,
 
-        tx: ResultSender<C, ClientWriteResponse<C>, ClientWriteError<C::NodeId, C::Node>>,
+        tx: ResultSender<C, ClientWriteResponse<C>, ClientWriteError<C>>,
     },
 
     ExternalCoreRequest {

--- a/openraft/src/core/sm/response.rs
+++ b/openraft/src/core/sm/response.rs
@@ -10,12 +10,12 @@ pub(crate) enum Response<C>
 where C: RaftTypeConfig
 {
     /// Build a snapshot, it returns result via the universal RaftCore response channel.
-    BuildSnapshot(SnapshotMeta<C::NodeId, C::Node>),
+    BuildSnapshot(SnapshotMeta<C>),
 
     /// When finishing installing a snapshot.
     ///
     /// It does not return any value to RaftCore.
-    InstallSnapshot(Option<SnapshotMeta<C::NodeId, C::Node>>),
+    InstallSnapshot(Option<SnapshotMeta<C>>),
 
     /// Send back applied result to RaftCore.
     Apply(ApplyResult<C>),

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -79,7 +79,7 @@ where C: RaftTypeConfig
     SaveVote { vote: Vote<C::NodeId> },
 
     /// Send vote to all other members
-    SendVote { vote_req: VoteRequest<C::NodeId> },
+    SendVote { vote_req: VoteRequest<C> },
 
     /// Purge log from the beginning to `upto`, inclusive.
     PurgeLog { upto: LogId<C::NodeId> },
@@ -223,12 +223,12 @@ where NID: NodeId
 pub(crate) enum Respond<C>
 where C: RaftTypeConfig
 {
-    Vote(ValueSender<C, Result<VoteResponse<C::NodeId>, Infallible>>),
-    AppendEntries(ValueSender<C, Result<AppendEntriesResponse<C::NodeId>, Infallible>>),
+    Vote(ValueSender<C, Result<VoteResponse<C>, Infallible>>),
+    AppendEntries(ValueSender<C, Result<AppendEntriesResponse<C>, Infallible>>),
     ReceiveSnapshotChunk(ValueSender<C, Result<(), InstallSnapshotError>>),
-    InstallSnapshot(ValueSender<C, Result<InstallSnapshotResponse<C::NodeId>, InstallSnapshotError>>),
-    InstallFullSnapshot(ValueSender<C, Result<SnapshotResponse<C::NodeId>, Infallible>>),
-    Initialize(ValueSender<C, Result<(), InitializeError<C::NodeId, C::Node>>>),
+    InstallSnapshot(ValueSender<C, Result<InstallSnapshotResponse<C>, InstallSnapshotError>>),
+    InstallFullSnapshot(ValueSender<C, Result<SnapshotResponse<C>, Infallible>>),
+    Initialize(ValueSender<C, Result<(), InitializeError<C>>>),
 }
 
 impl<C> Respond<C>

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -60,11 +60,11 @@ use crate::Vote;
 /// This structure only contains necessary information to run raft algorithm,
 /// but none of the application specific data.
 /// TODO: make the fields private
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct Engine<C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: EngineConfig<C::NodeId>,
+    pub(crate) config: EngineConfig<C>,
 
     /// The state of this raft node.
     pub(crate) state: Valid<RaftState<C>>,
@@ -86,7 +86,7 @@ where C: RaftTypeConfig
 impl<C> Engine<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(init_state: RaftState<C>, config: EngineConfig<C::NodeId>) -> Self {
+    pub(crate) fn new(init_state: RaftState<C>, config: EngineConfig<C>) -> Self {
         Self {
             config,
             state: Valid::new(init_state),
@@ -94,6 +94,14 @@ where C: RaftTypeConfig
             internal_server_state: InternalServerState::default(),
             output: EngineOutput::new(4096),
         }
+    }
+
+    /// Create a default Engine for testing.
+    #[allow(dead_code)]
+    pub(crate) fn testing_default(id: C::NodeId) -> Self {
+        let config = EngineConfig::new_default(id);
+        let state = RaftState::default();
+        Self::new(state, config)
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -150,7 +158,7 @@ where C: RaftTypeConfig
     ///
     /// [precondition]: crate::docs::cluster_control::cluster_formation#preconditions-for-initialization
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn initialize(&mut self, mut entry: C::Entry) -> Result<(), InitializeError<C::NodeId, C::Node>> {
+    pub(crate) fn initialize(&mut self, mut entry: C::Entry) -> Result<(), InitializeError<C>> {
         self.check_initialize()?;
 
         self.state.assign_log_ids([&mut entry]);
@@ -222,7 +230,7 @@ where C: RaftTypeConfig
     where
         T: OptionalSend,
         E: OptionalSend,
-        E: From<ForwardToLeader<C::NodeId, C::Node>>,
+        E: From<ForwardToLeader<C>>,
     {
         let res = self.leader_handler();
         let forward_err = match res {
@@ -241,7 +249,7 @@ where C: RaftTypeConfig
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn handle_vote_req(&mut self, req: VoteRequest<C::NodeId>) -> VoteResponse<C::NodeId> {
+    pub(crate) fn handle_vote_req(&mut self, req: VoteRequest<C>) -> VoteResponse<C> {
         let now = InstantOf::<C>::now();
         let lease = self.config.timer_config.leader_lease;
         let vote = self.state.vote_ref();
@@ -326,7 +334,7 @@ where C: RaftTypeConfig
     }
 
     #[tracing::instrument(level = "debug", skip(self, resp))]
-    pub(crate) fn handle_vote_resp(&mut self, target: C::NodeId, resp: VoteResponse<C::NodeId>) {
+    pub(crate) fn handle_vote_resp(&mut self, target: C::NodeId, resp: VoteResponse<C>) {
         tracing::info!(
             resp = display(resp.summary()),
             target = display(target),
@@ -404,7 +412,7 @@ where C: RaftTypeConfig
         let is_ok = res.is_ok();
 
         if let Some(tx) = tx {
-            let resp: AppendEntriesResponse<C::NodeId> = res.into();
+            let resp: AppendEntriesResponse<C> = res.into();
             self.output.push_command(Command::Respond {
                 when: None,
                 resp: Respond::new(Ok(resp), tx),
@@ -418,7 +426,7 @@ where C: RaftTypeConfig
         vote: &Vote<C::NodeId>,
         prev_log_id: Option<LogId<C::NodeId>>,
         entries: Vec<C::Entry>,
-    ) -> Result<(), RejectAppendEntries<C::NodeId>> {
+    ) -> Result<(), RejectAppendEntries<C>> {
         self.vote_handler().update_vote(vote)?;
 
         // Vote is legal.
@@ -451,7 +459,7 @@ where C: RaftTypeConfig
         &mut self,
         vote: Vote<C::NodeId>,
         snapshot: Snapshot<C>,
-        tx: ResultSender<C, SnapshotResponse<C::NodeId>>,
+        tx: ResultSender<C, SnapshotResponse<C>>,
     ) {
         tracing::info!(vote = display(vote), snapshot = display(&snapshot), "{}", func_name!());
 
@@ -522,7 +530,7 @@ where C: RaftTypeConfig
     /// - Engine only keeps the snapshot meta with the greatest last-log-id;
     /// - and a snapshot smaller than last-committed is not allowed to be installed.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn finish_building_snapshot(&mut self, meta: SnapshotMeta<C::NodeId, C::Node>) {
+    pub(crate) fn finish_building_snapshot(&mut self, meta: SnapshotMeta<C>) {
         tracing::info!(snapshot_meta = display(&meta), "{}", func_name!());
 
         self.state.io_state_mut().set_building_snapshot(false);
@@ -656,7 +664,7 @@ where C: RaftTypeConfig
     ///
     /// It is allowed to initialize only when `last_log_id.is_none()` and `vote==(term=0,
     /// node_id=0)`. See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
-    fn check_initialize(&self) -> Result<(), NotAllowed<C::NodeId>> {
+    fn check_initialize(&self) -> Result<(), NotAllowed<C>> {
         if self.state.last_log_id().is_none() && self.state.vote_ref() == &Vote::default() {
             return Ok(());
         }
@@ -675,10 +683,7 @@ where C: RaftTypeConfig
 
     /// When initialize, the node that accept initialize request has to be a member of the initial
     /// config.
-    fn check_members_contain_me(
-        &self,
-        m: &Membership<C::NodeId, C::Node>,
-    ) -> Result<(), NotInMembers<C::NodeId, C::Node>> {
+    fn check_members_contain_me(&self, m: &Membership<C>) -> Result<(), NotInMembers<C>> {
         if !m.is_voter(&self.config.id) {
             let e = NotInMembers {
                 node_id: self.config.id,
@@ -738,7 +743,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn leader_handler(&mut self) -> Result<LeaderHandler<C>, ForwardToLeader<C::NodeId, C::Node>> {
+    pub(crate) fn leader_handler(&mut self) -> Result<LeaderHandler<C>, ForwardToLeader<C>> {
         let leader = match self.internal_server_state.leading_mut() {
             None => {
                 tracing::debug!("this node is NOT a leader: {:?}", self.state.server_state);

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -13,16 +13,16 @@ use crate::MembershipState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
+fn m01() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
+fn m23() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {2,3}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -12,16 +12,16 @@ use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
 
-fn m01() -> Membership<u64, ()> {
+fn m01() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
+fn m23() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {2,3}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.state.committed = Some(log_id(1, 1, 1));

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -16,24 +16,24 @@ use crate::EntryPayload;
 use crate::Membership;
 use crate::MembershipState;
 
-fn m01() -> Membership<u64, ()> {
+fn m01() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
+fn m23() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, ()> {
+fn m34() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {3,4}], None)
 }
 
-fn m45() -> Membership<u64, ()> {
+fn m45() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {4,5}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -19,16 +19,16 @@ use crate::StoredMembership;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m12() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m1234() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
+fn m1234() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.state.vote.update(TokioInstant::now(), Vote::new_committed(2, 1));
@@ -163,7 +163,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     // Snapshot will be installed, all non-committed log will be deleted.
     // And there should be no conflicting logs left.
     let mut eng = {
-        let mut eng = Engine::<UTConfig>::default();
+        let mut eng = Engine::<UTConfig>::testing_default(0);
         eng.state.enable_validation(false); // Disable validation for incomplete state
 
         eng.state.vote.update(TokioInstant::now(), Vote::new_committed(2, 1));

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -35,7 +35,7 @@ use crate::StoredMembership;
 pub(crate) struct FollowingHandler<'x, C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: &'x mut EngineConfig<C::NodeId>,
+    pub(crate) config: &'x mut EngineConfig<C>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
@@ -92,7 +92,7 @@ where C: RaftTypeConfig
     pub(crate) fn ensure_log_consecutive(
         &mut self,
         prev_log_id: Option<LogId<C::NodeId>>,
-    ) -> Result<(), RejectAppendEntries<C::NodeId>> {
+    ) -> Result<(), RejectAppendEntries<C>> {
         if let Some(ref prev) = prev_log_id {
             if !self.state.has_log_id(prev) {
                 let local = self.state.get_log_id(prev.index);
@@ -224,7 +224,7 @@ where C: RaftTypeConfig
 
     /// Update membership state with a committed membership config
     #[tracing::instrument(level = "debug", skip_all)]
-    fn update_committed_membership(&mut self, membership: EffectiveMembership<C::NodeId, C::Node>) {
+    fn update_committed_membership(&mut self, membership: EffectiveMembership<C>) {
         tracing::debug!("update committed membership: {}", membership.summary());
 
         let m = Arc::new(membership);
@@ -294,9 +294,7 @@ where C: RaftTypeConfig
     ///
     /// A follower/learner reverts the effective membership to the previous one,
     /// when conflicting logs are found.
-    fn last_two_memberships<'a>(
-        entries: impl DoubleEndedIterator<Item = &'a C::Entry>,
-    ) -> Vec<StoredMembership<C::NodeId, C::Node>>
+    fn last_two_memberships<'a>(entries: impl DoubleEndedIterator<Item = &'a C::Entry>) -> Vec<StoredMembership<C>>
     where C::Entry: 'a {
         let mut memberships = vec![];
 

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -13,20 +13,20 @@ use crate::Membership;
 use crate::MembershipState;
 use crate::ServerState;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m12() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -10,20 +10,20 @@ use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {3,4}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -24,25 +24,25 @@ use crate::MembershipState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m1() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1}], None)
+fn m1() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1}], None)
 }
 
 /// members: {1}, learners: {2}
-fn m1_2() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1}], Some(btreeset! {2}))
+fn m1_2() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1}], Some(btreeset! {2}))
 }
 
-fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], btreeset! {1,2,3})
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], btreeset! {1,2,3})
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 1;

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -22,7 +22,7 @@ use crate::RaftTypeConfig;
 pub(crate) struct LeaderHandler<'x, C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: &'x mut EngineConfig<C::NodeId>,
+    pub(crate) config: &'x mut EngineConfig<C>,
     pub(crate) leader: &'x mut Leading<C, LeaderQuorumSet<C::NodeId>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -18,16 +18,16 @@ use crate::MembershipState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], btreeset! {1,2,3})
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], btreeset! {1,2,3})
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 1;

--- a/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
+++ b/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
@@ -12,7 +12,7 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.state.log_ids = LogIdList::new(vec![

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -15,7 +15,7 @@ use crate::RaftTypeConfig;
 pub(crate) struct LogHandler<'x, C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: &'x mut EngineConfig<C::NodeId>,
+    pub(crate) config: &'x mut EngineConfig<C>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -6,7 +6,7 @@ use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 2), log_id(4, 1, 4), log_id(4, 1, 6)]);

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -20,28 +20,28 @@ use crate::MembershipState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m23_45() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], Some(btreeset! {4,5}))
+fn m23_45() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], Some(btreeset! {4,5}))
 }
 
-fn m34() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {3,4}], None)
 }
 
-fn m4_356() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
+fn m4_356() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {4}], Some(btreeset! {3,5,6}))
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.config.id = 2;
     eng.state.membership_state = MembershipState::new(
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -40,7 +40,7 @@ use crate::ServerState;
 pub(crate) struct ReplicationHandler<'x, C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: &'x mut EngineConfig<C::NodeId>,
+    pub(crate) config: &'x mut EngineConfig<C>,
     pub(crate) leader: &'x mut Leading<C, LeaderQuorumSet<C::NodeId>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
@@ -79,7 +79,7 @@ where C: RaftTypeConfig
     ///
     /// It is called by the leader when a new membership log is appended to log store.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn append_membership(&mut self, log_id: &LogId<C::NodeId>, m: &Membership<C::NodeId, C::Node>) {
+    pub(crate) fn append_membership(&mut self, log_id: &LogId<C::NodeId>, m: &Membership<C>) {
         tracing::debug!("update effective membership: log_id:{} {}", log_id, m.summary());
 
         debug_assert!(

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -17,16 +17,16 @@ use crate::MembershipState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m123() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2,3}], None)
+fn m123() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2,3}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -11,7 +11,7 @@ use crate::ServerState;
 pub(crate) struct ServerStateHandler<'st, C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: &'st EngineConfig<C::NodeId>,
+    pub(crate) config: &'st EngineConfig<C>,
     pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'st mut EngineOutput<C>,
 }

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -15,16 +15,16 @@ use crate::ServerState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m123() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2,3}], None)
+fn m123() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2,3}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;

--- a/openraft/src/engine/handler/snapshot_handler/mod.rs
+++ b/openraft/src/engine/handler/snapshot_handler/mod.rs
@@ -49,7 +49,7 @@ where C: RaftTypeConfig
     ///
     /// [`RaftStateMachine`]: crate::storage::RaftStateMachine
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_snapshot(&mut self, meta: SnapshotMeta<C::NodeId, C::Node>) -> bool {
+    pub(crate) fn update_snapshot(&mut self, meta: SnapshotMeta<C>) -> bool {
         tracing::info!("update_snapshot: {:?}", meta);
 
         if meta.last_log_id <= self.state.snapshot_last_log_id().copied() {

--- a/openraft/src/engine/handler/snapshot_handler/trigger_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/trigger_snapshot_test.rs
@@ -6,7 +6,7 @@ use crate::engine::Command;
 use crate::engine::Engine;
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng

--- a/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
@@ -8,16 +8,16 @@ use crate::Membership;
 use crate::SnapshotMeta;
 use crate::StoredMembership;
 
-fn m12() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m1234() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
+fn m1234() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.state.snapshot_meta = SnapshotMeta {

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -19,13 +19,13 @@ use crate::Membership;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
 /// Make a sample VoteResponse
-fn mk_res() -> Result<VoteResponse<u64>, Infallible> {
-    Ok::<VoteResponse<u64>, Infallible>(VoteResponse {
+fn mk_res() -> Result<VoteResponse<UTConfig>, Infallible> {
+    Ok::<VoteResponse<UTConfig>, Infallible>(VoteResponse {
         vote: Vote::new(2, 1),
         vote_granted: false,
         last_log_id: None,
@@ -33,7 +33,7 @@ fn mk_res() -> Result<VoteResponse<u64>, Infallible> {
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 0;

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -16,12 +16,12 @@ use crate::Membership;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 0;

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -28,7 +28,7 @@ use crate::Vote;
 pub(crate) struct VoteHandler<'st, C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: &'st EngineConfig<C::NodeId>,
+    pub(crate) config: &'st EngineConfig<C>,
     pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'st mut EngineOutput<C>,
     pub(crate) internal_server_state: &'st mut InternalServerState<C>,
@@ -56,7 +56,7 @@ where C: RaftTypeConfig
         T: Debug + Eq + OptionalSend,
         E: Debug + Eq + OptionalSend,
         Respond<C>: From<ValueSender<C, Result<T, E>>>,
-        F: Fn(&RaftState<C>, RejectVoteRequest<C::NodeId>) -> Result<T, E>,
+        F: Fn(&RaftState<C>, RejectVoteRequest<C>) -> Result<T, E>,
     {
         let vote_res = self.update_vote(vote);
 
@@ -83,7 +83,7 @@ where C: RaftTypeConfig
     /// Note: This method does not check last-log-id. handle-vote-request has to deal with
     /// last-log-id itself.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), RejectVoteRequest<C::NodeId>> {
+    pub(crate) fn update_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), RejectVoteRequest<C>> {
         // Partial ord compare:
         // Vote does not has to be total ord.
         // `!(a >= b)` does not imply `a < b`.

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -6,13 +6,22 @@ use crate::TokioRuntime;
 
 /// Trivial Raft type config for Engine related unit tests,
 /// with an optional custom node type `N` for Node type.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct UTConfig<N = ()> {
     _p: std::marker::PhantomData<N>,
 }
+
+impl<N> Clone for UTConfig<N> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<N> Copy for UTConfig<N> {}
+
 impl<N> RaftTypeConfig for UTConfig<N>
-where N: Node + Copy + Ord
+where N: Node + Ord
 {
     type D = ();
     type R = ();

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -20,20 +20,20 @@ use crate::MembershipState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {3,4}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -21,16 +21,16 @@ use crate::Membership;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m1() -> Membership<u64, ()> {
+fn m1() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1}], None)
 }
 
-fn m12() -> Membership<u64, ()> {
+fn m12() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.log_ids = LogIdList::new([LogId::new(CommittedLeaderId::new(0, 0), 0)]);
     eng.state.enable_validation(false); // Disable validation for incomplete state
     eng

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -17,12 +17,12 @@ use crate::Membership;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m01() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {0,1}], None)
+fn m01() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {0,1}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 1;

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -24,16 +24,16 @@ use crate::Membership;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m12() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2}], None)
 }
 
-fn m1234() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4}], None)
+fn m1234() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.state.log_ids = LogIdList::new([LogId::new(CommittedLeaderId::new(0, 0), 0)]);

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -24,7 +24,7 @@ use crate::Vote;
 #[test]
 fn test_initialize_single_node() -> anyhow::Result<()> {
     let eng = || {
-        let mut eng = Engine::<UTConfig>::default();
+        let mut eng = Engine::<UTConfig>::testing_default(0);
         eng.state.enable_validation(false); // Disable validation for incomplete state
 
         eng.state.server_state = eng.calc_server_state();
@@ -36,7 +36,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
         index: 0,
     };
 
-    let m1 = || Membership::<u64, ()>::new(vec![btreeset! {1}], None);
+    let m1 = || Membership::<UTConfig>::new(vec![btreeset! {1}], None);
     let entry = Entry::<UTConfig>::new_membership(LogId::default(), m1());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");
@@ -97,7 +97,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
 #[test]
 fn test_initialize() -> anyhow::Result<()> {
     let eng = || {
-        let mut eng = Engine::<UTConfig>::default();
+        let mut eng = Engine::<UTConfig>::testing_default(0);
         eng.state.enable_validation(false); // Disable validation for incomplete state
 
         eng.state.server_state = eng.calc_server_state();
@@ -109,7 +109,7 @@ fn test_initialize() -> anyhow::Result<()> {
         index: 0,
     };
 
-    let m12 = || Membership::<u64, ()>::new(vec![btreeset! {1,2}], None);
+    let m12 = || Membership::<UTConfig>::new(vec![btreeset! {1,2}], None);
     let entry = || Entry::<UTConfig>::new_membership(LogId::default(), m12());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -15,20 +15,20 @@ use crate::ServerState;
 use crate::TokioInstant;
 use crate::Vote;
 
-fn m_empty() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {}], None)
+fn m_empty() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {}], None)
 }
 
-fn m23() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {2,3}], None)
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], None)
 }
 
-fn m34() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {3,4}], None)
+fn m34() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {3,4}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.config.id = 2;
     // This will be overridden
     eng.state.server_state = ServerState::default();

--- a/openraft/src/engine/tests/trigger_purge_log_test.rs
+++ b/openraft/src/engine/tests/trigger_purge_log_test.rs
@@ -17,12 +17,12 @@ use crate::MembershipState;
 use crate::SnapshotMeta;
 use crate::StoredMembership;
 
-fn m12() -> Membership<u64, ()> {
-    Membership::<u64, ()>::new(vec![btreeset! {1,2}], None)
+fn m12() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2}], None)
 }
 
 fn eng() -> Engine<UTConfig> {
-    let mut eng = Engine::default();
+    let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
     eng.state.membership_state = MembershipState::new(
         EffectiveMembership::new_arc(Some(log_id(1, 0, 1)), m12()),

--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -101,7 +101,7 @@ where C: RaftTypeConfig
         self.payload.is_blank()
     }
 
-    fn get_membership(&self) -> Option<&Membership<C::NodeId, C::Node>> {
+    fn get_membership(&self) -> Option<&Membership<C>> {
         self.payload.get_membership()
     }
 }
@@ -128,7 +128,7 @@ where C: RaftTypeConfig
         }
     }
 
-    fn new_membership(log_id: LogId<C::NodeId>, m: Membership<C::NodeId, C::Node>) -> Self {
+    fn new_membership(log_id: LogId<C::NodeId>, m: Membership<C>) -> Self {
         Self {
             log_id,
             payload: EntryPayload::Membership(m),

--- a/openraft/src/entry/payload.rs
+++ b/openraft/src/entry/payload.rs
@@ -8,7 +8,7 @@ use crate::RaftTypeConfig;
 
 /// Log entry payload variants.
 #[derive(PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum EntryPayload<C: RaftTypeConfig> {
     /// An empty payload committed by a new cluster leader.
     Blank,
@@ -16,7 +16,7 @@ pub enum EntryPayload<C: RaftTypeConfig> {
     Normal(C::D),
 
     /// A change-membership log entry.
-    Membership(Membership<C::NodeId, C::Node>),
+    Membership(Membership<C>),
 }
 
 impl<C> Clone for EntryPayload<C>
@@ -64,7 +64,7 @@ impl<C: RaftTypeConfig> RaftPayload<C> for EntryPayload<C> {
         matches!(self, EntryPayload::Blank)
     }
 
-    fn get_membership(&self) -> Option<&Membership<C::NodeId, C::Node>> {
+    fn get_membership(&self) -> Option<&Membership<C>> {
         if let EntryPayload::Membership(m) = self {
             Some(m)
         } else {

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -17,7 +17,7 @@ where C: RaftTypeConfig
     fn is_blank(&self) -> bool;
 
     /// Return `Some(&Membership)` if the entry payload is a membership payload.
-    fn get_membership(&self) -> Option<&Membership<C::NodeId, C::Node>>;
+    fn get_membership(&self) -> Option<&Membership<C>>;
 }
 
 /// Defines operations on an entry.
@@ -34,7 +34,7 @@ where
     /// Create a new membership log entry.
     ///
     /// The returned instance must return `Some()` for `Self::get_membership()`.
-    fn new_membership(log_id: LogId<C::NodeId>, m: Membership<C::NodeId, C::Node>) -> Self;
+    fn new_membership(log_id: LogId<C::NodeId>, m: Membership<C>) -> Self;
 }
 
 /// Build a raft log entry from app data.

--- a/openraft/src/error/streaming_error.rs
+++ b/openraft/src/error/streaming_error.rs
@@ -32,7 +32,7 @@ pub enum StreamingError<C: RaftTypeConfig, E: Error> {
 
     /// Timeout when streaming data to remote node.
     #[error(transparent)]
-    Timeout(#[from] Timeout<C::NodeId>),
+    Timeout(#[from] Timeout<C>),
 
     /// The node is temporarily unreachable and should backoff before retrying.
     #[error(transparent)]
@@ -44,13 +44,13 @@ pub enum StreamingError<C: RaftTypeConfig, E: Error> {
 
     /// Remote node returns an error.
     #[error(transparent)]
-    RemoteError(#[from] RemoteError<C::NodeId, C::Node, E>),
+    RemoteError(#[from] RemoteError<C, E>),
 }
 
-impl<C: RaftTypeConfig, E> From<StreamingError<C, E>> for ReplicationError<C::NodeId, C::Node>
+impl<C: RaftTypeConfig, E> From<StreamingError<C, E>> for ReplicationError<C>
 where
     E: Error,
-    RaftError<C::NodeId>: From<E>,
+    RaftError<C>: From<E>,
 {
     fn from(e: StreamingError<C, E>) -> Self {
         match e {

--- a/openraft/src/membership/bench/is_quorum.rs
+++ b/openraft/src/membership/bench/is_quorum.rs
@@ -4,13 +4,14 @@ use maplit::btreeset;
 use test::black_box;
 use test::Bencher;
 
+use crate::engine::testing::UTConfig;
 use crate::quorum::QuorumSet;
 use crate::EffectiveMembership;
 use crate::Membership;
 
 #[bench]
 fn m12345_ids_slice(b: &mut Bencher) {
-    let m = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4,5}], None);
     let m = EffectiveMembership::new(None, m);
     let x = [1, 2, 3, 6, 7];
 
@@ -19,7 +20,7 @@ fn m12345_ids_slice(b: &mut Bencher) {
 
 #[bench]
 fn m12345_ids_btreeset(b: &mut Bencher) {
-    let m = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4,5}], None);
     let m = EffectiveMembership::new(None, m);
     let x = btreeset! {1, 2, 3, 6, 7};
 
@@ -28,7 +29,7 @@ fn m12345_ids_btreeset(b: &mut Bencher) {
 
 #[bench]
 fn m12345_678_ids_slice(b: &mut Bencher) {
-    let m = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4,5}], None);
     let m = EffectiveMembership::new(None, m);
     let x = [1, 2, 3, 6, 7];
 
@@ -37,7 +38,7 @@ fn m12345_678_ids_slice(b: &mut Bencher) {
 
 #[bench]
 fn m12345_678_ids_btreeset(b: &mut Bencher) {
-    let m = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5}], None);
+    let m = Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4,5}], None);
     let m = EffectiveMembership::new(None, m);
     let x = btreeset! {1, 2, 3, 6, 7};
 

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -3,13 +3,12 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::log_id::RaftLogId;
-use crate::node::Node;
 use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
 use crate::LogId;
 use crate::Membership;
 use crate::MessageSummary;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::StoredMembership;
 
 /// The currently active membership config.
@@ -20,24 +19,20 @@ use crate::StoredMembership;
 ///
 /// An active config is just the last seen config in raft spec.
 #[derive(Clone, Default, Eq)]
-pub struct EffectiveMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+pub struct EffectiveMembership<C>
+where C: RaftTypeConfig
 {
-    stored_membership: Arc<StoredMembership<NID, N>>,
+    stored_membership: Arc<StoredMembership<C>>,
 
     /// The quorum set built from `membership`.
-    quorum_set: Joint<NID, Vec<NID>, Vec<Vec<NID>>>,
+    quorum_set: Joint<C::NodeId, Vec<C::NodeId>, Vec<Vec<C::NodeId>>>,
 
     /// Cache of union of all members
-    voter_ids: BTreeSet<NID>,
+    voter_ids: BTreeSet<C::NodeId>,
 }
 
-impl<NID, N> Debug for EffectiveMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> Debug for EffectiveMembership<C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EffectiveMembership")
@@ -48,37 +43,32 @@ where
     }
 }
 
-impl<NID, N> PartialEq for EffectiveMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> PartialEq for EffectiveMembership<C>
+where C: RaftTypeConfig
 {
     fn eq(&self, other: &Self) -> bool {
         self.stored_membership == other.stored_membership && self.voter_ids == other.voter_ids
     }
 }
 
-impl<NID, N, LID> From<(&LID, Membership<NID, N>)> for EffectiveMembership<NID, N>
+impl<C, LID> From<(&LID, Membership<C>)> for EffectiveMembership<C>
 where
-    N: Node,
-    NID: NodeId,
-    LID: RaftLogId<NID>,
+    C: RaftTypeConfig,
+    LID: RaftLogId<C::NodeId>,
 {
-    fn from(v: (&LID, Membership<NID, N>)) -> Self {
+    fn from(v: (&LID, Membership<C>)) -> Self {
         EffectiveMembership::new(Some(*v.0.get_log_id()), v.1)
     }
 }
 
-impl<NID, N> EffectiveMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> EffectiveMembership<C>
+where C: RaftTypeConfig
 {
-    pub(crate) fn new_arc(log_id: Option<LogId<NID>>, membership: Membership<NID, N>) -> Arc<Self> {
+    pub(crate) fn new_arc(log_id: Option<LogId<C::NodeId>>, membership: Membership<C>) -> Arc<Self> {
         Arc::new(Self::new(log_id, membership))
     }
 
-    pub fn new(log_id: Option<LogId<NID>>, membership: Membership<NID, N>) -> Self {
+    pub fn new(log_id: Option<LogId<C::NodeId>>, membership: Membership<C>) -> Self {
         let voter_ids = membership.voter_ids().collect();
 
         let configs = membership.get_joint_config();
@@ -96,51 +86,49 @@ where
         }
     }
 
-    pub(crate) fn new_from_stored_membership(stored: StoredMembership<NID, N>) -> Self {
+    pub(crate) fn new_from_stored_membership(stored: StoredMembership<C>) -> Self {
         Self::new(*stored.log_id(), stored.membership().clone())
     }
 
-    pub(crate) fn stored_membership(&self) -> &Arc<StoredMembership<NID, N>> {
+    pub(crate) fn stored_membership(&self) -> &Arc<StoredMembership<C>> {
         &self.stored_membership
     }
 
-    pub fn log_id(&self) -> &Option<LogId<NID>> {
+    pub fn log_id(&self) -> &Option<LogId<C::NodeId>> {
         self.stored_membership.log_id()
     }
 
-    pub fn membership(&self) -> &Membership<NID, N> {
+    pub fn membership(&self) -> &Membership<C> {
         self.stored_membership.membership()
     }
 }
 
 /// Membership API
-impl<NID, N> EffectiveMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> EffectiveMembership<C>
+where C: RaftTypeConfig
 {
     #[allow(dead_code)]
-    pub(crate) fn is_voter(&self, nid: &NID) -> bool {
+    pub(crate) fn is_voter(&self, nid: &C::NodeId) -> bool {
         self.membership().is_voter(nid)
     }
 
     /// Returns an Iterator of all voter node ids. Learners are not included.
-    pub fn voter_ids(&self) -> impl Iterator<Item = NID> + '_ {
+    pub fn voter_ids(&self) -> impl Iterator<Item = C::NodeId> + '_ {
         self.voter_ids.iter().copied()
     }
 
     /// Returns an Iterator of all learner node ids. Voters are not included.
-    pub(crate) fn learner_ids(&self) -> impl Iterator<Item = NID> + '_ {
+    pub(crate) fn learner_ids(&self) -> impl Iterator<Item = C::NodeId> + '_ {
         self.membership().learner_ids()
     }
 
     /// Get a the node(either voter or learner) by node id.
-    pub fn get_node(&self, node_id: &NID) -> Option<&N> {
+    pub fn get_node(&self, node_id: &C::NodeId) -> Option<&C::Node> {
         self.membership().get_node(node_id)
     }
 
     /// Returns an Iterator of all nodes(voters and learners).
-    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &N)> {
+    pub fn nodes(&self) -> impl Iterator<Item = (&C::NodeId, &C::Node)> {
         self.membership().nodes()
     }
 
@@ -148,15 +136,13 @@ where
     ///
     /// Membership is defined by a joint of multiple configs.
     /// Each config is a vec of node-id.
-    pub fn get_joint_config(&self) -> &Vec<Vec<NID>> {
+    pub fn get_joint_config(&self) -> &Vec<Vec<C::NodeId>> {
         self.quorum_set.children()
     }
 }
 
-impl<NID, N> MessageSummary<EffectiveMembership<NID, N>> for EffectiveMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> MessageSummary<EffectiveMembership<C>> for EffectiveMembership<C>
+where C: RaftTypeConfig
 {
     fn summary(&self) -> String {
         format!(
@@ -168,14 +154,12 @@ where
 }
 
 /// Implement node-id joint quorum set.
-impl<NID, N> QuorumSet<NID> for EffectiveMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> QuorumSet<C::NodeId> for EffectiveMembership<C>
+where C: RaftTypeConfig
 {
-    type Iter = std::collections::btree_set::IntoIter<NID>;
+    type Iter = std::collections::btree_set::IntoIter<C::NodeId>;
 
-    fn is_quorum<'a, I: Iterator<Item = &'a NID> + Clone>(&self, ids: I) -> bool {
+    fn is_quorum<'a, I: Iterator<Item = &'a C::NodeId> + Clone>(&self, ids: I) -> bool {
         self.quorum_set.is_quorum(ids)
     }
 

--- a/openraft/src/membership/effective_membership_test.rs
+++ b/openraft/src/membership/effective_membership_test.rs
@@ -1,5 +1,6 @@
 use maplit::btreeset;
 
+use crate::engine::testing::UTConfig;
 use crate::quorum::QuorumSet;
 use crate::EffectiveMembership;
 use crate::Membership;
@@ -7,8 +8,8 @@ use crate::Membership;
 #[test]
 fn test_effective_membership_majority() -> anyhow::Result<()> {
     {
-        let m12345 = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5 }], None);
-        let m = EffectiveMembership::new(None, m12345);
+        let m12345 = Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4,5 }], None);
+        let m = EffectiveMembership::<UTConfig>::new(None, m12345);
 
         assert!(!m.is_quorum([0].iter()));
         assert!(!m.is_quorum([0, 1, 2].iter()));
@@ -19,8 +20,8 @@ fn test_effective_membership_majority() -> anyhow::Result<()> {
     }
 
     {
-        let m12345_678 = Membership::<u64, ()>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
-        let m = EffectiveMembership::new(None, m12345_678);
+        let m12345_678 = Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4,5 }, btreeset! {6,7,8}], None);
+        let m = EffectiveMembership::<UTConfig>::new(None, m12345_678);
 
         assert!(!m.is_quorum([0].iter()));
         assert!(!m.is_quorum([0, 1, 2].iter()));

--- a/openraft/src/membership/stored_membership.rs
+++ b/openraft/src/membership/stored_membership.rs
@@ -4,8 +4,7 @@ use crate::display_ext::DisplayOption;
 use crate::LogId;
 use crate::Membership;
 use crate::MessageSummary;
-use crate::Node;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// This struct represents information about a membership config that has already been stored in the
 /// raft logs.
@@ -19,48 +18,42 @@ use crate::NodeId;
 #[derive(Clone, Debug, Default)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct StoredMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+pub struct StoredMembership<C>
+where C: RaftTypeConfig
 {
     /// The id of the log that stores this membership config
-    log_id: Option<LogId<NID>>,
+    log_id: Option<LogId<C::NodeId>>,
 
     /// Membership config
-    membership: Membership<NID, N>,
+    membership: Membership<C>,
 }
 
-impl<NID, N> StoredMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> StoredMembership<C>
+where C: RaftTypeConfig
 {
-    pub fn new(log_id: Option<LogId<NID>>, membership: Membership<NID, N>) -> Self {
+    pub fn new(log_id: Option<LogId<C::NodeId>>, membership: Membership<C>) -> Self {
         Self { log_id, membership }
     }
 
-    pub fn log_id(&self) -> &Option<LogId<NID>> {
+    pub fn log_id(&self) -> &Option<LogId<C::NodeId>> {
         &self.log_id
     }
 
-    pub fn membership(&self) -> &Membership<NID, N> {
+    pub fn membership(&self) -> &Membership<C> {
         &self.membership
     }
 
-    pub fn voter_ids(&self) -> impl Iterator<Item = NID> {
+    pub fn voter_ids(&self) -> impl Iterator<Item = C::NodeId> {
         self.membership.voter_ids()
     }
 
-    pub fn nodes(&self) -> impl Iterator<Item = (&NID, &N)> {
+    pub fn nodes(&self) -> impl Iterator<Item = (&C::NodeId, &C::Node)> {
         self.membership.nodes()
     }
 }
 
-impl<NID, N> fmt::Display for StoredMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> fmt::Display for StoredMembership<C>
+where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -72,10 +65,8 @@ where
     }
 }
 
-impl<NID, N> MessageSummary<StoredMembership<NID, N>> for StoredMembership<NID, N>
-where
-    N: Node,
-    NID: NodeId,
+impl<C> MessageSummary<StoredMembership<C>> for StoredMembership<C>
+where C: RaftTypeConfig
 {
     fn summary(&self) -> String {
         self.to_string()

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -16,7 +16,7 @@ use crate::Vote;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftMetrics<C: RaftTypeConfig> {
-    pub running_state: Result<(), Fatal<C::NodeId>>,
+    pub running_state: Result<(), Fatal<C>>,
 
     /// The ID of the Raft node.
     pub id: C::NodeId,
@@ -71,7 +71,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     pub millis_since_quorum_ack: Option<u64>,
 
     /// The current membership config of the cluster.
-    pub membership_config: Arc<StoredMembership<C::NodeId, C::Node>>,
+    pub membership_config: Arc<StoredMembership<C>>,
 
     // ---
     // --- replication ---
@@ -217,7 +217,7 @@ pub struct RaftServerMetrics<C: RaftTypeConfig> {
     pub state: ServerState,
     pub current_leader: Option<C::NodeId>,
 
-    pub membership_config: Arc<StoredMembership<C::NodeId, C::Node>>,
+    pub membership_config: Arc<StoredMembership<C>>,
 }
 
 impl<C> fmt::Display for RaftServerMetrics<C>

--- a/openraft/src/network/network.rs
+++ b/openraft/src/network/network.rs
@@ -37,7 +37,7 @@ where C: RaftTypeConfig
         &mut self,
         rpc: AppendEntriesRequest<C>,
         option: RPCOption,
-    ) -> Result<AppendEntriesResponse<C::NodeId>, RPCError<C::NodeId, C::Node, RaftError<C::NodeId>>>;
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C, RaftError<C>>>;
 
     /// Send an InstallSnapshot RPC to the target.
     #[cfg(feature = "generic-snapshot-data")]
@@ -49,10 +49,8 @@ where C: RaftTypeConfig
         &mut self,
         _rpc: crate::raft::InstallSnapshotRequest<C>,
         _option: RPCOption,
-    ) -> Result<
-        crate::raft::InstallSnapshotResponse<C::NodeId>,
-        RPCError<C::NodeId, C::Node, RaftError<C::NodeId, crate::error::InstallSnapshotError>>,
-    > {
+    ) -> Result<crate::raft::InstallSnapshotResponse<C>, RPCError<C, RaftError<C, crate::error::InstallSnapshotError>>>
+    {
         unimplemented!()
     }
 
@@ -62,17 +60,14 @@ where C: RaftTypeConfig
         &mut self,
         _rpc: crate::raft::InstallSnapshotRequest<C>,
         _option: RPCOption,
-    ) -> Result<
-        crate::raft::InstallSnapshotResponse<C::NodeId>,
-        RPCError<C::NodeId, C::Node, RaftError<C::NodeId, crate::error::InstallSnapshotError>>,
-    >;
+    ) -> Result<crate::raft::InstallSnapshotResponse<C>, RPCError<C, RaftError<C, crate::error::InstallSnapshotError>>>;
 
     /// Send a RequestVote RPC to the target.
     async fn vote(
         &mut self,
-        rpc: VoteRequest<C::NodeId>,
+        rpc: VoteRequest<C>,
         option: RPCOption,
-    ) -> Result<VoteResponse<C::NodeId>, RPCError<C::NodeId, C::Node, RaftError<C::NodeId>>>;
+    ) -> Result<VoteResponse<C>, RPCError<C, RaftError<C>>>;
 
     /// Send a complete Snapshot to the target.
     ///
@@ -96,7 +91,7 @@ where C: RaftTypeConfig
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
         option: RPCOption,
-    ) -> Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>;
+    ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>;
 
     /// Send a complete Snapshot to the target.
     ///
@@ -122,7 +117,7 @@ where C: RaftTypeConfig
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
         option: RPCOption,
-    ) -> Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>> {
+    ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>> {
         use crate::network::snapshot_transport::Chunked;
         use crate::network::snapshot_transport::SnapshotTransport;
 

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -54,7 +54,7 @@ pub trait SnapshotTransport<C: RaftTypeConfig> {
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
         option: RPCOption,
-    ) -> Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>
+    ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>
     where
         Net: RaftNetwork<C> + ?Sized;
 
@@ -87,7 +87,7 @@ pub trait SnapshotTransport<C: RaftTypeConfig> {
         streaming: &mut Option<Streaming<C>>,
         raft: &Raft<C>,
         req: InstallSnapshotRequest<C>,
-    ) -> Result<Option<Snapshot<C>>, RaftError<C::NodeId, crate::error::InstallSnapshotError>>;
+    ) -> Result<Option<Snapshot<C>>, RaftError<C, crate::error::InstallSnapshotError>>;
 }
 
 /// Send and Receive snapshot by chunks.
@@ -103,7 +103,7 @@ where C::SnapshotData: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io:
         mut snapshot: Snapshot<C>,
         mut cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
         option: RPCOption,
-    ) -> Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>
+    ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>
     where
         Net: RaftNetwork<C> + ?Sized,
     {
@@ -192,7 +192,7 @@ where C::SnapshotData: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io:
         streaming: &mut Option<Streaming<C>>,
         raft: &Raft<C>,
         req: InstallSnapshotRequest<C>,
-    ) -> Result<Option<Snapshot<C>>, RaftError<C::NodeId, crate::error::InstallSnapshotError>> {
+    ) -> Result<Option<Snapshot<C>>, RaftError<C, crate::error::InstallSnapshotError>> {
         let snapshot_id = &req.meta.snapshot_id;
         let snapshot_meta = req.meta.clone();
         let done = req.done;

--- a/openraft/src/raft/core_state.rs
+++ b/openraft/src/raft/core_state.rs
@@ -1,16 +1,14 @@
 use crate::error::Fatal;
-use crate::AsyncRuntime;
-use crate::NodeId;
+use crate::type_config::alias::JoinHandleOf;
+use crate::RaftTypeConfig;
 
 /// The running state of RaftCore
-pub(in crate::raft) enum CoreState<NID, A>
-where
-    NID: NodeId,
-    A: AsyncRuntime,
+pub(in crate::raft) enum CoreState<C>
+where C: RaftTypeConfig
 {
     /// The RaftCore task is still running.
-    Running(A::JoinHandle<Result<(), Fatal<NID>>>),
+    Running(JoinHandleOf<C, Result<(), Fatal<C>>>),
 
     /// The RaftCore task has finished. The return value of the task is stored.
-    Done(Result<(), Fatal<NID>>),
+    Done(Result<(), Fatal<C>>),
 }

--- a/openraft/src/raft/message/client_write.rs
+++ b/openraft/src/raft/message/client_write.rs
@@ -19,7 +19,7 @@ pub struct ClientWriteResponse<C: RaftTypeConfig> {
     pub data: C::R,
 
     /// If the log entry is a change-membership entry.
-    pub membership: Option<Membership<C::NodeId, C::Node>>,
+    pub membership: Option<Membership<C>>,
 }
 
 impl<C: RaftTypeConfig> Debug for ClientWriteResponse<C>

--- a/openraft/src/raft/message/install_snapshot.rs
+++ b/openraft/src/raft/message/install_snapshot.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use crate::MessageSummary;
-use crate::NodeId;
 use crate::RaftTypeConfig;
 use crate::SnapshotMeta;
 use crate::Vote;
@@ -14,7 +13,7 @@ pub struct InstallSnapshotRequest<C: RaftTypeConfig> {
     pub vote: Vote<C::NodeId>,
 
     /// Metadata of a snapshot: snapshot_id, last_log_ed membership etc.
-    pub meta: SnapshotMeta<C::NodeId, C::Node>,
+    pub meta: SnapshotMeta<C>,
 
     /// The byte offset where this chunk of data is positioned in the snapshot file.
     pub offset: u64,
@@ -51,8 +50,8 @@ impl<C: RaftTypeConfig> MessageSummary<InstallSnapshotRequest<C>> for InstallSna
 #[derive(derive_more::Display)]
 #[display(fmt = "{{vote:{}}}", vote)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct InstallSnapshotResponse<NID: NodeId> {
-    pub vote: Vote<NID>,
+pub struct InstallSnapshotResponse<C: RaftTypeConfig> {
+    pub vote: Vote<C::NodeId>,
 }
 
 /// The response to `Raft::install_full_snapshot` API.
@@ -61,18 +60,20 @@ pub struct InstallSnapshotResponse<NID: NodeId> {
 #[derive(derive_more::Display)]
 #[display(fmt = "SnapshotResponse{{vote:{}}}", vote)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct SnapshotResponse<NID: NodeId> {
-    pub vote: Vote<NID>,
+pub struct SnapshotResponse<C: RaftTypeConfig> {
+    pub vote: Vote<C::NodeId>,
 }
 
-impl<NID: NodeId> SnapshotResponse<NID> {
-    pub fn new(vote: Vote<NID>) -> Self {
+impl<C: RaftTypeConfig> SnapshotResponse<C> {
+    pub fn new(vote: Vote<C::NodeId>) -> Self {
         Self { vote }
     }
 }
 
-impl<NID: NodeId> From<SnapshotResponse<NID>> for InstallSnapshotResponse<NID> {
-    fn from(snap_resp: SnapshotResponse<NID>) -> Self {
+impl<C> From<SnapshotResponse<C>> for InstallSnapshotResponse<C>
+where C: RaftTypeConfig
+{
+    fn from(snap_resp: SnapshotResponse<C>) -> Self {
         Self { vote: snap_resp.vote }
     }
 }

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -3,31 +3,37 @@ use std::fmt;
 use crate::display_ext::DisplayOptionExt;
 use crate::LogId;
 use crate::MessageSummary;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::Vote;
 
 /// An RPC sent by candidates to gather votes (§5.2).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct VoteRequest<NID: NodeId> {
-    pub vote: Vote<NID>,
-    pub last_log_id: Option<LogId<NID>>,
+pub struct VoteRequest<C: RaftTypeConfig> {
+    pub vote: Vote<C::NodeId>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 }
 
-impl<NID: NodeId> fmt::Display for VoteRequest<NID> {
+impl<C> fmt::Display for VoteRequest<C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{vote:{}, last_log:{}}}", self.vote, self.last_log_id.display(),)
     }
 }
 
-impl<NID: NodeId> MessageSummary<VoteRequest<NID>> for VoteRequest<NID> {
+impl<C> MessageSummary<VoteRequest<C>> for VoteRequest<C>
+where C: RaftTypeConfig
+{
     fn summary(&self) -> String {
         self.to_string()
     }
 }
 
-impl<NID: NodeId> VoteRequest<NID> {
-    pub fn new(vote: Vote<NID>, last_log_id: Option<LogId<NID>>) -> Self {
+impl<C> VoteRequest<C>
+where C: RaftTypeConfig
+{
+    pub fn new(vote: Vote<C::NodeId>, last_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self { vote, last_log_id }
     }
 }
@@ -35,19 +41,21 @@ impl<NID: NodeId> VoteRequest<NID> {
 /// The response to a `VoteRequest`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct VoteResponse<NID: NodeId> {
+pub struct VoteResponse<C: RaftTypeConfig> {
     /// vote after a node handling vote-request.
     /// Thus `resp.vote >= req.vote` always holds.
-    pub vote: Vote<NID>,
+    pub vote: Vote<C::NodeId>,
 
     /// Will be true if the candidate received a vote from the responder.
     pub vote_granted: bool,
 
     /// The last log id stored on the remote voter.
-    pub last_log_id: Option<LogId<NID>>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 }
 
-impl<NID: NodeId> MessageSummary<VoteResponse<NID>> for VoteResponse<NID> {
+impl<C> MessageSummary<VoteResponse<C>> for VoteResponse<C>
+where C: RaftTypeConfig
+{
     fn summary(&self) -> String {
         format!(
             "{{granted:{}, {}, last_log:{:?}}}",

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -42,7 +42,7 @@ where C: RaftTypeConfig
     // TODO(xp): it does not need to be a async mutex.
     #[allow(clippy::type_complexity)]
     pub(in crate::raft) tx_shutdown: Mutex<Option<OneshotSenderOf<C, ()>>>,
-    pub(in crate::raft) core_state: Mutex<CoreState<C::NodeId, C::AsyncRuntime>>,
+    pub(in crate::raft) core_state: Mutex<CoreState<C>>,
 
     /// The ongoing snapshot transmission.
     pub(in crate::raft) snapshot: Mutex<Option<crate::network::snapshot_transport::Streaming<C>>>,
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
         &self,
         mes: RaftMsg<C>,
         rx: OneshotReceiverOf<C, Result<T, E>>,
-    ) -> Result<T, RaftError<C::NodeId, E>>
+    ) -> Result<T, RaftError<C, E>>
     where
         E: Debug + OptionalSend,
         T: OptionalSend,
@@ -95,7 +95,7 @@ where C: RaftTypeConfig
         &self,
         cmd: ExternalCommand<C>,
         cmd_desc: impl fmt::Display + Default,
-    ) -> Result<(), Fatal<C::NodeId>> {
+    ) -> Result<(), Fatal<C>> {
         let send_res = self.tx_api.send(RaftMsg::ExternalCommand { cmd });
 
         if send_res.is_err() {
@@ -110,7 +110,7 @@ where C: RaftTypeConfig
         &self,
         when: impl fmt::Display,
         message_summary: Option<impl fmt::Display + Default>,
-    ) -> Fatal<C::NodeId> {
+    ) -> Fatal<C> {
         // Wait for the core task to finish.
         self.join_core_task().await;
 

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -28,7 +28,7 @@ where C: RaftTypeConfig
     ///
     /// Returns error when RaftCore has [`Fatal`] error, e.g. shut down or having storage error.
     /// It is not affected by `Raft::enable_elect(false)`.
-    pub async fn elect(&self) -> Result<(), Fatal<C::NodeId>> {
+    pub async fn elect(&self) -> Result<(), Fatal<C>> {
         self.raft_inner.send_external_command(ExternalCommand::Elect, "trigger_elect").await
     }
 
@@ -36,14 +36,14 @@ where C: RaftTypeConfig
     ///
     /// Returns error when RaftCore has [`Fatal`] error, e.g. shut down or having storage error.
     /// It is not affected by `Raft::enable_heartbeat(false)`.
-    pub async fn heartbeat(&self) -> Result<(), Fatal<C::NodeId>> {
+    pub async fn heartbeat(&self) -> Result<(), Fatal<C>> {
         self.raft_inner.send_external_command(ExternalCommand::Heartbeat, "trigger_heartbeat").await
     }
 
     /// Trigger to build a snapshot at once and return at once.
     ///
     /// Returns error when RaftCore has [`Fatal`] error, e.g. shut down or having storage error.
-    pub async fn snapshot(&self) -> Result<(), Fatal<C::NodeId>> {
+    pub async fn snapshot(&self) -> Result<(), Fatal<C>> {
         self.raft_inner.send_external_command(ExternalCommand::Snapshot, "trigger_snapshot").await
     }
 
@@ -62,7 +62,7 @@ where C: RaftTypeConfig
     /// can't be purged until the replication task is finished.
     ///
     /// [`max_in_snapshot_log_to_keep`]: `crate::Config::max_in_snapshot_log_to_keep`
-    pub async fn purge_log(&self, upto: u64) -> Result<(), Fatal<C::NodeId>> {
+    pub async fn purge_log(&self, upto: u64) -> Result<(), Fatal<C>> {
         self.raft_inner.send_external_command(ExternalCommand::PurgeLog { upto }, "purge_log").await
     }
 }

--- a/openraft/src/raft_state/membership_state/change_handler_test.rs
+++ b/openraft/src/raft_state/membership_state/change_handler_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use maplit::btreemap;
 use maplit::btreeset;
 
+use crate::engine::testing::UTConfig;
 use crate::error::ChangeMembershipError;
 use crate::error::EmptyMembership;
 use crate::error::InProgress;
@@ -14,26 +15,26 @@ use crate::Membership;
 use crate::MembershipState;
 
 /// Create an Arc<EffectiveMembership>
-fn effmem(term: u64, index: u64, m: Membership<u64, ()>) -> Arc<EffectiveMembership<u64, ()>> {
+fn effmem(term: u64, index: u64, m: Membership<UTConfig>) -> Arc<EffectiveMembership<UTConfig>> {
     let lid = Some(log_id(term, 1, index));
     Arc::new(EffectiveMembership::new(lid, m))
 }
 
-fn m1() -> Membership<u64, ()> {
+fn m1() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1}], None)
 }
 
-fn m12() -> Membership<u64, ()> {
+fn m12() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
-fn m123_345() -> Membership<u64, ()> {
+fn m123_345() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None)
 }
 
 #[test]
 fn test_apply_not_committed() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
+    let new = || MembershipState::<UTConfig>::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
     let res = new().change_handler().apply(ChangeMembers::AddVoterIds(btreeset! {1}), false);
 
     assert_eq!(
@@ -49,7 +50,7 @@ fn test_apply_not_committed() -> anyhow::Result<()> {
 
 #[test]
 fn test_apply_empty_voters() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
+    let new = || MembershipState::<UTConfig>::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
     let res = new().change_handler().apply(ChangeMembers::RemoveVoters(btreeset! {1}), false);
 
     assert_eq!(Err(ChangeMembershipError::EmptyMembership(EmptyMembership {})), res);
@@ -59,7 +60,7 @@ fn test_apply_empty_voters() -> anyhow::Result<()> {
 
 #[test]
 fn test_apply_learner_not_found() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
+    let new = || MembershipState::<UTConfig>::new(effmem(3, 4, m1()), effmem(3, 4, m1()));
     let res = new().change_handler().apply(ChangeMembers::AddVoterIds(btreeset! {2}), false);
 
     assert_eq!(
@@ -72,7 +73,7 @@ fn test_apply_learner_not_found() -> anyhow::Result<()> {
 
 #[test]
 fn test_apply_retain_learner() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(3, 4, m12()), effmem(3, 4, m123_345()));
+    let new = || MembershipState::<UTConfig>::new(effmem(3, 4, m12()), effmem(3, 4, m123_345()));
 
     // Do not leave removed voters as learner
     let res = new().change_handler().apply(ChangeMembers::RemoveVoters(btreeset! {1,2}), false);

--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -2,32 +2,33 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
+use crate::engine::testing::UTConfig;
 use crate::testing::log_id;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
 
 /// Create an Arc<EffectiveMembership>
-fn effmem(term: u64, index: u64, m: Membership<u64, ()>) -> Arc<EffectiveMembership<u64, ()>> {
+fn effmem(term: u64, index: u64, m: Membership<UTConfig>) -> Arc<EffectiveMembership<UTConfig>> {
     let lid = Some(log_id(term, 1, index));
     Arc::new(EffectiveMembership::new(lid, m))
 }
 
-fn m1() -> Membership<u64, ()> {
+fn m1() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1}], None)
 }
 
-fn m12() -> Membership<u64, ()> {
+fn m12() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
-fn m123_345() -> Membership<u64, ()> {
+fn m123_345() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], None)
 }
 
 #[test]
 fn test_membership_state_is_member() -> anyhow::Result<()> {
-    let x = MembershipState::new(effmem(1, 1, m1()), effmem(3, 4, m123_345()));
+    let x = MembershipState::<UTConfig>::new(effmem(1, 1, m1()), effmem(3, 4, m123_345()));
 
     assert!(!x.is_voter(&0));
     assert!(x.is_voter(&1));
@@ -43,7 +44,7 @@ fn test_membership_state_is_member() -> anyhow::Result<()> {
 #[test]
 fn test_membership_state_update_committed() -> anyhow::Result<()> {
     let new = || {
-        MembershipState::new(
+        MembershipState::<UTConfig>::new(
             Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 2)), m1())),
             Arc::new(EffectiveMembership::new(Some(log_id(3, 1, 4)), m123_345())),
         )
@@ -93,7 +94,7 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
 
 #[test]
 fn test_membership_state_append() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
+    let new = || MembershipState::<UTConfig>::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
 
     let mut ms = new();
     ms.append(effmem(4, 5, m12()));
@@ -107,7 +108,7 @@ fn test_membership_state_append() -> anyhow::Result<()> {
 
 #[test]
 fn test_membership_state_commit() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
+    let new = || MembershipState::<UTConfig>::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
 
     // Less than committed
     {
@@ -146,7 +147,7 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
 
 #[test]
 fn test_membership_state_truncate() -> anyhow::Result<()> {
-    let new = || MembershipState::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
+    let new = || MembershipState::<UTConfig>::new(effmem(2, 2, m1()), effmem(3, 4, m123_345()));
 
     {
         let mut ms = new();

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -67,10 +67,10 @@ where C: RaftTypeConfig
     pub log_ids: LogIdList<C::NodeId>,
 
     /// The latest cluster membership configuration found, in log or in state machine.
-    pub membership_state: MembershipState<C::NodeId, C::Node>,
+    pub membership_state: MembershipState<C>,
 
     /// The metadata of the last snapshot.
-    pub snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+    pub snapshot_meta: SnapshotMeta<C>,
 
     // --
     // -- volatile fields: they are not persisted.
@@ -399,7 +399,7 @@ where C: RaftTypeConfig
     }
 
     /// Build a ForwardToLeader error that contains the leader id and node it knows.
-    pub(crate) fn forward_to_leader(&self) -> ForwardToLeader<C::NodeId, C::Node> {
+    pub(crate) fn forward_to_leader(&self) -> ForwardToLeader<C> {
         let vote = self.vote_ref();
 
         if vote.is_committed() {

--- a/openraft/src/raft_state/tests/forward_to_leader_test.rs
+++ b/openraft/src/raft_state/tests/forward_to_leader_test.rs
@@ -22,7 +22,7 @@ fn log_id(term: u64, index: u64) -> LogId<u64> {
     }
 }
 
-fn m12() -> Membership<u64, ()> {
+fn m12() -> Membership<UTConfig> {
     Membership::new(vec![btreeset! {1,2}], None)
 }
 
@@ -56,7 +56,7 @@ fn test_forward_to_leader_not_a_member() {
 
 #[test]
 fn test_forward_to_leader_has_leader() {
-    let m123 = || Membership::<u64, u64>::new(vec![btreeset! {1,2}], btreemap! {1=>4,2=>5,3=>6});
+    let m123 = || Membership::<UTConfig<u64>>::new(vec![btreeset! {1,2}], btreemap! {1=>4,2=>5,3=>6});
 
     let rs = RaftState::<UTConfig<u64>> {
         vote: UTime::new(TokioInstant::now(), Vote::new_committed(1, 3)),

--- a/openraft/src/replication/callbacks.rs
+++ b/openraft/src/replication/callbacks.rs
@@ -20,17 +20,17 @@ pub(crate) struct SnapshotCallback<C: RaftTypeConfig> {
     pub(crate) start_time: InstantOf<C>,
 
     /// Meta data of the snapshot to be replicated.
-    pub(crate) snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
+    pub(crate) snapshot_meta: SnapshotMeta<C>,
 
     /// The result of the snapshot replication.
-    pub(crate) result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
+    pub(crate) result: Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>,
 }
 
 impl<C: RaftTypeConfig> SnapshotCallback<C> {
     pub(in crate::replication) fn new(
         start_time: InstantOf<C>,
-        snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
-        result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
+        snapshot_meta: SnapshotMeta<C>,
+        result: Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>,
     ) -> Self {
         Self {
             start_time,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -360,7 +360,7 @@ where
     async fn send_log_entries(
         &mut self,
         log_ids: DataWithId<LogIdRange<C::NodeId>>,
-    ) -> Result<Option<Data<C>>, ReplicationError<C::NodeId, C::Node>> {
+    ) -> Result<Option<Data<C>>, ReplicationError<C>> {
         let request_id = log_ids.request_id();
 
         tracing::debug!(
@@ -491,11 +491,7 @@ where
 
     /// Send the error result to RaftCore.
     /// RaftCore will then submit another replication command.
-    fn send_progress_error(
-        &mut self,
-        request_id: RequestId,
-        err: RPCError<C::NodeId, C::Node, RaftError<C::NodeId, Infallible>>,
-    ) {
+    fn send_progress_error(&mut self, request_id: RequestId, err: RPCError<C, RaftError<C, Infallible>>) {
         let _ = self.tx_raft_core.send(Notify::Network {
             response: Response::Progress {
                 target: self.target,
@@ -722,7 +718,7 @@ where
     async fn stream_snapshot(
         &mut self,
         snapshot_rx: DataWithId<ResultReceiver<C, Option<Snapshot<C>>>>,
-    ) -> Result<Option<Data<C>>, ReplicationError<C::NodeId, C::Node>> {
+    ) -> Result<Option<Data<C>>, ReplicationError<C>> {
         let request_id = snapshot_rx.request_id();
         let rx = snapshot_rx.into_data();
 
@@ -813,7 +809,7 @@ where
     fn handle_snapshot_callback(
         &mut self,
         callback: DataWithId<SnapshotCallback<C>>,
-    ) -> Result<Option<Data<C>>, ReplicationError<C::NodeId, C::Node>> {
+    ) -> Result<Option<Data<C>>, ReplicationError<C>> {
         tracing::debug!(
             request_id = debug(callback.request_id()),
             response = display(callback.data()),

--- a/openraft/src/replication/request.rs
+++ b/openraft/src/replication/request.rs
@@ -150,8 +150,8 @@ where C: RaftTypeConfig
     pub(crate) fn new_snapshot_callback(
         request_id: RequestId,
         start_time: InstantOf<C>,
-        snapshot_meta: SnapshotMeta<C::NodeId, C::Node>,
-        result: Result<SnapshotResponse<C::NodeId>, StreamingError<C, Fatal<C::NodeId>>>,
+        snapshot_meta: SnapshotMeta<C>,
+        result: Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>,
     ) -> Self {
         Self::SnapshotCallback(DataWithId::new(
             request_id,

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -188,7 +188,7 @@ where
     /// a follower only need to revert at most one membership log.
     ///
     /// Thus a raft node will only need to store at most two recent membership logs.
-    pub async fn get_membership(&mut self) -> Result<MembershipState<C::NodeId, C::Node>, StorageError<C::NodeId>> {
+    pub async fn get_membership(&mut self) -> Result<MembershipState<C>, StorageError<C::NodeId>> {
         let (_, sm_mem) = self.state_machine.applied_state().await?;
 
         let sm_mem_next_index = sm_mem.log_id().next_index();
@@ -227,7 +227,7 @@ where
     pub async fn last_membership_in_log(
         &mut self,
         since_index: u64,
-    ) -> Result<Vec<StoredMembership<C::NodeId, C::Node>>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<StoredMembership<C>>, StorageError<C::NodeId>> {
         let st = self.log_store.get_log_state().await?;
 
         let mut end = st.last_log_id.next_index();

--- a/openraft/src/storage/v2.rs
+++ b/openraft/src/storage/v2.rs
@@ -154,7 +154,7 @@ where C: RaftTypeConfig
     /// last-applied-log-id.
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<C::NodeId>>, StoredMembership<C::NodeId, C::Node>), StorageError<C::NodeId>>;
+    ) -> Result<(Option<LogId<C::NodeId>>, StoredMembership<C>), StorageError<C::NodeId>>;
 
     /// Apply the given payload of entries to the state machine.
     ///
@@ -221,7 +221,7 @@ where C: RaftTypeConfig
     /// snapshot.
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<C::NodeId, C::Node>,
+        meta: &SnapshotMeta<C>,
         snapshot: Box<C::SnapshotData>,
     ) -> Result<(), StorageError<C::NodeId>>;
 

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -89,7 +89,7 @@ openraft::declare_raft_types!(
 /// The application snapshot type which the `MemStore` works with.
 #[derive(Debug)]
 pub struct MemStoreSnapshot {
-    pub meta: SnapshotMeta<MemNodeId, ()>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -100,7 +100,7 @@ pub struct MemStoreSnapshot {
 pub struct MemStoreStateMachine {
     pub last_applied_log: Option<LogId<MemNodeId>>,
 
-    pub last_membership: StoredMembership<MemNodeId, ()>,
+    pub last_membership: StoredMembership<TypeConfig>,
 
     /// A mapping of client IDs to their state info.
     pub client_serial_responses: HashMap<String, (u64, Option<String>)>,
@@ -430,7 +430,7 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<MemNodeId>>, StoredMembership<MemNodeId, ()>), StorageError<MemNodeId>> {
+    ) -> Result<(Option<LogId<MemNodeId>>, StoredMembership<TypeConfig>), StorageError<MemNodeId>> {
         let sm = self.sm.read().await;
         Ok((sm.last_applied_log, sm.last_membership.clone()))
     }
@@ -484,7 +484,7 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<MemNodeId, ()>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<MemNodeId>> {
         tracing::info!(

--- a/stores/rocksstore/src/lib.rs
+++ b/stores/rocksstore/src/lib.rs
@@ -89,7 +89,7 @@ pub struct RocksResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RocksSnapshot {
-    pub meta: SnapshotMeta<RocksNodeId, BasicNode>,
+    pub meta: SnapshotMeta<TypeConfig>,
 
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
@@ -101,7 +101,7 @@ pub struct RocksSnapshot {
 pub struct StateMachine {
     pub last_applied_log: Option<LogId<RocksNodeId>>,
 
-    pub last_membership: StoredMembership<RocksNodeId, BasicNode>,
+    pub last_membership: StoredMembership<TypeConfig>,
 
     /// Application data.
     pub data: BTreeMap<String, String>,
@@ -414,7 +414,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<RocksNodeId>>, StoredMembership<RocksNodeId, BasicNode>), StorageError<RocksNodeId>> {
+    ) -> Result<(Option<LogId<RocksNodeId>>, StoredMembership<TypeConfig>), StorageError<RocksNodeId>> {
         Ok((self.sm.last_applied_log, self.sm.last_membership.clone()))
     }
 
@@ -459,7 +459,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
 
     async fn install_snapshot(
         &mut self,
-        meta: &SnapshotMeta<RocksNodeId, BasicNode>,
+        meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
     ) -> Result<(), StorageError<RocksNodeId>> {
         tracing::info!(


### PR DESCRIPTION

## Changelog

##### Change: Consolidate type parameters into `C`

Affected types:
- Membership types;
- RPC request and response types;
- Error types;

Upgrade tip:

To adapt to this change, update type parameters with the single generic `C` constrained by `RaftTypeConfig`:

```rust,ignore

// Membership types:

MembershipState<NID, N>     --> MembershipState<C>
EffectiveMembership<NID, N> --> EffectiveMembership<C>
Membership<NID, N>          --> Membership<C>

// RPC types:

VoteRequest<NID>             --> VoteRequest<C>
VoteResponse<NID>            --> VoteResponse<C>
AppendEntriesResponse<NID>   --> AppendEntriesResponse<C>
InstallSnapshotResponse<NID> --> InstallSnapshotResponse<C>
SnapshotResponse<NID>        --> SnapshotResponse<C>
SnapshotMeta<NID, N>         --> SnapshotMeta<C>

// Errors:

InitializeError<NID, N>    --> InitializeError<C>
NotInMembers<NID, N>       --> NotInMembers<C>
ClientWriteError<NID>      --> ClientWriteError<C>
CheckIsLeaderError<NID>    --> CheckIsLeaderError<C>
RaftError<NID, E>          --> RaftError<C, E>
RPCError<NID, N, E>        --> RPCError<C, E>
RemoteError<NID, N, E>     --> RemoteError<C, E>
ChangeMembershipError<NID> --> ChangeMembershipError<C>
ForwardToLeader<NID, N>    --> ForwardToLeader<C>
HigherVote<NID>            --> HigherVote<C>
InProgress<NID>            --> InProgress<C>
LearnerNotFound<NID>       --> LearnerNotFound<C>
NotAllowed<NID>            --> NotAllowed<C>
QuorumNotEnough<NID>       --> QuorumNotEnough<C>
Timeout<NID>               --> Timeout<C>
RejectVoteRequest<NID>     --> RejectVoteRequest<C>
RejectAppendEntries<NID>   --> RejectAppendEntries<C>
Fatal<NID>                 --> Fatal<C>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1076)
<!-- Reviewable:end -->
