### PR TITLE
Feature: Add `RaftLogReader::limited_get_log_entries()`

### DIFF
--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -159,6 +159,23 @@ where C: RaftTypeConfig
     /// A log reader must also be able to read the last saved vote by [`RaftLogStorage::save_vote`],
     /// See: [log-stream](`crate::docs::protocol::replication::log_stream`)
     async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>>;
+
+    /// Returns log entries within range `[start, end)`, `end` is exclusive,
+    /// potentially limited by implementation-defined constraints.
+    ///
+    /// If the specified range is too large, the implementation may return only the first few log
+    /// entries to ensure the result is not excessively large.
+    ///
+    /// It must not return empty result if the input range is not empty.
+    ///
+    /// The default implementation just returns the full range of log entries.
+    async fn limited_get_log_entries(
+        &mut self,
+        start: u64,
+        end: u64,
+    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+        self.try_get_log_entries(start..end).await
+    }
 }
 
 /// A trait defining the interface for a Raft state machine snapshot subsystem.


### PR DESCRIPTION

## Changelog

##### Feature: Add `RaftLogReader::limited_get_log_entries()`

This commit adds the `RaftLogReader::limited_get_log_entries()` method,
which enables applications to fetch log entries that are equal to or
smaller than a specified range. This functionality is particularly
useful for customizing the size of AppendEntries requests at the storage
API level.

- Applications can now decide the number of log entries to return based
  on the input range. If the application determines that the requested
  log entries range is too large for a single RPC, it can opt to return
  only the first several requested log entries instead of the full
  range.

- The method provides a default implementation that delegates the
  operation to `RaftLogReader::try_get_log_entries`.

This enhancement allows for more flexible and efficient handling of log
entries, particularly in scenarios where network constraints or
performance considerations require smaller data transfers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1135)
<!-- Reviewable:end -->
