### PR TITLE
Change: `RaftNetworkV2` treat remote error as `Unreachable`

### DIFF
--- a/examples/raft-kv-memstore-network-v2/src/lib.rs
+++ b/examples/raft-kv-memstore-network-v2/src/lib.rs
@@ -48,8 +48,8 @@ pub mod typ {
     pub type Infallible = openraft::error::Infallible;
     pub type Fatal = openraft::error::Fatal<TypeConfig>;
     pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<TypeConfig, E>;
-    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<TypeConfig, RaftError<E>>;
-    pub type StreamingError<E> = openraft::error::StreamingError<TypeConfig, E>;
+    pub type RPCError = openraft::error::RPCError<TypeConfig>;
+    pub type StreamingError = openraft::error::StreamingError<TypeConfig>;
 
     pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 

--- a/examples/raft-kv-memstore-network-v2/src/network.rs
+++ b/examples/raft-kv-memstore-network-v2/src/network.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 
-use openraft::error::RemoteError;
 use openraft::error::ReplicationClosed;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
@@ -42,11 +41,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         req: AppendEntriesRequest<TypeConfig>,
         _option: RPCOption,
     ) -> Result<AppendEntriesResponse<TypeConfig>, typ::RPCError> {
-        let resp = self
-            .router
-            .send(self.target, "/raft/append", req)
-            .await
-            .map_err(|e| RemoteError::new(self.target, e))?;
+        let resp = self.router.send(self.target, "/raft/append", req).await?;
         Ok(resp)
     }
 
@@ -57,12 +52,8 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         snapshot: Snapshot<TypeConfig>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
-    ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError<typ::Fatal>> {
-        let resp = self
-            .router
-            .send::<_, _, typ::Infallible>(self.target, "/raft/snapshot", (vote, snapshot.meta, snapshot.snapshot))
-            .await
-            .map_err(|e| RemoteError::new(self.target, e.into_fatal().unwrap()))?;
+    ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError> {
+        let resp = self.router.send(self.target, "/raft/snapshot", (vote, snapshot.meta, snapshot.snapshot)).await?;
         Ok(resp)
     }
 
@@ -71,11 +62,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         req: VoteRequest<TypeConfig>,
         _option: RPCOption,
     ) -> Result<VoteResponse<TypeConfig>, typ::RPCError> {
-        let resp = self
-            .router
-            .send(self.target, "/raft/vote", req)
-            .await
-            .map_err(|e| RemoteError::new(self.target, e))?;
+        let resp = self.router.send(self.target, "/raft/vote", req).await?;
         Ok(resp)
     }
 }

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -47,8 +47,8 @@ pub mod typ {
     pub type Infallible = openraft::error::Infallible;
     pub type Fatal = openraft::error::Fatal<TypeConfig>;
     pub type RaftError<E = openraft::error::Infallible> = openraft::error::RaftError<TypeConfig, E>;
-    pub type RPCError<E = openraft::error::Infallible> = openraft::error::RPCError<TypeConfig, RaftError<E>>;
-    pub type StreamingError<E> = openraft::error::StreamingError<TypeConfig, E>;
+    pub type RPCError = openraft::error::RPCError<TypeConfig>;
+    pub type StreamingError = openraft::error::StreamingError<TypeConfig>;
 
     pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 
-use openraft::error::RemoteError;
 use openraft::error::ReplicationClosed;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
@@ -42,11 +41,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         req: AppendEntriesRequest<TypeConfig>,
         _option: RPCOption,
     ) -> Result<AppendEntriesResponse<TypeConfig>, typ::RPCError> {
-        let resp = self
-            .router
-            .send(self.target, "/raft/append", req)
-            .await
-            .map_err(|e| RemoteError::new(self.target, e))?;
+        let resp = self.router.send(self.target, "/raft/append", req).await?;
         Ok(resp)
     }
 
@@ -57,12 +52,8 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         snapshot: Snapshot<TypeConfig>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
-    ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError<typ::Fatal>> {
-        let resp = self
-            .router
-            .send::<_, _, typ::Infallible>(self.target, "/raft/snapshot", (vote, snapshot.meta, snapshot.snapshot))
-            .await
-            .map_err(|e| RemoteError::new(self.target, e.into_fatal().unwrap()))?;
+    ) -> Result<SnapshotResponse<TypeConfig>, typ::StreamingError> {
+        let resp = self.router.send(self.target, "/raft/snapshot", (vote, snapshot.meta, snapshot.snapshot)).await?;
         Ok(resp)
     }
 
@@ -71,11 +62,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
         req: VoteRequest<TypeConfig>,
         _option: RPCOption,
     ) -> Result<VoteResponse<TypeConfig>, typ::RPCError> {
-        let resp = self
-            .router
-            .send(self.target, "/raft/vote", req)
-            .await
-            .map_err(|e| RemoteError::new(self.target, e))?;
+        let resp = self.router.send(self.target, "/raft/vote", req).await?;
         Ok(resp)
     }
 }

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -1,5 +1,7 @@
 //! Error types exposed by this crate.
 
+pub mod decompose;
+pub mod into_ok;
 mod replication_closed;
 mod streaming_error;
 
@@ -236,7 +238,7 @@ where C: RaftTypeConfig
     StorageError(#[from] StorageError<C::NodeId>),
 
     #[error(transparent)]
-    RPCError(#[from] RPCError<C, RaftError<C, Infallible>>),
+    RPCError(#[from] RPCError<C>),
 }
 
 /// Error occurs when invoking a remote raft API.
@@ -250,7 +252,7 @@ where C: RaftTypeConfig
     serde(bound(serialize = "E: serde::Serialize")),
     serde(bound(deserialize = "E: for <'d> serde::Deserialize<'d>"))
 )]
-pub enum RPCError<C: RaftTypeConfig, E: Error> {
+pub enum RPCError<C: RaftTypeConfig, E: Error = Infallible> {
     #[error(transparent)]
     Timeout(#[from] Timeout<C>),
 

--- a/openraft/src/error/decompose.rs
+++ b/openraft/src/error/decompose.rs
@@ -1,0 +1,95 @@
+use std::error::Error;
+
+use crate::error::into_ok::into_ok;
+use crate::error::Fatal;
+use crate::error::Infallible;
+use crate::error::RPCError;
+use crate::error::RaftError;
+use crate::error::StreamingError;
+use crate::error::Unreachable;
+use crate::RaftTypeConfig;
+
+/// Simplifies error handling by extracting the inner error from a composite error.
+/// For example, converting `Result<R, CompositeError>`
+/// to `Result<Result<R, Self::InnerError>, OuterError>`,
+/// where `SomeCompositeError` is a composite of `Self::InnerError` and `OuterError`.
+pub trait DecomposeResult<C, R, OuterError>
+where C: RaftTypeConfig
+{
+    type InnerError;
+
+    fn decompose(self) -> Result<Result<R, Self::InnerError>, OuterError>;
+
+    /// Convert `Result<R, CompositeErr>`
+    /// to `Result<R, E>`,
+    /// if `Self::InnerError` is a infallible type.
+    fn decompose_infallible(self) -> Result<R, OuterError>
+    where
+        Self::InnerError: Into<Infallible>,
+        Self: Sized,
+    {
+        self.decompose().map(into_ok)
+    }
+}
+
+impl<C, R, E> DecomposeResult<C, R, RaftError<C>> for Result<R, RaftError<C, E>>
+where C: RaftTypeConfig
+{
+    type InnerError = E;
+
+    fn decompose(self) -> Result<Result<R, E>, RaftError<C>> {
+        match self {
+            Ok(r) => Ok(Ok(r)),
+            Err(e) => match e {
+                RaftError::APIError(e) => Ok(Err(e)),
+                RaftError::Fatal(e) => Err(RaftError::Fatal(e)),
+            },
+        }
+    }
+}
+
+impl<C, R, E> DecomposeResult<C, R, RPCError<C>> for Result<R, RPCError<C, RaftError<C, E>>>
+where
+    C: RaftTypeConfig,
+    E: Error,
+{
+    type InnerError = E;
+
+    /// `RaftError::Fatal` is considered as `RPCError::Unreachable`.
+    fn decompose(self) -> Result<Result<R, E>, RPCError<C>> {
+        match self {
+            Ok(r) => Ok(Ok(r)),
+            Err(e) => match e {
+                RPCError::Timeout(e) => Err(RPCError::Timeout(e)),
+                RPCError::Unreachable(e) => Err(RPCError::Unreachable(e)),
+                RPCError::PayloadTooLarge(e) => Err(RPCError::PayloadTooLarge(e)),
+                RPCError::Network(e) => Err(RPCError::Network(e)),
+                RPCError::RemoteError(e) => match e.source {
+                    RaftError::APIError(e) => Ok(Err(e)),
+                    RaftError::Fatal(e) => Err(RPCError::Unreachable(Unreachable::new(&e))),
+                },
+            },
+        }
+    }
+}
+
+impl<C, R> DecomposeResult<C, R, StreamingError<C>> for Result<R, StreamingError<C, Fatal<C>>>
+where C: RaftTypeConfig
+{
+    type InnerError = Infallible;
+
+    /// `Fatal` is considered as `RPCError::Unreachable`.
+    fn decompose(self) -> Result<Result<R, Self::InnerError>, StreamingError<C>> {
+        match self {
+            Ok(r) => Ok(Ok(r)),
+            Err(e) => match e {
+                StreamingError::Closed(e) => Err(StreamingError::Closed(e)),
+                StreamingError::StorageError(e) => Err(StreamingError::StorageError(e)),
+                StreamingError::Timeout(e) => Err(StreamingError::Timeout(e)),
+                StreamingError::Unreachable(e) => Err(StreamingError::Unreachable(e)),
+                StreamingError::Network(e) => Err(StreamingError::Network(e)),
+                StreamingError::RemoteError(e) => Err(StreamingError::Unreachable(Unreachable::new(&e.source))),
+            },
+        }
+    }
+}

--- a/openraft/src/error/into_ok.rs
+++ b/openraft/src/error/into_ok.rs
@@ -1,0 +1,23 @@
+use crate::error::Infallible;
+
+/// Trait to convert `Result<T, E>` to `T`, if `E` is a `never` type.
+pub(crate) trait UnwrapInfallible<T> {
+    fn into_ok(self) -> T;
+}
+
+impl<T, E> UnwrapInfallible<T> for Result<T, E>
+where E: Into<Infallible>
+{
+    fn into_ok(self) -> T {
+        match self {
+            Ok(t) => t,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+/// Convert `Result<T, E>` to `T`, if `E` is a `never` type.
+pub(crate) fn into_ok<T, E>(result: Result<T, E>) -> T
+where E: Into<Infallible> {
+    UnwrapInfallible::into_ok(result)
+}

--- a/openraft/src/error/streaming_error.rs
+++ b/openraft/src/error/streaming_error.rs
@@ -1,8 +1,9 @@
 use std::error::Error;
 
+use crate::error::Fatal;
+use crate::error::Infallible;
 use crate::error::NetworkError;
 use crate::error::RPCError;
-use crate::error::RaftError;
 use crate::error::RemoteError;
 use crate::error::ReplicationClosed;
 use crate::error::ReplicationError;
@@ -21,7 +22,7 @@ use crate::StorageError;
     serde(bound(serialize = "E: serde::Serialize")),
     serde(bound(deserialize = "E: for <'d> serde::Deserialize<'d>"))
 )]
-pub enum StreamingError<C: RaftTypeConfig, E: Error> {
+pub enum StreamingError<C: RaftTypeConfig, E: Error = Infallible> {
     /// The replication stream is closed intentionally.
     #[error(transparent)]
     Closed(#[from] ReplicationClosed),
@@ -47,12 +48,8 @@ pub enum StreamingError<C: RaftTypeConfig, E: Error> {
     RemoteError(#[from] RemoteError<C, E>),
 }
 
-impl<C: RaftTypeConfig, E> From<StreamingError<C, E>> for ReplicationError<C>
-where
-    E: Error,
-    RaftError<C>: From<E>,
-{
-    fn from(e: StreamingError<C, E>) -> Self {
+impl<C: RaftTypeConfig> From<StreamingError<C, Fatal<C>>> for ReplicationError<C> {
+    fn from(e: StreamingError<C, Fatal<C>>) -> Self {
         match e {
             StreamingError::Closed(e) => ReplicationError::Closed(e),
             StreamingError::StorageError(e) => ReplicationError::StorageError(e),
@@ -60,12 +57,23 @@ where
             StreamingError::Unreachable(e) => ReplicationError::RPCError(RPCError::Unreachable(e)),
             StreamingError::Network(e) => ReplicationError::RPCError(RPCError::Network(e)),
             StreamingError::RemoteError(e) => {
-                let remote_err = RemoteError {
-                    target: e.target,
-                    target_node: e.target_node,
-                    source: RaftError::from(e.source),
-                };
-                ReplicationError::RPCError(RPCError::RemoteError(remote_err))
+                // Fatal on remote error is considered as unreachable.
+                ReplicationError::RPCError(RPCError::Unreachable(Unreachable::new(&e.source)))
+            }
+        }
+    }
+}
+
+impl<C: RaftTypeConfig> From<StreamingError<C>> for ReplicationError<C> {
+    fn from(e: StreamingError<C>) -> Self {
+        match e {
+            StreamingError::Closed(e) => ReplicationError::Closed(e),
+            StreamingError::StorageError(e) => ReplicationError::StorageError(e),
+            StreamingError::Timeout(e) => ReplicationError::RPCError(RPCError::Timeout(e)),
+            StreamingError::Unreachable(e) => ReplicationError::RPCError(RPCError::Unreachable(e)),
+            StreamingError::Network(e) => ReplicationError::RPCError(RPCError::Network(e)),
+            StreamingError::RemoteError(_e) => {
+                unreachable!("Infallible error should not be converted to ReplicationError")
             }
         }
     }

--- a/openraft/src/network/v2/adapt_v1.rs
+++ b/openraft/src/network/v2/adapt_v1.rs
@@ -1,8 +1,7 @@
 use std::future::Future;
 
-use crate::error::Fatal;
+use crate::error::decompose::DecomposeResult;
 use crate::error::RPCError;
-use crate::error::RaftError;
 use crate::error::ReplicationClosed;
 use crate::error::StreamingError;
 use crate::network::v2::RaftNetworkV2;
@@ -29,16 +28,12 @@ where
         &mut self,
         rpc: AppendEntriesRequest<C>,
         option: RPCOption,
-    ) -> Result<AppendEntriesResponse<C>, RPCError<C, RaftError<C>>> {
-        RaftNetwork::<C>::append_entries(self, rpc, option).await
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C>> {
+        RaftNetwork::<C>::append_entries(self, rpc, option).await.decompose_infallible()
     }
 
-    async fn vote(
-        &mut self,
-        rpc: VoteRequest<C>,
-        option: RPCOption,
-    ) -> Result<VoteResponse<C>, RPCError<C, RaftError<C>>> {
-        RaftNetwork::<C>::vote(self, rpc, option).await
+    async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
+        RaftNetwork::<C>::vote(self, rpc, option).await.decompose_infallible()
     }
 
     async fn full_snapshot(
@@ -47,11 +42,11 @@ where
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,
-    ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>> {
+    ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
         use crate::network::snapshot_transport::Chunked;
         use crate::network::snapshot_transport::SnapshotTransport;
 
-        let resp = Chunked::send_snapshot(self, vote, snapshot, cancel, option).await?;
+        let resp = Chunked::send_snapshot(self, vote, snapshot, cancel, option).await.decompose_infallible()?;
         Ok(resp)
     }
 

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 
 use openraft_macros::add_async_trait;
 
-use crate::error::Fatal;
 use crate::error::RPCError;
-use crate::error::RaftError;
 use crate::error::ReplicationClosed;
 use crate::error::StreamingError;
 use crate::network::Backoff;
@@ -48,14 +46,10 @@ where C: RaftTypeConfig
         &mut self,
         rpc: AppendEntriesRequest<C>,
         option: RPCOption,
-    ) -> Result<AppendEntriesResponse<C>, RPCError<C, RaftError<C>>>;
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C>>;
 
     /// Send a RequestVote RPC to the target.
-    async fn vote(
-        &mut self,
-        rpc: VoteRequest<C>,
-        option: RPCOption,
-    ) -> Result<VoteResponse<C>, RPCError<C, RaftError<C>>>;
+    async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>>;
 
     /// Send a complete Snapshot to the target.
     ///
@@ -78,7 +72,7 @@ where C: RaftTypeConfig
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,
-    ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>;
+    ) -> Result<SnapshotResponse<C>, StreamingError<C>>;
 
     /// Build a backoff instance if the target node is temporarily(or permanently) unreachable.
     ///

--- a/openraft/src/replication/callbacks.rs
+++ b/openraft/src/replication/callbacks.rs
@@ -1,7 +1,6 @@
 //! Callbacks for ReplicationCore internal communication.
 use core::fmt;
 
-use crate::error::Fatal;
 use crate::error::StreamingError;
 use crate::raft::SnapshotResponse;
 use crate::type_config::alias::InstantOf;
@@ -23,14 +22,14 @@ pub(crate) struct SnapshotCallback<C: RaftTypeConfig> {
     pub(crate) snapshot_meta: SnapshotMeta<C>,
 
     /// The result of the snapshot replication.
-    pub(crate) result: Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>,
+    pub(crate) result: Result<SnapshotResponse<C>, StreamingError<C>>,
 }
 
 impl<C: RaftTypeConfig> SnapshotCallback<C> {
     pub(in crate::replication) fn new(
         start_time: InstantOf<C>,
         snapshot_meta: SnapshotMeta<C>,
-        result: Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>,
+        result: Result<SnapshotResponse<C>, StreamingError<C>>,
     ) -> Self {
         Self {
             start_time,

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -31,7 +31,6 @@ use crate::display_ext::DisplayOptionExt;
 use crate::error::HigherVote;
 use crate::error::PayloadTooLarge;
 use crate::error::RPCError;
-use crate::error::RaftError;
 use crate::error::ReplicationClosed;
 use crate::error::ReplicationError;
 use crate::error::Timeout;
@@ -495,7 +494,7 @@ where
 
     /// Send the error result to RaftCore.
     /// RaftCore will then submit another replication command.
-    fn send_progress_error(&mut self, request_id: RequestId, err: RPCError<C, RaftError<C>>) {
+    fn send_progress_error(&mut self, request_id: RequestId, err: RPCError<C>) {
         let _ = self.tx_raft_core.send(Notify::Network {
             response: Response::Progress {
                 target: self.target,

--- a/openraft/src/replication/request.rs
+++ b/openraft/src/replication/request.rs
@@ -44,7 +44,6 @@ impl<C: RaftTypeConfig> fmt::Display for Replicate<C> {
 }
 
 use crate::display_ext::DisplayOptionExt;
-use crate::error::Fatal;
 use crate::error::StreamingError;
 use crate::log_id_range::LogIdRange;
 use crate::raft::SnapshotResponse;
@@ -134,7 +133,7 @@ where C: RaftTypeConfig
         request_id: RequestId,
         start_time: InstantOf<C>,
         snapshot_meta: SnapshotMeta<C>,
-        result: Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>,
+        result: Result<SnapshotResponse<C>, StreamingError<C>>,
     ) -> Self {
         Self::SnapshotCallback(DataWithId::new(
             request_id,


### PR DESCRIPTION

## Changelog

##### Change: `RaftNetworkV2` treat remote error as `Unreachable`

This commit updates `RaftNetworkV2` to treat any remote errors occurring
during RPC, like a `Fatal` error, as an `Unreachable` error. This is due
to Openraft's current inability to distinguish between an unreachable
node and a broken node.

Other changes:

- **Helper trait `DecomposeResult`:** Introduced to simplify handling
  composite errors. It converts a result of the
  form `Result<R, ErrorAOrB>`
  into a nested result `Result<Result<R, ErrorA>, ErrorB>`.

Upgrade tip:

- Implementations of `RaftNetworkV2` or `RaftNetwork` should now convert
  remote errors such as `Raft::Fatal` to `Unreachable` errors to
  maintain consistency in error handling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1137)
<!-- Reviewable:end -->
