### PR TITLE
Doc: correct a statement feature singlethreaded eliminates Send bound

### DIFF
--- a/openraft/src/docs/feature_flags/feature-flags.md
+++ b/openraft/src/docs/feature_flags/feature-flags.md
@@ -74,7 +74,7 @@ Removes `Send` and `Sync` bounds from `AppData`, `AppDataResponse`, `RaftEntry`,
 and other types to force the  asynchronous runtime to spawn any tasks in the current thread.
 This is for any single-threaded application that never allows a raft instance to be shared among multiple threads.
 This feature relies on the `async_fn_in_trait` language feature that is officially supported from Rust 1.75.0.
-If the feature is enabled, affected asynchronous trait methods require `Send` bounds.
+If the feature is enabled, affected asynchronous trait methods will not require `Send` bounds.
 In order to use the feature, `AsyncRuntime::spawn` should invoke `tokio::task::spawn_local` or equivalents.
 
 


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

What does this PR do

1. Corrects a wrong statement in `openraft/src/docs/feature_flags/feature-flags.md` that enabling feature `singlethreaded` will eliminate the `Send` bound rather than requiring it.


**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1078)
<!-- Reviewable:end -->
