### PR TITLE
Chore: adjust the comment of VecProgress::update_with method

### DIFF
--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -250,7 +250,16 @@ where
     /// and avoids unnecessary sorting: progresses are kept in order and only values greater than
     /// committed need to sort.
     ///
-    /// E.g., given 3 ids with value `1,3,5`,
+    /// E.g., given 3 ids with value `1,3,5`, as shown in the figure below:
+    ///
+    /// ```text
+    /// a -----------+-------->
+    /// b -------+------------>
+    /// c ---+---------------->
+    /// ------------------------------
+    ///      1   3   5
+    /// ```
+    ///
     /// the committed is `3` and assumes a majority quorum set is used.
     /// Then:
     /// - update(a, 6): nothing to do: committed is still 3;
@@ -260,14 +269,6 @@ where
     /// - update(c, 3): nothing to do: committed is still 3;
     /// - update(c, 4): re-calc:       committed becomes 4;
     /// - update(c, 6): re-calc:       committed becomes 5;
-    ///
-    /// ```text
-    /// a -----------+-------->
-    /// b -------+------------>
-    /// c ---+---------------->
-    /// ------------------------------
-    ///      1   3   5
-    /// ```
     fn update_with<F>(&mut self, id: &ID, f: F) -> Result<&P, &P>
     where F: FnOnce(&mut V) {
         self.stat.update_count += 1;


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->


This PR only modifies the comment of the VecProgress::update_with method to make it easier to understand.

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1132)
<!-- Reviewable:end -->
