### PR TITLE
Refactor: Remove inappropraite error log on quit

### DIFF
--- a/openraft/src/raft/core_state.rs
+++ b/openraft/src/raft/core_state.rs
@@ -1,4 +1,5 @@
 use crate::error::Fatal;
+use crate::error::Infallible;
 use crate::type_config::alias::JoinHandleOf;
 use crate::RaftTypeConfig;
 
@@ -7,8 +8,8 @@ pub(in crate::raft) enum CoreState<C>
 where C: RaftTypeConfig
 {
     /// The RaftCore task is still running.
-    Running(JoinHandleOf<C, Result<(), Fatal<C>>>),
+    Running(JoinHandleOf<C, Result<Infallible, Fatal<C>>>),
 
     /// The RaftCore task has finished. The return value of the task is stored.
-    Done(Result<(), Fatal<C>>),
+    Done(Result<Infallible, Fatal<C>>),
 }


### PR DESCRIPTION

## Changelog

##### Refactor: Remove inappropraite error log on quit

`RaftCore` should not output ERROR level log on a normal quit.
Reduce ERROR level to INFO.

- Fix: #1096

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1097)
<!-- Reviewable:end -->
