### PR TITLE
Feature: Add `Raft::is_initialized()`

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -667,7 +667,7 @@ where C: RaftTypeConfig
     /// It is allowed to initialize only when `last_log_id.is_none()` and `vote==(term=0,
     /// node_id=0)`. See: [Conditions for initialization](https://datafuselabs.github.io/openraft/cluster-formation.html#conditions-for-initialization)
     fn check_initialize(&self) -> Result<(), NotAllowed<C>> {
-        if self.state.last_log_id().is_none() && self.state.vote_ref() == &Vote::default() {
+        if !self.state.is_initialized() {
             return Ok(());
         }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -698,6 +698,14 @@ where C: RaftTypeConfig
         Ok(client_write_response)
     }
 
+    /// Return `true` if this node is already initialized and can not be initialized again with
+    /// [`Raft::initialize`]
+    pub async fn is_initialized(&self) -> Result<bool, Fatal<C>> {
+        let initialized = self.with_raft_state(|st| st.is_initialized()).await?;
+
+        Ok(initialized)
+    }
+
     /// Initialize a pristine Raft node with the given config.
     ///
     /// This command should be called on pristine nodes — where the log index is 0 and the node is

--- a/openraft/src/raft_state/tests/is_initialized_test.rs
+++ b/openraft/src/raft_state/tests/is_initialized_test.rs
@@ -1,0 +1,47 @@
+use crate::engine::testing::UTConfig;
+use crate::engine::LogIdList;
+use crate::testing::log_id;
+use crate::utime::UTime;
+use crate::RaftState;
+use crate::TokioInstant;
+use crate::Vote;
+
+#[test]
+fn test_is_initialized() {
+    // empty
+    {
+        let rs = RaftState::<UTConfig> { ..Default::default() };
+
+        assert_eq!(false, rs.is_initialized());
+    }
+
+    // Vote is set but is default
+    {
+        let rs = RaftState::<UTConfig> {
+            vote: UTime::new(TokioInstant::now(), Vote::default()),
+            ..Default::default()
+        };
+
+        assert_eq!(false, rs.is_initialized());
+    }
+
+    // Vote is non-default value
+    {
+        let rs = RaftState::<UTConfig> {
+            vote: UTime::new(TokioInstant::now(), Vote::new(1, 2)),
+            ..Default::default()
+        };
+
+        assert_eq!(true, rs.is_initialized());
+    }
+
+    // Logs are non-empty
+    {
+        let rs = RaftState::<UTConfig> {
+            log_ids: LogIdList::new([log_id(0, 0, 0)]),
+            ..Default::default()
+        };
+
+        assert_eq!(true, rs.is_initialized());
+    }
+}

--- a/tests/tests/life_cycle/t10_initialization.rs
+++ b/tests/tests/life_cycle/t10_initialization.rs
@@ -48,6 +48,13 @@ async fn initialization() -> anyhow::Result<()> {
     router.new_raft_node(1).await;
     router.new_raft_node(2).await;
 
+    #[allow(clippy::bool_assert_comparison)]
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        let inited = n0.is_initialized().await?;
+        assert_eq!(false, inited);
+    }
+
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
@@ -82,6 +89,13 @@ async fn initialization() -> anyhow::Result<()> {
 
         for node_id in [0, 1, 2] {
             router.wait(&node_id, timeout()).applied_index(Some(log_index), "init").await?;
+        }
+
+        #[allow(clippy::bool_assert_comparison)]
+        for node_id in [0, 1, 2] {
+            let n = router.get_raft_handle(&node_id)?;
+            let inited = n.is_initialized().await?;
+            assert_eq!(true, inited);
         }
     }
 


### PR DESCRIPTION

## Changelog

##### Feature: Add `Raft::is_initialized()`

`Raft::is_initialized()` returns `true` if this raft node is already
initialized with `Raft::initialize()`, by checking if log is empty and
`vote` is not written.