### PR TITLE
Improve: `declare_raft_types` allows the types in any order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.63"
 async-entry = "0.3.1"
 byte-unit = "4.0.12"
 bytes = "1.0"
+chrono = { version = "0.4" }
 clap = { version = "4.1.11", features = ["derive", "env"] }
 derive_more = { version="0.99.9" }
 futures = "0.3"
@@ -29,6 +30,7 @@ pretty_assertions = "1.0.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 rand = "0.8"
+semver = "1.0.14"
 serde = { version="1.0.114", features=["derive", "rc"]}
 serde_json = "1.0.57"
 syn = "2.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,9 +16,11 @@ repository    = { workspace = true }
 proc-macro = true
 
 [dependencies]
+chrono = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["full"] }
+semver = { workspace = true }
+syn = { workspace = true, features = ["full", "extra-traits"] }
 
 [features]
 

--- a/macros/src/expand.rs
+++ b/macros/src/expand.rs
@@ -1,0 +1,216 @@
+use std::collections::HashSet;
+
+use proc_macro2::Ident;
+use quote::quote;
+use quote::ToTokens;
+use syn::parenthesized;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
+use syn::Attribute;
+use syn::Expr;
+use syn::ExprTuple;
+use syn::Token;
+use syn::Type;
+use syn::__private::TokenStream2;
+
+/// A type or an expression which is used as an argument in the `expand` macro.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+enum TypeOrExpr {
+    Attribute(Vec<Attribute>),
+    Type(Type),
+    Expr(Expr),
+    Empty,
+}
+
+impl ToTokens for TypeOrExpr {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            TypeOrExpr::Attribute(attrs) => {
+                for a in attrs {
+                    a.to_tokens(tokens)
+                }
+            }
+            TypeOrExpr::Type(t) => t.to_tokens(tokens),
+            TypeOrExpr::Expr(e) => e.to_tokens(tokens),
+            TypeOrExpr::Empty => {}
+        }
+    }
+}
+
+impl Parse for TypeOrExpr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let res = input.call(Attribute::parse_outer);
+        if let Ok(r) = res {
+            if !r.is_empty() {
+                return Ok(Self::Attribute(r));
+            }
+        }
+
+        let res = input.parse::<Type>();
+        if let Ok(t) = res {
+            return Ok(Self::Type(t));
+        }
+
+        let res = input.parse::<Expr>();
+        if let Ok(e) = res {
+            return Ok(Self::Expr(e));
+        }
+
+        let l = input.lookahead1();
+        if l.peek(Token![,]) {
+            Ok(Self::Empty)
+        } else {
+            Err(l.error())
+        }
+    }
+}
+
+pub(crate) struct Expand {
+    /// Whether to deduplicate by the first argument as key.
+    pub(crate) keyed: bool,
+
+    /// The template variables
+    pub(crate) idents: Vec<String>,
+
+    /// Template in tokens
+    pub(crate) template: TokenStream2,
+
+    /// Multiple arguments lists for rendering the template
+    args_list: Vec<Vec<TypeOrExpr>>,
+
+    /// The keys that have been present in one of the `args_list`.
+    /// It is used for deduplication, if `keyed` is true.
+    present_keys: HashSet<TypeOrExpr>,
+}
+
+impl Expand {
+    pub(crate) fn render(&self) -> TokenStream2 {
+        let mut output_tokens = TokenStream2::new();
+
+        for values in self.args_list.iter() {
+            for t in self.template.clone().into_iter() {
+                if let proc_macro2::TokenTree::Ident(ident) = t {
+                    let ident_str = ident.to_string();
+
+                    let ident_index = self.idents.iter().position(|x| x == &ident_str);
+                    if let Some(ident_index) = ident_index {
+                        let replacement = &values[ident_index];
+                        output_tokens.extend(replacement.to_token_stream());
+                    } else {
+                        output_tokens.extend(ident.into_token_stream());
+                    }
+                } else {
+                    output_tokens.extend(t.into_token_stream());
+                }
+            }
+        }
+
+        quote! {
+            #output_tokens
+        }
+    }
+}
+
+impl Parse for Expand {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut b = Expand {
+            keyed: true,
+            idents: vec![],
+            template: Default::default(),
+            args_list: vec![],
+            present_keys: Default::default(),
+        };
+
+        // KEYED, or !KEYED,
+        {
+            let not = input.parse::<Token![!]>();
+            let not_keyed = not.is_ok();
+
+            let keyed_lit = input.parse::<Ident>()?;
+            if keyed_lit != "KEYED" {
+                return Err(syn::Error::new_spanned(&keyed_lit, "Expected KEYED"));
+            };
+            b.keyed = !not_keyed;
+        }
+
+        input.parse::<Token![,]>()?;
+
+        // Template variables:
+        // (K, V...)
+
+        let idents_tuple = input.parse::<ExprTuple>()?;
+
+        for expr in idents_tuple.elems.iter() {
+            let Expr::Path(p) = expr else {
+                return Err(syn::Error::new_spanned(expr, "Expected path"));
+            };
+
+            let segment = p.path.segments.first().ok_or_else(|| syn::Error::new_spanned(p, "Expected ident"))?;
+            let ident = segment.ident.to_string();
+
+            b.idents.push(ident);
+        }
+
+        // Template body
+        // => { ... }
+        {
+            input.parse::<Token![=>]>()?;
+
+            let brace_group = input.parse::<proc_macro2::TokenTree>()?;
+            let proc_macro2::TokenTree::Group(tree) = brace_group else {
+                return Err(syn::Error::new_spanned(brace_group, "Expected { ... }"));
+            };
+            b.template = tree.stream();
+        }
+
+        // List of arguments tuples for rendering the template
+        // , (K1, V1...)...
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            input.parse::<Token![,]>()?;
+
+            if input.is_empty() {
+                break;
+            }
+
+            // A tuple of arguments for each rendering
+            // (K1, V1, V2...)
+            {
+                let content;
+                let _parenthesis = parenthesized!(content in input);
+
+                let k = content.parse::<TypeOrExpr>()?;
+                let mut args = vec![k.clone()];
+
+                loop {
+                    if content.is_empty() {
+                        break;
+                    }
+
+                    content.parse::<Token![,]>()?;
+
+                    if content.is_empty() {
+                        break;
+                    }
+
+                    let v = content.parse::<TypeOrExpr>()?;
+                    args.push(v);
+                }
+
+                // Ignore duplicates if keyed
+                if b.present_keys.contains(&k) && b.keyed {
+                    continue;
+                }
+
+                b.present_keys.insert(k);
+                b.args_list.push(args);
+            }
+        }
+
+        Ok(b)
+    }
+}

--- a/macros/src/lib_readme.md
+++ b/macros/src/lib_readme.md
@@ -2,7 +2,7 @@ Supporting utils for [Openraft](https://crates.io/crates/openraft).
 
 # `add_async_trait`
 
-`#[add_async_trait]` adds `Send` bounds to an async trait.
+[`#[add_async_trait]`](`macro@crate::add_async_trait`) adds `Send` bounds to an async trait.
 
 ## Example
 
@@ -24,14 +24,12 @@ trait MyTrait {
 
 # `since`
 
-`#[since(version = "1.0.0")]` adds a doc line `/// Since: 1.0.0`.
+[`#[since(version = "1.0.0")]`](`macro@crate::since`) adds a doc line `/// Since: 1.0.0`.
 
 ## Example
 
 ```rust,ignore
 /// Foo function
-///
-/// Does something.
 #[since(version = "1.0.0")]
 fn foo() {}
 ```
@@ -41,8 +39,34 @@ The above code will be transformed into:
 ```rust,ignore
 /// Foo function
 ///
-/// Does something.
-///
 /// Since: 1.0.0
 fn foo() {}
+```
+
+
+# `expand` a template
+
+[`expand!()`](`crate::expand!`) renders a template with arguments multiple times.
+
+# Example:
+
+```rust
+# use openraft_macros::expand;
+# fn foo () {
+expand!(KEYED, // ignore duplicate by `K`
+        (K, T, V) => {let K: T = V;},
+        (a, u64, 1),
+        (a, u32, 2), // duplicate `a` will be ignored
+        (c, Vec<u8>, vec![1,2])
+);
+# }
+```
+
+The above code will be transformed into:
+
+```rust
+# fn foo () {
+let a: u64 = 1;
+let c: Vec<u8> = vec![1, 2];
+# }
 ```

--- a/macros/src/lib_readme.md
+++ b/macros/src/lib_readme.md
@@ -1,8 +1,10 @@
 Supporting utils for [Openraft](https://crates.io/crates/openraft).
 
+# `add_async_trait`
+
 `#[add_async_trait]` adds `Send` bounds to an async trait.
 
-# Example
+## Example
 
 ```
 #[openraft_macros::add_async_trait]
@@ -17,4 +19,30 @@ The above code will be transformed into:
 trait MyTrait {
     fn my_method(&self) -> impl Future<Output=Result<(), String>> + Send;
 }
+```
+
+
+# `since`
+
+`#[since(version = "1.0.0")]` adds a doc line `/// Since: 1.0.0`.
+
+## Example
+
+```rust,ignore
+/// Foo function
+///
+/// Does something.
+#[since(version = "1.0.0")]
+fn foo() {}
+```
+
+The above code will be transformed into:
+
+```rust,ignore
+/// Foo function
+///
+/// Does something.
+///
+/// Since: 1.0.0
+fn foo() {}
 ```

--- a/macros/src/since.rs
+++ b/macros/src/since.rs
@@ -1,0 +1,198 @@
+use std::str::FromStr;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::parse::Parser;
+use syn::spanned::Spanned;
+
+use crate::utils;
+
+pub struct Since {
+    pub(crate) version: Option<String>,
+    pub(crate) date: Option<String>,
+}
+
+impl Since {
+    /// Build a `Since` struct from the given attribute arguments.
+    pub(crate) fn new(args: TokenStream) -> Result<Since, syn::Error> {
+        let mut since = Since {
+            version: None,
+            date: None,
+        };
+
+        type AttributeArgs = syn::punctuated::Punctuated<syn::Meta, syn::Token![,]>;
+
+        let parsed_args = AttributeArgs::parse_terminated.parse(args.clone())?;
+
+        for arg in parsed_args {
+            match arg {
+                syn::Meta::NameValue(namevalue) => {
+                    let q = namevalue
+                        .path
+                        .get_ident()
+                        .ok_or_else(|| syn::Error::new_spanned(&namevalue, "Must have specified ident"))?;
+
+                    let ident = q.to_string().to_lowercase();
+
+                    match ident.as_str() {
+                        "version" => {
+                            since.set_version(namevalue.value.clone(), Spanned::span(&namevalue.value))?;
+                        }
+
+                        "date" => {
+                            since.set_date(namevalue.value.clone(), Spanned::span(&namevalue.value))?;
+                        }
+
+                        name => {
+                            let msg = format!(
+                                "Unknown attribute {} is specified; expected one of: `version`, `date`",
+                                name,
+                            );
+                            return Err(syn::Error::new_spanned(namevalue, msg));
+                        }
+                    }
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(other, "Unknown attribute inside the macro"));
+                }
+            }
+        }
+
+        if since.version.is_none() {
+            return Err(syn::Error::new_spanned(
+                proc_macro2::TokenStream::from(args),
+                "Missing `version` attribute",
+            ));
+        }
+
+        Ok(since)
+    }
+    /// Append a `since` doc such as `Since: 1.0.0` to the bottom of the doc section.
+    pub(crate) fn append_since_doc(self, item: TokenStream) -> Result<TokenStream, syn::Error> {
+        let item = proc_macro2::TokenStream::from(item);
+
+        // Present docs to skip, in order to append `since` at bottom of doc section.
+        let mut present_docs = vec![];
+
+        // Tokens left after present docs.
+        let mut last_non_doc = vec![];
+
+        let mut it = item.clone().into_iter();
+        loop {
+            let Some(curr) = it.next() else {
+                break;
+            };
+            let Some(next) = it.next() else {
+                last_non_doc.push(curr);
+                break;
+            };
+
+            if utils::is_doc(&curr, &next) {
+                present_docs.push(curr);
+                present_docs.push(next);
+            } else {
+                last_non_doc.push(curr);
+                last_non_doc.push(next);
+                break;
+            }
+        }
+
+        let since_docs_str = if present_docs.is_empty() {
+            format!(r#"#[doc = " {}"]"#, self.to_doc_string())
+        } else {
+            // If there are already docs, insert a blank line.
+            format!(r#"#[doc = ""] #[doc = " {}"]"#, self.to_doc_string())
+        };
+        let since_docs = proc_macro2::TokenStream::from_str(&since_docs_str).unwrap();
+
+        let present_docs: proc_macro2::TokenStream = present_docs.into_iter().collect();
+        let last_non_docs: proc_macro2::TokenStream = last_non_doc.into_iter().collect();
+
+        // Other non doc tokens.
+        let other: proc_macro2::TokenStream = it.collect();
+
+        let tokens = quote! {
+            #present_docs
+            #since_docs
+            #last_non_docs
+            #other
+        };
+        Ok(tokens.into())
+    }
+
+    /// Build doc string: `Since: 1.0.0, Date(2021-01-01)` or  `Since: 1.0.0`
+    fn to_doc_string(&self) -> String {
+        let mut s = String::new();
+        s.push_str("Since: ");
+
+        if let Some(version) = &self.version {
+            s.push_str(version.as_str());
+        }
+        if let Some(date) = &self.date {
+            s.push_str(&format!(", Date({})", date));
+        }
+        s
+    }
+
+    pub(crate) fn set_version(&mut self, ver_lit: syn::Expr, span: Span) -> Result<(), syn::Error> {
+        if self.version.is_some() {
+            return Err(syn::Error::new(span, "`version` set multiple times."));
+        }
+
+        let ver = Self::parse_str(ver_lit, "version", span)?;
+
+        semver::Version::parse(&ver)
+            .map_err(|_e| syn::Error::new(span, format!("`version`(`{}`) is not valid semver.", ver)))?;
+
+        self.version = Some(ver);
+
+        Ok(())
+    }
+
+    pub(crate) fn set_date(&mut self, date_lit: syn::Expr, span: Span) -> Result<(), syn::Error> {
+        if self.date.is_some() {
+            return Err(syn::Error::new(span, "`date` set multiple times."));
+        }
+
+        let date_str = Self::parse_str(date_lit, "date", span)?;
+
+        chrono::NaiveDate::parse_from_str(&date_str, "%Y-%m-%d").map_err(|_e| {
+            syn::Error::new(
+                span,
+                format!(
+                    "`date`(`{}`) is not valid date string. Expected format: yyyy-mm-dd",
+                    date_str
+                ),
+            )
+        })?;
+
+        self.date = Some(date_str);
+
+        Ok(())
+    }
+
+    /// Extract string from `foo` or `"foo"`
+    fn parse_str(expr: syn::Expr, field: &str, span: Span) -> Result<String, syn::Error> {
+        let s = match expr {
+            syn::Expr::Lit(s) => match s.lit {
+                syn::Lit::Str(s) => s.value(),
+                syn::Lit::Verbatim(s) => s.to_string(),
+                _ => {
+                    return Err(syn::Error::new(
+                        span,
+                        format!("Failed to parse value of `{}` as string.", field),
+                    ))
+                }
+            },
+            syn::Expr::Verbatim(s) => s.to_string(),
+            _ => {
+                return Err(syn::Error::new(
+                    span,
+                    format!("Failed to parse value of `{}` as string.", field),
+                ))
+            }
+        };
+        Ok(s)
+    }
+}

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -1,0 +1,49 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenTree;
+
+/// Check if the next two token is a doc attribute, such as `#[doc = "foo"]`.
+///
+/// An doc attribute is composed of a `#` token and a `Group` token with a `Bracket` delimiter:
+/// ```ignore
+/// Punct { ch: '#', },
+/// Group {
+///     delimiter: Bracket,
+///     stream: TokenStream [
+///         Ident { ident: "doc", },
+///         Punct { ch: '=', },
+///         Literal { kind: Str, symbol: " Doc", },
+///     ],
+/// },
+/// ```
+pub(crate) fn is_doc(curr: &TokenTree, next: &TokenTree) -> bool {
+    let TokenTree::Punct(p) = curr else {
+        return false;
+    };
+
+    if p.as_char() != '#' {
+        return false;
+    }
+
+    let TokenTree::Group(g) = &next else {
+        return false;
+    };
+
+    if g.delimiter() != proc_macro2::Delimiter::Bracket {
+        return false;
+    }
+    let first = g.stream().into_iter().next();
+    let Some(first) = first else {
+        return false;
+    };
+
+    let TokenTree::Ident(i) = first else {
+        return false;
+    };
+
+    i == "doc"
+}
+
+pub(crate) fn token_stream_with_error(mut item: TokenStream, e: syn::Error) -> TokenStream {
+    item.extend(TokenStream::from(e.into_compile_error()));
+    item
+}

--- a/macros/tests/test_default_types.rs
+++ b/macros/tests/test_default_types.rs
@@ -1,0 +1,37 @@
+use openraft_macros::expand;
+
+#[allow(dead_code)]
+#[allow(unused_variables)]
+fn foo() {
+    expand!(
+        KEYED,
+        // template with variables K and V
+        (K, T, V) => {let K: T = V;},
+        // arguments for rendering the template
+        (a, u64, 1),
+        (b, String, "foo".to_string()),
+        (a, u32, 2), // duplicate `a` will be ignored
+        (c, Vec<u8>, vec![1,2]),
+    );
+
+    let _x = 1;
+
+    expand!(
+        !KEYED,
+        (K, T, V) => {let K: T = V;},
+        (c, u8, 8),
+        (c, u16, 16),
+    );
+
+    expand!(
+        !KEYED,
+        (K, M, T) => {M let K: T;},
+        (c, , u8, ),
+        (c, #[allow(dead_code)] , u16),
+        (c, #[allow(dead_code)] #[allow(dead_code)] , u16),
+    );
+}
+
+// #[parse_it]
+// #[allow(dead_code)]
+// fn bar() {}

--- a/macros/tests/test_since.rs
+++ b/macros/tests/test_since.rs
@@ -1,0 +1,30 @@
+use openraft_macros::since;
+
+/// Doc
+///
+/// By default, `Send` bounds will be added to the trait and to the return bounds of any async
+/// functions defined withing the trait.
+///
+/// If the `singlethreaded` feature is enabled, the trait definition remains the same without any
+/// added `Send` bounds.
+///
+/// # Example
+///
+/// - list
+#[since(version = "1.0.0", date = "2021-01-01")]
+#[allow(dead_code)]
+const A: i32 = 0;
+
+#[since(version = "1.0.0")]
+#[allow(dead_code)]
+fn foo() {}
+
+/*
+
+#[since(version = "1.0.0..0")]
+fn bad_semver() {}
+
+#[since(version = "1.0.0", date = "2021-01--")]
+fn bad_date() {}
+
+ */

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -21,6 +21,7 @@ macro_rules! func_name {
         // nn.split("::").last().unwrap_or_default()
     }};
 }
+pub extern crate openraft_macros;
 
 mod change_members;
 mod config;

--- a/openraft/src/raft/declare_raft_types_test.rs
+++ b/openraft/src/raft/declare_raft_types_test.rs
@@ -7,10 +7,14 @@ use crate::TokioRuntime;
 
 declare_raft_types!(
     All:
-        D = (),
-        R = (),
         NodeId = u64,
         Node = (),
+
+        /// This is AppData
+        D = (),
+        #[allow(dead_code)]
+        #[allow(dead_code)]
+        R = (),
         Entry = crate::Entry<Self>,
         SnapshotData = Cursor<Vec<u8>>,
         AsyncRuntime = TokioRuntime,

--- a/openraft/src/raft/message/client_write.rs
+++ b/openraft/src/raft/message/client_write.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::fmt::Debug;
 
+use openraft_macros::since;
+
 use crate::display_ext::DisplayOptionExt;
 use crate::error::ClientWriteError;
 use crate::LogId;
@@ -32,6 +34,7 @@ where C: RaftTypeConfig
 {
     /// Create a new instance of `ClientWriteResponse`.
     #[allow(dead_code)]
+    #[since(version = "0.10.0")]
     pub(crate) fn new_app_response(log_id: LogId<C::NodeId>, data: C::R) -> Self {
         Self {
             log_id,
@@ -40,15 +43,18 @@ where C: RaftTypeConfig
         }
     }
 
+    #[since(version = "0.10.0")]
     pub fn log_id(&self) -> &LogId<C::NodeId> {
         &self.log_id
     }
 
+    #[since(version = "0.10.0")]
     pub fn response(&self) -> &C::R {
         &self.data
     }
 
     /// Return membership config if the log entry is a change-membership entry.
+    #[since(version = "0.10.0")]
     pub fn membership(&self) -> &Option<Membership<C>> {
         &self.membership
     }

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -102,24 +102,20 @@ use crate::Vote;
 ///        Node         = openraft::BasicNode,
 ///        Entry        = openraft::Entry<TypeConfig>,
 ///        SnapshotData = Cursor<Vec<u8>>,
-///        AsyncRuntime = openraft::TokioRuntime,
 ///        Responder    = openraft::impls::OneshotResponder<TypeConfig>,
+///        AsyncRuntime = openraft::TokioRuntime,
 /// );
 /// ```
 ///
-/// **The types must be specified in the exact order**:
-/// `D`, `R`, `NodeId`, `Node`, `Entry`, `SnapshotData`, `AsyncRuntime`, `Responder`
-///
-/// Types can be omitted, in which case the default type will be used.
-/// The default values for each type are:
+/// Types can be omitted, and the following default type will be used:
 /// - `D`:            `String`
 /// - `R`:            `String`
 /// - `NodeId`:       `u64`
 /// - `Node`:         `::openraft::impls::BasicNode`
 /// - `Entry`:        `::openraft::impls::Entry<Self>`
 /// - `SnapshotData`: `Cursor<Vec<u8>>`
-/// - `AsyncRuntime`: `::openraft::impls::TokioRuntime`
 /// - `Responder`:    `::openraft::impls::OneshotResponder<Self>`
+/// - `AsyncRuntime`: `::openraft::impls::TokioRuntime`
 ///
 /// For example, to declare with only `D` and `R` types:
 /// ```ignore
@@ -150,111 +146,26 @@ macro_rules! declare_raft_types {
         $visibility struct $id {}
 
         impl $crate::RaftTypeConfig for $id {
-            $crate::declare_raft_types!(@F_0, $($(#[$inner])* $type_id = $type,)* @T);
+            // `expand!(KEYED, ...)` ignores the duplicates.
+            // Thus by appending default types after user defined types,
+            // the absent user defined types are filled with default types.
+            $crate::openraft_macros::expand!(
+                KEYED,
+                (T, ATTR, V) => {ATTR type T = V;},
+                $(($type_id, $(#[$inner])*, $type),)*
+
+                // Default types:
+                (D            , , String                                ),
+                (R            , , String                                ),
+                (NodeId       , , u64                                   ),
+                (Node         , , $crate::impls::BasicNode              ),
+                (Entry        , , $crate::impls::Entry<Self>            ),
+                (SnapshotData , , Cursor<Vec<u8>>                       ),
+                (Responder    , , $crate::impls::OneshotResponder<Self> ),
+                (AsyncRuntime , , $crate::impls::TokioRuntime           ),
+            );
+
         }
-    };
-
-    // Add explicit type D
-    (@F_0, $(#[$meta:meta])* D=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type D = $t;
-        $crate::declare_raft_types!(@F_1, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    // Add default type D
-    (@F_0, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type D = String;
-        $crate::declare_raft_types!(@F_1, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_1, $(#[$meta:meta])* R=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type R = $t;
-        $crate::declare_raft_types!(@F_2, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_1, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type R = String;
-        $crate::declare_raft_types!(@F_2, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_2, $(#[$meta:meta])* NodeId=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type NodeId = $t;
-        $crate::declare_raft_types!(@F_3, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_2, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type NodeId = u64;
-        $crate::declare_raft_types!(@F_3, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_3, $(#[$meta:meta])* Node=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type Node = $t;
-        $crate::declare_raft_types!(@F_4, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_3, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type Node = $crate::impls::BasicNode;
-        $crate::declare_raft_types!(@F_4, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_4, $(#[$meta:meta])* Entry=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type Entry = $t;
-        $crate::declare_raft_types!(@F_5, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_4, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type Entry = $crate::impls::Entry<Self>;
-        $crate::declare_raft_types!(@F_5, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_5, $(#[$meta:meta])* SnapshotData=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type SnapshotData = $t;
-        $crate::declare_raft_types!(@F_6, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_5, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type SnapshotData = Cursor<Vec<u8>>;
-        $crate::declare_raft_types!(@F_6, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_6, $(#[$meta:meta])* AsyncRuntime=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type AsyncRuntime = $t;
-        $crate::declare_raft_types!(@F_7, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_6, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type AsyncRuntime = $crate::impls::TokioRuntime;
-        $crate::declare_raft_types!(@F_7, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_7, $(#[$meta:meta])* Responder=$t:ty, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        $(#[$meta])*
-        type Responder = $t;
-        $crate::declare_raft_types!(@F_8, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_7, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T) => {
-        type Responder = $crate::impls::OneshotResponder<Self>;
-        $crate::declare_raft_types!(@F_8, $($(#[$inner])* $type_id = $type,)* @T);
-    };
-
-    (@F_8, @T ) => {};
-
-    // Match any non-captured items to raise compile error
-    (@F_8, $($(#[$inner:meta])* $type_id:ident = $type:ty,)* @T ) => {
-        compile_error!(
-            stringify!(
-                Type not in its expected position:
-                $($type_id=$type,)*
-                types must present in this order:  D, R, NodeId, Node, Entry, SnapshotData, AsyncRuntime, Responder
-            )
-        );
     };
 }
 


### PR DESCRIPTION
## Changelog

##### Improve: `declare_raft_types` allows the types in any order

By rewriting the template expanding part with a `#[proc_macro]`
`expand!()` defined in `openraft_macros`, `declare_raft_types`
does not require the types in fixed order:

Example:

```
declare_raft_types!(All:
        D = (),
        NodeId = u64,
        R = (),
        Node = (),
```


##### Feature: Add macro `expand!()` to expand a template

`expand!()` renders a template with arguments multiple times.

### Example:

```rust,ignore
expand!(KEYED, // ignore duplicate by `K`
        (K, T, V) => {let K: T = V;},
        (a, u64, 1),
        (a, u32, 2), // duplicate `a` will be ignored
        (c, Vec<u8>, vec![1,2])
);
```

The above code will be transformed into:

```rust,ignore
let a: u64 = 1;
let c: Vec<u8> = vec![1, 2];
```


##### Feature: Add `#[since(version="1.0")]` to specify first version of a feature

`#[since(version = "1.0.0")]` adds a doc line `/// Since: Version(1.0.0)`.

Example:

```rust,ignore
/// Foo function
#[since(version = "1.0.0")]
fn foo() {}
```

The above code will be transformed into:

```rust,ignore
/// Foo function
///
/// Since: Version(1.0.0)
fn foo() {}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1101)
<!-- Reviewable:end -->
