### PR TITLE
Chore: extend sleep time for rafk-kv-rocksdb example

### DIFF
--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -122,7 +122,8 @@ where
     management::rest(&mut app);
     api::rest(&mut app);
 
-    app.listen(http_addr).await?;
+    app.listen(http_addr.clone()).await?;
+    tracing::info!("App Server listening on: {}", http_addr);
     _ = handle.await;
     Ok(())
 }

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -96,7 +96,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Wait for server to start up.
-    tokio::time::sleep(Duration::from_millis(1_000)).await;
+    tokio::time::sleep(Duration::from_millis(3_000)).await;
 
     // --- Create a client to the first node, as a control handle to the cluster.
 


### PR DESCRIPTION

## Changelog

##### Chore: extend sleep time for rafk-kv-rocksdb example

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1138)
<!-- Reviewable:end -->
