### PR TITLE
Refactor: trait `AsyncOneshotSendExt` does not need `Unpin`

### DIFF
--- a/openraft/src/async_runtime.rs
+++ b/openraft/src/async_runtime.rs
@@ -172,7 +172,7 @@ impl AsyncRuntime for TokioRuntime {
     }
 }
 
-pub trait AsyncOneshotSendExt<T>: Unpin {
+pub trait AsyncOneshotSendExt<T> {
     /// Attempts to send a value on this channel, returning it back if it could
     /// not be sent.
     ///


### PR DESCRIPTION

## Changelog

##### Refactor: trait `AsyncOneshotSendExt` does not need `Unpin`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1090)
<!-- Reviewable:end -->
