### PR TITLE
Change: Add default value to `declare_raft_types`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -43,11 +43,7 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = ClientRequest,
         R = ClientResponse,
-        NodeId = NodeId,
         Node = (),
-        Entry = Entry<TypeConfig>,
-        SnapshotData = Cursor<Vec<u8>>,
-        AsyncRuntime = TokioRuntime
 );
 
 #[derive(Debug)]

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/lib.rs
@@ -3,9 +3,7 @@
 
 use std::sync::Arc;
 
-use openraft::BasicNode;
 use openraft::Config;
-use openraft::TokioRuntime;
 
 use crate::app::App;
 use crate::router::Router;
@@ -27,13 +25,9 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = Request,
         R = Response,
-        NodeId = NodeId,
-        Node = BasicNode,
-        Entry = openraft::Entry<TypeConfig>,
         // In this example, snapshot is just a copy of the state machine.
         // And it can be any type.
         SnapshotData = StateMachineData,
-        AsyncRuntime = TokioRuntime
 );
 
 pub type LogStore = store::LogStore;

--- a/examples/raft-kv-memstore-generic-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-generic-snapshot-data/src/network.rs
@@ -8,6 +8,7 @@ use openraft::raft::AppendEntriesResponse;
 use openraft::raft::SnapshotResponse;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
+use openraft::BasicNode;
 use openraft::OptionalSend;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
@@ -16,7 +17,6 @@ use openraft::Vote;
 
 use crate::router::Router;
 use crate::typ;
-use crate::BasicNode;
 use crate::NodeId;
 use crate::TypeConfig;
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -4,9 +4,7 @@
 use std::sync::Arc;
 
 use opendal::Operator;
-use openraft::BasicNode;
 use openraft::Config;
-use openraft::TokioRuntime;
 
 use crate::app::App;
 use crate::router::Router;
@@ -27,12 +25,8 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = Request,
         R = Response,
-        NodeId = NodeId,
-        Node = BasicNode,
-        Entry = openraft::Entry<TypeConfig>,
         // In this example, snapshot is a path pointing to a file stored in shared storage.
         SnapshotData = String,
-        AsyncRuntime = TokioRuntime
 );
 
 pub type LogStore = store::LogStore;

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
@@ -8,6 +8,7 @@ use openraft::raft::AppendEntriesResponse;
 use openraft::raft::SnapshotResponse;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
+use openraft::BasicNode;
 use openraft::OptionalSend;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
@@ -16,7 +17,6 @@ use openraft::Vote;
 
 use crate::router::Router;
 use crate::typ;
-use crate::BasicNode;
 use crate::NodeId;
 use crate::TypeConfig;
 

--- a/examples/raft-kv-memstore-singlethreaded/src/lib.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/lib.rs
@@ -6,9 +6,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use openraft::BasicNode;
 use openraft::Config;
-use openraft::TokioRuntime;
 
 use crate::app::App;
 use crate::router::Router;
@@ -51,10 +49,6 @@ openraft::declare_raft_types!(
         D = Request,
         R = Response,
         NodeId = NodeId,
-        Node = BasicNode,
-        Entry = openraft::Entry<TypeConfig>,
-        SnapshotData = Cursor<Vec<u8>>,
-        AsyncRuntime = TokioRuntime
 );
 
 pub type LogStore = store::LogStore;

--- a/examples/raft-kv-memstore-singlethreaded/src/network.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/network.rs
@@ -7,12 +7,12 @@ use openraft::raft::InstallSnapshotRequest;
 use openraft::raft::InstallSnapshotResponse;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
+use openraft::BasicNode;
 use openraft::RaftNetwork;
 use openraft::RaftNetworkFactory;
 
 use crate::router::Router;
 use crate::typ;
-use crate::BasicNode;
 use crate::NodeId;
 use crate::TypeConfig;
 

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -8,9 +8,7 @@ use actix_web::middleware;
 use actix_web::middleware::Logger;
 use actix_web::web::Data;
 use actix_web::HttpServer;
-use openraft::BasicNode;
 use openraft::Config;
-use openraft::TokioRuntime;
 
 use crate::app::App;
 use crate::network::api;
@@ -32,11 +30,6 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = Request,
         R = Response,
-        NodeId = NodeId,
-        Node = BasicNode,
-        Entry = openraft::Entry<TypeConfig>,
-        SnapshotData = Cursor<Vec<u8>>,
-        AsyncRuntime = TokioRuntime,
 );
 
 pub type LogStore = store::LogStore;

--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use openraft::Config;
-use openraft::TokioRuntime;
 use tokio::net::TcpListener;
 use tokio::task;
 
@@ -44,11 +43,7 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = Request,
         R = Response,
-        NodeId = NodeId,
         Node = Node,
-        Entry = openraft::Entry<TypeConfig>,
-        SnapshotData = SnapshotData,
-        AsyncRuntime = TokioRuntime
 );
 
 pub mod typ {

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -89,9 +89,9 @@ where C: RaftTypeConfig
     DeleteConflictLog { since: LogId<C::NodeId> },
 
     // TODO(1): current it is only used to replace BuildSnapshot, InstallSnapshot, CancelSnapshot.
-    /// A command send to state machine worker [`worker::Worker`].
+    /// A command send to state machine worker [`sm::worker::Worker`].
     ///
-    /// The runtime(`RaftCore`) will just forward this command to [`worker::Worker`].
+    /// The runtime(`RaftCore`) will just forward this command to [`sm::worker::Worker`].
     /// The response will be sent back in a `RaftMsg::StateMachine` message to `RaftCore`.
     StateMachine { command: sm::Command<C> },
 
@@ -212,7 +212,7 @@ where NID: NodeId
     #[allow(dead_code)]
     Applied { log_id: Option<LogId<NID>> },
 
-    /// Wait until a [`worker::Worker`] command is finished.
+    /// Wait until a [`sm::worker::Worker`] command is finished.
     #[allow(dead_code)]
     StateMachineCommand { command_seq: sm::CommandSeq },
 }

--- a/openraft/src/raft/declare_raft_types_test.rs
+++ b/openraft/src/raft/declare_raft_types_test.rs
@@ -1,0 +1,51 @@
+//! Test the `declare_raft_types` macro with default values
+
+use std::io::Cursor;
+
+use crate::declare_raft_types;
+use crate::TokioRuntime;
+
+declare_raft_types!(
+    All:
+        D = (),
+        R = (),
+        NodeId = u64,
+        Node = (),
+        Entry = crate::Entry<Self>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime,
+);
+
+declare_raft_types!(
+    WithoutD:
+        R = (),
+        NodeId = u64,
+        Node = (),
+        Entry = crate::Entry<Self>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime,
+);
+
+declare_raft_types!(
+    WithoutR:
+        D = (),
+        NodeId = u64,
+        Node = (),
+        Entry = crate::Entry<Self>,
+        SnapshotData = Cursor<Vec<u8>>,
+        AsyncRuntime = TokioRuntime,
+);
+
+// This raise an compile error:
+// > error: Type not in its expected position : NodeId = u64, D = (), types must present
+// > in this order : D, R, NodeId, Node, Entry, SnapshotData, AsyncRuntime
+// declare_raft_types!(
+//     Foo:
+//         Node = (),
+//         NodeId = u64,
+//         D = (),
+// );
+
+declare_raft_types!(EmptyWithColon:);
+
+declare_raft_types!(Empty);

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -28,7 +28,6 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
-use openraft::TokioRuntime;
 use openraft::Vote;
 use serde::Deserialize;
 use serde::Serialize;
@@ -79,11 +78,7 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = ClientRequest,
         R = ClientResponse,
-        NodeId = MemNodeId,
         Node = (),
-        Entry = Entry<TypeConfig>,
-        SnapshotData = Cursor<Vec<u8>>,
-        AsyncRuntime = TokioRuntime
 );
 
 /// The application snapshot type which the `MemStore` works with.

--- a/stores/rocksstore/src/lib.rs
+++ b/stores/rocksstore/src/lib.rs
@@ -25,7 +25,6 @@ use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::AnyError;
-use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::ErrorVerb;
@@ -38,7 +37,6 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
-use openraft::TokioRuntime;
 use openraft::Vote;
 use rand::Rng;
 use rocksdb::ColumnFamily;
@@ -56,11 +54,6 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = RocksRequest,
         R = RocksResponse,
-        NodeId = RocksNodeId,
-        Node = BasicNode,
-        Entry = Entry<TypeConfig>,
-        SnapshotData = Cursor<Vec<u8>>,
-        AsyncRuntime = TokioRuntime
 );
 
 /**

--- a/stores/sledstore/src/lib.rs
+++ b/stores/sledstore/src/lib.rs
@@ -21,7 +21,6 @@ use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::AnyError;
-use openraft::BasicNode;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
@@ -33,7 +32,6 @@ use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StorageIOError;
 use openraft::StoredMembership;
-use openraft::TokioRuntime;
 use openraft::Vote;
 use serde::Deserialize;
 use serde::Serialize;
@@ -46,11 +44,6 @@ openraft::declare_raft_types!(
     pub TypeConfig:
         D = ExampleRequest,
         R = ExampleResponse,
-        NodeId = ExampleNodeId,
-        Node = BasicNode,
-        Entry = Entry<TypeConfig>,
-        SnapshotData = Cursor<Vec<u8>>,
-        AsyncRuntime = TokioRuntime
 );
 
 /**


### PR DESCRIPTION

## Changelog

##### Change: Add default value to `declare_raft_types`

Types used in `declare_raft_types` can be omitted, in which case the default type will be used.
The default values for each type are:
- `D`:            `String`
- `R`:            `String`
- `NodeId`:       `u64`
- `Node`:         `::openraft::BasicNode`
- `Entry`:        `::openraft::Entry<Self>`
- `SnapshotData`: `Cursor<Vec<u8>>`
- `AsyncRuntime`: `::openraft::TokioRuntime`

Note that **The types must be specified in the exact order**:
`D`, `R`, `NodeId`, `Node`, `Entry`, `SnapshotData`, `AsyncRuntime`.

For example, to declare with only `D`, `R` and `Entry` types:
```rust,ignore
openraft::declare_raft_types!(
   pub TypeConfig:
       D = ClientRequest,
       R = ClientResponse,
       Entry = MyEntry,
);
```

Type `NodeId`, `Node`, `SnapshotData` and `AsyncRuntime` will be filled
with default values mentioned above.

Or one can just use the default types for all:
```rust,ignore
openraft::declare_raft_types!(pub TypeConfig);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1086)
<!-- Reviewable:end -->
