### PR TITLE
Fix: immediate response when snapshot installation is unnecessary

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -18,7 +18,6 @@ use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::handler::vote_handler::VoteHandler;
 use crate::engine::Command;
-use crate::engine::Condition;
 use crate::engine::EngineOutput;
 use crate::engine::Respond;
 use crate::entry::RaftPayload;
@@ -462,17 +461,16 @@ where C: RaftTypeConfig
         };
 
         let mut fh = self.following_handler();
-        fh.install_full_snapshot(snapshot);
+
+        // The condition to satisfy before running other command that depends on the snapshot.
+        // In this case, the response can only be sent when the snapshot is installed.
+        let cond = fh.install_full_snapshot(snapshot);
         let res = Ok(SnapshotResponse {
             vote: *self.state.vote_ref(),
         });
 
         self.output.push_command(Command::Respond {
-            // When there is an error, there may still be queued IO, we need to run them before sending back
-            // response.
-            when: Some(Condition::StateMachineCommand {
-                command_seq: self.output.last_sm_seq(),
-            }),
+            when: cond,
             resp: Respond::new(res, tx),
         });
     }

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -44,6 +44,7 @@ mod tests {
     mod handle_vote_req_test;
     mod handle_vote_resp_test;
     mod initialize_test;
+    mod install_full_snapshot_test;
     mod log_id_list_test;
     mod startup_test;
     mod trigger_purge_log_test;

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -1,0 +1,163 @@
+use std::io::Cursor;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::core::sm;
+use crate::engine::testing::UTConfig;
+use crate::engine::Command;
+use crate::engine::Condition;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::engine::Respond;
+use crate::raft::SnapshotResponse;
+use crate::testing::log_id;
+use crate::type_config::alias::AsyncRuntimeOf;
+use crate::AsyncRuntime;
+use crate::Membership;
+use crate::Snapshot;
+use crate::SnapshotMeta;
+use crate::StoredMembership;
+use crate::TokioInstant;
+use crate::Vote;
+
+fn m12() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2}], None)
+}
+
+fn m1234() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {1,2,3,4}], None)
+}
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(0);
+    eng.state.enable_validation(false); // Disable validation for incomplete state
+
+    eng.state.vote.update(TokioInstant::now(), Vote::new_committed(2, 1));
+    eng.state.committed = Some(log_id(4, 1, 5));
+    eng.state.log_ids = LogIdList::new(vec![
+        //
+        log_id(2, 1, 2),
+        log_id(3, 1, 5),
+        log_id(4, 1, 6),
+        log_id(4, 1, 8),
+    ]);
+    eng.state.snapshot_meta = SnapshotMeta {
+        last_log_id: Some(log_id(2, 1, 2)),
+        last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m12()),
+        snapshot_id: "1-2-3-4".to_string(),
+    };
+    eng.state.server_state = eng.calc_server_state();
+
+    eng
+}
+
+#[test]
+fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
+    // Snapshot will not be installed because new `last_log_id` is less or equal current
+    // `snapshot_meta.last_log_id`.
+    //
+    // It should respond at once.
+
+    let mut eng = eng();
+
+    let curr_vote = *eng.state.vote_ref();
+
+    let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+
+    eng.handle_install_full_snapshot(
+        curr_vote,
+        Snapshot {
+            meta: SnapshotMeta {
+                last_log_id: Some(log_id(1, 1, 2)),
+                last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
+                snapshot_id: "1-2-3-4".to_string(),
+            },
+            snapshot: Box::new(Cursor::new(vec![0u8])),
+        },
+        tx,
+    );
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(2, 1, 2)),
+            last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m12()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.state.snapshot_meta
+    );
+
+    let (dummy_tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    assert_eq!(
+        vec![
+            //
+            Command::Respond {
+                when: None,
+                resp: Respond::new(Ok(SnapshotResponse::new(curr_vote)), dummy_tx),
+            },
+        ],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
+    // Snapshot will be installed and there are no conflicting logs.
+    // The response should be sent after the snapshot is installed.
+
+    let mut eng = eng();
+
+    let curr_vote = *eng.state.vote_ref();
+
+    let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+
+    eng.handle_install_full_snapshot(
+        curr_vote,
+        Snapshot {
+            meta: SnapshotMeta {
+                last_log_id: Some(log_id(4, 1, 6)),
+                last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
+                snapshot_id: "1-2-3-4".to_string(),
+            },
+            snapshot: Box::new(Cursor::new(vec![0u8])),
+        },
+        tx,
+    );
+
+    assert_eq!(
+        SnapshotMeta {
+            last_log_id: Some(log_id(4, 1, 6)),
+            last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        eng.state.snapshot_meta
+    );
+
+    let (dummy_tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    assert_eq!(
+        vec![
+            //
+            Command::from(
+                sm::Command::install_full_snapshot(Snapshot {
+                    meta: SnapshotMeta {
+                        last_log_id: Some(log_id(4, 1, 6)),
+                        last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
+                        snapshot_id: "1-2-3-4".to_string(),
+                    },
+                    snapshot: Box::new(Cursor::new(vec![0u8])),
+                })
+                .with_seq(1)
+            ),
+            Command::PurgeLog { upto: log_id(4, 1, 6) },
+            Command::Respond {
+                when: Some(Condition::StateMachineCommand { command_seq: 1 }),
+                resp: Respond::new(Ok(SnapshotResponse::new(curr_vote)), dummy_tx),
+            },
+        ],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### Fix: immediate response when snapshot installation is unnecessary

When `Engine::handle_install_full_snapshot()` is called and the provided
snapshot is not up-to-date, the snapshot should not be installed, and
the response should be sent back immediately. Previously, the method
might delay the response unnecessarily, waiting for an installation
process that would not proceed.

This commit adjusts the logic so that if the snapshot is recognized as
outdated, it immediately returns a `None` `Condition`, ensuring the
caller is informed straightaway that no installation will occur.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1116)
<!-- Reviewable:end -->
