### PR TITLE
Avoid race conditions in `raft-kv-memstore` example

### DIFF
--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -22,6 +22,7 @@ pub mod app;
 pub mod client;
 pub mod network;
 pub mod store;
+#[cfg(test)] mod test;
 
 pub type NodeId = u64;
 

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -198,7 +198,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         let updated_state_machine = StateMachineData {
             last_applied_log: meta.last_log_id,
             last_membership: meta.last_membership.clone(),
-            data: updated_state_machine_data
+            data: updated_state_machine_data,
         };
         let mut state_machine = self.state_machine.write().await;
         *state_machine = updated_state_machine;

--- a/examples/raft-kv-memstore/src/test.rs
+++ b/examples/raft-kv-memstore/src/test.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+use openraft::testing::StoreBuilder;
+use openraft::testing::Suite;
+use openraft::StorageError;
+
+use crate::store::{LogStore, StateMachineStore};
+use crate::NodeId;
+use crate::TypeConfig;
+
+struct MemKVStoreBuilder {}
+
+impl StoreBuilder<TypeConfig, LogStore, Arc<StateMachineStore>, ()> for MemKVStoreBuilder {
+    async fn build(&self) -> Result<((), LogStore, Arc<StateMachineStore>), StorageError<NodeId>> {
+        Ok(((), LogStore::default(), Arc::default()))
+    }
+}
+
+#[test]
+pub fn test_mem_store() -> Result<(), StorageError<NodeId>> {
+    Suite::test_all(MemKVStoreBuilder {})?;
+    Ok(())
+}

--- a/examples/raft-kv-memstore/src/test.rs
+++ b/examples/raft-kv-memstore/src/test.rs
@@ -4,7 +4,8 @@ use openraft::testing::StoreBuilder;
 use openraft::testing::Suite;
 use openraft::StorageError;
 
-use crate::store::{LogStore, StateMachineStore};
+use crate::store::LogStore;
+use crate::store::StateMachineStore;
 use crate::NodeId;
 use crate::TypeConfig;
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -1139,7 +1139,7 @@ where
     /// Rudimentary test for snapshotting that builds a snapshot on one node and installs it on
     /// another
     pub async fn transfer_snapshot(builder: &B) -> Result<(), StorageError<C::NodeId>> {
-        // Create a snapshot on sm1, and install it on sm2
+        // Create a snapshot on sm_l, and install it on sm_f
         let (_g_l, _store_l, mut sm_l) = builder.build().await?;
         let (_g_f, _store_f, mut sm_f) = builder.build().await?;
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -116,8 +116,9 @@ where
         run_fut(run_test(builder, Self::apply_single))?;
         run_fut(run_test(builder, Self::apply_multiple))?;
 
-        // TODO(xp): test: finalized_snapshot, do_log_compaction, begin_receiving_snapshot,
-        // get_current_snapshot
+        run_fut(Self::transfer_snapshot(builder))?;
+
+        // TODO(xp): test: do_log_compaction
 
         Ok(())
     }
@@ -1132,6 +1133,62 @@ where
         assert_eq!(last_applied, Some(log_id_0(1, 1)),);
         assert_eq!(mem.membership(), &Membership::new(vec![btreeset! {1,2}], None));
 
+        Ok(())
+    }
+
+    /// Rudimentary test for snapshotting that builds a snapshot on one node and installs it on
+    /// another
+    pub async fn transfer_snapshot(builder: &B) -> Result<(), StorageError<C::NodeId>> {
+        // Create a snapshot on sm1, and install it on sm2
+        let (_g_l, _store_l, mut sm_l) = builder.build().await?;
+        let (_g_f, _store_f, mut sm_f) = builder.build().await?;
+
+        tracing::info!("--- make sure that initial snapshot is empty");
+        // Start with empty snapshot
+        assert!(sm_l.get_current_snapshot().await?.is_none(), "initialized snapshot");
+        assert!(sm_f.get_current_snapshot().await?.is_none(), "initialized snapshot");
+
+        // Add a few entries so we have state to snapshot
+        let snapshot_entries = vec![membership_ent_0::<C>(1, 2, btreeset! {1, 2, 3}), blank_ent_0::<C>(3, 3)];
+        sm_l.apply(snapshot_entries).await?;
+        let snapshot_last_log_id = Some(log_id_0(3, 3));
+        let snapshot_last_membership= StoredMembership::new(Some(log_id_0(1, 2)), Membership::new(vec![btreeset![1, 2, 3]], None));
+        let snapshot_applied_state = (
+            snapshot_last_log_id.clone(),
+            snapshot_last_membership.clone()
+        );
+
+        tracing::info!("--- build and get snapshot on leader state machine");
+        let ss1 = sm_l.get_snapshot_builder().await.build_snapshot().await?;
+        assert_eq!(
+            ss1.meta.last_log_id, snapshot_last_log_id,
+            "built snapshot has wrong last log id"
+        );
+        assert_eq!(
+            ss1.meta.last_membership, snapshot_last_membership,
+            "built snapshot has wrong last membership"
+        );
+        let ss1_cur = sm_l.get_current_snapshot().await?.expect("uninitialized snapshot");
+        assert_eq!(
+            ss1_cur.meta, ss1.meta,
+            "current snapshot metadata not updated correctly on leader sm"
+        );
+
+        tracing::info!("--- install snapshot on follower state machine");
+        let mut ss2_box = sm_f.begin_receiving_snapshot().await?;
+        *ss2_box = *ss1_cur.snapshot;
+
+        sm_f.install_snapshot(&ss1_cur.meta, ss2_box).await?;
+
+        tracing::info!("--- check correctness of installed snapshot");
+        // ... by requesting whole snapshot
+        let ss2 = sm_f.get_current_snapshot().await?.expect("uninitialized snapshot");
+        assert_eq!(
+            ss2.meta, ss1.meta,
+            "snapshot metadata not updated correctly on follower sm"
+        );
+        // ... by checking smstore state
+        assert_eq!(sm_f.applied_state().await?, snapshot_applied_state);
         Ok(())
     }
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -1152,11 +1152,9 @@ where
         let snapshot_entries = vec![membership_ent_0::<C>(1, 2, btreeset! {1, 2, 3}), blank_ent_0::<C>(3, 3)];
         sm_l.apply(snapshot_entries).await?;
         let snapshot_last_log_id = Some(log_id_0(3, 3));
-        let snapshot_last_membership= StoredMembership::new(Some(log_id_0(1, 2)), Membership::new(vec![btreeset![1, 2, 3]], None));
-        let snapshot_applied_state = (
-            snapshot_last_log_id.clone(),
-            snapshot_last_membership.clone()
-        );
+        let snapshot_last_membership =
+            StoredMembership::new(Some(log_id_0(1, 2)), Membership::new(vec![btreeset![1, 2, 3]], None));
+        let snapshot_applied_state = (snapshot_last_log_id.clone(), snapshot_last_membership.clone());
 
         tracing::info!("--- build and get snapshot on leader state machine");
         let ss1 = sm_l.get_snapshot_builder().await.build_snapshot().await?;

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -1154,7 +1154,7 @@ where
         let snapshot_last_log_id = Some(log_id_0(3, 3));
         let snapshot_last_membership =
             StoredMembership::new(Some(log_id_0(1, 2)), Membership::new(vec![btreeset![1, 2, 3]], None));
-        let snapshot_applied_state = (snapshot_last_log_id.clone(), snapshot_last_membership.clone());
+        let snapshot_applied_state = (snapshot_last_log_id, snapshot_last_membership.clone());
 
         tracing::info!("--- build and get snapshot on leader state machine");
         let ss1 = sm_l.get_snapshot_builder().await.build_snapshot().await?;


### PR DESCRIPTION
The `raft-kv-memstore` example made some inaccurate assumptions, which this PR aims to resolve by making locking more strict and thereby eliminating the following race conditions:

1. The fact that `build_snapshot` would not be invoked concurrently by the OpenRaft runtime is currently correct, but might not remain true in the future. If this were to happen in the future, this could constitute a race condition.
2. `build_snapshot` and `install_snapshot` might be invoked concurrently on a follower that has log compaction enabled. This could also constitute a race condition, even under the current runtime.

Also in this PR:
1. Wrote a test for snapshot transfer between state machine stores, since this was missing from the test suite and the PR alters the snapshotting logic
2. Use AtomicU64 rather than Mutex for `snapshot_idx`

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1121)
<!-- Reviewable:end -->
