### PR TITLE
Fix: Should not update `vote` when seeing higher vote in `RequestVote` response

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -79,9 +79,23 @@ where C: RaftTypeConfig
     /// should be greater.
     pub(crate) seen_greater_log: bool,
 
-    /// The internal server state(Leader or following) used by Engine.
+    /// The greatest vote this node has ever seen.
+    ///
+    /// It could be greater than `self.state.vote`,
+    /// because `self.state.vote` is update only when a node granted a vote,
+    /// i.e., the Leader with this vote is legal: has a greater log and vote.
+    ///
+    /// This vote value is used for election.
+    pub(crate) last_seen_vote: Vote<C::NodeId>,
+
+    /// Represents the Leader state.
     pub(crate) leader: LeaderState<C>,
 
+    /// Represents the Candidate state within Openraft.
+    ///
+    /// A Candidate can coexist with a Leader in the system.
+    /// This scenario is typically used to transition the Leader to a higher term (vote)
+    /// without losing leadership status.
     pub(crate) candidate: CandidateState<C>,
 
     /// Output entry for the runtime.
@@ -92,10 +106,12 @@ impl<C> Engine<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(init_state: RaftState<C>, config: EngineConfig<C>) -> Self {
+        let vote = *init_state.vote_ref();
         Self {
             config,
             state: Valid::new(init_state),
             seen_greater_log: false,
+            last_seen_vote: vote,
             leader: None,
             candidate: None,
             output: EngineOutput::new(4096),
@@ -204,7 +220,15 @@ where C: RaftTypeConfig
     /// Start to elect this node as leader
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn elect(&mut self) {
-        let new_vote = Vote::new(self.state.vote_ref().leader_id().term + 1, self.config.id);
+        debug_assert!(
+            self.last_seen_vote >= *self.state.vote_ref(),
+            "expect: last_seen_vote({}) >= state.vote({}), when elect()",
+            self.last_seen_vote,
+            self.state.vote_ref()
+        );
+
+        let new_term = self.last_seen_vote.leader_id().term + 1;
+        let new_vote = Vote::new(new_term, self.config.id);
 
         let candidate = self.new_candidate(new_vote);
 
@@ -335,6 +359,16 @@ where C: RaftTypeConfig
             func_name!()
         );
 
+        // Update the last seen vote, but not `state.vote`.
+        // `state.vote` is updated only when the vote is granted
+        // (allows the vote owner to be a Leader).
+        //
+        // But in this case, the responded greater vote is not yet granted
+        // because the remote peer may have smaller log.
+        // And even when the remote peer has greater log, it does not have to grant the vote,
+        // if greater logs does not form a quorum.
+        self.vote_handler().update_last_seen(&resp.vote);
+
         let Some(candidate) = self.candidate_mut() else {
             // If the voting process has finished or canceled,
             // just ignore the delayed vote_resp.
@@ -360,12 +394,6 @@ where C: RaftTypeConfig
         // - Or leader lease on remote node is not expired;
         // - It is a delayed response of previous voting(resp.vote_granted could be true)
         // In any case, no need to proceed.
-
-        // If peer's vote is greater than current vote, revert to follower state.
-        //
-        // Explicitly ignore the returned error:
-        // resp.vote being not greater than mine is all right.
-        let _ = self.vote_handler().update_vote(&resp.vote);
 
         // Seen a higher log. Record it so that the next election will be delayed for a while.
         if resp.last_log_id.as_ref() > self.state.last_log_id() {
@@ -697,6 +725,7 @@ where C: RaftTypeConfig
             config: &mut self.config,
             state: &mut self.state,
             output: &mut self.output,
+            last_seen_vote: &mut self.last_seen_vote,
             leader: &mut self.leader,
             candidate: &mut self.candidate,
         }

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -37,6 +37,7 @@ where C: RaftTypeConfig
     pub(crate) config: &'st mut EngineConfig<C>,
     pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'st mut EngineOutput<C>,
+    pub(crate) last_seen_vote: &'st mut Vote<C::NodeId>,
     pub(crate) leader: &'st mut LeaderState<C>,
     pub(crate) candidate: &'st mut CandidateState<C>,
 }
@@ -80,6 +81,27 @@ where C: RaftTypeConfig
         Some(tx)
     }
 
+    /// Update the `last_seen_vote` to a greater value.
+    ///
+    /// Return the replaced value if it is updated.
+    /// Return None if not updated.
+    pub(crate) fn update_last_seen(&mut self, vote: &Vote<C::NodeId>) -> Option<Vote<C::NodeId>> {
+        tracing::debug!(
+            "about to update last_seen_vote from {} to {}",
+            self.last_seen_vote,
+            vote
+        );
+
+        if vote >= self.last_seen_vote {
+            tracing::info!("updated last_seen_vote from {} to {}", self.last_seen_vote, vote);
+            let last = *self.last_seen_vote;
+            *self.last_seen_vote = *vote;
+            Some(last)
+        } else {
+            None
+        }
+    }
+
     /// Check and update the local vote and related state for every message received.
     ///
     /// This is used by all incoming event, such as the three RPC append-entries, vote,
@@ -89,8 +111,12 @@ where C: RaftTypeConfig
     ///
     /// Note: This method does not check last-log-id. handle-vote-request has to deal with
     /// last-log-id itself.
+    ///
+    /// This method also implies calling [`Self::update_last_seen`].
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn update_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), RejectVoteRequest<C>> {
+        self.update_last_seen(vote);
+
         // Partial ord compare:
         // Vote does not has to be total ord.
         // `!(a >= b)` does not imply `a < b`.

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -82,6 +82,7 @@ fn test_elect_single_node_elect_again() -> anyhow::Result<()> {
 
         // Build in-progress election state
         eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(1, 2));
+        eng.last_seen_vote = *eng.state.vote_ref();
         eng.testing_new_leader();
         eng.candidate_mut().map(|candidate| candidate.grant_by(&1));
 

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -53,6 +53,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 2), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
+        assert_eq!(Vote::new(2, 2), eng.last_seen_vote);
+
         assert!(eng.leader.is_none());
 
         assert_eq!(ServerState::Follower, eng.state.server_state);
@@ -79,6 +81,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse::new(Vote::new(1, 1), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
+        assert_eq!(Vote::new(1, 1), eng.last_seen_vote);
+
         assert_eq!(&Vote::new(2, 1), eng.candidate_ref().unwrap().vote_ref());
         assert_eq!(
             btreeset! {1},
@@ -110,14 +114,23 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
 
         eng.handle_vote_resp(2, VoteResponse::new(Vote::new(3, 2), Some(log_id(2, 1, 2))));
 
-        assert_eq!(Vote::new(3, 2), *eng.state.vote_ref());
+        assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
+        assert_eq!(Vote::new(3, 2), eng.last_seen_vote);
+
         assert!(eng.leader.is_none());
 
-        assert_eq!(ServerState::Follower, eng.state.server_state);
+        assert_eq!(
+            ServerState::Candidate,
+            eng.state.server_state,
+            "still in candidate state, until receives RequestVote/AppendEntries from other node"
+        );
 
         assert_eq!(
-            vec![Command::SaveVote { vote: Vote::new(3, 2) },],
-            eng.output.take_commands()
+            eng.output.take_commands(),
+            vec![
+                //
+            ],
+            "no SaveVote because the higher vote is not yet granted by this node"
         );
     }
 
@@ -140,6 +153,8 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
+        assert_eq!(Vote::new(2, 1), eng.last_seen_vote);
+
         assert_eq!(&Vote::new(2, 1), eng.candidate_ref().unwrap().vote_ref());
         assert_eq!(
             btreeset! {1,2},
@@ -173,6 +188,8 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
         eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 2))));
 
         assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref(),);
+        assert_eq!(Vote::new_committed(2, 1), eng.last_seen_vote);
+
         assert_eq!(Some(log_id(2, 1, 1)), eng.leader.as_ref().unwrap().noop_log_id);
         assert!(
             eng.candidate_ref().is_none(),


### PR DESCRIPTION

## Changelog

##### Fix: Should not update `vote` when seeing higher vote in `RequestVote` response

This commit addresses an issue in the vote updating mechanism during the
handling of `RequestVote` responses. Previously, encountering a higher
`vote` in a response incorrectly led to an update of the local
`state.vote`, which could break Raft consistency rules.

**Issue Description:**
- A higher `vote` seen in a `RequestVote` response does not necessarily
  mean that the vote is granted. The local `state.vote` should only be
  updated if the vote is actually granted, i.e., the responding node has
  a higher `vote` and a `last_log_id` that allows it to become a leader.

**Resolution:**
- The local `state.vote` will no longer be updated upon merely seeing a
  higher `vote` in the `RequestVote` response. Instead, this higher vote
  will be recorded in `last_seen_vote` for consideration in the next
  election cycle, without updating the current `state.vote`.

This bug is introduced in `0.10`: 36d2c11519e82b4c94edbf505051e9fe932a8b01

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1146)
<!-- Reviewable:end -->
