### PR TITLE
Refactor: Enhance Election and Replication

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -18,6 +18,7 @@ repository    = { workspace = true }
 anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
 byte-unit       = { workspace = true }
+chrono          = { workspace = true }
 clap            = { workspace = true }
 derive_more     = { workspace = true }
 futures         = { workspace = true }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -36,6 +36,7 @@ use crate::core::sm;
 use crate::core::sm::handle;
 use crate::core::sm::CommandSeq;
 use crate::core::ServerState;
+use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOption;
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySlice;
@@ -72,6 +73,7 @@ use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::ClientWriteResponse;
 use crate::raft::VoteRequest;
+use crate::raft::VoteResponse;
 use crate::raft_state::LogIOId;
 use crate::raft_state::LogStateReader;
 use crate::replication;
@@ -137,11 +139,6 @@ impl<C: RaftTypeConfig> Debug for ApplyResult<C> {
 ///
 /// It is created when RaftCore enters leader state, and will be dropped when it quits leader state.
 pub(crate) struct LeaderData<C: RaftTypeConfig> {
-    /// A mapping of node IDs the replication state of the target node.
-    // TODO(xp): make it a field of RaftCore. it does not have to belong to leader.
-    //           It requires the Engine to emit correct add/remove replication commands
-    pub(super) replications: BTreeMap<C::NodeId, ReplicationHandle<C>>,
-
     /// The time to send next heartbeat.
     pub(crate) next_heartbeat: InstantOf<C>,
 }
@@ -149,7 +146,6 @@ pub(crate) struct LeaderData<C: RaftTypeConfig> {
 impl<C: RaftTypeConfig> LeaderData<C> {
     pub(crate) fn new() -> Self {
         Self {
-            replications: BTreeMap::new(),
             next_heartbeat: InstantOf::<C>::now(),
         }
     }
@@ -185,6 +181,9 @@ where
 
     /// Channels to send result back to client when logs are applied.
     pub(crate) client_resp_channels: BTreeMap<u64, ResponderOf<C>>,
+
+    /// A mapping of node IDs the replication state of the target node.
+    pub(crate) replications: BTreeMap<C::NodeId, ReplicationHandle<C>>,
 
     pub(crate) leader_data: Option<LeaderData<C>>,
 
@@ -313,7 +312,7 @@ where
         let mut pending = FuturesUnordered::new();
 
         let voter_progresses = {
-            let l = &self.engine.internal_server_state.leading().unwrap();
+            let l = &self.engine.leader.leader_ref().unwrap();
             l.progress.iter().filter(|(id, _v)| l.progress.is_voter(id) == Some(true))
         };
 
@@ -523,7 +522,7 @@ where
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn flush_metrics(&mut self) {
-        let leader_metrics = if let Some(leader) = self.engine.internal_server_state.leading() {
+        let leader_metrics = if let Some(leader) = self.engine.leader.leader_ref() {
             let prog = &leader.progress;
             Some(prog.iter().map(|(id, p)| (*id, *p.borrow())).collect())
         } else {
@@ -692,7 +691,7 @@ where
     /// from a quorum of followers, indicating its leadership is current and recognized.
     /// If the node is not a leader or no acknowledgment has been received, `None` is returned.
     fn last_quorum_acked_time(&mut self) -> Option<InstantOf<C>> {
-        let leading = self.engine.internal_server_state.leading_mut();
+        let leading = self.engine.leader.leader_mut();
         leading.and_then(|l| l.last_quorum_acked_time())
     }
 
@@ -821,7 +820,9 @@ where
         let network = self.network.new_client(target, target_node).await;
         let snapshot_network = self.network.new_client(target, target_node).await;
 
-        let session_id = ReplicationSessionId::new(*self.engine.state.vote_ref(), *membership_log_id);
+        let leader = self.engine.leader.leader_ref().unwrap();
+
+        let session_id = ReplicationSessionId::new(leader.vote, *membership_log_id);
 
         ReplicationCore::<C, N, LS>::spawn(
             target,
@@ -843,27 +844,23 @@ where
     pub async fn remove_all_replication(&mut self) {
         tracing::info!("remove all replication");
 
-        if let Some(l) = &mut self.leader_data {
-            let nodes = std::mem::take(&mut l.replications);
+        let nodes = std::mem::take(&mut self.replications);
 
-            tracing::debug!(
-                targets = debug(nodes.iter().map(|x| *x.0).collect::<Vec<_>>()),
-                "remove all targets from replication_metrics"
-            );
+        tracing::debug!(
+            targets = debug(nodes.iter().map(|x| *x.0).collect::<Vec<_>>()),
+            "remove all targets from replication_metrics"
+        );
 
-            for (target, s) in nodes {
-                let handle = s.join_handle;
+        for (target, s) in nodes {
+            let handle = s.join_handle;
 
-                // Drop sender to notify the task to shutdown
-                drop(s.tx_repl);
+            // Drop sender to notify the task to shutdown
+            drop(s.tx_repl);
 
-                tracing::debug!("joining removed replication: {}", target);
-                let _x = handle.await;
-                tracing::info!("Done joining removed replication : {}", target);
-            }
-        } else {
-            unreachable!("it has to be a leader!!!");
-        };
+            tracing::debug!("joining removed replication: {}", target);
+            let _x = handle.await;
+            tracing::info!("Done joining removed replication : {}", target);
+        }
     }
 
     /// Run as many commands as possible.
@@ -1141,7 +1138,7 @@ where
             RaftMsg::RequestVote { rpc, tx } => {
                 let now = InstantOf::<C>::now();
                 tracing::info!(
-                    now = debug(now),
+                    now = display(now.display()),
                     vote_request = display(&rpc),
                     "received RaftMsg::RequestVote: {}",
                     func_name!()
@@ -1224,18 +1221,18 @@ where
             Notify::VoteResponse {
                 target,
                 resp,
-                sender_vote: vote,
+                sender_vote,
             } => {
                 let now = InstantOf::<C>::now();
 
                 tracing::info!(
-                    now = debug(now),
+                    now = display(now.display()),
                     resp = display(&resp),
                     "received Notify::VoteResponse: {}",
                     func_name!()
                 );
 
-                if self.does_vote_match(&vote, "VoteResponse") {
+                if self.does_vote_match(&sender_vote, "VoteResponse") {
                     self.engine.handle_vote_resp(target, resp);
                 }
             }
@@ -1269,6 +1266,7 @@ where
 
                 // TODO: test: fixture: make isolated_nodes a single-way isolating.
 
+                // TODO: check if it is Leader with Engine
                 // Leader send heartbeat
                 let heartbeat_at = self.leader_data.as_ref().map(|x| x.next_heartbeat);
                 if let Some(t) = heartbeat_at {
@@ -1334,7 +1332,11 @@ where
                         return Err(Fatal::from(error));
                     }
 
-                    replication::Response::HigherVote { target, higher, vote } => {
+                    replication::Response::HigherVote {
+                        target,
+                        higher,
+                        sender_vote: vote,
+                    } => {
                         tracing::info!(
                             target = display(target),
                             higher_vote = display(&higher),
@@ -1493,30 +1495,40 @@ where
             "handle_replication_progress"
         );
 
+        #[allow(clippy::collapsible_if)]
         if tracing::enabled!(Level::DEBUG) {
-            if let Some(l) = &self.leader_data {
-                if !l.replications.contains_key(&target) {
-                    tracing::warn!("leader has removed target: {}", target);
-                };
-            } else {
-                // TODO: A leader may have stepped down.
-            }
+            if !self.replications.contains_key(&target) {
+                tracing::warn!("leader has removed target: {}", target);
+            };
         }
 
         // A leader may have stepped down.
-        if self.engine.internal_server_state.is_leading() {
+        if self.engine.leader.is_leader() {
             self.engine.replication_handler().update_progress(target, request_id, result);
         }
     }
 
     /// If a message is sent by a previous server state but is received by current server state,
     /// it is a stale message and should be just ignored.
-    fn does_vote_match(&self, vote: &Vote<C::NodeId>, msg: impl Display) -> bool {
-        if vote != self.engine.state.vote_ref() {
+    fn does_vote_match(&self, sender_vote: &Vote<C::NodeId>, msg: impl Display) -> bool {
+        // Get the current leading vote:
+        // - If input `sender_vote` is committed, it is sent by a Leader. Therefore we check against current
+        //   Leader's vote.
+        // - Otherwise, it is sent by a Candidate, we check against the current in progress voting state.
+        let my_vote = if sender_vote.is_committed() {
+            let l = self.engine.leader.leader_ref();
+            l.map(|x| x.vote)
+        } else {
+            // If it finished voting, Candidate's vote is None.
+            let candidate = self.engine.candidate_ref();
+            candidate.map(|x| *x.vote_ref())
+        };
+
+        if Some(*sender_vote) != my_vote {
             tracing::warn!(
-                "vote changed: msg sent by: {:?}; curr: {}; ignore when ({})",
-                vote,
-                self.engine.state.vote_ref(),
+                "A message will be ignored because vote changed: msg sent by vote: {}; current my vote: {}; when ({})",
+                sender_vote,
+                my_vote.display(),
                 msg
             );
             false
@@ -1531,7 +1543,7 @@ where
         session_id: &ReplicationSessionId<C::NodeId>,
         msg: impl Display + Copy,
     ) -> bool {
-        if !self.does_vote_match(&session_id.vote, msg) {
+        if !self.does_vote_match(session_id.vote_ref(), msg) {
             return false;
         }
 
@@ -1611,6 +1623,13 @@ where
             Command::SaveVote { vote } => {
                 self.log_store.save_vote(&vote).await?;
                 self.engine.state.io_state_mut().update_vote(vote);
+
+                let _ = self.tx_notify.send(Notify::VoteResponse {
+                    target: self.id,
+                    // last_log_id is not used when sending VoteRequest to local node
+                    resp: VoteResponse::new(vote, None),
+                    sender_vote: vote,
+                });
             }
             Command::PurgeLog { upto } => {
                 self.log_store.purge(upto).await?;
@@ -1643,12 +1662,8 @@ where
                 self.spawn_parallel_vote_requests(&vote_req).await;
             }
             Command::ReplicateCommitted { committed } => {
-                if let Some(l) = &self.leader_data {
-                    for node in l.replications.values() {
-                        let _ = node.tx_repl.send(Replicate::Committed(committed));
-                    }
-                } else {
-                    unreachable!("it has to be a leader!!!");
+                for node in self.replications.values() {
+                    let _ = node.tx_repl.send(Replicate::Committed(committed));
                 }
             }
             Command::Commit {
@@ -1660,25 +1675,21 @@ where
                 self.apply_to_state_machine(seq, already_committed.next_index(), upto.index).await?;
             }
             Command::Replicate { req, target } => {
-                if let Some(l) = &self.leader_data {
-                    let node = l.replications.get(&target).expect("replication to target node exists");
+                let node = self.replications.get(&target).expect("replication to target node exists");
 
-                    match req {
-                        Inflight::None => {
-                            let _ = node.tx_repl.send(Replicate::Heartbeat);
-                        }
-                        Inflight::Logs { id, log_id_range } => {
-                            let _ = node.tx_repl.send(Replicate::logs(RequestId::new_append_entries(id), log_id_range));
-                        }
-                        Inflight::Snapshot { id, last_log_id } => {
-                            // unwrap: The replication channel must not be dropped or it is a bug.
-                            node.tx_repl.send(Replicate::snapshot(RequestId::new_snapshot(id), last_log_id)).map_err(
-                                |_e| StorageIOError::read_snapshot(None, AnyError::error("replication channel closed")),
-                            )?;
-                        }
+                match req {
+                    Inflight::None => {
+                        let _ = node.tx_repl.send(Replicate::Heartbeat);
                     }
-                } else {
-                    unreachable!("it has to be a leader!!!");
+                    Inflight::Logs { id, log_id_range } => {
+                        let _ = node.tx_repl.send(Replicate::logs(RequestId::new_append_entries(id), log_id_range));
+                    }
+                    Inflight::Snapshot { id, last_log_id } => {
+                        // unwrap: The replication channel must not be dropped or it is a bug.
+                        node.tx_repl.send(Replicate::snapshot(RequestId::new_snapshot(id), last_log_id)).map_err(
+                            |_e| StorageIOError::read_snapshot(None, AnyError::error("replication channel closed")),
+                        )?;
+                    }
                 }
             }
             Command::RebuildReplicationStreams { targets } => {
@@ -1686,12 +1697,7 @@ where
 
                 for (target, matching) in targets.iter() {
                     let handle = self.spawn_replication_stream(*target, *matching).await;
-
-                    if let Some(l) = &mut self.leader_data {
-                        l.replications.insert(*target, handle);
-                    } else {
-                        unreachable!("it has to be a leader!!!");
-                    }
+                    self.replications.insert(*target, handle);
                 }
             }
             Command::StateMachine { command } => {

--- a/openraft/src/display_ext.rs
+++ b/openraft/src/display_ext.rs
@@ -2,6 +2,12 @@
 
 use std::fmt;
 
+use chrono::DateTime;
+use chrono::Local;
+use chrono::Utc;
+
+use crate::Instant;
+
 /// Implement `Display` for `Option<T>` if T is `Display`.
 ///
 /// It outputs a literal string `"None"` if it is None. Otherwise it invokes the Display
@@ -69,9 +75,103 @@ impl<'a, T: fmt::Display, const MAX: usize> fmt::Display for DisplaySlice<'a, T,
     }
 }
 
+pub(crate) trait DisplaySliceExt<'a, T: fmt::Display> {
+    fn display(&'a self) -> DisplaySlice<'a, T>;
+}
+
+impl<T> DisplaySliceExt<'_, T> for [T]
+where T: fmt::Display
+{
+    fn display(&self) -> DisplaySlice<T> {
+        DisplaySlice(self)
+    }
+}
+
+/// Display `Instant` in human readable format.
+pub(crate) struct DisplayInstant<'a, T, const SIMPLE: bool = true, const LOCAL: bool = true>(pub &'a T);
+
+impl<'a, T, const SIMPLE: bool, const LOCAL: bool> DisplayInstant<'a, T, SIMPLE, LOCAL> {
+    /// Display `Instant` in full format: with date and timezone: the format is
+    /// "%Y-%m-%dT%H:%M:%S%.6fZ%z"
+    #[allow(dead_code)]
+    pub fn full(self) -> DisplayInstant<'a, T, false, LOCAL> {
+        DisplayInstant(self.0)
+    }
+
+    /// Display `Instant` in simple format: without date and timezone: the format is "%H:%M:%S%.6f"
+    #[allow(dead_code)]
+    pub fn simple(self) -> DisplayInstant<'a, T, true, LOCAL> {
+        DisplayInstant(self.0)
+    }
+
+    /// Display `Instant` in local timezone.
+    #[allow(dead_code)]
+    pub fn local(self) -> DisplayInstant<'a, T, SIMPLE, true> {
+        DisplayInstant(self.0)
+    }
+
+    /// Display `Instant` in UTC timezone.
+    #[allow(dead_code)]
+    pub fn utc(self) -> DisplayInstant<'a, T, SIMPLE, false> {
+        DisplayInstant(self.0)
+    }
+}
+
+impl<'a, T, const SIMPLE: bool, const LOCAL: bool> fmt::Display for DisplayInstant<'a, T, SIMPLE, LOCAL>
+where T: Instant
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Convert Instant to SystemTime
+        let sys_t = {
+            let sys_now = std::time::SystemTime::now();
+            let now = T::now();
+
+            if &now >= self.0 {
+                let d = now - *self.0;
+                sys_now - d
+            } else {
+                let d = *self.0 - now;
+                sys_now + d
+            }
+        };
+
+        if LOCAL {
+            let datetime: DateTime<Local> = sys_t.into();
+
+            if SIMPLE {
+                write!(f, "{}", datetime.format("%H:%M:%S%.6f"))
+            } else {
+                write!(f, "{}", datetime.format("%Y-%m-%dT%H:%M:%S%.6fZ%z"))
+            }
+        } else {
+            let datetime: DateTime<Utc> = sys_t.into();
+
+            if SIMPLE {
+                write!(f, "{}", datetime.format("%H:%M:%S%.6f"))
+            } else {
+                write!(f, "{}", datetime.format("%Y-%m-%dT%H:%M:%S%.6fZ%z"))
+            }
+        }
+    }
+}
+
+pub(crate) trait DisplayInstantExt<'a, T> {
+    fn display(&'a self) -> DisplayInstant<'a, T, true>;
+}
+
+impl<T> DisplayInstantExt<'_, T> for T
+where T: Instant
+{
+    fn display(&self) -> DisplayInstant<T, true> {
+        DisplayInstant(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::display_ext::DisplayInstantExt;
     use crate::display_ext::DisplaySlice;
+    use crate::TokioInstant;
 
     #[test]
     fn test_display_slice() {
@@ -89,5 +189,18 @@ mod tests {
 
         let a = vec![1, 2, 3, 4, 5, 6, 7];
         assert_eq!("[1,..,7]", DisplaySlice::<_, 2>(&a).to_string());
+    }
+
+    /// Check the result by a human.
+    #[test]
+    fn test_display_instant() -> anyhow::Result<()> {
+        let now = TokioInstant::now();
+        println!("now: {}", now.display());
+        println!("now: {}", now.display().full());
+        println!("now: {}", now.display().full().simple());
+        println!("now: {}", now.display().utc());
+        println!("now: {}", now.display().utc().local());
+        println!("now: {}", now.display().utc().full());
+        Ok(())
     }
 }

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -6,9 +6,11 @@ use crate::core::raft_msg::AppendEntriesTx;
 use crate::core::raft_msg::ResultSender;
 use crate::core::sm;
 use crate::core::ServerState;
+use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySlice;
 use crate::engine::engine_config::EngineConfig;
+use crate::engine::handler::establish_handler::EstablishHandler;
 use crate::engine::handler::following_handler::FollowingHandler;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::handler::log_handler::LogHandler;
@@ -20,7 +22,6 @@ use crate::engine::handler::vote_handler::VoteHandler;
 use crate::engine::Command;
 use crate::engine::EngineOutput;
 use crate::engine::Respond;
-use crate::entry::RaftEntry;
 use crate::entry::RaftPayload;
 use crate::error::ForwardToLeader;
 use crate::error::Infallible;
@@ -29,6 +30,8 @@ use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::error::RejectAppendEntries;
 use crate::internal_server_state::InternalServerState;
+use crate::internal_server_state::LeaderQuorumSet;
+use crate::leader::voting::Voting;
 use crate::raft::responder::Responder;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::SnapshotResponse;
@@ -74,8 +77,10 @@ where C: RaftTypeConfig
     /// should be greater.
     pub(crate) seen_greater_log: bool,
 
-    /// The internal server state used by Engine.
-    pub(crate) internal_server_state: InternalServerState<C>,
+    /// The internal server state(Leader or following) used by Engine.
+    pub(crate) leader: InternalServerState<C>,
+
+    pub(crate) candidate: Option<Voting<C, LeaderQuorumSet<C::NodeId>>>,
 
     /// Output entry for the runtime.
     pub(crate) output: EngineOutput<C>,
@@ -89,9 +94,31 @@ where C: RaftTypeConfig
             config,
             state: Valid::new(init_state),
             seen_greater_log: false,
-            internal_server_state: InternalServerState::default(),
+            leader: InternalServerState::default(),
+            candidate: None,
             output: EngineOutput::new(4096),
         }
+    }
+
+    /// Create a new candidate state and return the mutable reference to it.
+    ///
+    /// The candidate `last_log_id` is initialized with the attributes of Acceptor part:
+    /// [`RaftState`]
+    pub(crate) fn new_candidate(&mut self, vote: Vote<C::NodeId>) -> &mut Voting<C, LeaderQuorumSet<C::NodeId>> {
+        let now = InstantOf::<C>::now();
+        let last_log_id = self.state.last_log_id().copied();
+
+        let membership = self.state.membership_state.effective().membership();
+
+        self.candidate = Some(Voting::new(
+            now,
+            vote,
+            last_log_id,
+            membership.to_quorum_set(),
+            membership.learner_ids(),
+        ));
+
+        self.candidate.as_mut().unwrap()
     }
 
     /// Create a default Engine for testing.
@@ -118,7 +145,6 @@ where C: RaftTypeConfig
             self.vote_handler().update_internal_server_state();
 
             let mut rh = self.replication_handler();
-            rh.rebuild_replication_streams();
 
             // Restore the progress about the local log
             rh.update_local_progress(rh.state.last_log_id().copied());
@@ -176,36 +202,31 @@ where C: RaftTypeConfig
     /// Start to elect this node as leader
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn elect(&mut self) {
-        let v = Vote::new(self.state.vote_ref().leader_id().term + 1, self.config.id);
-        tracing::info!(vote = display(&v), "{}", func_name!());
+        let new_vote = Vote::new(self.state.vote_ref().leader_id().term + 1, self.config.id);
 
+        let candidate = self.new_candidate(new_vote);
+
+        tracing::info!("{}, new candidate: {}", func_name!(), candidate);
+
+        let last_log_id = candidate.last_log_id().copied();
+
+        // Simulate sending RequestVote RPC to local node.
         // Safe unwrap(): it won't reject itself ˙–˙
-        self.vote_handler().update_vote(&v).unwrap();
-
-        // TODO: simplify voting initialization.
-        //       - update_vote() should be moved to after initialize_voting(), because it can be considered
-        //         as a local RPC
-
-        // Safe unwrap(): leading state is just created
-        let leading = self.internal_server_state.leading_mut().unwrap();
-        let voting = leading.initialize_voting(self.state.last_log_id().copied(), InstantOf::<C>::now());
-
-        let quorum_granted = voting.grant_by(&self.config.id);
-
-        // Fast-path: if there is only one voter in the cluster.
-
-        if quorum_granted {
-            self.establish_leader();
-            return;
-        }
-
-        // Slow-path: send vote request, let a quorum grant it.
+        self.vote_handler().update_vote(&new_vote).unwrap();
 
         self.output.push_command(Command::SendVote {
-            vote_req: VoteRequest::new(*self.state.vote_ref(), self.state.last_log_id().copied()),
+            vote_req: VoteRequest::new(new_vote, last_log_id),
         });
 
         self.server_state_handler().update_server_state_if_changed();
+    }
+
+    pub(crate) fn candidate_ref(&self) -> Option<&Voting<C, LeaderQuorumSet<C::NodeId>>> {
+        self.candidate.as_ref()
+    }
+
+    pub(crate) fn candidate_mut(&mut self) -> Option<&mut Voting<C, LeaderQuorumSet<C::NodeId>>> {
+        self.candidate.as_mut()
     }
 
     /// Get a LeaderHandler for handling leader's operation. If it is not a leader, it send back a
@@ -249,10 +270,10 @@ where C: RaftTypeConfig
             "Engine::handle_vote_req"
         );
         tracing::info!(
-            "now; {:?}, vote is updated at: {:?}, vote is updated before {:?}, leader lease({:?}) will expire after {:?}",
-            now,
-            vote_utime,
-            now- vote_utime,
+            "now; {}, vote is updated at: {}, vote is updated before {:?}, leader lease({:?}) will expire after {:?}",
+            now.display(),
+            vote_utime.display(),
+            now - vote_utime,
             lease,
             vote_utime + lease - now
         );
@@ -268,11 +289,7 @@ where C: RaftTypeConfig
                     vote_utime + lease - now
                 );
 
-                return VoteResponse {
-                    vote: *self.state.vote_ref(),
-                    vote_granted: false,
-                    last_log_id: self.state.last_log_id().copied(),
-                };
+                return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().copied());
             }
         }
 
@@ -288,13 +305,10 @@ where C: RaftTypeConfig
             );
             // The res is not used yet.
             // let _res = Err(RejectVoteRequest::ByLastLogId(self.state.last_log_id().copied()));
-            return VoteResponse {
-                // Return the updated vote, this way the candidate knows which vote is granted, in case
-                // the candidate's vote is changed after sending the vote request.
-                vote: *self.state.vote_ref(),
-                vote_granted: false,
-                last_log_id: self.state.last_log_id().copied(),
-            };
+
+            // Return the updated vote, this way the candidate knows which vote is granted, in case
+            // the candidate's vote is changed after sending the vote request.
+            return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().copied());
         }
 
         // Then check vote just as it does for every incoming event.
@@ -303,15 +317,9 @@ where C: RaftTypeConfig
 
         tracing::info!(req = display(&req), result = debug(&res), "handle vote request result");
 
-        let vote_granted = res.is_ok();
-
-        VoteResponse {
-            // Return the updated vote, this way the candidate knows which vote is granted, in case
-            // the candidate's vote is changed after sending the vote request.
-            vote: *self.state.vote_ref(),
-            vote_granted,
-            last_log_id: self.state.last_log_id().copied(),
-        }
+        // Return the updated vote, this way the candidate knows which vote is granted, in case
+        // the candidate's vote is changed after sending the vote request.
+        VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().copied())
     }
 
     #[tracing::instrument(level = "debug", skip(self, resp))]
@@ -325,21 +333,15 @@ where C: RaftTypeConfig
             func_name!()
         );
 
-        let voting = if let Some(voting) = self.internal_server_state.voting_mut() {
-            // TODO check the sending vote matches current vote
-            voting
-        } else {
-            // If this node is no longer a leader(i.e., electing) or candidate,
+        let Some(candidate) = self.candidate_mut() else {
+            // If the voting process has finished or canceled,
             // just ignore the delayed vote_resp.
             return;
         };
 
-        if &resp.vote < self.state.vote_ref() {
-            debug_assert!(!resp.vote_granted);
-        }
-
-        if resp.vote_granted {
-            let quorum_granted = voting.grant_by(&target);
+        // A vote request is granted iff the replied vote is the same as the requested vote.
+        if &resp.vote == candidate.vote_ref() {
+            let quorum_granted = candidate.grant_by(&target);
             if quorum_granted {
                 tracing::info!("a quorum granted my vote");
                 self.establish_leader();
@@ -347,9 +349,15 @@ where C: RaftTypeConfig
             return;
         }
 
-        // vote is rejected:
+        // TODO: resp.granted is never used.
 
-        debug_assert!(self.state.membership_state.effective().is_voter(&self.config.id));
+        // If not equal, vote is rejected:
+
+        // Note that it is still possible seeing a smaller vote:
+        // - The target has more logs than this node;
+        // - Or leader lease on remote node is not expired;
+        // - It is a delayed response of previous voting(resp.vote_granted could be true)
+        // In any case, no need to proceed.
 
         // If peer's vote is greater than current vote, revert to follower state.
         //
@@ -541,7 +549,7 @@ where C: RaftTypeConfig
             func_name!()
         );
 
-        if self.internal_server_state.is_leading() {
+        if self.leader.is_leader() {
             // If it is leading, it must not delete a log that is in use by a replication task.
             self.replication_handler().try_purge_log();
         } else {
@@ -601,58 +609,8 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     fn establish_leader(&mut self) {
         tracing::info!("{}", func_name!());
-
-        // Mark the vote as committed, i.e., being granted and saved by a quorum.
-        //
-        // The committed vote, is not necessary in original raft.
-        // Openraft insists doing this because:
-        // - Voting is not in the hot path, thus no performance penalty.
-        // - Leadership won't be lost if a leader restarted quick enough.
-        {
-            let leading = self.internal_server_state.leading_mut().unwrap();
-            let voting = leading.finish_voting();
-            let mut vote = *voting.vote_ref();
-
-            debug_assert!(!vote.is_committed());
-            debug_assert_eq!(
-                vote.leader_id().voted_for(),
-                Some(self.config.id),
-                "it can only commit its own vote"
-            );
-            vote.commit();
-
-            let _res = self.vote_handler().update_vote(&vote);
-            debug_assert!(_res.is_ok(), "commit vote can not fail but: {:?}", _res);
-        }
-
-        // Update the noop log index
-        {
-            let vote = *self.state.vote_ref();
-            let index = self.state.last_log_id().next_index();
-
-            let leading = self.internal_server_state.leading_mut().unwrap();
-
-            // TODO: in future the leader will be able to start another new election without quit leader.
-            debug_assert!(leading.noop_log_id.is_none());
-            leading.noop_log_id = Some(LogId::new(vote.committed_leader_id().unwrap(), index));
-        }
-
-        let mut rh = self.replication_handler();
-
-        // It has to setup replication stream first because append_blank_log() may update the
-        // committed-log-id(a single leader with several learners), in which case the
-        // committed-log-id will be at once submitted to replicate before replication stream
-        // is built.
-        //
-        // TODO: But replication streams should be built when a node enters leading state.
-        //       Thus append_blank_log() can be moved before rebuild_replication_streams()
-
-        rh.rebuild_replication_streams();
-
-        // Safe unwrap(): Leader is just established
-        self.leader_handler()
-            .unwrap()
-            .leader_append_entries(vec![C::Entry::new_blank(LogId::<C::NodeId>::default())]);
+        let candidate = self.candidate.take().unwrap();
+        self.establish_handler().establish(candidate);
     }
 
     /// Check if a raft node is in a state that allows to initialize.
@@ -716,10 +674,10 @@ where C: RaftTypeConfig
 
     pub(crate) fn vote_handler(&mut self) -> VoteHandler<C> {
         VoteHandler {
-            config: &self.config,
+            config: &mut self.config,
             state: &mut self.state,
             output: &mut self.output,
-            internal_server_state: &mut self.internal_server_state,
+            leader: &mut self.leader,
         }
     }
 
@@ -739,7 +697,7 @@ where C: RaftTypeConfig
     }
 
     pub(crate) fn leader_handler(&mut self) -> Result<LeaderHandler<C>, ForwardToLeader<C>> {
-        let leader = match self.internal_server_state.leading_mut() {
+        let leader = match self.leader.leader_mut() {
             None => {
                 tracing::debug!("this node is NOT a leader: {:?}", self.state.server_state);
                 return Err(self.state.forward_to_leader());
@@ -747,7 +705,12 @@ where C: RaftTypeConfig
             Some(x) => x,
         };
 
-        if !self.state.is_leader(&self.config.id) {
+        // This leader is not accepted by a quorum yet.
+        // Not a valid leader.
+        //
+        // Note that leading state is separated from local RaftState(which is used by the `Acceptor` part),
+        // and do not consider the vote in the local RaftState.
+        if !leader.vote.is_committed() {
             return Err(self.state.forward_to_leader());
         }
 
@@ -760,7 +723,7 @@ where C: RaftTypeConfig
     }
 
     pub(crate) fn replication_handler(&mut self) -> ReplicationHandler<C> {
-        let leader = match self.internal_server_state.leading_mut() {
+        let leader = match self.leader.leader_mut() {
             None => {
                 unreachable!("There is no leader, can not handle replication");
             }
@@ -776,7 +739,7 @@ where C: RaftTypeConfig
     }
 
     pub(crate) fn following_handler(&mut self) -> FollowingHandler<C> {
-        debug_assert!(self.internal_server_state.is_following());
+        debug_assert!(self.leader.is_following());
 
         FollowingHandler {
             config: &mut self.config,
@@ -790,6 +753,36 @@ where C: RaftTypeConfig
             config: &self.config,
             state: &mut self.state,
             output: &mut self.output,
+        }
+    }
+    pub(crate) fn establish_handler(&mut self) -> EstablishHandler<C> {
+        EstablishHandler {
+            config: &mut self.config,
+            leader: &mut self.leader,
+            state: &mut self.state,
+            output: &mut self.output,
+        }
+    }
+}
+
+/// Supporting utilities for unit test
+#[cfg(test)]
+mod engine_testing {
+    use crate::engine::Engine;
+    use crate::internal_server_state::InternalServerState;
+    use crate::internal_server_state::LeaderQuorumSet;
+    use crate::RaftTypeConfig;
+
+    impl<C> Engine<C>
+    where C: RaftTypeConfig
+    {
+        /// Create a Leader state just for testing purpose only,
+        /// without initializing related resource,
+        /// such as setting up replication, propose blank log.
+        pub(crate) fn testing_new_leader(&mut self) -> &mut crate::leader::Leader<C, LeaderQuorumSet<C::NodeId>> {
+            let leader = self.state.new_leader();
+            self.leader = InternalServerState::Leader(Box::new(leader));
+            self.leader.leader_mut().unwrap()
         }
     }
 }

--- a/openraft/src/engine/engine_output.rs
+++ b/openraft/src/engine/engine_output.rs
@@ -39,6 +39,8 @@ where C: RaftTypeConfig
 
     /// Push a command to the queue.
     pub(crate) fn push_command(&mut self, mut cmd: Command<C>) {
+        tracing::debug!("push command: {:?}", cmd);
+
         match &mut cmd {
             Command::StateMachine { command } => {
                 let seq = self.next_sm_seq();

--- a/openraft/src/engine/handler/establish_handler/mod.rs
+++ b/openraft/src/engine/handler/establish_handler/mod.rs
@@ -1,0 +1,93 @@
+use crate::engine::handler::leader_handler::LeaderHandler;
+use crate::engine::handler::replication_handler::ReplicationHandler;
+use crate::engine::handler::vote_handler::VoteHandler;
+use crate::engine::EngineConfig;
+use crate::engine::EngineOutput;
+use crate::entry::RaftEntry;
+use crate::internal_server_state::InternalServerState;
+use crate::internal_server_state::LeaderQuorumSet;
+use crate::leader::voting::Voting;
+use crate::LogId;
+use crate::RaftState;
+use crate::RaftTypeConfig;
+
+/// Establish a leader for the Engine, when Candidate finishes voting stage.
+pub(crate) struct EstablishHandler<'x, C>
+where C: RaftTypeConfig
+{
+    pub(crate) config: &'x mut EngineConfig<C>,
+    pub(crate) leader: &'x mut InternalServerState<C>,
+    pub(crate) state: &'x mut RaftState<C>,
+    pub(crate) output: &'x mut EngineOutput<C>,
+}
+
+impl<'x, C> EstablishHandler<'x, C>
+where C: RaftTypeConfig
+{
+    /// Consume the `candidate` state and establish a leader.
+    pub(crate) fn establish(&mut self, candidate: Voting<C, LeaderQuorumSet<C::NodeId>>) {
+        let vote = *candidate.vote_ref();
+
+        debug_assert_eq!(
+            vote.leader_id().voted_for(),
+            Some(self.config.id),
+            "it can only commit its own vote"
+        );
+
+        if let Some(l) = self.leader.leader_ref() {
+            #[allow(clippy::neg_cmp_op_on_partial_ord)]
+            if !(&vote > l.vote_ref()) {
+                tracing::warn!(
+                    "vote is not greater than current existing leader vote. Do not establish new leader and quit"
+                );
+                return;
+            }
+        }
+
+        let leader = candidate.into_leader();
+        let vote = *leader.vote_ref();
+        *self.leader = InternalServerState::Leader(Box::new(leader));
+
+        self.replication_handler().rebuild_replication_streams();
+
+        // Before sending any log, update the vote.
+        // This could not fail because `internal_server_state` will be cleared
+        // once `state.vote` is changed to a value of other node.
+        let _res = self.vote_handler().update_vote(&vote);
+        debug_assert!(_res.is_ok(), "commit vote can not fail but: {:?}", _res);
+
+        self.leader_handler()
+            .leader_append_entries(vec![C::Entry::new_blank(LogId::<C::NodeId>::default())]);
+    }
+
+    pub(crate) fn replication_handler(&mut self) -> ReplicationHandler<C> {
+        let leader = self.leader.leader_mut().unwrap();
+
+        ReplicationHandler {
+            config: self.config,
+            leader,
+            state: self.state,
+            output: self.output,
+        }
+    }
+
+    pub(crate) fn vote_handler(&mut self) -> VoteHandler<C> {
+        VoteHandler {
+            config: self.config,
+            state: self.state,
+            output: self.output,
+            leader: self.leader,
+        }
+    }
+
+    pub(crate) fn leader_handler(&mut self) -> LeaderHandler<C> {
+        let leader = self.leader.leader_mut().unwrap();
+
+        LeaderHandler {
+            config: self.config,
+            leader,
+            state: self.state,
+            output: self.output,
+        }
+    }
+}

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -54,6 +54,7 @@ fn eng() -> Engine<UTConfig> {
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),
     );
+    eng.testing_new_leader();
     eng.state.server_state = eng.calc_server_state();
 
     eng
@@ -62,7 +63,7 @@ fn eng() -> Engine<UTConfig> {
 #[test]
 fn test_leader_append_entries_empty() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.vote_handler().become_leading();
+    eng.output.take_commands();
 
     eng.leader_handler()?.leader_append_entries(Vec::<Entry<UTConfig>>::new());
 
@@ -81,7 +82,7 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
         ),
         eng.state.membership_state
     );
-    assert_eq!(0, eng.output.take_commands().len());
+    assert_eq!(eng.output.take_commands(), vec![]);
 
     Ok(())
 }
@@ -89,7 +90,7 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
 #[test]
 fn test_leader_append_entries_normal() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.vote_handler().become_leading();
+    eng.output.take_commands();
 
     // log id will be assigned by eng.
     eng.leader_handler()?.leader_append_entries(vec![
@@ -149,7 +150,7 @@ fn test_leader_append_entries_single_node_leader() -> anyhow::Result<()> {
     eng.state
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m1())));
-    eng.vote_handler().become_leading();
+    eng.testing_new_leader();
 
     eng.output.clear_commands();
 
@@ -199,7 +200,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
     eng.state
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m1())));
-    eng.vote_handler().become_leading();
+    eng.testing_new_leader();
     eng.state.server_state = eng.calc_server_state();
 
     eng.output.clear_commands();

--- a/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
+++ b/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
@@ -36,6 +36,7 @@ fn eng() -> Engine<UTConfig> {
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),
     );
+    eng.testing_new_leader();
     eng.state.server_state = eng.calc_server_state();
 
     eng
@@ -44,10 +45,9 @@ fn eng() -> Engine<UTConfig> {
 #[test]
 fn test_get_read_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.vote_handler().become_leading();
 
     eng.state.committed = Some(log_id(0, 1, 0));
-    eng.internal_server_state.leading_mut().unwrap().noop_log_id = Some(log_id(1, 1, 2));
+    eng.leader.leader_mut().unwrap().noop_log_id = Some(log_id(1, 1, 2));
 
     let got = eng.leader_handler()?.get_read_log_id();
     assert_eq!(Some(log_id(1, 1, 2)), got);

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -5,7 +5,7 @@ use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::entry::RaftPayload;
 use crate::internal_server_state::LeaderQuorumSet;
-use crate::leader::Leading;
+use crate::leader::Leader;
 use crate::raft_state::LogStateReader;
 use crate::type_config::alias::LogIdOf;
 use crate::RaftLogId;
@@ -25,7 +25,7 @@ pub(crate) struct LeaderHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C>,
-    pub(crate) leader: &'x mut Leading<C, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C::NodeId>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }
@@ -49,8 +49,7 @@ where C: RaftTypeConfig
             return;
         }
 
-        // Engine::leader_handler() ensures it is a valid leader.
-        self.leader.assign_log_ids(&mut entries).unwrap();
+        self.leader.assign_log_ids(&mut entries);
 
         self.state.extend_log_ids_from_same_leader(&entries);
 

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -39,6 +39,7 @@ fn eng() -> Engine<UTConfig> {
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),
     );
+    eng.testing_new_leader();
     eng.state.server_state = eng.calc_server_state();
 
     eng
@@ -47,7 +48,7 @@ fn eng() -> Engine<UTConfig> {
 #[test]
 fn test_leader_send_heartbeat() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.vote_handler().become_leading();
+    eng.output.take_commands();
 
     // A heartbeat is a normal AppendEntries RPC if there are pending data to send.
     {

--- a/openraft/src/engine/handler/mod.rs
+++ b/openraft/src/engine/handler/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod establish_handler;
 pub(crate) mod following_handler;
 pub(crate) mod leader_handler;
 pub(crate) mod log_handler;

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use maplit::btreeset;
+use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTConfig;
@@ -47,7 +48,7 @@ fn eng() -> Engine<UTConfig> {
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),
     );
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(2, 2));
+    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(6, 2));
     eng.state.server_state = eng.calc_server_state();
     eng
 }
@@ -56,7 +57,8 @@ fn eng() -> Engine<UTConfig> {
 fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
     let mut eng = eng();
     // Make it a real leader: voted for itself and vote is committed.
-    eng.vote_handler().become_leading();
+    eng.testing_new_leader();
+    eng.output.take_commands();
 
     eng.replication_handler().append_membership(&log_id(3, 1, 4), &m34());
 
@@ -85,7 +87,7 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
     );
 
     assert!(
-        eng.internal_server_state.leading().unwrap().progress.get(&4).matching.is_none(),
+        eng.leader.leader_ref().unwrap().progress.get(&4).matching.is_none(),
         "exists, but it is a None"
     );
 
@@ -110,9 +112,9 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23_45())));
 
     // Make it a real leader: voted for itself and vote is committed.
-    eng.vote_handler().become_leading();
+    eng.testing_new_leader();
 
-    if let Some(l) = &mut eng.internal_server_state.leading_mut() {
+    if let Some(l) = &mut eng.leader.leader_mut() {
         assert_eq!(&ProgressEntry::empty(11), l.progress.get(&4));
         assert_eq!(&ProgressEntry::empty(11), l.progress.get(&5));
 
@@ -141,7 +143,7 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
         eng.state.membership_state
     );
 
-    if let Some(l) = &mut eng.internal_server_state.leading_mut() {
+    if let Some(l) = &mut eng.leader.leader_mut() {
         assert_eq!(
             &ProgressEntry::new(Some(log_id(1, 1, 4)))
                 .with_inflight(Inflight::logs(Some(log_id(1, 1, 4)), Some(log_id(5, 1, 10))).with_id(1))

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -7,7 +7,7 @@ use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::internal_server_state::LeaderQuorumSet;
-use crate::leader::Leading;
+use crate::leader::Leader;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
@@ -38,7 +38,7 @@ pub(crate) struct ReplicationHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C>,
-    pub(crate) leader: &'x mut Leading<C, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C::NodeId>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -56,7 +56,8 @@ fn test_update_matching_no_leader() -> anyhow::Result<()> {
 #[test]
 fn test_update_matching() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.vote_handler().become_leading();
+    eng.testing_new_leader();
+    eng.output.take_commands();
 
     let mut rh = eng.replication_handler();
     let inflight_id_1 = {

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -25,11 +25,7 @@ fn m01() -> Membership<UTConfig> {
 
 /// Make a sample VoteResponse
 fn mk_res() -> Result<VoteResponse<UTConfig>, Infallible> {
-    Ok::<VoteResponse<UTConfig>, Infallible>(VoteResponse {
-        vote: Vote::new(2, 1),
-        vote_granted: false,
-        last_log_id: None,
-    })
+    Ok::<VoteResponse<UTConfig>, Infallible>(VoteResponse::new(Vote::new(2, 1), None))
 }
 
 fn eng() -> Engine<UTConfig> {
@@ -43,7 +39,6 @@ fn eng() -> Engine<UTConfig> {
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())));
 
-    eng.vote_handler().become_leading();
     eng
 }
 
@@ -51,6 +46,7 @@ fn eng() -> Engine<UTConfig> {
 fn test_accept_vote_reject_smaller_vote() -> anyhow::Result<()> {
     // When a vote is reject, it generate SendResultCommand and return an error.
     let mut eng = eng();
+    eng.output.take_commands();
 
     let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
     let resp = eng.vote_handler().accept_vote(&Vote::new(1, 2), tx, |_state, _err| mk_res());
@@ -76,6 +72,7 @@ fn test_accept_vote_reject_smaller_vote() -> anyhow::Result<()> {
 fn test_accept_vote_granted_greater_vote() -> anyhow::Result<()> {
     // When a vote is accepted, it generate SaveVote command and return an Ok.
     let mut eng = eng();
+    eng.output.take_commands();
 
     let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
     let resp = eng.vote_handler().accept_vote(&Vote::new(3, 3), tx, |_state, _err| mk_res());

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
+use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTConfig;
@@ -31,22 +32,24 @@ fn eng() -> Engine<UTConfig> {
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())));
 
-    eng.vote_handler().become_leading();
+    eng.output.take_commands();
     eng
 }
 
 #[test]
 fn test_handle_message_vote_reject_smaller_vote() -> anyhow::Result<()> {
     let mut eng = eng();
+    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(2, 1));
+    eng.testing_new_leader();
 
     let resp = eng.vote_handler().update_vote(&Vote::new(1, 2));
 
-    assert_eq!(Err(RejectVoteRequest::ByVote(Vote::new(2, 1))), resp);
+    assert_eq!(Err(RejectVoteRequest::ByVote(Vote::new_committed(2, 1))), resp);
 
-    assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_leading());
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
+    assert!(eng.leader.is_leader());
 
-    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_eq!(ServerState::Candidate, eng.state.server_state);
 
     assert_eq!(0, eng.output.take_commands().len());
 
@@ -64,7 +67,7 @@ fn test_handle_message_vote_committed_vote() -> anyhow::Result<()> {
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new_committed(3, 2), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_following());
+    assert!(eng.leader.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
 
@@ -93,7 +96,7 @@ fn test_handle_message_vote_granted_equal_vote() -> anyhow::Result<()> {
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_following());
+    assert!(eng.leader.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
 
@@ -116,7 +119,7 @@ fn test_handle_message_vote_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(Ok(()), resp);
 
     assert_eq!(Vote::new(3, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_following());
+    assert!(eng.leader.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -1,18 +1,21 @@
 use std::fmt::Debug;
 
 use crate::core::raft_msg::ResultSender;
+use crate::engine::handler::leader_handler::LeaderHandler;
+use crate::engine::handler::replication_handler::ReplicationHandler;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::engine::Respond;
 use crate::engine::ValueSender;
+use crate::entry::RaftEntry;
 use crate::error::RejectVoteRequest;
 use crate::internal_server_state::InternalServerState;
-use crate::leader::Leading;
 use crate::raft_state::LogStateReader;
 use crate::type_config::alias::InstantOf;
 use crate::Instant;
+use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftState;
 use crate::RaftTypeConfig;
@@ -28,10 +31,10 @@ use crate::Vote;
 pub(crate) struct VoteHandler<'st, C>
 where C: RaftTypeConfig
 {
-    pub(crate) config: &'st EngineConfig<C>,
+    pub(crate) config: &'st mut EngineConfig<C>,
     pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'st mut EngineOutput<C>,
-    pub(crate) internal_server_state: &'st mut InternalServerState<C>,
+    pub(crate) leader: &'st mut InternalServerState<C>,
 }
 
 impl<'st, C> VoteHandler<'st, C>
@@ -115,28 +118,45 @@ where C: RaftTypeConfig
         Ok(())
     }
 
-    /// Enter leading or following state by checking `vote`.
+    /// Update to Leader or following state depending on `Engine.state.vote`.
     pub(crate) fn update_internal_server_state(&mut self) {
-        if self.state.is_leading(&self.config.id) {
-            self.become_leading();
+        if self.state.is_leader(&self.config.id) {
+            self.become_leader();
+        } else if self.state.is_leading(&self.config.id) {
+            // candidate, nothing to do
         } else {
             self.become_following();
         }
     }
 
-    /// Enter leading state(vote.node_id == self.id) .
+    /// Enter Leader state(vote.node_id == self.id && vote.committed == true) .
     ///
-    /// Create a new leading state, when raft enters candidate state.
-    /// Leading state has two phase: election phase and replication phase, similar to paxos phase-1
-    /// and phase-2. Leader and Candidate shares the same state.
-    pub(crate) fn become_leading(&mut self) {
-        if let Some(l) = self.internal_server_state.leading_mut() {
+    /// Note that this is called when the Leader state changes caused by
+    /// the change of vote in the **Acceptor** part `engine.state.vote`.
+    /// This is **NOT** called when a node is elected as a leader.
+    ///
+    /// An example use of this mechanism is when node-a electing for node-b,
+    /// which can be used for Leader-a to transfer leadership to Follower-b.
+    pub(crate) fn become_leader(&mut self) {
+        tracing::debug!(
+            "become leader: node-{}, my vote: {}, last-log-id: {}",
+            self.config.id,
+            self.state.vote_ref(),
+            self.state.last_log_id().copied().unwrap_or_default()
+        );
+
+        if let Some(l) = self.leader.leader_mut() {
+            tracing::debug!("leading vote: {}", l.vote,);
+
             if l.vote.leader_id() == self.state.vote_ref().leader_id() {
                 tracing::debug!(
                     "vote still belongs to the same leader. Just updating vote is enough: node-{}, {}",
                     self.config.id,
                     self.state.vote_ref()
                 );
+                // TODO: this is not gonna happen,
+                //       because `self.leader`(previous `internal_server_state`)
+                //       does not include Candidate any more.
                 l.vote = *self.state.vote_ref();
                 self.server_state_handler().update_server_state_if_changed();
                 return;
@@ -146,19 +166,23 @@ where C: RaftTypeConfig
         // It's a different leader that creates this vote.
         // Re-create a new Leader instance.
 
-        let em = &self.state.membership_state.effective();
-        let leading = Leading::new(
-            *self.state.vote_ref(),
-            em.membership().to_quorum_set(),
-            em.learner_ids(),
-            self.state.last_log_id().copied(),
-        );
-
-        // Do not update clock_progress, until the first blank log is committed.
-
-        *self.internal_server_state = InternalServerState::Leading(Box::new(leading));
+        let leader = self.state.new_leader();
+        *self.leader = InternalServerState::Leader(Box::new(leader));
 
         self.server_state_handler().update_server_state_if_changed();
+
+        self.replication_handler().rebuild_replication_streams();
+
+        let leader = self.leader.leader_ref().unwrap();
+
+        // TODO: test building a Leader with proposed logs, check leader.noop_log_id, last_log_id
+        //       test restarted leader, no need to re-propose noop log
+
+        // If the leader has not yet proposed any log, propose a blank log
+        if leader.last_log_id() < leader.noop_log_id() {
+            self.leader_handler()
+                .leader_append_entries(vec![C::Entry::new_blank(LogId::<C::NodeId>::default())]);
+        }
     }
 
     /// Enter following state(vote.node_id != self.id or self is not a voter).
@@ -174,11 +198,11 @@ where C: RaftTypeConfig
             "It must hold: vote is not mine, or I am not a voter(leader just left the cluster)"
         );
 
-        if self.internal_server_state.is_following() {
-            return;
-        }
+        // if self.leader.is_following() {
+        //     return;
+        // }
 
-        *self.internal_server_state = InternalServerState::Following;
+        *self.leader = InternalServerState::Following;
 
         self.server_state_handler().update_server_state_if_changed();
     }
@@ -186,6 +210,28 @@ where C: RaftTypeConfig
     pub(crate) fn server_state_handler(&mut self) -> ServerStateHandler<C> {
         ServerStateHandler {
             config: self.config,
+            state: self.state,
+            output: self.output,
+        }
+    }
+
+    pub(crate) fn replication_handler(&mut self) -> ReplicationHandler<C> {
+        let leader = self.leader.leader_mut().unwrap();
+
+        ReplicationHandler {
+            config: self.config,
+            leader,
+            state: self.state,
+            output: self.output,
+        }
+    }
+
+    pub(crate) fn leader_handler(&mut self) -> LeaderHandler<C> {
+        let leader = self.leader.leader_mut().unwrap();
+
+        LeaderHandler {
+            config: self.config,
+            leader,
             state: self.state,
             output: self.output,
         }

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -83,7 +83,7 @@ fn test_append_entries_prev_log_id_is_applied() -> anyhow::Result<()> {
     // An applied log id has to be committed thus
     let mut eng = eng();
     eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(1, 2));
-    eng.vote_handler().become_leading();
+    eng.output.take_commands();
 
     let res = eng.append_entries(
         &Vote::new_committed(2, 1),
@@ -213,7 +213,7 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
 fn test_append_entries_prev_log_id_not_exists() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(1, 2));
-    eng.vote_handler().become_leading();
+    eng.output.take_commands();
 
     let res = eng.append_entries(&Vote::new_committed(2, 1), Some(log_id(2, 1, 4)), vec![
         blank_ent(2, 1, 5),

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
+use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
 use crate::engine::testing::UTConfig;
@@ -32,7 +33,8 @@ fn eng() -> Engine<UTConfig> {
     eng.state
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())));
-    eng.vote_handler().become_leading();
+    eng.new_candidate(*eng.state.vote_ref());
+    eng.output.take_commands();
 
     eng
 }
@@ -47,17 +49,11 @@ fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
         last_log_id: Some(log_id(2, 1, 3)),
     });
 
-    assert_eq!(
-        VoteResponse {
-            vote: Vote::new_committed(2, 1),
-            vote_granted: false,
-            last_log_id: None
-        },
-        resp
-    );
+    assert_eq!(VoteResponse::new(Vote::new_committed(2, 1), None), resp);
 
     assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_leading());
+    assert!(!eng.leader.is_leader());
+    assert_eq!(eng.candidate_ref().unwrap().vote_ref(), &Vote::new(2, 1));
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(0, eng.output.take_commands().len());
@@ -74,17 +70,11 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
         last_log_id: None,
     });
 
-    assert_eq!(
-        VoteResponse {
-            vote: Vote::new(2, 1),
-            vote_granted: false,
-            last_log_id: None
-        },
-        resp
-    );
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), None), resp);
 
     assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_leading());
+    assert!(!eng.leader.is_leader());
+    assert_eq!(eng.candidate_ref().unwrap().vote_ref(), &Vote::new(2, 1));
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(0, eng.output.take_commands().len());
@@ -102,17 +92,11 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
         last_log_id: Some(log_id(1, 1, 3)),
     });
 
-    assert_eq!(
-        VoteResponse {
-            vote: Vote::new(2, 1),
-            vote_granted: false,
-            last_log_id: Some(log_id(2, 1, 3))
-        },
-        resp
-    );
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3))), resp);
 
     assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_leading());
+    assert!(!eng.leader.is_leader());
+    assert_eq!(eng.candidate_ref().unwrap().vote_ref(), &Vote::new(2, 1));
 
     assert_eq!(ServerState::Candidate, eng.state.server_state);
     assert_eq!(0, eng.output.take_commands().len());
@@ -135,17 +119,10 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         last_log_id: Some(log_id(2, 1, 3)),
     });
 
-    assert_eq!(
-        VoteResponse {
-            vote: Vote::new(2, 1),
-            vote_granted: true,
-            last_log_id: Some(log_id(2, 1, 3))
-        },
-        resp
-    );
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3))), resp);
 
     assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_following());
+    assert!(eng.leader.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert!(eng.output.take_commands().is_empty());
@@ -168,18 +145,11 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
         last_log_id: Some(log_id(2, 1, 3)),
     });
 
-    assert_eq!(
-        VoteResponse {
-            // respond the updated vote.
-            vote: Vote::new(3, 1),
-            vote_granted: true,
-            last_log_id: Some(log_id(2, 1, 3))
-        },
-        resp
-    );
+    // respond the updated vote.
+    assert_eq!(VoteResponse::new(Vote::new(3, 1), Some(log_id(2, 1, 3))), resp);
 
     assert_eq!(Vote::new(3, 1), *eng.state.vote_ref());
-    assert!(eng.internal_server_state.is_following());
+    assert!(eng.leader.is_following());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -13,7 +13,6 @@ use crate::entry::RaftEntry;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft::VoteResponse;
-use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
 use crate::utime::UTime;
 use crate::CommittedLeaderId;
@@ -51,21 +50,17 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));
 
-        eng.handle_vote_resp(2, VoteResponse {
-            vote: Vote::new(2, 2),
-            vote_granted: true,
-            last_log_id: Some(log_id(2, 1, 2)),
-        });
+        eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 2), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-        assert!(eng.internal_server_state.is_following());
+        assert!(eng.leader.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
 
         assert_eq!(0, eng.output.take_commands().len());
     }
 
-    tracing::info!("--- recv a smaller vote. vote_granted==false; always keep trying in candidate state");
+    tracing::info!("--- recv a smaller vote; always keep trying in candidate state");
     {
         let mut eng = eng();
         eng.config.id = 1;
@@ -73,32 +68,26 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));
-        eng.vote_handler().become_leading();
+        eng.new_candidate(*eng.state.vote_ref());
+        eng.output.take_commands();
 
-        let last_log_id = eng.state.last_log_id().copied();
+        let voting = eng.new_candidate(*eng.state.vote_ref());
+        voting.grant_by(&1);
 
-        eng.internal_server_state.leading_mut().map(|l| {
-            l.initialize_voting(last_log_id, TokioInstant::now());
-            l.voting_mut().unwrap().grant_by(&1)
-        });
         eng.state.server_state = ServerState::Candidate;
 
-        eng.handle_vote_resp(2, VoteResponse {
-            vote: Vote::new(1, 1),
-            vote_granted: false,
-            last_log_id: Some(log_id(2, 1, 2)),
-        });
+        eng.handle_vote_resp(2, VoteResponse::new(Vote::new(1, 1), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-        assert_eq!(None, eng.internal_server_state.leading().unwrap().noop_log_id);
+        assert_eq!(&Vote::new(2, 1), eng.candidate_ref().unwrap().vote_ref());
         assert_eq!(
-            Some(btreeset! {1},),
-            eng.internal_server_state.leading().map(|x| x.voting().unwrap().granters().collect::<BTreeSet<_>>())
+            btreeset! {1},
+            eng.candidate_ref().unwrap().granters().collect::<BTreeSet<_>>()
         );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
 
-        assert!(eng.output.take_commands().is_empty());
+        assert_eq!(eng.output.take_commands(), vec![]);
     }
 
     // TODO: when seeing a higher vote, keep trying until a majority of higher votes are seen.
@@ -111,24 +100,18 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));
-        eng.vote_handler().become_leading();
+        eng.new_candidate(*eng.state.vote_ref());
+        eng.output.take_commands();
 
-        let last_log_id = eng.state.last_log_id().copied();
+        let voting = eng.new_candidate(*eng.state.vote_ref());
+        voting.grant_by(&1);
 
-        eng.internal_server_state.leading_mut().map(|l| {
-            l.initialize_voting(last_log_id, TokioInstant::now());
-            l.voting_mut().unwrap().grant_by(&1)
-        });
         eng.state.server_state = ServerState::Candidate;
 
-        eng.handle_vote_resp(2, VoteResponse {
-            vote: Vote::new(3, 2),
-            vote_granted: false,
-            last_log_id: Some(log_id(2, 1, 2)),
-        });
+        eng.handle_vote_resp(2, VoteResponse::new(Vote::new(3, 2), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new(3, 2), *eng.state.vote_ref());
-        assert!(eng.internal_server_state.is_following());
+        assert!(eng.leader.is_following());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
 
@@ -136,43 +119,6 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
             vec![Command::SaveVote { vote: Vote::new(3, 2) },],
             eng.output.take_commands()
         );
-    }
-
-    tracing::info!("--- equal vote, rejected by higher last_log_id. keep trying in candidate state");
-    {
-        let mut eng = eng();
-        eng.config.id = 1;
-        eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
-        eng.state
-            .membership_state
-            .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));
-        eng.vote_handler().become_leading();
-
-        let last_log_id = eng.state.last_log_id().copied();
-
-        eng.internal_server_state.leading_mut().map(|l| {
-            l.initialize_voting(last_log_id, TokioInstant::now());
-            l.voting_mut().unwrap().grant_by(&1)
-        });
-
-        eng.state.server_state = ServerState::Candidate;
-
-        eng.handle_vote_resp(2, VoteResponse {
-            vote: Vote::new(2, 1),
-            vote_granted: false,
-            last_log_id: Some(log_id(2, 1, 2)),
-        });
-
-        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-        assert_eq!(None, eng.internal_server_state.leading().unwrap().noop_log_id);
-        assert_eq!(
-            Some(btreeset! {1},),
-            eng.internal_server_state.leading().map(|x| x.voting().unwrap().granters().collect::<BTreeSet<_>>())
-        );
-
-        assert_eq!(ServerState::Candidate, eng.state.server_state);
-
-        assert!(eng.output.take_commands().is_empty());
     }
 
     tracing::info!("--- equal vote, granted, but not constitute a quorum. nothing to do");
@@ -183,35 +129,32 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m1234())));
-        eng.vote_handler().become_leading();
+        eng.new_candidate(*eng.state.vote_ref());
+        eng.output.take_commands();
 
-        let last_log_id = eng.state.last_log_id().copied();
-
-        eng.internal_server_state.leading_mut().map(|l| {
-            l.initialize_voting(last_log_id, TokioInstant::now());
-            l.voting_mut().unwrap().grant_by(&1)
-        });
+        let voting = eng.new_candidate(*eng.state.vote_ref());
+        voting.grant_by(&1);
 
         eng.state.server_state = ServerState::Candidate;
 
-        eng.handle_vote_resp(2, VoteResponse {
-            vote: Vote::new(2, 1),
-            vote_granted: true,
-            last_log_id: Some(log_id(2, 1, 2)),
-        });
+        eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
-        assert_eq!(None, eng.internal_server_state.leading().unwrap().noop_log_id);
+        assert_eq!(&Vote::new(2, 1), eng.candidate_ref().unwrap().vote_ref());
         assert_eq!(
-            Some(btreeset! {1,2},),
-            eng.internal_server_state.leading().map(|x| x.voting().unwrap().granters().collect::<BTreeSet<_>>())
+            btreeset! {1,2},
+            eng.candidate_ref().unwrap().granters().collect::<BTreeSet<_>>()
         );
 
         assert_eq!(ServerState::Candidate, eng.state.server_state);
 
-        assert_eq!(0, eng.output.take_commands().len());
+        assert_eq!(eng.output.take_commands(), vec![]);
     }
+    Ok(())
+}
 
+#[test]
+fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
     tracing::info!("--- equal vote, granted, constitute a quorum. become leader");
     {
         let mut eng = eng();
@@ -220,44 +163,33 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));
-        eng.vote_handler().become_leading();
+        eng.new_candidate(*eng.state.vote_ref());
 
-        let last_log_id = eng.state.last_log_id().copied();
-
-        eng.internal_server_state.leading_mut().map(|l| {
-            l.initialize_voting(last_log_id, TokioInstant::now());
-            l.voting_mut().unwrap().grant_by(&1)
-        });
+        let voting = eng.new_candidate(*eng.state.vote_ref());
+        voting.grant_by(&1);
 
         eng.state.server_state = ServerState::Candidate;
 
-        eng.handle_vote_resp(2, VoteResponse {
-            vote: Vote::new(2, 1),
-            vote_granted: true,
-            last_log_id: Some(log_id(2, 1, 2)),
-        });
+        eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 2))));
 
-        assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
-        assert_eq!(
-            Some(log_id(2, 1, 1)),
-            eng.internal_server_state.leading().unwrap().noop_log_id
-        );
+        assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref(),);
+        assert_eq!(Some(log_id(2, 1, 1)), eng.leader.leader_ref().unwrap().noop_log_id);
         assert!(
-            eng.internal_server_state.voting_mut().is_none(),
-            "voting state is removed when becoming leader"
+            eng.candidate_ref().is_none(),
+            "candidate state is removed when becoming leader"
         );
 
         assert_eq!(ServerState::Leader, eng.state.server_state);
 
         assert_eq!(
             vec![
+                Command::RebuildReplicationStreams {
+                    targets: vec![(2, ProgressEntry::empty(1))]
+                },
                 Command::SaveVote {
                     vote: Vote::new_committed(2, 1)
                 },
                 Command::BecomeLeader,
-                Command::RebuildReplicationStreams {
-                    targets: vec![(2, ProgressEntry::empty(1))]
-                },
                 Command::AppendInputEntries {
                     vote: Vote::new_committed(2, 1),
                     entries: vec![Entry::<UTConfig>::new_blank(log_id(2, 1, 1))],

--- a/openraft/src/engine/tests/trigger_purge_log_test.rs
+++ b/openraft/src/engine/tests/trigger_purge_log_test.rs
@@ -9,6 +9,7 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::progress::Progress;
 use crate::testing::log_id;
+use crate::utime::UTime;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
 use crate::LogId;
@@ -16,6 +17,8 @@ use crate::Membership;
 use crate::MembershipState;
 use crate::SnapshotMeta;
 use crate::StoredMembership;
+use crate::TokioInstant;
+use crate::Vote;
 
 fn m12() -> Membership<UTConfig> {
     Membership::<UTConfig>::new(vec![btreeset! {1,2}], None)
@@ -105,10 +108,11 @@ fn test_trigger_purge_log_in_used_wont_be_delete() -> anyhow::Result<()> {
     eng.state.purge_upto = Some(log_id(1, 0, 2));
     eng.state.io_state.purged = Some(log_id(1, 0, 2));
     eng.state.log_ids = LogIdList::new([log_id(1, 0, 2), log_id(1, 0, 10)]);
+    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(2, 1));
 
     // Make it a leader and mark the logs are in flight.
-    eng.vote_handler().become_leading();
-    let l = eng.internal_server_state.leading_mut().unwrap();
+    eng.testing_new_leader();
+    let l = eng.leader.leader_mut().unwrap();
     let _ = l.progress.get_mut(&2).unwrap().next_send(eng.state.deref(), 10).unwrap();
 
     eng.trigger_purge_log(5);

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -336,10 +336,10 @@ where
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-#[error("seen a higher vote: {higher} GT mine: {mine}")]
-pub struct HigherVote<C: RaftTypeConfig> {
-    pub higher: Vote<C::NodeId>,
-    pub mine: Vote<C::NodeId>,
+#[error("seen a higher vote: {higher} GT mine: {sender_vote}")]
+pub(crate) struct HigherVote<C: RaftTypeConfig> {
+    pub(crate) higher: Vote<C::NodeId>,
+    pub(crate) sender_vote: Vote<C::NodeId>,
 }
 
 /// Error that indicates a **temporary** network error and when it is returned, Openraft will retry

--- a/openraft/src/leader/mod.rs
+++ b/openraft/src/leader/mod.rs
@@ -1,4 +1,4 @@
 #[allow(clippy::module_inception)] mod leader;
 pub(crate) mod voting;
 
-pub(crate) use leader::Leading;
+pub(crate) use leader::Leader;

--- a/openraft/src/leader/voting.rs
+++ b/openraft/src/leader/voting.rs
@@ -1,11 +1,14 @@
 use std::fmt;
 
+use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
+use crate::leader::Leader;
 use crate::progress::Progress;
 use crate::progress::VecProgress;
 use crate::quorum::QuorumSet;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
+use crate::LogId;
 use crate::RaftTypeConfig;
 use crate::Vote;
 
@@ -27,6 +30,10 @@ where
 
     /// Which nodes have granted the the vote at certain time point.
     progress: VecProgress<C::NodeId, bool, bool, QS>,
+
+    quorum_set: QS,
+
+    learner_ids: Vec<C::NodeId>,
 }
 
 impl<C, QS> fmt::Display for Voting<C, QS>
@@ -37,9 +44,9 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{{{}@{:?}, last_log_id:{} progress:{}}}",
+            "{{{}@{}, last_log_id:{} progress:{}}}",
             self.vote,
-            self.starting_time,
+            self.starting_time.display(),
             self.last_log_id.display(),
             self.progress
         )
@@ -49,24 +56,31 @@ where
 impl<C, QS> Voting<C, QS>
 where
     C: RaftTypeConfig,
-    QS: QuorumSet<C::NodeId> + fmt::Debug + 'static,
+    QS: QuorumSet<C::NodeId> + fmt::Debug + Clone + 'static,
 {
     pub(crate) fn new(
         starting_time: InstantOf<C>,
         vote: Vote<C::NodeId>,
         last_log_id: Option<LogIdOf<C>>,
         quorum_set: QS,
+        learner_ids: impl IntoIterator<Item = C::NodeId>,
     ) -> Self {
         Self {
             starting_time,
             vote,
             last_log_id,
-            progress: VecProgress::new(quorum_set, [], false),
+            progress: VecProgress::new(quorum_set.clone(), [], false),
+            quorum_set,
+            learner_ids: learner_ids.into_iter().collect::<Vec<_>>(),
         }
     }
 
     pub(crate) fn vote_ref(&self) -> &Vote<C::NodeId> {
         &self.vote
+    }
+
+    pub(crate) fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+        self.last_log_id.as_ref()
     }
 
     pub(crate) fn progress(&self) -> &VecProgress<C::NodeId, bool, bool, QS> {
@@ -77,7 +91,7 @@ where
     pub(crate) fn grant_by(&mut self, target: &C::NodeId) -> bool {
         let granted = *self.progress.update(target, true).expect("target not in quorum set");
 
-        tracing::info!(voting = debug(&self), "{}", func_name!());
+        tracing::info!(voting = display(&self), "{}", func_name!());
 
         granted
     }
@@ -86,5 +100,19 @@ where
     #[allow(dead_code)]
     pub(crate) fn granters(&self) -> impl Iterator<Item = C::NodeId> + '_ {
         self.progress().iter().filter(|(_, granted)| *granted).map(|(target, _)| *target)
+    }
+
+    pub(crate) fn into_leader(self) -> Leader<C, QS> {
+        // Mark the vote as committed, i.e., being granted and saved by a quorum.
+        let vote = {
+            let mut vote = *self.vote_ref();
+            debug_assert!(!vote.is_committed());
+            vote.commit();
+            vote
+        };
+
+        let last_leader_log_ids = self.last_log_id().copied().into_iter().collect::<Vec<_>>();
+
+        Leader::new(vote, self.quorum_set.clone(), self.learner_ids, &last_leader_log_ids)
     }
 }

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -49,20 +49,6 @@ impl<NID: NodeId> Display for LogId<NID> {
 impl<NID: NodeId> LogId<NID> {
     /// Creates a log id proposed by a committed leader with `leader_id` at the given index.
     pub fn new(leader_id: CommittedLeaderId<NID>, index: u64) -> Self {
-        if leader_id.term == 0 || index == 0 {
-            assert_eq!(
-                leader_id,
-                CommittedLeaderId::default(),
-                "zero-th log entry must be (0,0,0), but {} {}",
-                leader_id,
-                index
-            );
-            assert_eq!(
-                index, 0,
-                "zero-th log entry must be (0,0,0), but {} {}",
-                leader_id, index
-            );
-        }
         LogId { leader_id, index }
     }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -285,6 +285,7 @@ where C: RaftTypeConfig
 
             client_resp_channels: BTreeMap::new(),
 
+            replications: Default::default(),
             leader_data: None,
 
             tx_api: tx_api.clone(),

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -38,6 +38,8 @@ pub(crate) use log_state_reader::LogStateReader;
 pub use membership_state::MembershipState;
 pub(crate) use vote_state_reader::VoteStateReader;
 
+use crate::internal_server_state::LeaderQuorumSet;
+use crate::leader::Leader;
 pub(crate) use crate::raft_state::snapshot_streaming::StreamingState;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
@@ -371,6 +373,25 @@ where C: RaftTypeConfig
     /// [Determine Server State]: crate::docs::data::vote#vote-and-membership-define-the-server-state
     pub(crate) fn is_leader(&self, id: &C::NodeId) -> bool {
         self.is_leading(id) && self.vote.is_committed()
+    }
+
+    /// Create a Leader using the state of the local `Acceptor`: `Engine.state`.
+    ///
+    /// This is used when building a Leader without an election,
+    /// for example, node-1 elects node-2 as a Leader, node-2 will become a Leader when receives the
+    /// vote.
+    /// A Leader established with election using the state in `Engine.candidate`.
+    pub(crate) fn new_leader(&mut self) -> Leader<C, LeaderQuorumSet<C::NodeId>> {
+        let em = &self.membership_state.effective().membership();
+
+        let last_leader_log_ids = self.log_ids.by_last_leader();
+
+        Leader::new(
+            *self.vote_ref(),
+            em.to_quorum_set(),
+            em.learner_ids(),
+            last_leader_log_ids,
+        )
     }
 
     /// Build a ForwardToLeader error that contains the leader id and node it knows.

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -265,7 +265,7 @@ where
                                 response: Response::HigherVote {
                                     target: self.target,
                                     higher: h.higher,
-                                    vote: self.session_id.vote,
+                                    sender_vote: *self.session_id.vote_ref(),
                                 },
                             });
                             return Ok(());
@@ -417,7 +417,7 @@ where
 
         // Build the heartbeat frame to be sent to the follower.
         let payload = AppendEntriesRequest {
-            vote: self.session_id.vote,
+            vote: *self.session_id.vote_ref(),
             prev_log_id: sending_range.prev,
             leader_commit: self.committed,
             entries: logs,
@@ -440,7 +440,7 @@ where
         let append_res = res.map_err(|_e| {
             let to = Timeout {
                 action: RPCTypes::AppendEntries,
-                id: self.session_id.vote.leader_id().voted_for().unwrap(),
+                id: self.session_id.vote_ref().leader_id().voted_for().unwrap(),
                 target: self.target,
                 timeout: the_timeout,
             };
@@ -468,16 +468,16 @@ where
             }
             AppendEntriesResponse::HigherVote(vote) => {
                 debug_assert!(
-                    vote > self.session_id.vote,
+                    &vote > self.session_id.vote_ref(),
                     "higher vote({}) should be greater than leader's vote({})",
                     vote,
-                    self.session_id.vote,
+                    self.session_id.vote_ref(),
                 );
                 tracing::debug!(%vote, "append entries failed. converting to follower");
 
                 Err(ReplicationError::HigherVote(HigherVote {
                     higher: vote,
-                    mine: self.session_id.vote,
+                    sender_vote: *self.session_id.vote_ref(),
                 }))
             }
             AppendEntriesResponse::Conflict => {
@@ -737,7 +737,7 @@ where
         let jh = AsyncRuntimeOf::<C>::spawn(Self::send_snapshot(
             request_id,
             self.snapshot_network.clone(),
-            self.session_id.vote,
+            *self.session_id.vote_ref(),
             snapshot,
             option,
             rx_cancel,
@@ -811,10 +811,11 @@ where
         let resp = result?;
 
         // Handle response conditions.
-        if resp.vote > self.session_id.vote {
+        let sender_vote = *self.session_id.vote_ref();
+        if resp.vote > sender_vote {
             return Err(ReplicationError::HigherVote(HigherVote {
                 higher: resp.vote,
-                mine: self.session_id.vote,
+                sender_vote,
             }));
         }
 

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -30,7 +30,7 @@ use crate::Vote;
 /// core believe node `c` already has `log_id=1`, and commit it.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ReplicationSessionId<NID: NodeId> {
-    /// The vote of the leader.
+    /// The Leader or Candidate this replication belongs to.
     pub(crate) vote: Vote<NID>,
 
     /// The log id of the membership log this replication works for.
@@ -49,5 +49,9 @@ impl<NID: NodeId> ReplicationSessionId<NID> {
             vote,
             membership_log_id,
         }
+    }
+
+    pub(crate) fn vote_ref(&self) -> &Vote<NID> {
+        &self.vote
     }
 }

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -59,8 +59,8 @@ where C: RaftTypeConfig
         /// The higher vote observed.
         higher: Vote<C::NodeId>,
 
-        /// Which ServerState sent this message
-        vote: Vote<C::NodeId>,
+        /// Which state(a Leader or Candidate) sent this message
+        sender_vote: Vote<C::NodeId>,
         // TODO: need this?
         // /// The cluster this replication works for.
         // membership_log_id: Option<LogId<C::NodeId>>,
@@ -87,7 +87,11 @@ where C: RaftTypeConfig
 
             Self::StorageError { error } => write!(f, "ReplicationStorageError: {}", error),
 
-            Self::HigherVote { target, higher, vote } => {
+            Self::HigherVote {
+                target,
+                higher,
+                sender_vote: vote,
+            } => {
                 write!(
                     f,
                     "Seen a higher vote: target: {}, vote: {}, server_state_vote: {}",

--- a/openraft/src/summary.rs
+++ b/openraft/src/summary.rs
@@ -86,15 +86,15 @@ mod tests {
         use crate::MessageSummary;
 
         let lid = crate::testing::log_id(1, 2, 3);
-        assert_eq!("1-2-3", lid.to_string());
-        assert_eq!("1-2-3", lid.summary());
-        assert_eq!("Some(1-2-3)", Some(&lid).summary());
-        assert_eq!("Some(1-2-3)", Some(lid).summary());
+        assert_eq!("T1-N2-3", lid.to_string());
+        assert_eq!("T1-N2-3", lid.summary());
+        assert_eq!("Some(T1-N2-3)", Some(&lid).summary());
+        assert_eq!("Some(T1-N2-3)", Some(lid).summary());
 
         let slc = vec![lid, lid];
-        assert_eq!("1-2-3,1-2-3", slc.as_slice().summary());
+        assert_eq!("T1-N2-3,T1-N2-3", slc.as_slice().summary());
 
         let slc = vec![&lid, &lid];
-        assert_eq!("1-2-3,1-2-3", slc.as_slice().summary());
+        assert_eq!("T1-N2-3,T1-N2-3", slc.as_slice().summary());
     }
 }

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -147,6 +147,7 @@ where
             assert!(mem.is_empty());
         }
 
+        // Ensure last_membership_in_log() won't be affected by state machine.
         tracing::info!("--- membership presents in log, smaller than last_applied, read from log");
         {
             append(&mut store, [membership_ent_0::<C>(1, 1, btreeset! {1,2,3})]).await?;

--- a/openraft/src/utime.rs
+++ b/openraft/src/utime.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
+use crate::display_ext::DisplayInstantExt;
 use crate::Instant;
 
 /// Record the last update time for an object
@@ -14,7 +15,7 @@ pub(crate) struct UTime<T, I: Instant> {
 impl<T: fmt::Display, I: Instant> fmt::Display for UTime<T, I> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.utime {
-            Some(utime) => write!(f, "{}@{:?}", self.data, utime),
+            Some(utime) => write!(f, "{}@{}", self.data, utime.display()),
             None => write!(f, "{}", self.data),
         }
     }
@@ -93,9 +94,9 @@ impl<T, I: Instant> UTime<T, I> {
     pub(crate) fn touch(&mut self, now: I) {
         debug_assert!(
             Some(now) >= self.utime,
-            "expect now: {:?}, must >= self.utime: {:?}, {:?}",
-            now,
-            self.utime,
+            "expect now: {}, must >= self.utime: {}, {:?}",
+            now.display(),
+            self.utime.unwrap().display(),
             self.utime.unwrap() - now,
         );
         self.utime = Some(now);

--- a/openraft/src/vote/leader_id/leader_id_adv.rs
+++ b/openraft/src/vote/leader_id/leader_id_adv.rs
@@ -49,7 +49,7 @@ impl<NID: NodeId> LeaderId<NID> {
 
 impl<NID: NodeId> fmt::Display for LeaderId<NID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}-{}", self.term, self.node_id)
+        write!(f, "T{}-N{}", self.term, self.node_id)
     }
 }
 
@@ -69,7 +69,7 @@ pub type CommittedLeaderId<NID> = LeaderId<NID>;
 
 #[cfg(test)]
 mod tests {
-    use crate::LeaderId;
+    use crate::Vote;
 
     #[cfg(feature = "serde")]
     #[test]
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn test_leader_id_partial_order() -> anyhow::Result<()> {
         #[allow(clippy::redundant_closure)]
-        let lid = |term, node_id| LeaderId::<u64>::new(term, node_id);
+        let lid = |term, node_id| Vote::<u64>::new(term, node_id);
 
         // Compare term first
         assert!(lid(2, 2) > lid(1, 2));

--- a/openraft/src/vote/leader_id/leader_id_std.rs
+++ b/openraft/src/vote/leader_id/leader_id_std.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::marker::PhantomData;
 
+use crate::display_ext::DisplayOptionExt;
 use crate::NodeId;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -69,7 +70,7 @@ impl<NID: NodeId> LeaderId<NID> {
 
 impl<NID: NodeId> fmt::Display for LeaderId<NID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}-{:?}", self.term, self.voted_for)
+        write!(f, "T{}-N{}", self.term, self.voted_for.display())
     }
 }
 
@@ -99,7 +100,7 @@ impl<NID: NodeId> CommittedLeaderId<NID> {
 #[allow(clippy::nonminimal_bool)]
 mod tests {
     use crate::CommittedLeaderId;
-    use crate::LeaderId;
+    use crate::Vote;
 
     #[cfg(feature = "serde")]
     #[test]
@@ -118,9 +119,9 @@ mod tests {
     #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn test_leader_id_partial_order() -> anyhow::Result<()> {
         #[allow(clippy::redundant_closure)]
-        let lid = |term, node_id| LeaderId::<u64>::new(term, node_id);
+        let lid = |term, node_id| Vote::<u64>::new(term, node_id);
 
-        let lid_none = |term| LeaderId::<u64> { term, voted_for: None };
+        let lid_none = |term| Vote::<u64> { term, voted_for: None };
 
         // Compare term first
         assert!(lid(2, 2) > lid(1, 2));

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -60,6 +60,7 @@ impl<NID: NodeId> Vote<NID> {
             committed: false,
         }
     }
+
     pub fn new_committed(term: u64, node_id: NID) -> Self {
         Self {
             leader_id: LeaderId::new(term, node_id),
@@ -75,7 +76,7 @@ impl<NID: NodeId> Vote<NID> {
         self.committed
     }
 
-    /// Return the [`LeaderId`] this vote represents for.
+    /// Return the [`Vote`] this vote represents for.
     ///
     /// The leader may or may not be granted by a quorum.
     pub fn leader_id(&self) -> &LeaderId<NID> {
@@ -148,7 +149,6 @@ mod tests {
     mod feature_single_term_leader {
         use std::panic::UnwindSafe;
 
-        use crate::LeaderId;
         use crate::Vote;
 
         #[cfg(feature = "serde")]
@@ -171,7 +171,7 @@ mod tests {
             let vote = |term, node_id| Vote::<u64>::new(term, node_id);
 
             let none = |term| Vote::<u64> {
-                leader_id: LeaderId { term, voted_for: None },
+                leader_id: Vote { term, voted_for: None },
                 committed: false,
             };
 

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -55,7 +55,7 @@ async fn append_sees_higher_vote() -> Result<()> {
             )
             .await?;
 
-        assert!(resp.vote_granted);
+        assert!(resp.is_granted_to(&Vote::new(10, 1)));
     }
 
     // Current state:

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -57,12 +57,12 @@ async fn append_inconsistent_log() -> Result<()> {
     r2.shutdown().await?;
 
     for i in log_index + 1..=100 {
-        sto0.blocking_append([blank_ent(2, 0, i)]).await?;
-        sto2.blocking_append([blank_ent(3, 0, i)]).await?;
+        sto0.blocking_append([blank_ent(2, 1, i)]).await?;
+        sto2.blocking_append([blank_ent(3, 3, i)]).await?;
     }
 
-    sto0.save_vote(&Vote::new(2, 0)).await?;
-    sto2.save_vote(&Vote::new(3, 0)).await?;
+    sto0.save_vote(&Vote::new(4, 1)).await?;
+    sto2.save_vote(&Vote::new(3, 3)).await?;
 
     log_index = 100;
 

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -62,7 +62,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
     tracing::info!(log_index, "--- leader lease rejects vote request");
     {
         let res = node1.vote(VoteRequest::new(Vote::new(10, 2), Some(log_id(10, 1, 10)))).await?;
-        assert!(!res.vote_granted);
+        assert!(!res.is_granted_to(&Vote::new(10, 2)), "vote is rejected");
     }
 
     tracing::info!(log_index, "--- ensures no more blank-log heartbeat is used");
@@ -80,7 +80,10 @@ async fn heartbeat_reject_vote() -> Result<()> {
         router.wait(&1, timeout()).applied_index(Some(log_index), "no log is written").await?;
 
         let res = node1.vote(VoteRequest::new(Vote::new(10, 2), Some(log_id(10, 1, 10)))).await?;
-        assert!(res.vote_granted, "vote is granted after leader lease expired");
+        assert!(
+            res.is_granted_to(&Vote::new(10, 2)),
+            "vote is granted after leader lease expired"
+        );
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Refactor: Enhance Election and Replication

- **Election Update Delay:**
  - The `Voting` state is now updated only after `SaveVote` is
    successfully persisted on disk. This change anticipates future
    modifications where `SaveVote` will be callback-based, ensuring
    state consistency.

- **Deprecation of `VoteResponse.vote_granted`:**
  - The grant of a `RequestVote` is now determined solely by whether
    `VoteResponse.vote` matches the candidate's vote, simplifying the
    logic and reducing ambiguity in vote handling.

- **Replication Stream Reorganization:**
  - Replication stream handles have been moved from
    `RaftCore::LeaderData` to `RaftCore`. This reorganization lays the
    groundwork for supporting `RequestVote` RPCs in the replication
    mechanism, although it currently continues to support only log and
    snapshot replication.

- **Vote Comparison Enhancement:**
  - When filtering out stale messages, such as when a new Leader
    receives an `AppendEntries` response intended for a previous Leader,
    the responded vote is now compared with the vote in the `Leading`
    state. Previously, it was compared with
    `RaftCore.engine.raft_state.vote`, which might differ from the
    `Leading` state's vote in future scenarios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1140)
<!-- Reviewable:end -->
