### PR TITLE
Feature: Add `TypeConfigExt` to simplify `RaftTypeConfig` Access

### DIFF
--- a/openraft/src/core/sm/handle.rs
+++ b/openraft/src/core/sm/handle.rs
@@ -3,9 +3,8 @@
 use tokio::sync::mpsc;
 
 use crate::core::sm;
-use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::JoinHandleOf;
-use crate::AsyncRuntime;
+use crate::type_config::TypeConfigExt;
 use crate::RaftTypeConfig;
 use crate::Snapshot;
 
@@ -55,7 +54,7 @@ where C: RaftTypeConfig
     /// If the state machine worker has shutdown, it will return an error.
     /// If there is not snapshot available, it will return `Ok(None)`.
     pub(crate) async fn get_snapshot(&self) -> Result<Option<Snapshot<C>>, &'static str> {
-        let (tx, rx) = AsyncRuntimeOf::<C>::oneshot();
+        let (tx, rx) = C::oneshot();
 
         let cmd = sm::Command::get_snapshot(tx);
         tracing::debug!("SnapshotReader sending command to sm::Worker: {:?}", cmd);

--- a/openraft/src/display_ext.rs
+++ b/openraft/src/display_ext.rs
@@ -1,4 +1,4 @@
-//! Implement [`fmt::Display`] for types such as `Option<T>` and slice `&[T]`.
+//! Implement [`std::fmt::Display`] for types such as `Option<T>` and slice `&[T]`.
 
 pub(crate) mod display_instant;
 pub(crate) mod display_option;

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -41,10 +41,9 @@ use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::raft_state::LogStateReader;
 use crate::raft_state::RaftState;
-use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
-use crate::Instant;
+use crate::type_config::TypeConfigExt;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::Membership;
@@ -123,7 +122,7 @@ where C: RaftTypeConfig
     /// The candidate `last_log_id` is initialized with the attributes of Acceptor part:
     /// [`RaftState`]
     pub(crate) fn new_candidate(&mut self, vote: Vote<C::NodeId>) -> &mut Candidate<C, LeaderQuorumSet<C::NodeId>> {
-        let now = InstantOf::<C>::now();
+        let now = C::now();
         let last_log_id = self.state.last_log_id().copied();
 
         let membership = self.state.membership_state.effective().membership();
@@ -282,7 +281,7 @@ where C: RaftTypeConfig
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn handle_vote_req(&mut self, req: VoteRequest<C>) -> VoteResponse<C> {
-        let now = InstantOf::<C>::now();
+        let now = C::now();
         let lease = self.config.timer_config.leader_lease;
         let vote = self.state.vote_ref();
 

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -11,9 +11,8 @@ use crate::engine::Respond;
 use crate::error::Infallible;
 use crate::raft::VoteResponse;
 use crate::testing::log_id;
-use crate::type_config::alias::AsyncRuntimeOf;
+use crate::type_config::TypeConfigExt;
 use crate::utime::UTime;
-use crate::AsyncRuntime;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::TokioInstant;
@@ -48,12 +47,12 @@ fn test_accept_vote_reject_smaller_vote() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.output.take_commands();
 
-    let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    let (tx, _rx) = UTConfig::<()>::oneshot();
     let resp = eng.vote_handler().accept_vote(&Vote::new(1, 2), tx, |_state, _err| mk_res());
 
     assert!(resp.is_none());
 
-    let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    let (tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
         vec![
             //
@@ -74,7 +73,7 @@ fn test_accept_vote_granted_greater_vote() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.output.take_commands();
 
-    let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    let (tx, _rx) = UTConfig::<()>::oneshot();
     let resp = eng.vote_handler().accept_vote(&Vote::new(3, 3), tx, |_state, _err| mk_res());
 
     assert!(resp.is_some());

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -14,8 +14,7 @@ use crate::error::RejectVoteRequest;
 use crate::proposer::CandidateState;
 use crate::proposer::LeaderState;
 use crate::raft_state::LogStateReader;
-use crate::type_config::alias::InstantOf;
-use crate::Instant;
+use crate::type_config::TypeConfigExt;
 use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftState;
@@ -133,15 +132,15 @@ where C: RaftTypeConfig
         if vote > self.state.vote_ref() {
             tracing::info!("vote is changing from {} to {}", self.state.vote_ref(), vote);
 
-            self.state.vote.update(InstantOf::<C>::now(), *vote);
+            self.state.vote.update(C::now(), *vote);
             self.output.push_command(Command::SaveVote { vote: *vote });
         } else {
-            self.state.vote.touch(InstantOf::<C>::now());
+            self.state.vote.touch(C::now());
         }
 
         // Update vote related timer and lease.
 
-        tracing::debug!(now = debug(InstantOf::<C>::now()), "{}", func_name!());
+        tracing::debug!(now = debug(C::now()), "{}", func_name!());
 
         self.update_internal_server_state();
 

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -12,8 +12,7 @@ use crate::engine::LogIdList;
 use crate::engine::Respond;
 use crate::raft::SnapshotResponse;
 use crate::testing::log_id;
-use crate::type_config::alias::AsyncRuntimeOf;
-use crate::AsyncRuntime;
+use crate::type_config::TypeConfigExt;
 use crate::Membership;
 use crate::Snapshot;
 use crate::SnapshotMeta;
@@ -63,7 +62,7 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
 
     let curr_vote = *eng.state.vote_ref();
 
-    let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    let (tx, _rx) = UTConfig::<()>::oneshot();
 
     eng.handle_install_full_snapshot(
         curr_vote,
@@ -87,7 +86,7 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
         eng.state.snapshot_meta
     );
 
-    let (dummy_tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    let (dummy_tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
         vec![
             //
@@ -111,7 +110,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
 
     let curr_vote = *eng.state.vote_ref();
 
-    let (tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    let (tx, _rx) = UTConfig::<()>::oneshot();
 
     eng.handle_install_full_snapshot(
         curr_vote,
@@ -135,7 +134,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
         eng.state.snapshot_meta
     );
 
-    let (dummy_tx, _rx) = AsyncRuntimeOf::<UTConfig>::oneshot();
+    let (dummy_tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
         vec![
             //

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -46,7 +46,6 @@ pub(crate) mod log_id_range;
 pub(crate) mod proposer;
 pub(crate) mod raft_state;
 pub(crate) mod timer;
-pub(crate) mod type_config;
 pub(crate) mod utime;
 
 pub mod async_runtime;
@@ -63,6 +62,7 @@ pub mod network;
 pub mod raft;
 pub mod storage;
 pub mod testing;
+pub mod type_config;
 
 #[cfg(test)]
 mod feature_serde_test;

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -20,8 +20,7 @@ use crate::error::StreamingError;
 use crate::network::RPCOption;
 use crate::raft::InstallSnapshotRequest;
 use crate::raft::SnapshotResponse;
-use crate::type_config::alias::AsyncRuntimeOf;
-use crate::AsyncRuntime;
+use crate::type_config::TypeConfigExt;
 use crate::ErrorSubject;
 use crate::ErrorVerb;
 use crate::OptionalSend;
@@ -124,7 +123,7 @@ where C::SnapshotData: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io:
             // Sleep a short time otherwise in test environment it is a dead-loop that never
             // yields.
             // Because network implementation does not yield.
-            AsyncRuntimeOf::<C>::sleep(Duration::from_millis(1)).await;
+            C::sleep(Duration::from_millis(1)).await;
 
             snapshot.snapshot.seek(SeekFrom::Start(offset)).await.sto_res(subject_verb)?;
 
@@ -160,7 +159,7 @@ where C::SnapshotData: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io:
             );
 
             #[allow(deprecated)]
-            let res = AsyncRuntimeOf::<C>::timeout(option.hard_ttl(), net.install_snapshot(req, option.clone())).await;
+            let res = C::timeout(option.hard_ttl(), net.install_snapshot(req, option.clone())).await;
 
             let resp = match res {
                 Ok(outer_res) => match outer_res {

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -209,7 +209,7 @@ mod tests {
     use crate::proposer::Leader;
     use crate::testing::blank_ent;
     use crate::testing::log_id;
-    use crate::type_config::alias::InstantOf;
+    use crate::type_config::TypeConfigExt;
     use crate::Entry;
     use crate::RaftLogId;
     use crate::Vote;
@@ -309,7 +309,7 @@ mod tests {
     fn test_leading_last_quorum_acked_time_leader_is_voter() {
         let mut leading = Leader::<UTConfig, Vec<u64>>::new(Vote::new_committed(2, 1), vec![1, 2, 3], [4], &[]);
 
-        let now1 = InstantOf::<UTConfig>::now();
+        let now1 = UTConfig::<()>::now();
 
         let _t2 = leading.clock_progress.increase_to(&2, Some(now1));
         let t1 = leading.last_quorum_acked_time();
@@ -320,12 +320,12 @@ mod tests {
     fn test_leading_last_quorum_acked_time_leader_is_learner() {
         let mut leading = Leader::<UTConfig, Vec<u64>>::new(Vote::new_committed(2, 4), vec![1, 2, 3], [4], &[]);
 
-        let t2 = InstantOf::<UTConfig>::now();
+        let t2 = UTConfig::<()>::now();
         let _ = leading.clock_progress.increase_to(&2, Some(t2));
         let t = leading.last_quorum_acked_time();
         assert!(t.is_none(), "n1(leader+learner) does not count in quorum");
 
-        let t3 = InstantOf::<UTConfig>::now();
+        let t3 = UTConfig::<()>::now();
         let _ = leading.clock_progress.increase_to(&3, Some(t3));
         let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");
@@ -335,12 +335,12 @@ mod tests {
     fn test_leading_last_quorum_acked_time_leader_is_not_member() {
         let mut leading = Leader::<UTConfig, Vec<u64>>::new(Vote::new_committed(2, 5), vec![1, 2, 3], [4], &[]);
 
-        let t2 = InstantOf::<UTConfig>::now();
+        let t2 = UTConfig::<()>::now();
         let _ = leading.clock_progress.increase_to(&2, Some(t2));
         let t = leading.last_quorum_acked_time();
         assert!(t.is_none(), "n1(leader+learner) does not count in quorum");
 
-        let t3 = InstantOf::<UTConfig>::now();
+        let t3 = UTConfig::<()>::now();
         let _ = leading.clock_progress.increase_to(&3, Some(t3));
         let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -77,11 +77,11 @@ pub use crate::raft::runtime_config_handle::RuntimeConfigHandle;
 use crate::raft::trigger::Trigger;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
-use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::ResponderReceiverOf;
 use crate::type_config::alias::SnapshotDataOf;
+use crate::type_config::TypeConfigExt;
 use crate::AsyncRuntime;
 use crate::LogId;
 use crate::LogIdOptionExt;
@@ -398,7 +398,7 @@ where C: RaftTypeConfig
     pub async fn begin_receiving_snapshot(&self) -> Result<Box<SnapshotDataOf<C>>, RaftError<C, Infallible>> {
         tracing::info!("Raft::begin_receiving_snapshot()");
 
-        let (tx, rx) = AsyncRuntimeOf::<C>::oneshot();
+        let (tx, rx) = C::oneshot();
         let resp = self.inner.call_core(RaftMsg::BeginReceivingSnapshot { tx }, rx).await?;
         Ok(resp)
     }

--- a/openraft/src/raft/responder/impls.rs
+++ b/openraft/src/raft/responder/impls.rs
@@ -1,10 +1,9 @@
 use crate::async_runtime::AsyncOneshotSendExt;
 use crate::raft::message::ClientWriteResult;
 use crate::raft::responder::Responder;
-use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
-use crate::AsyncRuntime;
+use crate::type_config::TypeConfigExt;
 use crate::RaftTypeConfig;
 
 /// A [`Responder`] implementation that sends the response via a oneshot channel.
@@ -22,6 +21,8 @@ impl<C> OneshotResponder<C>
 where C: RaftTypeConfig
 {
     /// Create a new instance from a [`AsyncRuntime::OneshotSender`].
+    ///
+    /// [`AsyncRuntime::OneshotSender`]: `crate::async_runtime::AsyncRuntime::OneshotSender`
     pub fn new(tx: OneshotSenderOf<C, ClientWriteResult<C>>) -> Self {
         Self { tx }
     }
@@ -34,7 +35,7 @@ where C: RaftTypeConfig
 
     fn from_app_data(app_data: C::D) -> (C::D, Self, Self::Receiver)
     where Self: Sized {
-        let (tx, rx) = AsyncRuntimeOf::<C>::oneshot();
+        let (tx, rx) = C::oneshot();
         (app_data, Self { tx }, rx)
     }
 

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -48,12 +48,11 @@ use crate::replication::request_id::RequestId;
 use crate::storage::RaftLogReader;
 use crate::storage::RaftLogStorage;
 use crate::storage::Snapshot;
-use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinHandleOf;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::TypeConfigExt;
 use crate::AsyncRuntime;
-use crate::Instant;
 use crate::LogId;
 use crate::RaftLogId;
 use crate::RaftNetworkFactory;
@@ -325,7 +324,7 @@ where
                 Duration::from_millis(500)
             });
 
-            self.backoff_drain_events(InstantOf::<C>::now() + duration).await?;
+            self.backoff_drain_events(C::now() + duration).await?;
         }
 
         self.drain_events().await?;
@@ -413,7 +412,7 @@ where
             }
         };
 
-        let leader_time = InstantOf::<C>::now();
+        let leader_time = C::now();
 
         // Build the heartbeat frame to be sent to the follower.
         let payload = AppendEntriesRequest {
@@ -433,7 +432,7 @@ where
 
         let the_timeout = Duration::from_millis(self.config.heartbeat_interval);
         let option = RPCOption::new(the_timeout);
-        let res = AsyncRuntimeOf::<C>::timeout(the_timeout, self.network.append_entries(payload, option)).await;
+        let res = C::timeout(the_timeout, self.network.append_entries(payload, option)).await;
 
         tracing::debug!("append_entries res: {:?}", res);
 
@@ -571,7 +570,7 @@ where
     /// in case the channel is closed, it should quit at once.
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn backoff_drain_events(&mut self, until: InstantOf<C>) -> Result<(), ReplicationClosed> {
-        let d = until - InstantOf::<C>::now();
+        let d = until - C::now();
         tracing::warn!(
             interval = debug(d),
             "{} backoff mode: drain events without processing them",
@@ -579,8 +578,8 @@ where
         );
 
         loop {
-            let sleep_duration = until - InstantOf::<C>::now();
-            let sleep = C::AsyncRuntime::sleep(sleep_duration);
+            let sleep_duration = until - C::now();
+            let sleep = C::sleep(sleep_duration);
 
             let recv = self.rx_event.recv();
 
@@ -734,7 +733,7 @@ where
 
         let (tx_cancel, rx_cancel) = oneshot::channel();
 
-        let jh = AsyncRuntimeOf::<C>::spawn(Self::send_snapshot(
+        let jh = C::spawn(Self::send_snapshot(
             request_id,
             self.snapshot_network.clone(),
             *self.session_id.vote_ref(),
@@ -765,7 +764,7 @@ where
 
         let mut net = network.lock().await;
 
-        let start_time = InstantOf::<C>::now();
+        let start_time = C::now();
 
         let cancel = async move {
             let _ = cancel.await;

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -142,17 +142,17 @@ mod tests {
     use crate::engine::testing::UTConfig;
     use crate::replication::response::ReplicationResult;
     use crate::testing::log_id;
-    use crate::type_config::alias::InstantOf;
+    use crate::type_config::TypeConfigExt;
 
     #[test]
     fn test_replication_result_display() {
         // NOTE that with single-term-leader, log id is `1-3`
 
-        let result = ReplicationResult::<UTConfig>::new(InstantOf::<UTConfig>::now(), Ok(Some(log_id(1, 2, 3))));
+        let result = ReplicationResult::<UTConfig>::new(UTConfig::<()>::now(), Ok(Some(log_id(1, 2, 3))));
         let want = format!(", result:Match:{}}}", log_id(1, 2, 3));
         assert!(result.to_string().ends_with(&want), "{}", result.to_string());
 
-        let result = ReplicationResult::<UTConfig>::new(InstantOf::<UTConfig>::now(), Err(log_id(1, 2, 3)));
+        let result = ReplicationResult::<UTConfig>::new(UTConfig::<()>::now(), Err(log_id(1, 2, 3)));
         let want = format!(", result:Conflict:{}}}", log_id(1, 2, 3));
         assert!(result.to_string().ends_with(&want), "{}", result.to_string());
     }

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -10,10 +10,9 @@ use crate::raft_state::IOState;
 use crate::storage::RaftLogReaderExt;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
-use crate::type_config::alias::InstantOf;
+use crate::type_config::TypeConfigExt;
 use crate::utime::UTime;
 use crate::EffectiveMembership;
-use crate::Instant;
 use crate::LogIdOptionExt;
 use crate::MembershipState;
 use crate::RaftSnapshotBuilder;
@@ -149,7 +148,7 @@ where
             last_purged_log_id,
         );
 
-        let now = InstantOf::<C>::now();
+        let now = C::now();
 
         Ok(RaftState {
             committed: last_applied,

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -4,8 +4,7 @@ use openraft_macros::add_async_trait;
 use crate::raft_state::LogIOId;
 use crate::storage::LogFlushed;
 use crate::storage::RaftLogStorage;
-use crate::type_config::alias::AsyncRuntimeOf;
-use crate::AsyncRuntime;
+use crate::type_config::TypeConfigExt;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -27,7 +26,7 @@ where C: RaftTypeConfig
         I: IntoIterator<Item = C::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,
     {
-        let (tx, rx) = AsyncRuntimeOf::<C>::oneshot();
+        let (tx, rx) = C::oneshot();
 
         // dummy log_io_id
         let log_io_id = LogIOId::<C::NodeId>::new(Vote::<C::NodeId>::default(), None);

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -20,9 +20,8 @@ use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::storage::StorageHelper;
 use crate::testing::StoreBuilder;
-use crate::type_config::alias::AsyncRuntimeOf;
+use crate::type_config::TypeConfigExt;
 use crate::vote::CommittedLeaderId;
-use crate::AsyncRuntime;
 use crate::LogId;
 use crate::Membership;
 use crate::NodeId;
@@ -1304,7 +1303,7 @@ where
     I: IntoIterator<Item = C::Entry> + OptionalSend,
     I::IntoIter: OptionalSend,
 {
-    let (tx, rx) = AsyncRuntimeOf::<C>::oneshot();
+    let (tx, rx) = C::oneshot();
 
     // Dummy log io id for blocking append
     let log_io_id = LogIOId::<C::NodeId>::new(Vote::<C::NodeId>::default(), None);

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -1,4 +1,13 @@
+//! Define the configuration of types used by the Raft, such as [`NodeId`], log [`Entry`], etc.
+//!
+//! [`NodeId`]: `RaftTypeConfig::NodeId`
+//! [`Entry`]: `RaftTypeConfig::Entry`
+
+pub(crate) mod util;
+
 use std::fmt::Debug;
+
+pub use util::TypeConfigExt;
 
 use crate::entry::FromAppData;
 use crate::entry::RaftEntry;

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -1,0 +1,71 @@
+use std::future::Future;
+use std::time::Duration;
+
+use crate::type_config::alias::AsyncRuntimeOf;
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::alias::OneshotSenderOf;
+use crate::type_config::alias::SleepOf;
+use crate::type_config::alias::TimeoutOf;
+use crate::AsyncRuntime;
+use crate::Instant;
+use crate::OptionalSend;
+use crate::RaftTypeConfig;
+
+/// Collection of utility methods to `RaftTypeConfig` function.
+pub trait TypeConfigExt: RaftTypeConfig {
+    // Time related methods
+
+    /// Returns the current time.
+    fn now() -> InstantOf<Self> {
+        InstantOf::<Self>::now()
+    }
+
+    /// Wait until `duration` has elapsed.
+    fn sleep(duration: Duration) -> SleepOf<Self> {
+        AsyncRuntimeOf::<Self>::sleep(duration)
+    }
+
+    /// Wait until `deadline` is reached.
+    fn sleep_until(deadline: InstantOf<Self>) -> SleepOf<Self> {
+        AsyncRuntimeOf::<Self>::sleep_until(deadline)
+    }
+
+    /// Require a [`Future`] to complete before the specified duration has elapsed.
+    fn timeout<R, F: Future<Output = R> + OptionalSend>(duration: Duration, future: F) -> TimeoutOf<Self, R, F> {
+        AsyncRuntimeOf::<Self>::timeout(duration, future)
+    }
+
+    /// Require a [`Future`] to complete before the specified instant in time.
+    fn timeout_at<R, F: Future<Output = R> + OptionalSend>(
+        deadline: InstantOf<Self>,
+        future: F,
+    ) -> TimeoutOf<Self, R, F> {
+        AsyncRuntimeOf::<Self>::timeout_at(deadline, future)
+    }
+
+    // Synchronization methods
+
+    /// Creates a new one-shot channel for sending single values.
+    ///
+    /// This is just a wrapper of
+    /// [`AsyncRuntime::oneshot`](`crate::async_runtime::AsyncRuntime::oneshot`).
+    fn oneshot<T>() -> (OneshotSenderOf<Self, T>, OneshotReceiverOf<Self, T>)
+    where T: OptionalSend {
+        AsyncRuntimeOf::<Self>::oneshot()
+    }
+
+    // Task methods
+
+    /// Spawn a new task.
+    fn spawn<T>(future: T) -> JoinHandleOf<Self, T::Output>
+    where
+        T: Future + OptionalSend + 'static,
+        T::Output: OptionalSend + 'static,
+    {
+        AsyncRuntimeOf::<Self>::spawn(future)
+    }
+}
+
+impl<T> TypeConfigExt for T where T: RaftTypeConfig {}

--- a/tests/tests/append_entries/t60_enable_heartbeat.rs
+++ b/tests/tests/append_entries/t60_enable_heartbeat.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::alias::InstantOf;
+use openraft::type_config::TypeConfigExt;
 use openraft::AsyncRuntime;
 use openraft::Config;
 use openraft::TokioRuntime;
@@ -32,7 +32,7 @@ async fn enable_heartbeat() -> Result<()> {
     node0.runtime_config().heartbeat(true);
 
     for _i in 0..3 {
-        let now = InstantOf::<TypeConfig>::now();
+        let now = TypeConfig::now();
         TokioRuntime::sleep(Duration::from_millis(500)).await;
 
         for node_id in [1, 2, 3] {

--- a/tests/tests/metrics/t10_leader_last_ack.rs
+++ b/tests/tests/metrics/t10_leader_last_ack.rs
@@ -3,8 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::alias::AsyncRuntimeOf;
-use openraft::AsyncRuntime;
+use openraft::type_config::TypeConfigExt;
 use openraft::Config;
 use openraft_memstore::TypeConfig;
 
@@ -41,7 +40,7 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
 
     tracing::info!(log_index, "--- sleep 500 ms, the `millis` should extend");
     {
-        AsyncRuntimeOf::<TypeConfig>::sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
 
         let greater = n0.metrics().borrow().millis_since_quorum_ack;
         println!("greater: {:?}", greater);
@@ -70,7 +69,7 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
         "--- sleep and heartbeat again; millis_since_quorum_ack refreshes"
     );
     {
-        AsyncRuntimeOf::<TypeConfig>::sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
 
         n0.trigger().heartbeat().await?;
 
@@ -93,7 +92,7 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
         "--- sleep and heartbeat again; millis_since_quorum_ack does not refresh"
     );
     {
-        AsyncRuntimeOf::<TypeConfig>::sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
 
         n0.trigger().heartbeat().await?;
 


### PR DESCRIPTION

## Changelog

##### Feature: Add `TypeConfigExt` to simplify `RaftTypeConfig` Access

This commit introduces a new trait, `TypeConfigExt`, which extends
`RaftTypeConfig`. The purpose of this trait is to simplify the access to
various functionalities provided by the `RaftTypeConfig` trait,
enhancing code readability and reducing complexity.

**Methods Added to `TypeConfigExt`:**
- `now()`
- `sleep()`
- `sleep_until()`
- `timeout()`
- `timeout_at()`
- `oneshot()`
- `spawn()`

**Usage Improvement:**
- Instead of using the
  `<<C as RaftTypeConfig>::AsyncRuntime as AsyncRuntime>::Instant::now()`,
  you can now simply call `C::now()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1145)
<!-- Reviewable:end -->
