### PR TITLE
Fix: Load mebmership since `last_applied`, not `last_membership.index` on startup

### DIFF
--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -189,11 +189,9 @@ where
     ///
     /// Thus a raft node will only need to store at most two recent membership logs.
     pub async fn get_membership(&mut self) -> Result<MembershipState<C>, StorageError<C::NodeId>> {
-        let (_, sm_mem) = self.state_machine.applied_state().await?;
+        let (last_applied, sm_mem) = self.state_machine.applied_state().await?;
 
-        let sm_mem_next_index = sm_mem.log_id().next_index();
-
-        let log_mem = self.last_membership_in_log(sm_mem_next_index).await?;
+        let log_mem = self.last_membership_in_log(last_applied.next_index()).await?;
         tracing::debug!(membership_in_sm=?sm_mem, membership_in_log=?log_mem, "{}", func_name!());
 
         // There 2 membership configs in logs.
@@ -231,6 +229,9 @@ where
         let st = self.log_store.get_log_state().await?;
 
         let mut end = st.last_log_id.next_index();
+
+        tracing::info!("load membership from log: [{}..{})", since_index, end);
+
         let start = std::cmp::max(st.last_purged_log_id.next_index(), since_index);
         let step = 64;
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### Fix: Load mebmership since `last_applied`, not `last_membership.index` on startup

Modify `StorageHelper::last_membership_in_log()` to scan the log
starting from the last applied index rather than the index of the last
applied membership log. This change reduces unnecessary I/O operations
during startup, previously caused by scanning from an incorrect starting
point.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1105)
<!-- Reviewable:end -->
