### PR TITLE
Change: use RaftTypeConfig to replace NID

### DIFF
--- a/cluster_benchmark/tests/benchmark/store/test.rs
+++ b/cluster_benchmark/tests/benchmark/store/test.rs
@@ -5,14 +5,13 @@ use openraft::testing::Suite;
 use openraft::StorageError;
 
 use crate::store::LogStore;
-use crate::store::NodeId;
 use crate::store::StateMachineStore;
 use crate::store::TypeConfig;
 
 struct Builder {}
 
 impl StoreBuilder<TypeConfig, Arc<LogStore>, Arc<StateMachineStore>> for Builder {
-    async fn build(&self) -> Result<((), Arc<LogStore>, Arc<StateMachineStore>), StorageError<NodeId>> {
+    async fn build(&self) -> Result<((), Arc<LogStore>, Arc<StateMachineStore>), StorageError<TypeConfig>> {
         let log_store = LogStore::new_async().await;
         let sm = Arc::new(StateMachineStore::new());
         Ok(((), log_store, sm))
@@ -20,7 +19,7 @@ impl StoreBuilder<TypeConfig, Arc<LogStore>, Arc<StateMachineStore>> for Builder
 }
 
 #[test]
-pub fn test_store() -> Result<(), StorageError<NodeId>> {
+pub fn test_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(Builder {})?;
     Ok(())
 }

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -77,7 +77,7 @@ pub struct StateMachineStore {
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<NodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<TypeConfig>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -131,13 +131,13 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<NodeId>>
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<TypeConfig>>
     where I: IntoIterator<Item = Entry<TypeConfig>> {
         let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
 
@@ -168,7 +168,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(Box::default())
     }
 
@@ -177,7 +177,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
-    ) -> Result<(), StorageError<NodeId>> {
+    ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!("install snapshot");
 
         let new_snapshot = StoredSnapshot {
@@ -199,7 +199,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<NodeId>> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<TypeConfig>> {
         match &*self.current_snapshot.lock().unwrap() {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -92,7 +92,7 @@ impl StateMachineStore {
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<NodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<TypeConfig>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -152,13 +152,13 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<NodeId>>
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<TypeConfig>>
     where I: IntoIterator<Item = Entry<TypeConfig>> {
         let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
 
@@ -189,7 +189,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(Box::default())
     }
 
@@ -198,7 +198,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
-    ) -> Result<(), StorageError<NodeId>> {
+    ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!("install snapshot");
 
         let new_snapshot = StoredSnapshot {
@@ -221,7 +221,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<NodeId>> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<TypeConfig>> {
         match &*self.current_snapshot.lock().unwrap() {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/examples/raft-kv-memstore/src/test.rs
+++ b/examples/raft-kv-memstore/src/test.rs
@@ -6,19 +6,18 @@ use openraft::StorageError;
 
 use crate::store::LogStore;
 use crate::store::StateMachineStore;
-use crate::NodeId;
 use crate::TypeConfig;
 
 struct MemKVStoreBuilder {}
 
 impl StoreBuilder<TypeConfig, LogStore, Arc<StateMachineStore>, ()> for MemKVStoreBuilder {
-    async fn build(&self) -> Result<((), LogStore, Arc<StateMachineStore>), StorageError<NodeId>> {
+    async fn build(&self) -> Result<((), LogStore, Arc<StateMachineStore>), StorageError<TypeConfig>> {
         Ok(((), LogStore::default(), Arc::default()))
     }
 }
 
 #[test]
-pub fn test_mem_store() -> Result<(), StorageError<NodeId>> {
+pub fn test_mem_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(MemKVStoreBuilder {})?;
     Ok(())
 }

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -98,7 +98,7 @@ pub struct StateMachineData {
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<NodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<TypeConfig>> {
         let last_applied_log = self.data.last_applied_log_id;
         let last_membership = self.data.last_membership.clone();
 
@@ -134,7 +134,7 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
 }
 
 impl StateMachineStore {
-    async fn new(db: Arc<DB>) -> Result<StateMachineStore, StorageError<NodeId>> {
+    async fn new(db: Arc<DB>) -> Result<StateMachineStore, StorageError<TypeConfig>> {
         let mut sm = Self {
             data: StateMachineData {
                 last_applied_log_id: None,
@@ -153,7 +153,7 @@ impl StateMachineStore {
         Ok(sm)
     }
 
-    async fn update_state_machine_(&mut self, snapshot: StoredSnapshot) -> Result<(), StorageError<NodeId>> {
+    async fn update_state_machine_(&mut self, snapshot: StoredSnapshot) -> Result<(), StorageError<TypeConfig>> {
         let kvs: BTreeMap<String, String> = serde_json::from_slice(&snapshot.data)
             .map_err(|e| StorageIOError::read_snapshot(Some(snapshot.meta.signature()), &e))?;
 
@@ -200,11 +200,11 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         Ok((self.data.last_applied_log_id, self.data.last_membership.clone()))
     }
 
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<NodeId>>
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<TypeConfig>>
     where
         I: IntoIterator<Item = typ::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,
@@ -242,7 +242,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
         self.clone()
     }
 
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Cursor<Vec<u8>>>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Cursor<Vec<u8>>>, StorageError<TypeConfig>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -250,7 +250,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotData>,
-    ) -> Result<(), StorageError<NodeId>> {
+    ) -> Result<(), StorageError<TypeConfig>> {
         let new_snapshot = StoredSnapshot {
             meta: meta.clone(),
             data: snapshot.into_inner(),
@@ -263,7 +263,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
         Ok(())
     }
 
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<NodeId>> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<TypeConfig>> {
         let x = self.get_current_snapshot_()?;
         Ok(x.map(|s| Snapshot {
             meta: s.meta.clone(),
@@ -276,7 +276,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
 pub struct LogStore {
     db: Arc<DB>,
 }
-type StorageResult<T> = Result<T, StorageError<NodeId>>;
+type StorageResult<T> = Result<T, StorageError<TypeConfig>>;
 
 /// converts an id to a byte vector for storing in the database.
 /// Note that we're using big endian encoding to ensure correct sorting of keys
@@ -393,7 +393,7 @@ impl RaftLogReader<TypeConfig> for LogStore {
             .collect()
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<NodeId>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<TypeConfig>> {
         self.get_vote_()
     }
 }
@@ -419,18 +419,18 @@ impl RaftLogStorage<TypeConfig> for LogStore {
         })
     }
 
-    async fn save_committed(&mut self, _committed: Option<LogId<NodeId>>) -> Result<(), StorageError<NodeId>> {
+    async fn save_committed(&mut self, _committed: Option<LogId<NodeId>>) -> Result<(), StorageError<TypeConfig>> {
         self.set_committed_(&_committed)?;
         Ok(())
     }
 
-    async fn read_committed(&mut self) -> Result<Option<LogId<NodeId>>, StorageError<NodeId>> {
+    async fn read_committed(&mut self) -> Result<Option<LogId<NodeId>>, StorageError<TypeConfig>> {
         let c = self.get_committed_()?;
         Ok(c)
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<NodeId>> {
+    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<TypeConfig>> {
         self.set_vote_(vote)
     }
 
@@ -467,7 +467,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
+    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<TypeConfig>> {
         tracing::debug!("delete_log: [0, {:?}]", log_id);
 
         self.set_last_purged_(log_id)?;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -807,7 +807,7 @@ where
     pub(crate) async fn spawn_replication_stream(
         &mut self,
         target: C::NodeId,
-        progress_entry: ProgressEntry<C::NodeId>,
+        progress_entry: ProgressEntry<C>,
     ) -> ReplicationHandle<C> {
         // Safe unwrap(): target must be in membership
         let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
@@ -1533,11 +1533,7 @@ where
     }
     /// If a message is sent by a previous replication session but is received by current server
     /// state, it is a stale message and should be just ignored.
-    fn does_replication_session_match(
-        &self,
-        session_id: &ReplicationSessionId<C::NodeId>,
-        msg: impl Display + Copy,
-    ) -> bool {
+    fn does_replication_session_match(&self, session_id: &ReplicationSessionId<C>, msg: impl Display + Copy) -> bool {
         if !self.does_vote_match(session_id.vote_ref(), msg) {
             return false;
         }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -707,7 +707,7 @@ where
         entries: I,
         vote: Vote<C::NodeId>,
         last_log_id: LogId<C::NodeId>,
-    ) -> Result<(), StorageError<C::NodeId>>
+    ) -> Result<(), StorageError<C>>
     where
         I: IntoIterator<Item = C::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,
@@ -732,7 +732,7 @@ where
         seq: CommandSeq,
         since: u64,
         upto_index: u64,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    ) -> Result<(), StorageError<C>> {
         tracing::debug!(upto_index = display(upto_index), "{}", func_name!());
 
         let end = upto_index + 1;
@@ -864,7 +864,7 @@ where
     /// If there is a command that waits for a callback, just return and wait for
     /// next RaftMsg.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn run_engine_commands(&mut self) -> Result<(), StorageError<C::NodeId>> {
+    pub(crate) async fn run_engine_commands(&mut self) -> Result<(), StorageError<C>> {
         if tracing::enabled!(Level::DEBUG) {
             tracing::debug!("queued commands: start...");
             for c in self.engine.output.iter_commands() {
@@ -1558,7 +1558,7 @@ where
     LS: RaftLogStorage<C>,
     SM: RaftStateMachine<C>,
 {
-    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C::NodeId>> {
+    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C>> {
         let condition = cmd.condition();
         tracing::debug!("condition: {:?}", condition);
 

--- a/openraft/src/core/sm/response.rs
+++ b/openraft/src/core/sm/response.rs
@@ -28,13 +28,13 @@ where C: RaftTypeConfig
 {
     #[allow(dead_code)]
     pub(crate) command_seq: CommandSeq,
-    pub(crate) result: Result<Response<C>, StorageError<C::NodeId>>,
+    pub(crate) result: Result<Response<C>, StorageError<C>>,
 }
 
 impl<C> CommandResult<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(command_seq: CommandSeq, result: Result<Response<C>, StorageError<C::NodeId>>) -> Self {
+    pub(crate) fn new(command_seq: CommandSeq, result: Result<Response<C>, StorageError<C>>) -> Self {
         Self { command_seq, result }
     }
 }

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -72,7 +72,7 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn worker_loop(&mut self) -> Result<(), StorageError<C::NodeId>> {
+    async fn worker_loop(&mut self) -> Result<(), StorageError<C>> {
         loop {
             let cmd = self.cmd_rx.recv().await;
             let cmd = match cmd {
@@ -126,7 +126,7 @@ where
         }
     }
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn apply(&mut self, entries: Vec<C::Entry>) -> Result<ApplyResult<C>, StorageError<C::NodeId>> {
+    async fn apply(&mut self, entries: Vec<C::Entry>) -> Result<ApplyResult<C>, StorageError<C>> {
         // TODO: prepare response before apply,
         //       so that an Entry does not need to be Clone,
         //       and no references will be used by apply
@@ -193,7 +193,7 @@ where
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_snapshot(&mut self, tx: ResultSender<C, Option<Snapshot<C>>>) -> Result<(), StorageError<C::NodeId>> {
+    async fn get_snapshot(&mut self, tx: ResultSender<C, Option<Snapshot<C>>>) -> Result<(), StorageError<C>> {
         tracing::info!("{}", func_name!());
 
         let snapshot = self.state_machine.get_current_snapshot().await?;

--- a/openraft/src/defensive.rs
+++ b/openraft/src/defensive.rs
@@ -13,7 +13,7 @@ use crate::Violation;
 pub fn check_range_matches_entries<C: RaftTypeConfig, RB: RangeBounds<u64> + Debug + OptionalSend>(
     range: RB,
     entries: &[C::Entry],
-) -> Result<(), StorageError<C::NodeId>> {
+) -> Result<(), StorageError<C>> {
     let want_first = match range.start_bound() {
         Bound::Included(i) => Some(*i),
         Bound::Excluded(i) => Some(*i + 1),

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -121,7 +121,7 @@ where C: RaftTypeConfig
     ///
     /// The candidate `last_log_id` is initialized with the attributes of Acceptor part:
     /// [`RaftState`]
-    pub(crate) fn new_candidate(&mut self, vote: Vote<C::NodeId>) -> &mut Candidate<C, LeaderQuorumSet<C::NodeId>> {
+    pub(crate) fn new_candidate(&mut self, vote: Vote<C::NodeId>) -> &mut Candidate<C, LeaderQuorumSet<C>> {
         let now = C::now();
         let last_log_id = self.state.last_log_id().copied();
 
@@ -246,11 +246,11 @@ where C: RaftTypeConfig
         self.server_state_handler().update_server_state_if_changed();
     }
 
-    pub(crate) fn candidate_ref(&self) -> Option<&Candidate<C, LeaderQuorumSet<C::NodeId>>> {
+    pub(crate) fn candidate_ref(&self) -> Option<&Candidate<C, LeaderQuorumSet<C>>> {
         self.candidate.as_ref()
     }
 
-    pub(crate) fn candidate_mut(&mut self) -> Option<&mut Candidate<C, LeaderQuorumSet<C::NodeId>>> {
+    pub(crate) fn candidate_mut(&mut self) -> Option<&mut Candidate<C, LeaderQuorumSet<C>>> {
         self.candidate.as_mut()
     }
 
@@ -825,7 +825,7 @@ mod engine_testing {
         /// Create a Leader state just for testing purpose only,
         /// without initializing related resource,
         /// such as setting up replication, propose blank log.
-        pub(crate) fn testing_new_leader(&mut self) -> &mut crate::proposer::Leader<C, LeaderQuorumSet<C::NodeId>> {
+        pub(crate) fn testing_new_leader(&mut self) -> &mut crate::proposer::Leader<C, LeaderQuorumSet<C>> {
             let leader = self.state.new_leader();
             self.leader = Some(Box::new(leader));
             self.leader.as_mut().unwrap()

--- a/openraft/src/engine/handler/establish_handler/mod.rs
+++ b/openraft/src/engine/handler/establish_handler/mod.rs
@@ -19,8 +19,8 @@ where C: RaftTypeConfig
     /// Consume the `candidate` state and establish a leader.
     pub(crate) fn establish(
         self,
-        candidate: Candidate<C, LeaderQuorumSet<C::NodeId>>,
-    ) -> Option<&'x mut Leader<C, LeaderQuorumSet<C::NodeId>>> {
+        candidate: Candidate<C, LeaderQuorumSet<C>>,
+    ) -> Option<&'x mut Leader<C, LeaderQuorumSet<C>>> {
         let vote = *candidate.vote_ref();
 
         debug_assert_eq!(

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -267,7 +267,7 @@ where C: RaftTypeConfig
     /// - Otherwise `None` if the snapshot will not be installed (e.g., if it is not newer than the
     ///   current state).
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn install_full_snapshot(&mut self, snapshot: Snapshot<C>) -> Option<Condition<C::NodeId>> {
+    pub(crate) fn install_full_snapshot(&mut self, snapshot: Snapshot<C>) -> Option<Condition<C>> {
         let meta = &snapshot.meta;
         tracing::info!("install_full_snapshot: meta:{:?}", meta);
 

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -28,7 +28,7 @@ pub(crate) struct LeaderHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C>,
-    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -40,7 +40,7 @@ pub(crate) struct ReplicationHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C>,
-    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/tests/log_id_list_test.rs
+++ b/openraft/src/engine/tests/log_id_list_test.rs
@@ -1,9 +1,10 @@
+use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::testing::log_id;
 
 #[test]
 fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
-    let mut ids = LogIdList::<u64>::default();
+    let mut ids = LogIdList::<UTConfig>::default();
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
@@ -49,7 +50,7 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
 
 #[test]
 fn test_log_id_list_extend() -> anyhow::Result<()> {
-    let mut ids = LogIdList::<u64>::default();
+    let mut ids = LogIdList::<UTConfig>::default();
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
@@ -113,7 +114,7 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
 
 #[test]
 fn test_log_id_list_append() -> anyhow::Result<()> {
-    let mut ids = LogIdList::<u64>::default();
+    let mut ids = LogIdList::<UTConfig>::default();
 
     // Append log id one by one, check the internally constructed `key_log_id` as expected.
 
@@ -138,7 +139,7 @@ fn test_log_id_list_append() -> anyhow::Result<()> {
 fn test_log_id_list_truncate() -> anyhow::Result<()> {
     // Sample data for test
     let make_ids = || {
-        LogIdList::<u64>::new(vec![
+        LogIdList::<UTConfig>::new(vec![
             log_id(2, 1, 2), //
             log_id(3, 1, 3),
             log_id(6, 1, 6),
@@ -234,14 +235,14 @@ fn test_log_id_list_truncate() -> anyhow::Result<()> {
 fn test_log_id_list_purge() -> anyhow::Result<()> {
     // Purge on an empty log id list:
     {
-        let mut ids = LogIdList::<u64>::new(vec![]);
+        let mut ids = LogIdList::<UTConfig>::new(vec![]);
         ids.purge(&log_id(2, 1, 2));
         assert_eq!(vec![log_id(2, 1, 2)], ids.key_log_ids());
     }
 
     // Sample data for test
     let make_ids = || {
-        LogIdList::<u64>::new(vec![
+        LogIdList::<UTConfig>::new(vec![
             log_id(2, 1, 2), //
             log_id(3, 1, 3),
             log_id(6, 1, 6),
@@ -319,7 +320,7 @@ fn test_log_id_list_purge() -> anyhow::Result<()> {
 fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
     // Get log id from empty list always returns `None`.
 
-    let ids = LogIdList::<u64>::default();
+    let ids = LogIdList::<UTConfig>::default();
 
     assert!(ids.get(0).is_none());
     assert!(ids.get(1).is_none());
@@ -327,7 +328,7 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
 
     // Get log id that is a key log id or not.
 
-    let ids = LogIdList::<u64>::new(vec![
+    let ids = LogIdList::<UTConfig>::new(vec![
         log_id(1, 1, 1),
         log_id(1, 1, 2),
         log_id(3, 1, 3),
@@ -355,23 +356,23 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
 #[test]
 fn test_log_id_list_by_last_leader() -> anyhow::Result<()> {
     // len == 0
-    let ids = LogIdList::<u64>::default();
+    let ids = LogIdList::<UTConfig>::default();
     assert_eq!(ids.by_last_leader(), &[]);
 
     // len == 1
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1)]);
     assert_eq!(&[log_id(1, 1, 1)], ids.by_last_leader());
 
     // len == 2, the last leader has only one log
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
     assert_eq!(&[log_id(3, 1, 3)], ids.by_last_leader());
 
     // len == 2, the last leader has two logs
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
     assert_eq!(&[log_id(1, 1, 1), log_id(1, 1, 3)], ids.by_last_leader());
 
     // len > 2, the last leader has only more than one logs
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
     assert_eq!(&[log_id(7, 1, 8), log_id(7, 1, 10)], ids.by_last_leader());
 
     Ok(())

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -109,10 +109,10 @@ where
     }
 }
 
-impl<C, E> From<StorageError<C::NodeId>> for RaftError<C, E>
+impl<C, E> From<StorageError<C>> for RaftError<C, E>
 where C: RaftTypeConfig
 {
-    fn from(se: StorageError<C::NodeId>) -> Self {
+    fn from(se: StorageError<C>) -> Self {
         RaftError::Fatal(Fatal::from(se))
     }
 }
@@ -124,7 +124,7 @@ pub enum Fatal<C>
 where C: RaftTypeConfig
 {
     #[error(transparent)]
-    StorageError(#[from] StorageError<C::NodeId>),
+    StorageError(#[from] StorageError<C>),
 
     #[error("panicked")]
     Panicked,
@@ -235,7 +235,7 @@ where C: RaftTypeConfig
     // TODO(xp): two sub type: StorageError / TransportError
     // TODO(xp): a sub error for just append_entries()
     #[error(transparent)]
-    StorageError(#[from] StorageError<C::NodeId>),
+    StorageError(#[from] StorageError<C>),
 
     #[error(transparent)]
     RPCError(#[from] RPCError<C>),

--- a/openraft/src/error/streaming_error.rs
+++ b/openraft/src/error/streaming_error.rs
@@ -29,7 +29,7 @@ pub enum StreamingError<C: RaftTypeConfig, E: Error = Infallible> {
 
     /// Storage error occurs when reading local data.
     #[error(transparent)]
-    StorageError(#[from] StorageError<C::NodeId>),
+    StorageError(#[from] StorageError<C>),
 
     /// Timeout when streaming data to remote node.
     #[error(transparent)]

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -319,7 +319,7 @@ where
     C::SnapshotData: tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin,
 {
     /// Receive a chunk of snapshot data.
-    pub async fn receive(&mut self, req: InstallSnapshotRequest<C>) -> Result<bool, StorageError<C::NodeId>> {
+    pub async fn receive(&mut self, req: InstallSnapshotRequest<C>) -> Result<bool, StorageError<C>> {
         // TODO: check id?
 
         // Always seek to the target offset if not an exact match.

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 
 use crate::error::RPCError;
 use crate::error::ReplicationClosed;
@@ -37,6 +38,7 @@ use crate::Vote;
 ///
 /// [`RaftNetwork`]: crate::network::v1::RaftNetwork
 /// [correct-node]: `crate::docs::cluster_control::dynamic_membership#ensure-connection-to-the-correct-node`
+#[since(version = "0.10.0")]
 #[add_async_trait]
 pub trait RaftNetworkV2<C>: OptionalSend + OptionalSync + 'static
 where C: RaftTypeConfig

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 
+use crate::engine::testing::UTConfig;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight::Inflight;
 use crate::raft_state::LogStateReader;
@@ -19,7 +20,7 @@ fn inflight_logs(prev_index: u64, last_index: u64) -> Inflight<u64> {
 
 #[test]
 fn test_is_log_range_inflight() -> anyhow::Result<()> {
-    let mut pe = ProgressEntry::empty(20);
+    let mut pe = ProgressEntry::<UTConfig>::empty(20);
     assert_eq!(false, pe.is_log_range_inflight(&log_id(2)));
 
     pe.inflight = inflight_logs(2, 4);
@@ -39,7 +40,7 @@ fn test_is_log_range_inflight() -> anyhow::Result<()> {
 fn test_update_matching() -> anyhow::Result<()> {
     // Update matching and inflight
     {
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.inflight = inflight_logs(5, 10);
         pe.update_matching(pe.inflight.id(), Some(log_id(6)))?;
         assert_eq!(inflight_logs(6, 10), pe.inflight);
@@ -54,7 +55,7 @@ fn test_update_matching() -> anyhow::Result<()> {
 
     // `searching_end` should be updated
     {
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(6));
         pe.inflight = inflight_logs(5, 20);
 
@@ -67,7 +68,7 @@ fn test_update_matching() -> anyhow::Result<()> {
 
 #[test]
 fn test_update_conflicting() -> anyhow::Result<()> {
-    let mut pe = ProgressEntry::empty(20);
+    let mut pe = ProgressEntry::<UTConfig>::empty(20);
     pe.matching = Some(log_id(3));
     pe.inflight = inflight_logs(5, 10);
     pe.update_conflicting(pe.inflight.id(), 5)?;
@@ -146,7 +147,7 @@ impl LogStateReader<u64> for LogState {
 fn test_next_send() -> anyhow::Result<()> {
     // There is already inflight data, return it in an Err
     {
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.inflight = inflight_logs(10, 11);
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
         assert_eq!(Err(&inflight_logs(10, 11)), res);
@@ -160,7 +161,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(4);
+        let mut pe = ProgressEntry::<UTConfig>::empty(4);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -174,7 +175,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(6);
+        let mut pe = ProgressEntry::<UTConfig>::empty(6);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -189,7 +190,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(7);
+        let mut pe = ProgressEntry::<UTConfig>::empty(7);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -204,7 +205,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -221,7 +222,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(7);
+        let mut pe = ProgressEntry::<UTConfig>::empty(7);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -236,7 +237,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(8);
+        let mut pe = ProgressEntry::<UTConfig>::empty(8);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -251,7 +252,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -266,7 +267,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -281,7 +282,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(8);
+        let mut pe = ProgressEntry::<UTConfig>::empty(8);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -296,7 +297,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(21);
+        let mut pe = ProgressEntry::<UTConfig>::empty(21);
         pe.matching = Some(log_id(20));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -312,7 +313,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 5);

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -47,7 +47,7 @@ where C: RaftTypeConfig
     pub(crate) noop_log_id: Option<LogIdOf<C>>,
 
     /// Tracks the replication progress and committed index
-    pub(crate) progress: VecProgress<C::NodeId, ProgressEntry<C::NodeId>, Option<LogIdOf<C>>, QS>,
+    pub(crate) progress: VecProgress<C::NodeId, ProgressEntry<C>, Option<LogIdOf<C>>, QS>,
 
     /// Tracks the clock time acknowledged by other nodes.
     ///

--- a/openraft/src/proposer/leader_state.rs
+++ b/openraft/src/proposer/leader_state.rs
@@ -4,7 +4,7 @@ use crate::quorum::Joint;
 use crate::type_config::alias::NodeIdOf;
 
 /// The quorum set type used by `Leader`.
-pub(crate) type LeaderQuorumSet<NID> = Joint<NID, Vec<NID>, Vec<Vec<NID>>>;
+pub(crate) type LeaderQuorumSet<C> = Joint<NodeIdOf<C>, Vec<NodeIdOf<C>>, Vec<Vec<NodeIdOf<C>>>>;
 
-pub(crate) type LeaderState<C> = Option<Box<Leader<C, LeaderQuorumSet<NodeIdOf<C>>>>>;
-pub(crate) type CandidateState<C> = Option<Candidate<C, LeaderQuorumSet<NodeIdOf<C>>>>;
+pub(crate) type LeaderState<C> = Option<Box<Leader<C, LeaderQuorumSet<C>>>>;
+pub(crate) type CandidateState<C> = Option<Candidate<C, LeaderQuorumSet<C>>>;

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -63,7 +63,7 @@ where C: RaftTypeConfig
     pub(crate) purged_next: u64,
 
     /// All log ids this node has.
-    pub log_ids: LogIdList<C::NodeId>,
+    pub log_ids: LogIdList<C>,
 
     /// The latest cluster membership configuration found, in log or in state machine.
     pub membership_state: MembershipState<C>,

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -377,7 +377,7 @@ where C: RaftTypeConfig
     /// for example, node-1 elects node-2 as a Leader, node-2 will become a Leader when receives the
     /// vote.
     /// A Leader established with election using the state in `Engine.candidate`.
-    pub(crate) fn new_leader(&mut self) -> Leader<C, LeaderQuorumSet<C::NodeId>> {
+    pub(crate) fn new_leader(&mut self) -> Leader<C, LeaderQuorumSet<C>> {
         let em = &self.membership_state.effective().membership();
 
         let last_leader_log_ids = self.log_ids.by_last_leader();

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -87,7 +87,7 @@ where
     target: C::NodeId,
 
     /// Identifies which session this replication belongs to.
-    session_id: ReplicationSessionId<C::NodeId>,
+    session_id: ReplicationSessionId<C>,
 
     /// A channel for sending events to the RaftCore.
     #[allow(clippy::type_complexity)]
@@ -157,7 +157,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn spawn(
         target: C::NodeId,
-        session_id: ReplicationSessionId<C::NodeId>,
+        session_id: ReplicationSessionId<C>,
         config: Arc<Config>,
         committed: Option<LogId<C::NodeId>>,
         matching: Option<LogId<C::NodeId>>,

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -3,7 +3,7 @@ use std::fmt::Formatter;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::Vote;
 
 /// Uniquely identifies a replication session.
@@ -29,29 +29,35 @@ use crate::Vote;
 /// But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft
 /// core believe node `c` already has `log_id=1`, and commit it.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ReplicationSessionId<NID: NodeId> {
+pub(crate) struct ReplicationSessionId<C>
+where C: RaftTypeConfig
+{
     /// The Leader or Candidate this replication belongs to.
-    pub(crate) vote: Vote<NID>,
+    pub(crate) vote: Vote<C::NodeId>,
 
     /// The log id of the membership log this replication works for.
-    pub(crate) membership_log_id: Option<LogId<NID>>,
+    pub(crate) membership_log_id: Option<LogId<C::NodeId>>,
 }
 
-impl<NID: NodeId> Display for ReplicationSessionId<NID> {
+impl<C> Display for ReplicationSessionId<C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}", self.vote, self.membership_log_id.display())
     }
 }
 
-impl<NID: NodeId> ReplicationSessionId<NID> {
-    pub(crate) fn new(vote: Vote<NID>, membership_log_id: Option<LogId<NID>>) -> Self {
+impl<C> ReplicationSessionId<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(vote: Vote<C::NodeId>, membership_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self {
             vote,
             membership_log_id,
         }
     }
 
-    pub(crate) fn vote_ref(&self) -> &Vote<NID> {
+    pub(crate) fn vote_ref(&self) -> &Vote<C::NodeId> {
         &self.vote
     }
 }

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -48,7 +48,7 @@ where C: RaftTypeConfig
     /// [`StorageError`] error has taken place locally(not on remote node) when replicating, and
     /// [`RaftCore`](`crate::core::RaftCore`) needs to shutdown. Sent by a replication task
     /// [`crate::replication::ReplicationCore`].
-    StorageError { error: StorageError<C::NodeId> },
+    StorageError { error: StorageError<C> },
 
     /// ReplicationCore has seen a higher `vote`.
     /// Sent by a replication task `ReplicationCore`.

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -42,7 +42,7 @@ where C: RaftTypeConfig
         ///
         /// A message should be discarded if it does not match the present vote and
         /// membership_log_id.
-        session_id: ReplicationSessionId<C::NodeId>,
+        session_id: ReplicationSessionId<C>,
     },
 
     /// [`StorageError`] error has taken place locally(not on remote node) when replicating, and

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -62,5 +62,5 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// Run a command produced by the engine.
     ///
     /// If a command can not be run, i.e., waiting for some event, it will be returned
-    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C::NodeId>>;
+    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C>>;
 }

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -58,7 +58,7 @@ where
     ///
     /// When the Raft node is first started, it will call this interface to fetch the last known
     /// state from stable storage.
-    pub async fn get_initial_state(&mut self) -> Result<RaftState<C>, StorageError<C::NodeId>> {
+    pub async fn get_initial_state(&mut self) -> Result<RaftState<C>, StorageError<C>> {
         let vote = self.log_store.read_vote().await?;
         let vote = vote.unwrap_or_default();
 
@@ -186,7 +186,7 @@ where
     /// a follower only need to revert at most one membership log.
     ///
     /// Thus a raft node will only need to store at most two recent membership logs.
-    pub async fn get_membership(&mut self) -> Result<MembershipState<C>, StorageError<C::NodeId>> {
+    pub async fn get_membership(&mut self) -> Result<MembershipState<C>, StorageError<C>> {
         let (last_applied, sm_mem) = self.state_machine.applied_state().await?;
 
         let log_mem = self.last_membership_in_log(last_applied.next_index()).await?;
@@ -223,7 +223,7 @@ where
     pub async fn last_membership_in_log(
         &mut self,
         since_index: u64,
-    ) -> Result<Vec<StoredMembership<C>>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<StoredMembership<C>>, StorageError<C>> {
         let st = self.log_store.get_log_state().await?;
 
         let mut end = st.last_log_id.next_index();

--- a/openraft/src/storage/log_store_ext.rs
+++ b/openraft/src/storage/log_store_ext.rs
@@ -19,7 +19,7 @@ where C: RaftTypeConfig
     /// Try to get an log entry.
     ///
     /// It does not return an error if the log entry at `log_index` is not found.
-    async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<C::Entry>, StorageError<C::NodeId>> {
+    async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<C::Entry>, StorageError<C>> {
         let mut res = self.try_get_log_entries(log_index..(log_index + 1)).await?;
         Ok(res.pop())
     }
@@ -31,7 +31,7 @@ where C: RaftTypeConfig
     async fn get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<C::Entry>, StorageError<C>> {
         let res = self.try_get_log_entries(range.clone()).await?;
 
         check_range_matches_entries::<C, _>(range, &res)?;
@@ -40,7 +40,7 @@ where C: RaftTypeConfig
     }
 
     /// Get the log id of the entry at `index`.
-    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C::NodeId>> {
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C>> {
         let entries = self.get_log_entries(log_index..=log_index).await?;
 
         Ok(*entries[0].get_log_id())

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -153,13 +153,13 @@ where C: RaftTypeConfig
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>>;
+    ) -> Result<Vec<C::Entry>, StorageError<C>>;
 
     /// Return the last saved vote by [`RaftLogStorage::save_vote`].
     ///
     /// A log reader must also be able to read the last saved vote by [`RaftLogStorage::save_vote`],
     /// See: [log-stream](`crate::docs::protocol::replication::log_stream`)
-    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>>;
+    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C>>;
 
     /// Returns log entries within range `[start, end)`, `end` is exclusive,
     /// potentially limited by implementation-defined constraints.
@@ -171,11 +171,7 @@ where C: RaftTypeConfig
     ///
     /// The default implementation just returns the full range of log entries.
     #[since(version = "0.10.0")]
-    async fn limited_get_log_entries(
-        &mut self,
-        start: u64,
-        end: u64,
-    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+    async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<C::Entry>, StorageError<C>> {
         self.try_get_log_entries(start..end).await
     }
 }
@@ -201,7 +197,7 @@ where C: RaftTypeConfig
     /// - Performing log compaction, e.g. merge log entries that operates on the same key, like a
     ///   LSM-tree does,
     /// - or by fetching a snapshot from the state machine.
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C>, StorageError<C::NodeId>>;
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C>, StorageError<C>>;
 
     // NOTES:
     // This interface is geared toward small file-based snapshots. However, not all snapshots can

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -13,6 +13,7 @@ use std::ops::RangeBounds;
 pub use helper::StorageHelper;
 pub use log_store_ext::RaftLogReaderExt;
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 pub use snapshot_signature::SnapshotSignature;
 pub use v2::RaftLogStorage;
 pub use v2::RaftLogStorageExt;
@@ -169,6 +170,7 @@ where C: RaftTypeConfig
     /// It must not return empty result if the input range is not empty.
     ///
     /// The default implementation just returns the full range of log entries.
+    #[since(version = "0.10.0")]
     async fn limited_get_log_entries(
         &mut self,
         start: u64,

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -21,7 +21,7 @@ where C: RaftTypeConfig
     /// Blocking mode append log entries to the storage.
     ///
     /// It blocks until the callback is called by the underlying storage implementation.
-    async fn blocking_append<I>(&mut self, entries: I) -> Result<(), StorageError<C::NodeId>>
+    async fn blocking_append<I>(&mut self, entries: I) -> Result<(), StorageError<C>>
     where
         I: IntoIterator<Item = C::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,

--- a/openraft/src/testing/store_builder.rs
+++ b/openraft/src/testing/store_builder.rs
@@ -23,5 +23,5 @@ where
     SM: RaftStateMachine<C>,
 {
     /// Build a [`RaftLogStorage`] and [`RaftStateMachine`] implementation
-    async fn build(&self) -> Result<(G, LS, SM), StorageError<C::NodeId>>;
+    async fn build(&self) -> Result<(G, LS, SM), StorageError<C>>;
 }

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -75,12 +75,12 @@ where
     B: StoreBuilder<C, LS, SM, G>,
     G: Send + Sync,
 {
-    pub fn test_all(builder: B) -> Result<(), StorageError<C::NodeId>> {
+    pub fn test_all(builder: B) -> Result<(), StorageError<C>> {
         Suite::test_store(&builder)?;
         Ok(())
     }
 
-    pub fn test_store(builder: &B) -> Result<(), StorageError<C::NodeId>> {
+    pub fn test_store(builder: &B) -> Result<(), StorageError<C>> {
         run_fut(run_test(builder, Self::last_membership_in_log_initial))?;
         run_fut(run_test(builder, Self::last_membership_in_log))?;
         run_fut(run_test(builder, Self::last_membership_in_log_multi_step))?;
@@ -124,7 +124,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let membership = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
 
         assert!(membership.is_empty());
@@ -132,7 +132,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- no log, do not read membership from state machine");
         {
             apply(&mut sm, [
@@ -207,7 +207,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log_multi_step(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log_multi_step(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- find membership log entry backwards, multiple steps");
         {
             append(&mut store, [
@@ -235,7 +235,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
         assert_eq!(&EffectiveMembership::default(), mem_state.committed().as_ref());
@@ -244,10 +244,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_log_and_empty_sm(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_log_and_empty_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- no log, read membership from state machine");
         {
             // There is an empty membership config in an empty state machine.
@@ -266,10 +263,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_empty_log_and_sm(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_empty_log_and_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- no log, read membership from state machine");
         {
             apply(&mut sm, [
@@ -292,10 +286,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_log_le_sm_last_applied(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_log_le_sm_last_applied(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- membership presents in log, but smaller than last_applied, read from state machine");
         {
             apply(&mut sm, [
@@ -332,7 +323,7 @@ where
     pub async fn get_membership_from_log_gt_sm_last_applied_1(
         mut store: LS,
         mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    ) -> Result<(), StorageError<C>> {
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
         {
             apply(&mut sm, [
@@ -365,7 +356,7 @@ where
     pub async fn get_membership_from_log_gt_sm_last_applied_2(
         mut store: LS,
         mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    ) -> Result<(), StorageError<C>> {
         tracing::info!("--- two membership present in log and > sm.last_applied, read 2 from log");
         {
             apply(&mut sm, [
@@ -398,7 +389,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
         let mut want = RaftState::<C>::default();
         want.vote.update(initial.vote.utime().unwrap(), Vote::default());
@@ -407,7 +398,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_with_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_with_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [
@@ -442,7 +433,7 @@ where
     pub async fn get_initial_state_membership_from_log_and_sm(
         mut store: LS,
         mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    ) -> Result<(), StorageError<C>> {
         // It should never return membership from logs that are included in state machine present.
 
         Self::default_vote(&mut store).await?;
@@ -492,7 +483,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_gt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_last_log_gt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [blank_ent_0::<C>(0, 0), blank_ent_0::<C>(2, 1)]).await?;
@@ -509,7 +500,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_lt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_last_log_lt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [blank_ent_0::<C>(1, 2)]).await?;
@@ -531,7 +522,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_log_ids(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_log_ids(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let log_id = |t, n: u64, i| LogId::<C::NodeId> {
             leader_id: CommittedLeaderId::new(t, n.into()),
             index: i,
@@ -655,10 +646,7 @@ where
     }
 
     /// Test if committed logs are re-applied.
-    pub async fn get_initial_state_re_apply_committed(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_re_apply_committed(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [
@@ -691,7 +679,7 @@ where
         Ok(())
     }
 
-    pub async fn save_vote(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn save_vote(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         store.save_vote(&Vote::new(100, NODE_ID.into())).await?;
 
         let got = store.read_vote().await?;
@@ -700,7 +688,7 @@ where
         Ok(())
     }
 
-    pub async fn get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         tracing::info!("--- get start == stop");
@@ -721,7 +709,7 @@ where
         Ok(())
     }
 
-    pub async fn limited_get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn limited_get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         tracing::info!("--- get start == stop");
@@ -742,7 +730,7 @@ where
         Ok(())
     }
 
-    pub async fn try_get_log_entry(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn try_get_log_entry(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         store.purge(LogId::new(CommittedLeaderId::new(0, C::NodeId::default()), 0)).await?;
@@ -763,14 +751,14 @@ where
         Ok(())
     }
 
-    pub async fn initial_logs(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn initial_logs(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let ent = store.try_get_log_entry(0).await?;
         assert!(ent.is_none(), "store initialized");
 
         Ok(())
     }
 
-    pub async fn get_log_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let st = store.get_log_state().await?;
 
         assert_eq!(None, st.last_purged_log_id);
@@ -827,7 +815,7 @@ where
         Ok(())
     }
 
-    pub async fn get_log_id(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_id(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         store.purge(log_id_0(1, 3)).await?;
@@ -854,7 +842,7 @@ where
         Ok(())
     }
 
-    pub async fn last_id_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_id_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let last_log_id = store.get_log_state().await?.last_log_id;
         assert_eq!(None, last_log_id);
 
@@ -893,7 +881,7 @@ where
         Ok(())
     }
 
-    pub async fn last_applied_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_applied_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let (applied, mem) = sm.applied_state().await?;
         assert_eq!(None, applied);
         assert_eq!(StoredMembership::default(), mem);
@@ -925,7 +913,7 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete (-oo, 0]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -950,7 +938,7 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_5(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_5(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete (-oo, 5]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -975,7 +963,7 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_20(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_20(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete (-oo, 20]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -999,7 +987,7 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_11(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn delete_logs_since_11(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete [11, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -1019,7 +1007,7 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn delete_logs_since_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete [0, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -1040,7 +1028,7 @@ where
         Ok(())
     }
 
-    pub async fn append_to_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn append_to_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         store.purge(log_id_0(0, 0)).await?;
@@ -1059,7 +1047,7 @@ where
         Ok(())
     }
 
-    pub async fn snapshot_meta(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn snapshot_meta(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- just initialized");
         {
             apply(&mut sm, [membership_ent_0::<C>(0, 0, btreeset! {1,2})]).await?;
@@ -1097,7 +1085,7 @@ where
         Ok(())
     }
 
-    pub async fn apply_single(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn apply_single(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let (last_applied, _) = sm.applied_state().await?;
         assert_eq!(last_applied, None,);
 
@@ -1143,7 +1131,7 @@ where
         Ok(())
     }
 
-    pub async fn apply_multiple(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn apply_multiple(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let (last_applied, _) = sm.applied_state().await?;
         assert_eq!(last_applied, None,);
 
@@ -1161,7 +1149,7 @@ where
 
     /// Rudimentary test for snapshotting that builds a snapshot on one node and installs it on
     /// another
-    pub async fn transfer_snapshot(builder: &B) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn transfer_snapshot(builder: &B) -> Result<(), StorageError<C>> {
         // Create a snapshot on sm_l, and install it on sm_f
         let (_g_l, _store_l, mut sm_l) = builder.build().await?;
         let (_g_f, _store_f, mut sm_f) = builder.build().await?;
@@ -1213,7 +1201,7 @@ where
         Ok(())
     }
 
-    pub async fn feed_10_logs_vote_self(sto: &mut LS) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn feed_10_logs_vote_self(sto: &mut LS) -> Result<(), StorageError<C>> {
         append(sto, [blank_ent_0::<C>(0, 0)]).await?;
 
         for i in 1..=10 {
@@ -1225,7 +1213,7 @@ where
         Ok(())
     }
 
-    pub async fn default_vote(sto: &mut LS) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn default_vote(sto: &mut LS) -> Result<(), StorageError<C>> {
         sto.save_vote(&Vote::new(1, NODE_ID.into())).await?;
 
         Ok(())
@@ -1256,10 +1244,10 @@ where C::NodeId: From<u64> {
 /// Block until a future is finished.
 /// The future will be running in a clean tokio runtime, to prevent an unfinished task affecting the
 /// test.
-pub fn run_fut<NID, F>(f: F) -> Result<(), StorageError<NID>>
+pub fn run_fut<C, F>(f: F) -> Result<(), StorageError<C>>
 where
-    NID: NodeId,
-    F: Future<Output = Result<(), StorageError<NID>>>,
+    C: RaftTypeConfig,
+    F: Future<Output = Result<(), StorageError<C>>>,
 {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(f)?;
@@ -1267,16 +1255,13 @@ where
 }
 
 /// Build a `RaftLogStorage` and `RaftStateMachine` implementation and run a test on it.
-async fn run_test<C, LS, SM, G, B, TestFn, Ret, Fu>(
-    builder: &B,
-    test_fn: TestFn,
-) -> Result<Ret, StorageError<C::NodeId>>
+async fn run_test<C, LS, SM, G, B, TestFn, Ret, Fu>(builder: &B, test_fn: TestFn) -> Result<Ret, StorageError<C>>
 where
     C: RaftTypeConfig,
     LS: RaftLogStorage<C>,
     SM: RaftStateMachine<C>,
     B: StoreBuilder<C, LS, SM, G>,
-    Fu: Future<Output = Result<Ret, StorageError<C::NodeId>>> + OptionalSend,
+    Fu: Future<Output = Result<Ret, StorageError<C>>> + OptionalSend,
     TestFn: Fn(LS, SM) -> Fu + Sync + Send,
 {
     let (_g, store, sm) = builder.build().await?;
@@ -1284,7 +1269,7 @@ where
 }
 
 /// A wrapper for calling nonblocking `RaftStateMachine::apply()`
-async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<Vec<C::R>, StorageError<C::NodeId>>
+async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<Vec<C::R>, StorageError<C>>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
@@ -1296,7 +1281,7 @@ where
 }
 
 /// A wrapper for calling nonblocking `RaftLogStorage::append()`
-async fn append<C, LS, I>(store: &mut LS, entries: I) -> Result<(), StorageError<C::NodeId>>
+async fn append<C, LS, I>(store: &mut LS, entries: I) -> Result<(), StorageError<C>>
 where
     C: RaftTypeConfig,
     LS: RaftLogStorage<C>,

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::time::Duration;
 
+use openraft_macros::since;
+
 use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinHandleOf;
@@ -14,6 +16,7 @@ use crate::OptionalSend;
 use crate::RaftTypeConfig;
 
 /// Collection of utility methods to `RaftTypeConfig` function.
+#[since(version = "0.10.0")]
 pub trait TypeConfigExt: RaftTypeConfig {
     // Time related methods
 

--- a/stores/memstore/src/test.rs
+++ b/stores/memstore/src/test.rs
@@ -5,21 +5,20 @@ use openraft::testing::Suite;
 use openraft::StorageError;
 
 use crate::MemLogStore;
-use crate::MemNodeId;
 use crate::MemStateMachine;
 use crate::TypeConfig;
 
 struct MemStoreBuilder {}
 
 impl StoreBuilder<TypeConfig, Arc<MemLogStore>, Arc<MemStateMachine>, ()> for MemStoreBuilder {
-    async fn build(&self) -> Result<((), Arc<MemLogStore>, Arc<MemStateMachine>), StorageError<MemNodeId>> {
+    async fn build(&self) -> Result<((), Arc<MemLogStore>, Arc<MemStateMachine>), StorageError<TypeConfig>> {
         let (log_store, sm) = crate::new_mem_store();
         Ok(((), log_store, sm))
     }
 }
 
 #[test]
-pub fn test_mem_store() -> Result<(), StorageError<MemNodeId>> {
+pub fn test_mem_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(MemStoreBuilder {})?;
     Ok(())
 }

--- a/stores/rocksstore/src/test.rs
+++ b/stores/rocksstore/src/test.rs
@@ -4,14 +4,13 @@ use openraft::StorageError;
 use tempfile::TempDir;
 
 use crate::RocksLogStore;
-use crate::RocksNodeId;
 use crate::RocksStateMachine;
 use crate::TypeConfig;
 
 struct RocksBuilder {}
 
 impl StoreBuilder<TypeConfig, RocksLogStore, RocksStateMachine, TempDir> for RocksBuilder {
-    async fn build(&self) -> Result<(TempDir, RocksLogStore, RocksStateMachine), StorageError<RocksNodeId>> {
+    async fn build(&self) -> Result<(TempDir, RocksLogStore, RocksStateMachine), StorageError<TypeConfig>> {
         let td = TempDir::new().expect("couldn't create temp dir");
         let (log_store, sm) = crate::new(td.path()).await;
         Ok((td, log_store, sm))
@@ -37,7 +36,7 @@ impl StoreBuilder<TypeConfig, RocksLogStore, RocksStateMachine, TempDir> for Roc
 /// }
 /// ```
 #[test]
-pub fn test_rocks_store() -> Result<(), StorageError<RocksNodeId>> {
+pub fn test_rocks_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(RocksBuilder {})?;
     Ok(())
 }

--- a/stores/sledstore/src/lib.rs
+++ b/stores/sledstore/src/lib.rs
@@ -277,7 +277,7 @@ pub struct SledStore {
     pub state_machine: RwLock<ExampleStateMachine>,
 }
 
-type StorageResult<T> = Result<T, StorageError<ExampleNodeId>>;
+type StorageResult<T> = Result<T, StorageError<TypeConfig>>;
 
 /// converts an id to a byte vector for storing in the database.
 /// Note that we're using big endian encoding to ensure correct sorting of keys
@@ -335,7 +335,7 @@ impl SledStore {
         Ok(())
     }
 
-    async fn set_vote_(&self, vote: &Vote<ExampleNodeId>) -> Result<(), StorageError<ExampleNodeId>> {
+    async fn set_vote_(&self, vote: &Vote<ExampleNodeId>) -> Result<(), StorageError<TypeConfig>> {
         let store_tree = store(&self.db);
         let val = serde_json::to_vec(vote).unwrap();
         store_tree.insert(b"vote", val).map_err(write_vote_err)?;
@@ -418,14 +418,14 @@ impl RaftLogReader<TypeConfig> for Arc<SledStore> {
         logs
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<ExampleNodeId>>, StorageError<ExampleNodeId>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<ExampleNodeId>>, StorageError<TypeConfig>> {
         self.get_vote_()
     }
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<SledStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<ExampleNodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<TypeConfig>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -497,7 +497,7 @@ impl RaftLogStorage<TypeConfig> for Arc<SledStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<ExampleNodeId>) -> Result<(), StorageError<ExampleNodeId>> {
+    async fn save_vote(&mut self, vote: &Vote<ExampleNodeId>) -> Result<(), StorageError<TypeConfig>> {
         self.set_vote_(vote).await
     }
 
@@ -542,7 +542,7 @@ impl RaftLogStorage<TypeConfig> for Arc<SledStore> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn purge(&mut self, log_id: LogId<ExampleNodeId>) -> Result<(), StorageError<ExampleNodeId>> {
+    async fn purge(&mut self, log_id: LogId<ExampleNodeId>) -> Result<(), StorageError<TypeConfig>> {
         tracing::debug!("delete_log: [0, {:?}]", log_id);
 
         self.set_last_purged_(log_id).await?;
@@ -567,7 +567,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<ExampleNodeId>>, StoredMembership<TypeConfig>), StorageError<ExampleNodeId>> {
+    ) -> Result<(Option<LogId<ExampleNodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.read().await;
         Ok((
             state_machine.get_last_applied_log()?,
@@ -576,7 +576,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<ExampleResponse>, StorageError<ExampleNodeId>>
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<ExampleResponse>, StorageError<TypeConfig>>
     where
         I: IntoIterator<Item = Entry<TypeConfig>> + OptionalSend,
         I::IntoIter: OptionalSend,
@@ -625,9 +625,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(
-        &mut self,
-    ) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<ExampleNodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -636,7 +634,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
-    ) -> Result<(), StorageError<ExampleNodeId>> {
+    ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },
             "decoding snapshot for installation"
@@ -660,7 +658,7 @@ impl RaftStateMachine<TypeConfig> for Arc<SledStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<ExampleNodeId>> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<TypeConfig>> {
         match SledStore::get_current_snapshot_(self)? {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/stores/sledstore/src/test.rs
+++ b/stores/sledstore/src/test.rs
@@ -5,14 +5,13 @@ use openraft::testing::Suite;
 use openraft::StorageError;
 use tempfile::TempDir;
 
-use crate::ExampleNodeId;
 use crate::SledStore;
 use crate::TypeConfig;
 
 struct SledBuilder {}
 
 #[test]
-pub fn test_sled_store() -> Result<(), StorageError<ExampleNodeId>> {
+pub fn test_sled_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(SledBuilder {})
 }
 
@@ -20,7 +19,7 @@ type LogStore = Arc<SledStore>;
 type StateMachine = Arc<SledStore>;
 
 impl StoreBuilder<TypeConfig, LogStore, StateMachine, TempDir> for SledBuilder {
-    async fn build(&self) -> Result<(TempDir, LogStore, StateMachine), StorageError<ExampleNodeId>> {
+    async fn build(&self) -> Result<(TempDir, LogStore, StateMachine), StorageError<TypeConfig>> {
         let td = TempDir::new().expect("couldn't create temp dir");
 
         let db: sled::Db = sled::open(td.path()).unwrap();


### PR DESCRIPTION

## Changelog

##### Change: use RaftTypeConfig to replace NID

- `StorageError<NID>` to `StorageError<C>`
- `LogIdList<NID>` to `LogIdList<C>`


##### Refactor: use RaftTypeConfig to replace NID

- `ReplicationSessionId<NID>` to `ReplicationSessionId<C>`
- `LeaderQuorumSet<NID>` to `LeaderQuorumSet<C>`
- `Condition<NID>` to `Condition<C>`
- `ProgressEntry<NID>` to `ProgressEntry<C>`


##### Chore: add `since` to new methods

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1147)
<!-- Reviewable:end -->
