### PR TITLE
Doc: Add link to `Raft::trigger()` for doc of `Trigger`, disable appearence order in doc page

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -116,6 +116,8 @@ features = [
 # "singlethreaded" makes `Raft<C>` a `!Send`, which confuses users.
 # all-features = true
 
+# Disabled appearance order. It produce multiple `Trait`, `Struct` sections in a doc page.
+#
 # Sort modules by appearance order for crate `docs`.
 # https://doc.rust-lang.org/rustdoc/unstable-features.html#--sort-modules-by-appearance-control-how-items-on-module-pages-are-sorted
-rustdoc-args = ["-Z", "unstable-options", "--sort-modules-by-appearance"]
+# rustdoc-args = ["-Z", "unstable-options", "--sort-modules-by-appearance"]

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -21,25 +21,38 @@ macro_rules! func_name {
         // nn.split("::").last().unwrap_or_default()
     }};
 }
+
 pub extern crate openraft_macros;
 
 mod change_members;
 mod config;
 mod core;
 mod defensive;
+mod display_ext;
+mod internal_server_state;
+mod leader;
 mod membership;
 mod node;
 mod progress;
 mod quorum;
 mod raft_types;
 mod replication;
+mod runtime;
 mod storage_error;
 mod summary;
+mod try_as_ref;
 mod vote;
 
-#[cfg(feature = "compat")] pub mod compat;
+pub(crate) mod engine;
+pub(crate) mod log_id_range;
+pub(crate) mod raft_state;
+pub(crate) mod timer;
+pub(crate) mod type_config;
+pub(crate) mod utime;
 
 pub mod async_runtime;
+#[cfg(feature = "compat")] pub mod compat;
+pub mod docs;
 pub mod entry;
 pub mod error;
 pub mod impls;
@@ -51,31 +64,11 @@ pub mod raft;
 pub mod storage;
 pub mod testing;
 
-pub(crate) mod engine;
-pub(crate) mod log_id_range;
-pub(crate) mod timer;
-pub(crate) mod type_config;
-pub(crate) mod utime;
-
-mod display_ext;
-
-pub mod docs;
-mod internal_server_state;
-mod leader;
-pub(crate) mod raft_state;
-mod runtime;
-mod try_as_ref;
-
 #[cfg(test)] mod feature_serde_test;
 
 pub use anyerror;
 pub use anyerror::AnyError;
-pub use network::RPCTypes;
-pub use network::RaftNetwork;
-pub use network::RaftNetworkFactory;
 pub use openraft_macros::add_async_trait;
-#[cfg(feature = "type-alias")] pub use type_config::alias;
-pub use type_config::RaftTypeConfig;
 
 pub use crate::async_runtime::AsyncRuntime;
 pub use crate::async_runtime::TokioRuntime;
@@ -96,6 +89,9 @@ pub use crate::membership::EffectiveMembership;
 pub use crate::membership::Membership;
 pub use crate::membership::StoredMembership;
 pub use crate::metrics::RaftMetrics;
+pub use crate::network::RPCTypes;
+pub use crate::network::RaftNetwork;
+pub use crate::network::RaftNetworkFactory;
 pub use crate::node::BasicNode;
 pub use crate::node::EmptyNode;
 pub use crate::node::Node;
@@ -120,6 +116,8 @@ pub use crate::storage_error::ToStorageResult;
 pub use crate::storage_error::Violation;
 pub use crate::summary::MessageSummary;
 pub use crate::try_as_ref::TryAsRef;
+#[cfg(feature = "type-alias")] pub use crate::type_config::alias;
+pub use crate::type_config::RaftTypeConfig;
 pub use crate::vote::CommittedLeaderId;
 pub use crate::vote::LeaderId;
 pub use crate::vote::Vote;

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -1,4 +1,12 @@
 //! Public Raft interface and data types.
+//!
+//! [`Raft`] serves as the primary interface to a Raft node,
+//! facilitating all interactions with the underlying RaftCore.
+//!
+//! While `RaftCore` operates as a singleton within an application, [`Raft`] instances are designed
+//! to be cheaply cloneable.
+//! This allows multiple components within the application that require interaction with `RaftCore`
+//! to efficiently share access.
 
 #[cfg(test)] mod declare_raft_types_test;
 mod external_request;

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -7,10 +7,22 @@ use crate::RaftTypeConfig;
 
 /// Trigger is an interface to trigger an action to RaftCore by external caller.
 ///
+/// It is create with [`Raft::trigger()`].
+///
 /// For example, to trigger an election at once, you can use the following code
 /// ```ignore
 /// raft.trigger().elect().await?;
 /// ```
+///
+/// Or to fire an heartbeat, building a snapshot, or purging logs:
+///
+/// ```ignore
+/// raft.trigger().heartbeat().await?;
+/// raft.trigger().snapshot().await?;
+/// raft.trigger().purge_log().await?;
+/// ```
+///
+/// [`Raft::trigger()`]: crate::Raft::trigger
 pub struct Trigger<'r, C>
 where C: RaftTypeConfig
 {

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -30,6 +30,11 @@ use crate::StorageError;
 use crate::StoredMembership;
 use crate::Vote;
 
+/// The metadata of a snapshot.
+///
+/// Including the last log id that included in this snapshot,
+/// the last membership included,
+/// and a snapshot id.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct SnapshotMeta<C>

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -77,6 +77,10 @@ pub trait RaftTypeConfig:
 
 #[allow(dead_code)]
 /// Type alias for types used in `RaftTypeConfig`.
+///
+/// Alias are enabled by feature flag [`type-alias`].
+///
+/// [`type-alias`]: crate::docs::feature_flags#feature-flag-type-alias
 pub mod alias {
     use crate::raft::responder::Responder;
     use crate::AsyncRuntime;

--- a/scripts/watch-doc.sh
+++ b/scripts/watch-doc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Appearence order is disabled
+# RUSTDOCFLAGS='-Z unstable-options --sort-modules-by-appearance' cargo watch -x 'doc --document-private-items --all --no-deps'
+
+if [ ".$1" = ".-p" ]; then
+    cargo watch -x 'doc --document-private-items --all --no-deps'
+else
+    cargo watch -x 'doc --all --no-deps'
+fi


### PR DESCRIPTION

## Changelog

##### Doc: Add link to `Raft::trigger()` for doc of `Trigger`, disable appearence order in doc page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1122)
<!-- Reviewable:end -->
