### PR TITLE
Chore: refactor Inflight

### DIFF
--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -66,17 +66,10 @@ impl<NID: NodeId> Validate for Inflight<NID> {
 impl<NID: NodeId> Display for Inflight<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Inflight::None => {
-                write!(f, "None")
-            }
-            Inflight::Logs { id, log_id_range: l } => {
-                write!(f, "Logs(id={}):{}", id, l)
-            }
-            Inflight::Snapshot {
-                id,
-                last_log_id: last_next,
-            } => {
-                write!(f, "Snapshot(id={}):{}", id, last_next.display())
+            Inflight::None => write!(f, "None"),
+            Inflight::Logs { id, log_id_range: r } => write!(f, "Logs(id={}):{}", id, r),
+            Inflight::Snapshot { id, last_log_id } => {
+                write!(f, "Snapshot(id={}):{}", id, last_log_id.display())
             }
         }
     }

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -7,7 +7,7 @@ use maplit::btreemap;
 use crate::core::raft_msg::RaftMsg;
 use crate::error::ClientWriteError;
 use crate::error::RaftError;
-use crate::raft::message::WriteResult;
+use crate::raft::message::ClientWriteResult;
 use crate::raft::responder::OneshotResponder;
 use crate::raft::ClientWriteResponse;
 use crate::type_config::alias::OneshotReceiverOf;
@@ -168,7 +168,7 @@ where C: RaftTypeConfig<Responder = OneshotResponder<C>>
     }
 }
 
-fn oneshot_channel<C>() -> (OneshotResponder<C>, OneshotReceiverOf<C, WriteResult<C>>)
+fn oneshot_channel<C>() -> (OneshotResponder<C>, OneshotReceiverOf<C, ClientWriteResult<C>>)
 where C: RaftTypeConfig {
     let (tx, rx) = C::AsyncRuntime::oneshot();
 

--- a/openraft/src/raft/message/client_write.rs
+++ b/openraft/src/raft/message/client_write.rs
@@ -10,7 +10,7 @@ use crate::Membership;
 use crate::RaftTypeConfig;
 
 /// The result of a write request to Raft.
-pub type WriteResult<C> = Result<ClientWriteResponse<C>, ClientWriteError<C>>;
+pub type ClientWriteResult<C> = Result<ClientWriteResponse<C>, ClientWriteError<C>>;
 
 /// The response to a client-request.
 #[cfg_attr(

--- a/openraft/src/raft/message/mod.rs
+++ b/openraft/src/raft/message/mod.rs
@@ -12,7 +12,7 @@ mod client_write;
 pub use append_entries::AppendEntriesRequest;
 pub use append_entries::AppendEntriesResponse;
 pub use client_write::ClientWriteResponse;
-pub use client_write::WriteResult;
+pub use client_write::ClientWriteResult;
 pub use install_snapshot::InstallSnapshotRequest;
 pub use install_snapshot::InstallSnapshotResponse;
 pub use install_snapshot::SnapshotResponse;

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -25,12 +25,12 @@ use core_state::CoreState;
 pub use message::AppendEntriesRequest;
 pub use message::AppendEntriesResponse;
 pub use message::ClientWriteResponse;
+pub use message::ClientWriteResult;
 pub use message::InstallSnapshotRequest;
 pub use message::InstallSnapshotResponse;
 pub use message::SnapshotResponse;
 pub use message::VoteRequest;
 pub use message::VoteResponse;
-pub use message::WriteResult;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
@@ -597,12 +597,12 @@ where C: RaftTypeConfig
         app_data: C::D,
     ) -> Result<ClientWriteResponse<C>, RaftError<C, ClientWriteError<C>>>
     where
-        ResponderReceiverOf<C>: Future<Output = Result<WriteResult<C>, E>>,
+        ResponderReceiverOf<C>: Future<Output = Result<ClientWriteResult<C>, E>>,
         E: Error + OptionalSend,
     {
         let rx = self.client_write_ff(app_data).await?;
 
-        let res: WriteResult<C> = self.inner.recv_msg(rx).await?;
+        let res: ClientWriteResult<C> = self.inner.recv_msg(rx).await?;
 
         let client_write_response = res.map_err(|e| RaftError::APIError(e))?;
         Ok(client_write_response)

--- a/openraft/src/raft/responder/impls.rs
+++ b/openraft/src/raft/responder/impls.rs
@@ -1,5 +1,5 @@
 use crate::async_runtime::AsyncOneshotSendExt;
-use crate::raft::message::WriteResult;
+use crate::raft::message::ClientWriteResult;
 use crate::raft::responder::Responder;
 use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::OneshotReceiverOf;
@@ -15,14 +15,14 @@ use crate::RaftTypeConfig;
 pub struct OneshotResponder<C>
 where C: RaftTypeConfig
 {
-    tx: OneshotSenderOf<C, WriteResult<C>>,
+    tx: OneshotSenderOf<C, ClientWriteResult<C>>,
 }
 
 impl<C> OneshotResponder<C>
 where C: RaftTypeConfig
 {
     /// Create a new instance from a [`AsyncRuntime::OneshotSender`].
-    pub fn new(tx: OneshotSenderOf<C, WriteResult<C>>) -> Self {
+    pub fn new(tx: OneshotSenderOf<C, ClientWriteResult<C>>) -> Self {
         Self { tx }
     }
 }
@@ -30,7 +30,7 @@ where C: RaftTypeConfig
 impl<C> Responder<C> for OneshotResponder<C>
 where C: RaftTypeConfig
 {
-    type Receiver = OneshotReceiverOf<C, WriteResult<C>>;
+    type Receiver = OneshotReceiverOf<C, ClientWriteResult<C>>;
 
     fn from_app_data(app_data: C::D) -> (C::D, Self, Self::Receiver)
     where Self: Sized {
@@ -38,7 +38,7 @@ where C: RaftTypeConfig
         (app_data, Self { tx }, rx)
     }
 
-    fn send(self, res: WriteResult<C>) {
+    fn send(self, res: ClientWriteResult<C>) {
         let res = self.tx.send(res);
 
         if res.is_ok() {

--- a/openraft/src/raft/responder/mod.rs
+++ b/openraft/src/raft/responder/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) mod impls;
 pub use impls::OneshotResponder;
 
-use crate::raft::message::WriteResult;
+use crate::raft::message::ClientWriteResult;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
 
@@ -12,7 +12,7 @@ use crate::RaftTypeConfig;
 ///
 /// It is created for each request [`AppData`], and is sent to `RaftCore`.
 /// Once the request is completed,
-/// the `RaftCore` send the result [`WriteResult`] via it.
+/// the `RaftCore` send the result [`ClientWriteResult`] via it.
 /// The implementation of the trait then forward the response to application.
 /// There could optionally be a receiver to wait for the response.
 ///
@@ -35,5 +35,5 @@ where C: RaftTypeConfig
     /// Send result when the request has been completed.
     ///
     /// This method is called by the `RaftCore` once the request has been applied to state machine.
-    fn send(self, result: WriteResult<C>);
+    fn send(self, result: ClientWriteResult<C>);
 }

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -79,7 +79,7 @@ pub trait RaftTypeConfig:
     /// some application defined channel.
     ///
     /// [`Raft::client_write`]: `crate::raft::Raft::client_write`
-    /// [`WriteResult`]: `crate::raft::message::WriteResult`
+    /// [`WriteResult`]: `crate::raft::message::ClientWriteResult`
     type Responder: Responder<Self>;
 }
 


### PR DESCRIPTION

## Changelog

##### Chore: refactor Inflight


##### Refactor: rename `WriteResult` to `ClientWriteResult`

`WriteResult` is public but is sealed behind a private mod,
thus this is not a breaking change.