### PR TITLE
Improve: `cancel` passed to `full_snapshot()` should be `static`

### DIFF
--- a/examples/raft-kv-memstore-network-v2/src/network.rs
+++ b/examples/raft-kv-memstore-network-v2/src/network.rs
@@ -55,7 +55,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         &mut self,
         vote: Vote<NodeId>,
         snapshot: Snapshot<TypeConfig>,
-        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
     ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError<typ::Fatal>> {
         let resp = self

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
@@ -55,7 +55,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         &mut self,
         vote: Vote<NodeId>,
         snapshot: Snapshot<TypeConfig>,
-        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
     ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError<typ::Fatal>> {
         let resp = self

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -54,7 +54,7 @@ pub trait SnapshotTransport<C: RaftTypeConfig> {
         net: &mut Net,
         vote: Vote<C::NodeId>,
         snapshot: Snapshot<C>,
-        cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>
     where
@@ -103,7 +103,7 @@ where C::SnapshotData: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io:
         net: &mut Net,
         vote: Vote<C::NodeId>,
         mut snapshot: Snapshot<C>,
-        mut cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        mut cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>
     where

--- a/openraft/src/network/v2/adapt_v1.rs
+++ b/openraft/src/network/v2/adapt_v1.rs
@@ -45,7 +45,7 @@ where
         &mut self,
         vote: Vote<C::NodeId>,
         snapshot: Snapshot<C>,
-        cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>> {
         use crate::network::snapshot_transport::Chunked;

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -73,7 +73,7 @@ where C: RaftTypeConfig
         &mut self,
         vote: Vote<C::NodeId>,
         snapshot: Snapshot<C>,
-        cancel: impl Future<Output = ReplicationClosed> + OptionalSend,
+        cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>;
 


### PR DESCRIPTION

## Changelog

##### Improve: `cancel` passed to `full_snapshot()` should be `static`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1120)
<!-- Reviewable:end -->
