### PR TITLE
Change: use RaftTypeConfig to replace NID

### DIFF
--- a/cluster_benchmark/tests/benchmark/store/test.rs
+++ b/cluster_benchmark/tests/benchmark/store/test.rs
@@ -5,14 +5,13 @@ use openraft::testing::Suite;
 use openraft::StorageError;
 
 use crate::store::LogStore;
-use crate::store::NodeId;
 use crate::store::StateMachineStore;
 use crate::store::TypeConfig;
 
 struct Builder {}
 
 impl StoreBuilder<TypeConfig, Arc<LogStore>, Arc<StateMachineStore>> for Builder {
-    async fn build(&self) -> Result<((), Arc<LogStore>, Arc<StateMachineStore>), StorageError<NodeId>> {
+    async fn build(&self) -> Result<((), Arc<LogStore>, Arc<StateMachineStore>), StorageError<TypeConfig>> {
         let log_store = LogStore::new_async().await;
         let sm = Arc::new(StateMachineStore::new());
         Ok(((), log_store, sm))
@@ -20,7 +19,7 @@ impl StoreBuilder<TypeConfig, Arc<LogStore>, Arc<StateMachineStore>> for Builder
 }
 
 #[test]
-pub fn test_store() -> Result<(), StorageError<NodeId>> {
+pub fn test_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(Builder {})?;
     Ok(())
 }

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -77,7 +77,7 @@ pub struct StateMachineStore {
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<NodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<TypeConfig>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -131,13 +131,13 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<NodeId>>
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<TypeConfig>>
     where I: IntoIterator<Item = Entry<TypeConfig>> {
         let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
 
@@ -168,7 +168,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(Box::default())
     }
 
@@ -177,7 +177,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
-    ) -> Result<(), StorageError<NodeId>> {
+    ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!("install snapshot");
 
         let new_snapshot = StoredSnapshot {
@@ -199,7 +199,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<NodeId>> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<TypeConfig>> {
         match &*self.current_snapshot.lock().unwrap() {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -92,7 +92,7 @@ impl StateMachineStore {
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<NodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<TypeConfig>> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -152,13 +152,13 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<NodeId>> {
+    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<NodeId>>
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<TypeConfig>>
     where I: IntoIterator<Item = Entry<TypeConfig>> {
         let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
 
@@ -189,7 +189,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<NodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(Box::default())
     }
 
@@ -198,7 +198,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
-    ) -> Result<(), StorageError<NodeId>> {
+    ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!("install snapshot");
 
         let new_snapshot = StoredSnapshot {
@@ -221,7 +221,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<NodeId>> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<TypeConfig>> {
         match &*self.current_snapshot.lock().unwrap() {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/examples/raft-kv-memstore/src/test.rs
+++ b/examples/raft-kv-memstore/src/test.rs
@@ -6,19 +6,18 @@ use openraft::StorageError;
 
 use crate::store::LogStore;
 use crate::store::StateMachineStore;
-use crate::NodeId;
 use crate::TypeConfig;
 
 struct MemKVStoreBuilder {}
 
 impl StoreBuilder<TypeConfig, LogStore, Arc<StateMachineStore>, ()> for MemKVStoreBuilder {
-    async fn build(&self) -> Result<((), LogStore, Arc<StateMachineStore>), StorageError<NodeId>> {
+    async fn build(&self) -> Result<((), LogStore, Arc<StateMachineStore>), StorageError<TypeConfig>> {
         Ok(((), LogStore::default(), Arc::default()))
     }
 }
 
 #[test]
-pub fn test_mem_store() -> Result<(), StorageError<NodeId>> {
+pub fn test_mem_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(MemKVStoreBuilder {})?;
     Ok(())
 }

--- a/openraft/src/change_members.rs
+++ b/openraft/src/change_members.rs
@@ -1,29 +1,30 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-use crate::Node;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// Defines various actions to change the membership, including adding or removing learners or
 /// voters.
 #[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum ChangeMembers<NID: NodeId, N: Node> {
+pub enum ChangeMembers<C>
+where C: RaftTypeConfig
+{
     /// Upgrade learners to voters.
     ///
     /// The learners have to present or [`error::LearnerNotFound`](`crate::error::LearnerNotFound`)
     /// error will be returned.
-    AddVoterIds(BTreeSet<NID>),
+    AddVoterIds(BTreeSet<C::NodeId>),
 
     /// Add voters with corresponding nodes.
-    AddVoters(BTreeMap<NID, N>),
+    AddVoters(BTreeMap<C::NodeId, C::Node>),
 
     /// Remove voters, leave removed voters as learner or not.
-    RemoveVoters(BTreeSet<NID>),
+    RemoveVoters(BTreeSet<C::NodeId>),
 
     /// Replace voter ids with a new set. The node of every new voter has to already be a learner.
-    ReplaceAllVoters(BTreeSet<NID>),
+    ReplaceAllVoters(BTreeSet<C::NodeId>),
 
     /// Add nodes to membership, as learners.
     ///
@@ -32,7 +33,7 @@ pub enum ChangeMembers<NID: NodeId, N: Node> {
     /// Prefer using this variant instead of `SetNodes` whenever possible, as `AddNodes` ensures
     /// safety, whereas incorrect usage of `SetNodes` can result in a brain split.
     /// See: [Update-Node](`crate::docs::cluster_control::dynamic_membership#update-node`)
-    AddNodes(BTreeMap<NID, N>),
+    AddNodes(BTreeMap<C::NodeId, C::Node>),
 
     /// Add or replace nodes in membership config.
     ///
@@ -41,30 +42,29 @@ pub enum ChangeMembers<NID: NodeId, N: Node> {
     /// Prefer using `AddNodes` instead of `SetNodes` whenever possible, as `AddNodes` ensures
     /// safety, whereas incorrect usage of `SetNodes` can result in a brain split.
     /// See: [Update-Node](`crate::docs::cluster_control::dynamic_membership#update-node`)
-    SetNodes(BTreeMap<NID, N>),
+    SetNodes(BTreeMap<C::NodeId, C::Node>),
 
     /// Remove nodes from membership.
     ///
     /// If a node is still a voter, it returns
     /// [`error::LearnerNotFound`](`crate::error::LearnerNotFound`) error.
-    RemoveNodes(BTreeSet<NID>),
+    RemoveNodes(BTreeSet<C::NodeId>),
 
     /// Replace all nodes with a new set.
     ///
     /// Every voter has to have a corresponding node in the new
     /// set, otherwise it returns [`error::LearnerNotFound`](`crate::error::LearnerNotFound`) error.
-    ReplaceAllNodes(BTreeMap<NID, N>),
+    ReplaceAllNodes(BTreeMap<C::NodeId, C::Node>),
 }
 
 /// Convert a series of ids to a `Replace` operation.
-impl<NID, N, I> From<I> for ChangeMembers<NID, N>
+impl<C, I> From<I> for ChangeMembers<C>
 where
-    NID: NodeId,
-    N: Node,
-    I: IntoIterator<Item = NID>,
+    C: RaftTypeConfig,
+    I: IntoIterator<Item = C::NodeId>,
 {
     fn from(r: I) -> Self {
-        let ids = r.into_iter().collect::<BTreeSet<NID>>();
+        let ids = r.into_iter().collect::<BTreeSet<C::NodeId>>();
         ChangeMembers::ReplaceAllVoters(ids)
     }
 }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -807,7 +807,7 @@ where
     pub(crate) async fn spawn_replication_stream(
         &mut self,
         target: C::NodeId,
-        progress_entry: ProgressEntry<C::NodeId>,
+        progress_entry: ProgressEntry<C>,
     ) -> ReplicationHandle<C> {
         // Safe unwrap(): target must be in membership
         let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
@@ -1533,11 +1533,7 @@ where
     }
     /// If a message is sent by a previous replication session but is received by current server
     /// state, it is a stale message and should be just ignored.
-    fn does_replication_session_match(
-        &self,
-        session_id: &ReplicationSessionId<C::NodeId>,
-        msg: impl Display + Copy,
-    ) -> bool {
+    fn does_replication_session_match(&self, session_id: &ReplicationSessionId<C>, msg: impl Display + Copy) -> bool {
         if !self.does_vote_match(session_id.vote_ref(), msg) {
             return false;
         }

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -81,7 +81,7 @@ where C: RaftTypeConfig
     },
 
     ChangeMembership {
-        changes: ChangeMembers<C::NodeId, C::Node>,
+        changes: ChangeMembers<C>,
 
         /// If `retain` is `true`, then the voters that are not in the new
         /// config will be converted into learners, otherwise they will be removed.

--- a/openraft/src/core/sm/response.rs
+++ b/openraft/src/core/sm/response.rs
@@ -28,13 +28,13 @@ where C: RaftTypeConfig
 {
     #[allow(dead_code)]
     pub(crate) command_seq: CommandSeq,
-    pub(crate) result: Result<Response<C>, StorageError<C::NodeId>>,
+    pub(crate) result: Result<Response<C>, StorageError<C>>,
 }
 
 impl<C> CommandResult<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(command_seq: CommandSeq, result: Result<Response<C>, StorageError<C::NodeId>>) -> Self {
+    pub(crate) fn new(command_seq: CommandSeq, result: Result<Response<C>, StorageError<C>>) -> Self {
         Self { command_seq, result }
     }
 }

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -72,7 +72,7 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn worker_loop(&mut self) -> Result<(), StorageError<C::NodeId>> {
+    async fn worker_loop(&mut self) -> Result<(), StorageError<C>> {
         loop {
             let cmd = self.cmd_rx.recv().await;
             let cmd = match cmd {
@@ -126,7 +126,7 @@ where
         }
     }
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn apply(&mut self, entries: Vec<C::Entry>) -> Result<ApplyResult<C>, StorageError<C::NodeId>> {
+    async fn apply(&mut self, entries: Vec<C::Entry>) -> Result<ApplyResult<C>, StorageError<C>> {
         // TODO: prepare response before apply,
         //       so that an Entry does not need to be Clone,
         //       and no references will be used by apply
@@ -193,7 +193,7 @@ where
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_snapshot(&mut self, tx: ResultSender<C, Option<Snapshot<C>>>) -> Result<(), StorageError<C::NodeId>> {
+    async fn get_snapshot(&mut self, tx: ResultSender<C, Option<Snapshot<C>>>) -> Result<(), StorageError<C>> {
         tracing::info!("{}", func_name!());
 
         let snapshot = self.state_machine.get_current_snapshot().await?;

--- a/openraft/src/defensive.rs
+++ b/openraft/src/defensive.rs
@@ -13,7 +13,7 @@ use crate::Violation;
 pub fn check_range_matches_entries<C: RaftTypeConfig, RB: RangeBounds<u64> + Debug + OptionalSend>(
     range: RB,
     entries: &[C::Entry],
-) -> Result<(), StorageError<C::NodeId>> {
+) -> Result<(), StorageError<C>> {
     let want_first = match range.start_bound() {
         Bound::Included(i) => Some(*i),
         Bound::Excluded(i) => Some(*i + 1),

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -121,7 +121,7 @@ where C: RaftTypeConfig
     ///
     /// The candidate `last_log_id` is initialized with the attributes of Acceptor part:
     /// [`RaftState`]
-    pub(crate) fn new_candidate(&mut self, vote: Vote<C::NodeId>) -> &mut Candidate<C, LeaderQuorumSet<C::NodeId>> {
+    pub(crate) fn new_candidate(&mut self, vote: Vote<C::NodeId>) -> &mut Candidate<C, LeaderQuorumSet<C>> {
         let now = C::now();
         let last_log_id = self.state.last_log_id().copied();
 
@@ -246,11 +246,11 @@ where C: RaftTypeConfig
         self.server_state_handler().update_server_state_if_changed();
     }
 
-    pub(crate) fn candidate_ref(&self) -> Option<&Candidate<C, LeaderQuorumSet<C::NodeId>>> {
+    pub(crate) fn candidate_ref(&self) -> Option<&Candidate<C, LeaderQuorumSet<C>>> {
         self.candidate.as_ref()
     }
 
-    pub(crate) fn candidate_mut(&mut self) -> Option<&mut Candidate<C, LeaderQuorumSet<C::NodeId>>> {
+    pub(crate) fn candidate_mut(&mut self) -> Option<&mut Candidate<C, LeaderQuorumSet<C>>> {
         self.candidate.as_mut()
     }
 
@@ -825,7 +825,7 @@ mod engine_testing {
         /// Create a Leader state just for testing purpose only,
         /// without initializing related resource,
         /// such as setting up replication, propose blank log.
-        pub(crate) fn testing_new_leader(&mut self) -> &mut crate::proposer::Leader<C, LeaderQuorumSet<C::NodeId>> {
+        pub(crate) fn testing_new_leader(&mut self) -> &mut crate::proposer::Leader<C, LeaderQuorumSet<C>> {
             let leader = self.state.new_leader();
             self.leader = Some(Box::new(leader));
             self.leader.as_mut().unwrap()

--- a/openraft/src/engine/handler/establish_handler/mod.rs
+++ b/openraft/src/engine/handler/establish_handler/mod.rs
@@ -19,8 +19,8 @@ where C: RaftTypeConfig
     /// Consume the `candidate` state and establish a leader.
     pub(crate) fn establish(
         self,
-        candidate: Candidate<C, LeaderQuorumSet<C::NodeId>>,
-    ) -> Option<&'x mut Leader<C, LeaderQuorumSet<C::NodeId>>> {
+        candidate: Candidate<C, LeaderQuorumSet<C>>,
+    ) -> Option<&'x mut Leader<C, LeaderQuorumSet<C>>> {
         let vote = *candidate.vote_ref();
 
         debug_assert_eq!(

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -267,7 +267,7 @@ where C: RaftTypeConfig
     /// - Otherwise `None` if the snapshot will not be installed (e.g., if it is not newer than the
     ///   current state).
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn install_full_snapshot(&mut self, snapshot: Snapshot<C>) -> Option<Condition<C::NodeId>> {
+    pub(crate) fn install_full_snapshot(&mut self, snapshot: Snapshot<C>) -> Option<Condition<C>> {
         let meta = &snapshot.meta;
         tracing::info!("install_full_snapshot: meta:{:?}", meta);
 

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -28,7 +28,7 @@ pub(crate) struct LeaderHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C>,
-    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -40,7 +40,7 @@ pub(crate) struct ReplicationHandler<'x, C>
 where C: RaftTypeConfig
 {
     pub(crate) config: &'x mut EngineConfig<C>,
-    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C::NodeId>>,
+    pub(crate) leader: &'x mut Leader<C, LeaderQuorumSet<C>>,
     pub(crate) state: &'x mut RaftState<C>,
     pub(crate) output: &'x mut EngineOutput<C>,
 }

--- a/openraft/src/engine/tests/log_id_list_test.rs
+++ b/openraft/src/engine/tests/log_id_list_test.rs
@@ -1,9 +1,10 @@
+use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::testing::log_id;
 
 #[test]
 fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
-    let mut ids = LogIdList::<u64>::default();
+    let mut ids = LogIdList::<UTConfig>::default();
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
@@ -49,7 +50,7 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
 
 #[test]
 fn test_log_id_list_extend() -> anyhow::Result<()> {
-    let mut ids = LogIdList::<u64>::default();
+    let mut ids = LogIdList::<UTConfig>::default();
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
@@ -113,7 +114,7 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
 
 #[test]
 fn test_log_id_list_append() -> anyhow::Result<()> {
-    let mut ids = LogIdList::<u64>::default();
+    let mut ids = LogIdList::<UTConfig>::default();
 
     // Append log id one by one, check the internally constructed `key_log_id` as expected.
 
@@ -138,7 +139,7 @@ fn test_log_id_list_append() -> anyhow::Result<()> {
 fn test_log_id_list_truncate() -> anyhow::Result<()> {
     // Sample data for test
     let make_ids = || {
-        LogIdList::<u64>::new(vec![
+        LogIdList::<UTConfig>::new(vec![
             log_id(2, 1, 2), //
             log_id(3, 1, 3),
             log_id(6, 1, 6),
@@ -234,14 +235,14 @@ fn test_log_id_list_truncate() -> anyhow::Result<()> {
 fn test_log_id_list_purge() -> anyhow::Result<()> {
     // Purge on an empty log id list:
     {
-        let mut ids = LogIdList::<u64>::new(vec![]);
+        let mut ids = LogIdList::<UTConfig>::new(vec![]);
         ids.purge(&log_id(2, 1, 2));
         assert_eq!(vec![log_id(2, 1, 2)], ids.key_log_ids());
     }
 
     // Sample data for test
     let make_ids = || {
-        LogIdList::<u64>::new(vec![
+        LogIdList::<UTConfig>::new(vec![
             log_id(2, 1, 2), //
             log_id(3, 1, 3),
             log_id(6, 1, 6),
@@ -319,7 +320,7 @@ fn test_log_id_list_purge() -> anyhow::Result<()> {
 fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
     // Get log id from empty list always returns `None`.
 
-    let ids = LogIdList::<u64>::default();
+    let ids = LogIdList::<UTConfig>::default();
 
     assert!(ids.get(0).is_none());
     assert!(ids.get(1).is_none());
@@ -327,7 +328,7 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
 
     // Get log id that is a key log id or not.
 
-    let ids = LogIdList::<u64>::new(vec![
+    let ids = LogIdList::<UTConfig>::new(vec![
         log_id(1, 1, 1),
         log_id(1, 1, 2),
         log_id(3, 1, 3),
@@ -355,23 +356,23 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
 #[test]
 fn test_log_id_list_by_last_leader() -> anyhow::Result<()> {
     // len == 0
-    let ids = LogIdList::<u64>::default();
+    let ids = LogIdList::<UTConfig>::default();
     assert_eq!(ids.by_last_leader(), &[]);
 
     // len == 1
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1)]);
     assert_eq!(&[log_id(1, 1, 1)], ids.by_last_leader());
 
     // len == 2, the last leader has only one log
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
     assert_eq!(&[log_id(3, 1, 3)], ids.by_last_leader());
 
     // len == 2, the last leader has two logs
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
     assert_eq!(&[log_id(1, 1, 1), log_id(1, 1, 3)], ids.by_last_leader());
 
     // len > 2, the last leader has only more than one logs
-    let ids = LogIdList::<u64>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
+    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
     assert_eq!(&[log_id(7, 1, 8), log_id(7, 1, 10)], ids.by_last_leader());
 
     Ok(())

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -109,10 +109,10 @@ where
     }
 }
 
-impl<C, E> From<StorageError<C::NodeId>> for RaftError<C, E>
+impl<C, E> From<StorageError<C>> for RaftError<C, E>
 where C: RaftTypeConfig
 {
-    fn from(se: StorageError<C::NodeId>) -> Self {
+    fn from(se: StorageError<C>) -> Self {
         RaftError::Fatal(Fatal::from(se))
     }
 }
@@ -124,7 +124,7 @@ pub enum Fatal<C>
 where C: RaftTypeConfig
 {
     #[error(transparent)]
-    StorageError(#[from] StorageError<C::NodeId>),
+    StorageError(#[from] StorageError<C>),
 
     #[error("panicked")]
     Panicked,
@@ -235,7 +235,7 @@ where C: RaftTypeConfig
     // TODO(xp): two sub type: StorageError / TransportError
     // TODO(xp): a sub error for just append_entries()
     #[error(transparent)]
-    StorageError(#[from] StorageError<C::NodeId>),
+    StorageError(#[from] StorageError<C>),
 
     #[error(transparent)]
     RPCError(#[from] RPCError<C>),

--- a/openraft/src/error/streaming_error.rs
+++ b/openraft/src/error/streaming_error.rs
@@ -29,7 +29,7 @@ pub enum StreamingError<C: RaftTypeConfig, E: Error = Infallible> {
 
     /// Storage error occurs when reading local data.
     #[error(transparent)]
-    StorageError(#[from] StorageError<C::NodeId>),
+    StorageError(#[from] StorageError<C>),
 
     /// Timeout when streaming data to remote node.
     #[error(transparent)]

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -274,11 +274,7 @@ where C: RaftTypeConfig
     ///
     /// `retain` specifies whether to retain the removed voters as a learners, i.e., nodes that
     /// continue to receive log replication from the leader.
-    pub(crate) fn change(
-        mut self,
-        change: ChangeMembers<C::NodeId, C::Node>,
-        retain: bool,
-    ) -> Result<Self, ChangeMembershipError<C>> {
+    pub(crate) fn change(mut self, change: ChangeMembers<C>, retain: bool) -> Result<Self, ChangeMembershipError<C>> {
         tracing::debug!(change = debug(&change), "{}", func_name!());
 
         let last = self.get_joint_config().last().unwrap().clone();

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -46,6 +46,7 @@ pub use wait::Wait;
 pub use wait::WaitError;
 pub(crate) use wait_condition::Condition;
 
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::NodeIdOf;
 
-pub(crate) type ReplicationMetrics<NID> = BTreeMap<NID, Option<LogId<NID>>>;
+pub(crate) type ReplicationMetrics<C> = BTreeMap<NodeIdOf<C>, Option<LogIdOf<C>>>;

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -76,7 +76,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     // --- replication ---
     // ---
     /// The replication states. It is Some() only when this node is leader.
-    pub replication: Option<ReplicationMetrics<C::NodeId>>,
+    pub replication: Option<ReplicationMetrics<C>>,
 }
 
 impl<C> fmt::Display for RaftMetrics<C>
@@ -164,7 +164,7 @@ pub struct RaftDataMetrics<C: RaftTypeConfig> {
     /// being partitioned from the cluster.
     pub millis_since_quorum_ack: Option<u64>,
 
-    pub replication: Option<ReplicationMetrics<C::NodeId>>,
+    pub replication: Option<ReplicationMetrics<C>>,
 }
 
 impl<C> fmt::Display for RaftDataMetrics<C>

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -319,7 +319,7 @@ where
     C::SnapshotData: tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin,
 {
     /// Receive a chunk of snapshot data.
-    pub async fn receive(&mut self, req: InstallSnapshotRequest<C>) -> Result<bool, StorageError<C::NodeId>> {
+    pub async fn receive(&mut self, req: InstallSnapshotRequest<C>) -> Result<bool, StorageError<C>> {
         // TODO: check id?
 
         // Always seek to the target offset if not an exact match.

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 
 use crate::error::RPCError;
 use crate::error::ReplicationClosed;
@@ -37,6 +38,7 @@ use crate::Vote;
 ///
 /// [`RaftNetwork`]: crate::network::v1::RaftNetwork
 /// [correct-node]: `crate::docs::cluster_control::dynamic_membership#ensure-connection-to-the-correct-node`
+#[since(version = "0.10.0")]
 #[add_async_trait]
 pub trait RaftNetworkV2<C>: OptionalSend + OptionalSync + 'static
 where C: RaftTypeConfig

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 
+use crate::engine::testing::UTConfig;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight::Inflight;
 use crate::raft_state::LogStateReader;
@@ -19,7 +20,7 @@ fn inflight_logs(prev_index: u64, last_index: u64) -> Inflight<u64> {
 
 #[test]
 fn test_is_log_range_inflight() -> anyhow::Result<()> {
-    let mut pe = ProgressEntry::empty(20);
+    let mut pe = ProgressEntry::<UTConfig>::empty(20);
     assert_eq!(false, pe.is_log_range_inflight(&log_id(2)));
 
     pe.inflight = inflight_logs(2, 4);
@@ -39,7 +40,7 @@ fn test_is_log_range_inflight() -> anyhow::Result<()> {
 fn test_update_matching() -> anyhow::Result<()> {
     // Update matching and inflight
     {
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.inflight = inflight_logs(5, 10);
         pe.update_matching(pe.inflight.id(), Some(log_id(6)))?;
         assert_eq!(inflight_logs(6, 10), pe.inflight);
@@ -54,7 +55,7 @@ fn test_update_matching() -> anyhow::Result<()> {
 
     // `searching_end` should be updated
     {
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(6));
         pe.inflight = inflight_logs(5, 20);
 
@@ -67,7 +68,7 @@ fn test_update_matching() -> anyhow::Result<()> {
 
 #[test]
 fn test_update_conflicting() -> anyhow::Result<()> {
-    let mut pe = ProgressEntry::empty(20);
+    let mut pe = ProgressEntry::<UTConfig>::empty(20);
     pe.matching = Some(log_id(3));
     pe.inflight = inflight_logs(5, 10);
     pe.update_conflicting(pe.inflight.id(), 5)?;
@@ -146,7 +147,7 @@ impl LogStateReader<u64> for LogState {
 fn test_next_send() -> anyhow::Result<()> {
     // There is already inflight data, return it in an Err
     {
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.inflight = inflight_logs(10, 11);
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
         assert_eq!(Err(&inflight_logs(10, 11)), res);
@@ -160,7 +161,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(4);
+        let mut pe = ProgressEntry::<UTConfig>::empty(4);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -174,7 +175,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(6);
+        let mut pe = ProgressEntry::<UTConfig>::empty(6);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -189,7 +190,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(7);
+        let mut pe = ProgressEntry::<UTConfig>::empty(7);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -204,7 +205,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -221,7 +222,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(7);
+        let mut pe = ProgressEntry::<UTConfig>::empty(7);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -236,7 +237,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(8);
+        let mut pe = ProgressEntry::<UTConfig>::empty(8);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -251,7 +252,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -266,7 +267,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -281,7 +282,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(8);
+        let mut pe = ProgressEntry::<UTConfig>::empty(8);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -296,7 +297,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(21);
+        let mut pe = ProgressEntry::<UTConfig>::empty(21);
         pe.matching = Some(log_id(20));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 100);
@@ -312,7 +313,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::empty(20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(20);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&LogState::new(6, 10, 20), 5);

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -47,7 +47,7 @@ where C: RaftTypeConfig
     pub(crate) noop_log_id: Option<LogIdOf<C>>,
 
     /// Tracks the replication progress and committed index
-    pub(crate) progress: VecProgress<C::NodeId, ProgressEntry<C::NodeId>, Option<LogIdOf<C>>, QS>,
+    pub(crate) progress: VecProgress<C::NodeId, ProgressEntry<C>, Option<LogIdOf<C>>, QS>,
 
     /// Tracks the clock time acknowledged by other nodes.
     ///

--- a/openraft/src/proposer/leader_state.rs
+++ b/openraft/src/proposer/leader_state.rs
@@ -4,7 +4,7 @@ use crate::quorum::Joint;
 use crate::type_config::alias::NodeIdOf;
 
 /// The quorum set type used by `Leader`.
-pub(crate) type LeaderQuorumSet<NID> = Joint<NID, Vec<NID>, Vec<Vec<NID>>>;
+pub(crate) type LeaderQuorumSet<C> = Joint<NodeIdOf<C>, Vec<NodeIdOf<C>>, Vec<Vec<NodeIdOf<C>>>>;
 
-pub(crate) type LeaderState<C> = Option<Box<Leader<C, LeaderQuorumSet<NodeIdOf<C>>>>>;
-pub(crate) type CandidateState<C> = Option<Candidate<C, LeaderQuorumSet<NodeIdOf<C>>>>;
+pub(crate) type LeaderState<C> = Option<Box<Leader<C, LeaderQuorumSet<C>>>>;
+pub(crate) type CandidateState<C> = Option<Candidate<C, LeaderQuorumSet<C>>>;

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -47,10 +47,10 @@ where C: RaftTypeConfig<Responder = OneshotResponder<C>>
     #[tracing::instrument(level = "info", skip_all)]
     pub async fn change_membership(
         &self,
-        members: impl Into<ChangeMembers<C::NodeId, C::Node>>,
+        members: impl Into<ChangeMembers<C>>,
         retain: bool,
     ) -> Result<ClientWriteResponse<C>, RaftError<C, ClientWriteError<C>>> {
-        let changes: ChangeMembers<C::NodeId, C::Node> = members.into();
+        let changes: ChangeMembers<C> = members.into();
 
         tracing::info!(
             changes = debug(&changes),

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -2,7 +2,7 @@ use log_io_id::LogIOId;
 
 use crate::display_ext::DisplayOption;
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::Vote;
 
 pub(crate) mod log_io_id;
@@ -26,38 +26,42 @@ pub(crate) mod log_io_id;
 #[derive(Debug, Clone, Copy)]
 #[derive(Default)]
 #[derive(PartialEq, Eq)]
-pub(crate) struct IOState<NID: NodeId> {
+pub(crate) struct IOState<C>
+where C: RaftTypeConfig
+{
     /// Whether it is building a snapshot
     building_snapshot: bool,
 
     /// The last flushed vote.
-    pub(crate) vote: Vote<NID>,
+    pub(crate) vote: Vote<C::NodeId>,
 
     /// The last log id that has been flushed to storage.
     // TODO: this wont be used until we move log io into separate task.
-    pub(crate) flushed: LogIOId<NID>,
+    pub(crate) flushed: LogIOId<C>,
 
     /// The last log id that has been applied to state machine.
-    pub(crate) applied: Option<LogId<NID>>,
+    pub(crate) applied: Option<LogId<C::NodeId>>,
 
     /// The last log id in the currently persisted snapshot.
-    pub(crate) snapshot: Option<LogId<NID>>,
+    pub(crate) snapshot: Option<LogId<C::NodeId>>,
 
     /// The last log id that has been purged from storage.
     ///
     /// `RaftState::last_purged_log_id()`
     /// is just the log id that is going to be purged, i.e., there is a `PurgeLog` command queued to
     /// be executed, and it may not be the actually purged log id.
-    pub(crate) purged: Option<LogId<NID>>,
+    pub(crate) purged: Option<LogId<C::NodeId>>,
 }
 
-impl<NID: NodeId> IOState<NID> {
+impl<C> IOState<C>
+where C: RaftTypeConfig
+{
     pub(crate) fn new(
-        vote: Vote<NID>,
-        flushed: LogIOId<NID>,
-        applied: Option<LogId<NID>>,
-        snapshot: Option<LogId<NID>>,
-        purged: Option<LogId<NID>>,
+        vote: Vote<C::NodeId>,
+        flushed: LogIOId<C>,
+        applied: Option<LogId<C::NodeId>>,
+        snapshot: Option<LogId<C::NodeId>>,
+        purged: Option<LogId<C::NodeId>>,
     ) -> Self {
         Self {
             building_snapshot: false,
@@ -69,15 +73,15 @@ impl<NID: NodeId> IOState<NID> {
         }
     }
 
-    pub(crate) fn update_vote(&mut self, vote: Vote<NID>) {
+    pub(crate) fn update_vote(&mut self, vote: Vote<C::NodeId>) {
         self.vote = vote;
     }
 
-    pub(crate) fn vote(&self) -> &Vote<NID> {
+    pub(crate) fn vote(&self) -> &Vote<C::NodeId> {
         &self.vote
     }
 
-    pub(crate) fn update_applied(&mut self, log_id: Option<LogId<NID>>) {
+    pub(crate) fn update_applied(&mut self, log_id: Option<LogId<C::NodeId>>) {
         tracing::debug!(applied = display(DisplayOption(&log_id)), "{}", func_name!());
 
         // TODO: should we update flushed if applied is newer?
@@ -91,11 +95,11 @@ impl<NID: NodeId> IOState<NID> {
         self.applied = log_id;
     }
 
-    pub(crate) fn applied(&self) -> Option<&LogId<NID>> {
+    pub(crate) fn applied(&self) -> Option<&LogId<C::NodeId>> {
         self.applied.as_ref()
     }
 
-    pub(crate) fn update_snapshot(&mut self, log_id: Option<LogId<NID>>) {
+    pub(crate) fn update_snapshot(&mut self, log_id: Option<LogId<C::NodeId>>) {
         tracing::debug!(snapshot = display(DisplayOption(&log_id)), "{}", func_name!());
 
         debug_assert!(
@@ -108,7 +112,7 @@ impl<NID: NodeId> IOState<NID> {
         self.snapshot = log_id;
     }
 
-    pub(crate) fn snapshot(&self) -> Option<&LogId<NID>> {
+    pub(crate) fn snapshot(&self) -> Option<&LogId<C::NodeId>> {
         self.snapshot.as_ref()
     }
 
@@ -120,11 +124,11 @@ impl<NID: NodeId> IOState<NID> {
         self.building_snapshot
     }
 
-    pub(crate) fn update_purged(&mut self, log_id: Option<LogId<NID>>) {
+    pub(crate) fn update_purged(&mut self, log_id: Option<LogId<C::NodeId>>) {
         self.purged = log_id;
     }
 
-    pub(crate) fn purged(&self) -> Option<&LogId<NID>> {
+    pub(crate) fn purged(&self) -> Option<&LogId<C::NodeId>> {
         self.purged.as_ref()
     }
 }

--- a/openraft/src/raft_state/io_state/log_io_id.rs
+++ b/openraft/src/raft_state/io_state/log_io_id.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::display_ext::DisplayOptionExt;
 use crate::CommittedLeaderId;
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// A monotonic increasing id for log io operation.
 ///
@@ -16,22 +16,31 @@ use crate::NodeId;
 #[derive(Debug, Clone, Copy)]
 #[derive(Default)]
 #[derive(PartialEq, Eq)]
-pub(crate) struct LogIOId<NID: NodeId> {
+pub(crate) struct LogIOId<C>
+where C: RaftTypeConfig
+{
     /// The id of the leader that performs the log io operation.
-    pub(crate) committed_leader_id: CommittedLeaderId<NID>,
+    pub(crate) committed_leader_id: CommittedLeaderId<C::NodeId>,
 
     /// The last log id that has been flushed to storage.
-    pub(crate) log_id: Option<LogId<NID>>,
+    pub(crate) log_id: Option<LogId<C::NodeId>>,
 }
 
-impl<NID: NodeId> fmt::Display for LogIOId<NID> {
+impl<C> fmt::Display for LogIOId<C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "by_leader({}):{}", self.committed_leader_id, self.log_id.display())
     }
 }
 
-impl<NID: NodeId> LogIOId<NID> {
-    pub(crate) fn new(committed_leader_id: impl Into<CommittedLeaderId<NID>>, log_id: Option<LogId<NID>>) -> Self {
+impl<C> LogIOId<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(
+        committed_leader_id: impl Into<CommittedLeaderId<C::NodeId>>,
+        log_id: Option<LogId<C::NodeId>>,
+    ) -> Self {
         Self {
             committed_leader_id: committed_leader_id.into(),
             log_id,

--- a/openraft/src/raft_state/membership_state/change_handler.rs
+++ b/openraft/src/raft_state/membership_state/change_handler.rs
@@ -30,7 +30,7 @@ where C: RaftTypeConfig
     /// configuration.
     pub(crate) fn apply(
         &self,
-        change: ChangeMembers<C::NodeId, C::Node>,
+        change: ChangeMembers<C>,
         retain: bool,
     ) -> Result<Membership<C>, ChangeMembershipError<C>> {
         self.ensure_committed()?;

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -63,7 +63,7 @@ where C: RaftTypeConfig
     pub(crate) purged_next: u64,
 
     /// All log ids this node has.
-    pub log_ids: LogIdList<C::NodeId>,
+    pub log_ids: LogIdList<C>,
 
     /// The latest cluster membership configuration found, in log or in state machine.
     pub membership_state: MembershipState<C>,
@@ -79,7 +79,7 @@ where C: RaftTypeConfig
 
     pub(crate) accepted: Accepted<C::NodeId>,
 
-    pub(crate) io_state: IOState<C::NodeId>,
+    pub(crate) io_state: IOState<C>,
 
     /// The log id upto which the next time it purges.
     ///
@@ -265,7 +265,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn io_state_mut(&mut self) -> &mut IOState<C::NodeId> {
+    pub(crate) fn io_state_mut(&mut self) -> &mut IOState<C> {
         &mut self.io_state
     }
 
@@ -279,7 +279,7 @@ where C: RaftTypeConfig
     ///
     /// Usually, when a client request is handled, [`RaftState`] is updated and several IO command
     /// is enqueued. And when the IO commands are completed, [`IOState`] is updated.
-    pub(crate) fn io_state(&self) -> &IOState<C::NodeId> {
+    pub(crate) fn io_state(&self) -> &IOState<C> {
         &self.io_state
     }
 

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -377,7 +377,7 @@ where C: RaftTypeConfig
     /// for example, node-1 elects node-2 as a Leader, node-2 will become a Leader when receives the
     /// vote.
     /// A Leader established with election using the state in `Engine.candidate`.
-    pub(crate) fn new_leader(&mut self) -> Leader<C, LeaderQuorumSet<C::NodeId>> {
+    pub(crate) fn new_leader(&mut self) -> Leader<C, LeaderQuorumSet<C>> {
         let em = &self.membership_state.effective().membership();
 
         let last_leader_log_ids = self.log_ids.by_last_leader();

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -87,7 +87,7 @@ where
     target: C::NodeId,
 
     /// Identifies which session this replication belongs to.
-    session_id: ReplicationSessionId<C::NodeId>,
+    session_id: ReplicationSessionId<C>,
 
     /// A channel for sending events to the RaftCore.
     #[allow(clippy::type_complexity)]
@@ -157,7 +157,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn spawn(
         target: C::NodeId,
-        session_id: ReplicationSessionId<C::NodeId>,
+        session_id: ReplicationSessionId<C>,
         config: Arc<Config>,
         committed: Option<LogId<C::NodeId>>,
         matching: Option<LogId<C::NodeId>>,

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -3,7 +3,7 @@ use std::fmt::Formatter;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::Vote;
 
 /// Uniquely identifies a replication session.
@@ -29,29 +29,35 @@ use crate::Vote;
 /// But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft
 /// core believe node `c` already has `log_id=1`, and commit it.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ReplicationSessionId<NID: NodeId> {
+pub(crate) struct ReplicationSessionId<C>
+where C: RaftTypeConfig
+{
     /// The Leader or Candidate this replication belongs to.
-    pub(crate) vote: Vote<NID>,
+    pub(crate) vote: Vote<C::NodeId>,
 
     /// The log id of the membership log this replication works for.
-    pub(crate) membership_log_id: Option<LogId<NID>>,
+    pub(crate) membership_log_id: Option<LogId<C::NodeId>>,
 }
 
-impl<NID: NodeId> Display for ReplicationSessionId<NID> {
+impl<C> Display for ReplicationSessionId<C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}", self.vote, self.membership_log_id.display())
     }
 }
 
-impl<NID: NodeId> ReplicationSessionId<NID> {
-    pub(crate) fn new(vote: Vote<NID>, membership_log_id: Option<LogId<NID>>) -> Self {
+impl<C> ReplicationSessionId<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(vote: Vote<C::NodeId>, membership_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self {
             vote,
             membership_log_id,
         }
     }
 
-    pub(crate) fn vote_ref(&self) -> &Vote<NID> {
+    pub(crate) fn vote_ref(&self) -> &Vote<C::NodeId> {
         &self.vote
     }
 }

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -48,7 +48,7 @@ where C: RaftTypeConfig
     /// [`StorageError`] error has taken place locally(not on remote node) when replicating, and
     /// [`RaftCore`](`crate::core::RaftCore`) needs to shutdown. Sent by a replication task
     /// [`crate::replication::ReplicationCore`].
-    StorageError { error: StorageError<C::NodeId> },
+    StorageError { error: StorageError<C> },
 
     /// ReplicationCore has seen a higher `vote`.
     /// Sent by a replication task `ReplicationCore`.

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -42,7 +42,7 @@ where C: RaftTypeConfig
         ///
         /// A message should be discarded if it does not match the present vote and
         /// membership_log_id.
-        session_id: ReplicationSessionId<C::NodeId>,
+        session_id: ReplicationSessionId<C>,
     },
 
     /// [`StorageError`] error has taken place locally(not on remote node) when replicating, and

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -62,5 +62,5 @@ pub(crate) trait RaftRuntime<C: RaftTypeConfig> {
     /// Run a command produced by the engine.
     ///
     /// If a command can not be run, i.e., waiting for some event, it will be returned
-    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C::NodeId>>;
+    async fn run_command<'e>(&mut self, cmd: Command<C>) -> Result<Option<Command<C>>, StorageError<C>>;
 }

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -15,17 +15,14 @@ use crate::StorageIOError;
 pub struct LogFlushed<C>
 where C: RaftTypeConfig
 {
-    log_io_id: LogIOId<C::NodeId>,
-    tx: OneshotSenderOf<C, Result<LogIOId<C::NodeId>, io::Error>>,
+    log_io_id: LogIOId<C>,
+    tx: OneshotSenderOf<C, Result<LogIOId<C>, io::Error>>,
 }
 
 impl<C> LogFlushed<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(
-        log_io_id: LogIOId<C::NodeId>,
-        tx: OneshotSenderOf<C, Result<LogIOId<C::NodeId>, io::Error>>,
-    ) -> Self {
+    pub(crate) fn new(log_io_id: LogIOId<C>, tx: OneshotSenderOf<C, Result<LogIOId<C>, io::Error>>) -> Self {
         Self { log_io_id, tx }
     }
 
@@ -51,7 +48,7 @@ pub struct LogApplied<C>
 where C: RaftTypeConfig
 {
     last_log_id: LogId<C::NodeId>,
-    tx: oneshot::Sender<Result<(LogId<C::NodeId>, Vec<C::R>), StorageIOError<C::NodeId>>>,
+    tx: oneshot::Sender<Result<(LogId<C::NodeId>, Vec<C::R>), StorageIOError<C>>>,
 }
 
 impl<C> LogApplied<C>
@@ -60,7 +57,7 @@ where C: RaftTypeConfig
     #[allow(dead_code)]
     pub(crate) fn new(
         last_log_id: LogId<C::NodeId>,
-        tx: oneshot::Sender<Result<(LogId<C::NodeId>, Vec<C::R>), StorageIOError<C::NodeId>>>,
+        tx: oneshot::Sender<Result<(LogId<C::NodeId>, Vec<C::R>), StorageIOError<C>>>,
     ) -> Self {
         Self { last_log_id, tx }
     }
@@ -69,7 +66,7 @@ where C: RaftTypeConfig
     ///
     /// It will be called when the log is successfully applied to the state machine or an error
     /// occurs.
-    pub fn completed(self, result: Result<Vec<C::R>, StorageIOError<C::NodeId>>) {
+    pub fn completed(self, result: Result<Vec<C::R>, StorageIOError<C>>) {
         let res = match result {
             Ok(x) => {
                 tracing::debug!("LogApplied upto {}", self.last_log_id);

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -58,7 +58,7 @@ where
     ///
     /// When the Raft node is first started, it will call this interface to fetch the last known
     /// state from stable storage.
-    pub async fn get_initial_state(&mut self) -> Result<RaftState<C>, StorageError<C::NodeId>> {
+    pub async fn get_initial_state(&mut self) -> Result<RaftState<C>, StorageError<C>> {
         let vote = self.log_store.read_vote().await?;
         let vote = vote.unwrap_or_default();
 
@@ -186,7 +186,7 @@ where
     /// a follower only need to revert at most one membership log.
     ///
     /// Thus a raft node will only need to store at most two recent membership logs.
-    pub async fn get_membership(&mut self) -> Result<MembershipState<C>, StorageError<C::NodeId>> {
+    pub async fn get_membership(&mut self) -> Result<MembershipState<C>, StorageError<C>> {
         let (last_applied, sm_mem) = self.state_machine.applied_state().await?;
 
         let log_mem = self.last_membership_in_log(last_applied.next_index()).await?;
@@ -223,7 +223,7 @@ where
     pub async fn last_membership_in_log(
         &mut self,
         since_index: u64,
-    ) -> Result<Vec<StoredMembership<C>>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<StoredMembership<C>>, StorageError<C>> {
         let st = self.log_store.get_log_state().await?;
 
         let mut end = st.last_log_id.next_index();

--- a/openraft/src/storage/log_store_ext.rs
+++ b/openraft/src/storage/log_store_ext.rs
@@ -19,7 +19,7 @@ where C: RaftTypeConfig
     /// Try to get an log entry.
     ///
     /// It does not return an error if the log entry at `log_index` is not found.
-    async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<C::Entry>, StorageError<C::NodeId>> {
+    async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<C::Entry>, StorageError<C>> {
         let mut res = self.try_get_log_entries(log_index..(log_index + 1)).await?;
         Ok(res.pop())
     }
@@ -31,7 +31,7 @@ where C: RaftTypeConfig
     async fn get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend + OptionalSync>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+    ) -> Result<Vec<C::Entry>, StorageError<C>> {
         let res = self.try_get_log_entries(range.clone()).await?;
 
         check_range_matches_entries::<C, _>(range, &res)?;
@@ -40,7 +40,7 @@ where C: RaftTypeConfig
     }
 
     /// Get the log id of the entry at `index`.
-    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C::NodeId>> {
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C>> {
         let entries = self.get_log_entries(log_index..=log_index).await?;
 
         Ok(*entries[0].get_log_id())

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -13,6 +13,7 @@ use std::ops::RangeBounds;
 pub use helper::StorageHelper;
 pub use log_store_ext::RaftLogReaderExt;
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 pub use snapshot_signature::SnapshotSignature;
 pub use v2::RaftLogStorage;
 pub use v2::RaftLogStorageExt;
@@ -169,6 +170,7 @@ where C: RaftTypeConfig
     /// It must not return empty result if the input range is not empty.
     ///
     /// The default implementation just returns the full range of log entries.
+    #[since(version = "0.10.0")]
     async fn limited_get_log_entries(
         &mut self,
         start: u64,

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -70,7 +70,7 @@ where C: RaftTypeConfig
 impl<C> SnapshotMeta<C>
 where C: RaftTypeConfig
 {
-    pub fn signature(&self) -> SnapshotSignature<C::NodeId> {
+    pub fn signature(&self) -> SnapshotSignature<C> {
         SnapshotSignature {
             last_log_id: self.last_log_id,
             last_membership_log_id: *self.last_membership.log_id(),
@@ -153,13 +153,13 @@ where C: RaftTypeConfig
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>>;
+    ) -> Result<Vec<C::Entry>, StorageError<C>>;
 
     /// Return the last saved vote by [`RaftLogStorage::save_vote`].
     ///
     /// A log reader must also be able to read the last saved vote by [`RaftLogStorage::save_vote`],
     /// See: [log-stream](`crate::docs::protocol::replication::log_stream`)
-    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C::NodeId>>;
+    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C>>;
 
     /// Returns log entries within range `[start, end)`, `end` is exclusive,
     /// potentially limited by implementation-defined constraints.
@@ -171,11 +171,7 @@ where C: RaftTypeConfig
     ///
     /// The default implementation just returns the full range of log entries.
     #[since(version = "0.10.0")]
-    async fn limited_get_log_entries(
-        &mut self,
-        start: u64,
-        end: u64,
-    ) -> Result<Vec<C::Entry>, StorageError<C::NodeId>> {
+    async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<C::Entry>, StorageError<C>> {
         self.try_get_log_entries(start..end).await
     }
 }
@@ -201,7 +197,7 @@ where C: RaftTypeConfig
     /// - Performing log compaction, e.g. merge log entries that operates on the same key, like a
     ///   LSM-tree does,
     /// - or by fetching a snapshot from the state machine.
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C>, StorageError<C::NodeId>>;
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C>, StorageError<C>>;
 
     // NOTES:
     // This interface is geared toward small file-based snapshots. However, not all snapshots can

--- a/openraft/src/storage/snapshot_signature.rs
+++ b/openraft/src/storage/snapshot_signature.rs
@@ -1,16 +1,18 @@
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::SnapshotId;
 
 /// A small piece of information for identifying a snapshot and error tracing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct SnapshotSignature<NID: NodeId> {
+pub struct SnapshotSignature<C>
+where C: RaftTypeConfig
+{
     /// Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: Option<LogId<NID>>,
+    pub last_log_id: Option<LogId<C::NodeId>>,
 
     /// The last applied membership log id.
-    pub last_membership_log_id: Option<LogId<NID>>,
+    pub last_membership_log_id: Option<LogId<C::NodeId>>,
 
     /// To identify a snapshot when transferring.
     pub snapshot_id: SnapshotId,

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -21,7 +21,7 @@ where C: RaftTypeConfig
     /// Blocking mode append log entries to the storage.
     ///
     /// It blocks until the callback is called by the underlying storage implementation.
-    async fn blocking_append<I>(&mut self, entries: I) -> Result<(), StorageError<C::NodeId>>
+    async fn blocking_append<I>(&mut self, entries: I) -> Result<(), StorageError<C>>
     where
         I: IntoIterator<Item = C::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,
@@ -29,7 +29,7 @@ where C: RaftTypeConfig
         let (tx, rx) = C::oneshot();
 
         // dummy log_io_id
-        let log_io_id = LogIOId::<C::NodeId>::new(Vote::<C::NodeId>::default(), None);
+        let log_io_id = LogIOId::<C>::new(Vote::<C::NodeId>::default(), None);
 
         let callback = LogFlushed::<C>::new(log_io_id, tx);
         self.append(entries, callback).await?;

--- a/openraft/src/testing/store_builder.rs
+++ b/openraft/src/testing/store_builder.rs
@@ -23,5 +23,5 @@ where
     SM: RaftStateMachine<C>,
 {
     /// Build a [`RaftLogStorage`] and [`RaftStateMachine`] implementation
-    async fn build(&self) -> Result<(G, LS, SM), StorageError<C::NodeId>>;
+    async fn build(&self) -> Result<(G, LS, SM), StorageError<C>>;
 }

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -75,12 +75,12 @@ where
     B: StoreBuilder<C, LS, SM, G>,
     G: Send + Sync,
 {
-    pub fn test_all(builder: B) -> Result<(), StorageError<C::NodeId>> {
+    pub fn test_all(builder: B) -> Result<(), StorageError<C>> {
         Suite::test_store(&builder)?;
         Ok(())
     }
 
-    pub fn test_store(builder: &B) -> Result<(), StorageError<C::NodeId>> {
+    pub fn test_store(builder: &B) -> Result<(), StorageError<C>> {
         run_fut(run_test(builder, Self::last_membership_in_log_initial))?;
         run_fut(run_test(builder, Self::last_membership_in_log))?;
         run_fut(run_test(builder, Self::last_membership_in_log_multi_step))?;
@@ -124,7 +124,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let membership = StorageHelper::new(&mut store, &mut sm).last_membership_in_log(0).await?;
 
         assert!(membership.is_empty());
@@ -132,7 +132,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- no log, do not read membership from state machine");
         {
             apply(&mut sm, [
@@ -207,7 +207,7 @@ where
         Ok(())
     }
 
-    pub async fn last_membership_in_log_multi_step(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_membership_in_log_multi_step(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- find membership log entry backwards, multiple steps");
         {
             append(&mut store, [
@@ -235,7 +235,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_initial(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let mem_state = StorageHelper::new(&mut store, &mut sm).get_membership().await?;
 
         assert_eq!(&EffectiveMembership::default(), mem_state.committed().as_ref());
@@ -244,10 +244,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_log_and_empty_sm(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_log_and_empty_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- no log, read membership from state machine");
         {
             // There is an empty membership config in an empty state machine.
@@ -266,10 +263,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_empty_log_and_sm(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_empty_log_and_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- no log, read membership from state machine");
         {
             apply(&mut sm, [
@@ -292,10 +286,7 @@ where
         Ok(())
     }
 
-    pub async fn get_membership_from_log_le_sm_last_applied(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_membership_from_log_le_sm_last_applied(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- membership presents in log, but smaller than last_applied, read from state machine");
         {
             apply(&mut sm, [
@@ -332,7 +323,7 @@ where
     pub async fn get_membership_from_log_gt_sm_last_applied_1(
         mut store: LS,
         mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    ) -> Result<(), StorageError<C>> {
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
         {
             apply(&mut sm, [
@@ -365,7 +356,7 @@ where
     pub async fn get_membership_from_log_gt_sm_last_applied_2(
         mut store: LS,
         mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    ) -> Result<(), StorageError<C>> {
         tracing::info!("--- two membership present in log and > sm.last_applied, read 2 from log");
         {
             apply(&mut sm, [
@@ -398,7 +389,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
         let mut want = RaftState::<C>::default();
         want.vote.update(initial.vote.utime().unwrap(), Vote::default());
@@ -407,7 +398,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_with_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_with_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [
@@ -442,7 +433,7 @@ where
     pub async fn get_initial_state_membership_from_log_and_sm(
         mut store: LS,
         mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    ) -> Result<(), StorageError<C>> {
         // It should never return membership from logs that are included in state machine present.
 
         Self::default_vote(&mut store).await?;
@@ -492,7 +483,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_gt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_last_log_gt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [blank_ent_0::<C>(0, 0), blank_ent_0::<C>(2, 1)]).await?;
@@ -509,7 +500,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_last_log_lt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_last_log_lt_sm(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [blank_ent_0::<C>(1, 2)]).await?;
@@ -531,7 +522,7 @@ where
         Ok(())
     }
 
-    pub async fn get_initial_state_log_ids(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_log_ids(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let log_id = |t, n: u64, i| LogId::<C::NodeId> {
             leader_id: CommittedLeaderId::new(t, n.into()),
             index: i,
@@ -655,10 +646,7 @@ where
     }
 
     /// Test if committed logs are re-applied.
-    pub async fn get_initial_state_re_apply_committed(
-        mut store: LS,
-        mut sm: SM,
-    ) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_initial_state_re_apply_committed(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::default_vote(&mut store).await?;
 
         append(&mut store, [
@@ -691,7 +679,7 @@ where
         Ok(())
     }
 
-    pub async fn save_vote(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn save_vote(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         store.save_vote(&Vote::new(100, NODE_ID.into())).await?;
 
         let got = store.read_vote().await?;
@@ -700,7 +688,7 @@ where
         Ok(())
     }
 
-    pub async fn get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         tracing::info!("--- get start == stop");
@@ -721,7 +709,7 @@ where
         Ok(())
     }
 
-    pub async fn limited_get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn limited_get_log_entries(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         tracing::info!("--- get start == stop");
@@ -742,7 +730,7 @@ where
         Ok(())
     }
 
-    pub async fn try_get_log_entry(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn try_get_log_entry(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         store.purge(LogId::new(CommittedLeaderId::new(0, C::NodeId::default()), 0)).await?;
@@ -763,14 +751,14 @@ where
         Ok(())
     }
 
-    pub async fn initial_logs(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn initial_logs(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let ent = store.try_get_log_entry(0).await?;
         assert!(ent.is_none(), "store initialized");
 
         Ok(())
     }
 
-    pub async fn get_log_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let st = store.get_log_state().await?;
 
         assert_eq!(None, st.last_purged_log_id);
@@ -827,7 +815,7 @@ where
         Ok(())
     }
 
-    pub async fn get_log_id(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn get_log_id(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         store.purge(log_id_0(1, 3)).await?;
@@ -854,7 +842,7 @@ where
         Ok(())
     }
 
-    pub async fn last_id_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_id_in_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let last_log_id = store.get_log_state().await?.last_log_id;
         assert_eq!(None, last_log_id);
 
@@ -893,7 +881,7 @@ where
         Ok(())
     }
 
-    pub async fn last_applied_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn last_applied_state(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let (applied, mem) = sm.applied_state().await?;
         assert_eq!(None, applied);
         assert_eq!(StoredMembership::default(), mem);
@@ -925,7 +913,7 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete (-oo, 0]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -950,7 +938,7 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_5(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_5(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete (-oo, 5]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -975,7 +963,7 @@ where
         Ok(())
     }
 
-    pub async fn purge_logs_upto_20(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn purge_logs_upto_20(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete (-oo, 20]");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -999,7 +987,7 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_11(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn delete_logs_since_11(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete [11, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -1019,7 +1007,7 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn delete_logs_since_0(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- delete [0, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
@@ -1040,7 +1028,7 @@ where
         Ok(())
     }
 
-    pub async fn append_to_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn append_to_log(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         Self::feed_10_logs_vote_self(&mut store).await?;
 
         store.purge(log_id_0(0, 0)).await?;
@@ -1059,7 +1047,7 @@ where
         Ok(())
     }
 
-    pub async fn snapshot_meta(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn snapshot_meta(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         tracing::info!("--- just initialized");
         {
             apply(&mut sm, [membership_ent_0::<C>(0, 0, btreeset! {1,2})]).await?;
@@ -1097,7 +1085,7 @@ where
         Ok(())
     }
 
-    pub async fn apply_single(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn apply_single(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let (last_applied, _) = sm.applied_state().await?;
         assert_eq!(last_applied, None,);
 
@@ -1143,7 +1131,7 @@ where
         Ok(())
     }
 
-    pub async fn apply_multiple(mut store: LS, mut sm: SM) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn apply_multiple(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let (last_applied, _) = sm.applied_state().await?;
         assert_eq!(last_applied, None,);
 
@@ -1161,7 +1149,7 @@ where
 
     /// Rudimentary test for snapshotting that builds a snapshot on one node and installs it on
     /// another
-    pub async fn transfer_snapshot(builder: &B) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn transfer_snapshot(builder: &B) -> Result<(), StorageError<C>> {
         // Create a snapshot on sm_l, and install it on sm_f
         let (_g_l, _store_l, mut sm_l) = builder.build().await?;
         let (_g_f, _store_f, mut sm_f) = builder.build().await?;
@@ -1213,7 +1201,7 @@ where
         Ok(())
     }
 
-    pub async fn feed_10_logs_vote_self(sto: &mut LS) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn feed_10_logs_vote_self(sto: &mut LS) -> Result<(), StorageError<C>> {
         append(sto, [blank_ent_0::<C>(0, 0)]).await?;
 
         for i in 1..=10 {
@@ -1225,7 +1213,7 @@ where
         Ok(())
     }
 
-    pub async fn default_vote(sto: &mut LS) -> Result<(), StorageError<C::NodeId>> {
+    pub async fn default_vote(sto: &mut LS) -> Result<(), StorageError<C>> {
         sto.save_vote(&Vote::new(1, NODE_ID.into())).await?;
 
         Ok(())
@@ -1256,10 +1244,10 @@ where C::NodeId: From<u64> {
 /// Block until a future is finished.
 /// The future will be running in a clean tokio runtime, to prevent an unfinished task affecting the
 /// test.
-pub fn run_fut<NID, F>(f: F) -> Result<(), StorageError<NID>>
+pub fn run_fut<C, F>(f: F) -> Result<(), StorageError<C>>
 where
-    NID: NodeId,
-    F: Future<Output = Result<(), StorageError<NID>>>,
+    C: RaftTypeConfig,
+    F: Future<Output = Result<(), StorageError<C>>>,
 {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(f)?;
@@ -1267,16 +1255,13 @@ where
 }
 
 /// Build a `RaftLogStorage` and `RaftStateMachine` implementation and run a test on it.
-async fn run_test<C, LS, SM, G, B, TestFn, Ret, Fu>(
-    builder: &B,
-    test_fn: TestFn,
-) -> Result<Ret, StorageError<C::NodeId>>
+async fn run_test<C, LS, SM, G, B, TestFn, Ret, Fu>(builder: &B, test_fn: TestFn) -> Result<Ret, StorageError<C>>
 where
     C: RaftTypeConfig,
     LS: RaftLogStorage<C>,
     SM: RaftStateMachine<C>,
     B: StoreBuilder<C, LS, SM, G>,
-    Fu: Future<Output = Result<Ret, StorageError<C::NodeId>>> + OptionalSend,
+    Fu: Future<Output = Result<Ret, StorageError<C>>> + OptionalSend,
     TestFn: Fn(LS, SM) -> Fu + Sync + Send,
 {
     let (_g, store, sm) = builder.build().await?;
@@ -1284,7 +1269,7 @@ where
 }
 
 /// A wrapper for calling nonblocking `RaftStateMachine::apply()`
-async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<Vec<C::R>, StorageError<C::NodeId>>
+async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<Vec<C::R>, StorageError<C>>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
@@ -1296,7 +1281,7 @@ where
 }
 
 /// A wrapper for calling nonblocking `RaftLogStorage::append()`
-async fn append<C, LS, I>(store: &mut LS, entries: I) -> Result<(), StorageError<C::NodeId>>
+async fn append<C, LS, I>(store: &mut LS, entries: I) -> Result<(), StorageError<C>>
 where
     C: RaftTypeConfig,
     LS: RaftLogStorage<C>,
@@ -1306,7 +1291,7 @@ where
     let (tx, rx) = C::oneshot();
 
     // Dummy log io id for blocking append
-    let log_io_id = LogIOId::<C::NodeId>::new(Vote::<C::NodeId>::default(), None);
+    let log_io_id = LogIOId::<C>::new(Vote::<C::NodeId>::default(), None);
     let cb = LogFlushed::new(log_io_id, tx);
 
     store.append(entries, cb).await?;

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::time::Duration;
 
+use openraft_macros::since;
+
 use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinHandleOf;
@@ -14,6 +16,7 @@ use crate::OptionalSend;
 use crate::RaftTypeConfig;
 
 /// Collection of utility methods to `RaftTypeConfig` function.
+#[since(version = "0.10.0")]
 pub trait TypeConfigExt: RaftTypeConfig {
     // Time related methods
 

--- a/stores/memstore/src/test.rs
+++ b/stores/memstore/src/test.rs
@@ -5,21 +5,20 @@ use openraft::testing::Suite;
 use openraft::StorageError;
 
 use crate::MemLogStore;
-use crate::MemNodeId;
 use crate::MemStateMachine;
 use crate::TypeConfig;
 
 struct MemStoreBuilder {}
 
 impl StoreBuilder<TypeConfig, Arc<MemLogStore>, Arc<MemStateMachine>, ()> for MemStoreBuilder {
-    async fn build(&self) -> Result<((), Arc<MemLogStore>, Arc<MemStateMachine>), StorageError<MemNodeId>> {
+    async fn build(&self) -> Result<((), Arc<MemLogStore>, Arc<MemStateMachine>), StorageError<TypeConfig>> {
         let (log_store, sm) = crate::new_mem_store();
         Ok(((), log_store, sm))
     }
 }
 
 #[test]
-pub fn test_mem_store() -> Result<(), StorageError<MemNodeId>> {
+pub fn test_mem_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(MemStoreBuilder {})?;
     Ok(())
 }

--- a/stores/rocksstore/src/lib.rs
+++ b/stores/rocksstore/src/lib.rs
@@ -133,7 +133,7 @@ pub struct RocksLogStore {
     db: Arc<DB>,
 }
 
-type StorageResult<T> = Result<T, StorageError<RocksNodeId>>;
+type StorageResult<T> = Result<T, StorageError<TypeConfig>>;
 
 /// converts an id to a byte vector for storing in the database.
 /// Note that we're using big endian encoding to ensure correct sorting of keys
@@ -156,6 +156,7 @@ mod meta {
     use openraft::LogId;
 
     use crate::RocksNodeId;
+    use crate::TypeConfig;
 
     /// Defines metadata key and value
     pub(crate) trait StoreMeta {
@@ -166,7 +167,7 @@ mod meta {
         type Value: serde::Serialize + serde::de::DeserializeOwned;
 
         /// The subject this meta belongs to, and will be embedded into the returned storage error.
-        fn subject(v: Option<&Self::Value>) -> ErrorSubject<RocksNodeId>;
+        fn subject(v: Option<&Self::Value>) -> ErrorSubject<TypeConfig>;
     }
 
     pub(crate) struct LastPurged {}
@@ -176,7 +177,7 @@ mod meta {
         const KEY: &'static str = "last_purged_log_id";
         type Value = LogId<u64>;
 
-        fn subject(_v: Option<&Self::Value>) -> ErrorSubject<RocksNodeId> {
+        fn subject(_v: Option<&Self::Value>) -> ErrorSubject<TypeConfig> {
             ErrorSubject::Store
         }
     }
@@ -184,7 +185,7 @@ mod meta {
         const KEY: &'static str = "vote";
         type Value = openraft::Vote<RocksNodeId>;
 
-        fn subject(_v: Option<&Self::Value>) -> ErrorSubject<RocksNodeId> {
+        fn subject(_v: Option<&Self::Value>) -> ErrorSubject<TypeConfig> {
             ErrorSubject::Vote
         }
     }
@@ -202,7 +203,7 @@ impl RocksLogStore {
     /// Get a store metadata.
     ///
     /// It returns `None` if the store does not have such a metadata stored.
-    fn get_meta<M: meta::StoreMeta>(&self) -> Result<Option<M::Value>, StorageError<RocksNodeId>> {
+    fn get_meta<M: meta::StoreMeta>(&self) -> Result<Option<M::Value>, StorageError<TypeConfig>> {
         let v = self
             .db
             .get_cf(self.cf_meta(), M::KEY)
@@ -219,7 +220,7 @@ impl RocksLogStore {
     }
 
     /// Save a store metadata.
-    fn put_meta<M: meta::StoreMeta>(&self, value: &M::Value) -> Result<(), StorageError<RocksNodeId>> {
+    fn put_meta<M: meta::StoreMeta>(&self, value: &M::Value) -> Result<(), StorageError<TypeConfig>> {
         let json_value = serde_json::to_vec(value)
             .map_err(|e| StorageIOError::new(M::subject(Some(value)), ErrorVerb::Write, AnyError::new(&e)))?;
 
@@ -262,14 +263,14 @@ impl RaftLogReader<TypeConfig> for RocksLogStore {
         Ok(res)
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<RocksNodeId>>, StorageError<RocksNodeId>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<RocksNodeId>>, StorageError<TypeConfig>> {
         self.get_meta::<meta::Vote>()
     }
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for RocksStateMachine {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<RocksNodeId>> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<TypeConfig>> {
         // Serialize the data of the state machine.
         let data = serde_json::to_vec(&self.sm).map_err(|e| StorageIOError::read_state_machine(&e))?;
 
@@ -338,7 +339,7 @@ impl RaftLogStorage<TypeConfig> for RocksLogStore {
         })
     }
 
-    async fn save_vote(&mut self, vote: &Vote<RocksNodeId>) -> Result<(), StorageError<RocksNodeId>> {
+    async fn save_vote(&mut self, vote: &Vote<RocksNodeId>) -> Result<(), StorageError<TypeConfig>> {
         self.put_meta::<meta::Vote>(vote)?;
         self.db.flush_wal(true).map_err(|e| StorageIOError::write_vote(&e))?;
         Ok(())
@@ -352,7 +353,7 @@ impl RaftLogStorage<TypeConfig> for RocksLogStore {
         &mut self,
         entries: I,
         callback: LogFlushed<TypeConfig>,
-    ) -> Result<(), StorageError<RocksNodeId>>
+    ) -> Result<(), StorageError<TypeConfig>>
     where
         I: IntoIterator<Item = Entry<TypeConfig>> + Send,
     {
@@ -375,7 +376,7 @@ impl RaftLogStorage<TypeConfig> for RocksLogStore {
         Ok(())
     }
 
-    async fn truncate(&mut self, log_id: LogId<RocksNodeId>) -> Result<(), StorageError<RocksNodeId>> {
+    async fn truncate(&mut self, log_id: LogId<RocksNodeId>) -> Result<(), StorageError<TypeConfig>> {
         tracing::debug!("truncate: [{:?}, +oo)", log_id);
 
         let from = id_to_bin(log_id.index);
@@ -386,7 +387,7 @@ impl RaftLogStorage<TypeConfig> for RocksLogStore {
         Ok(())
     }
 
-    async fn purge(&mut self, log_id: LogId<RocksNodeId>) -> Result<(), StorageError<RocksNodeId>> {
+    async fn purge(&mut self, log_id: LogId<RocksNodeId>) -> Result<(), StorageError<TypeConfig>> {
         tracing::debug!("delete_log: [0, {:?}]", log_id);
 
         // Write the last-purged log id before purging the logs.
@@ -408,11 +409,11 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<RocksNodeId>>, StoredMembership<TypeConfig>), StorageError<RocksNodeId>> {
+    ) -> Result<(Option<LogId<RocksNodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         Ok((self.sm.last_applied_log, self.sm.last_membership.clone()))
     }
 
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<RocksResponse>, StorageError<RocksNodeId>>
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<RocksResponse>, StorageError<TypeConfig>>
     where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
         let entries_iter = entries.into_iter();
         let mut res = Vec::with_capacity(entries_iter.size_hint().0);
@@ -447,7 +448,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         self.clone()
     }
 
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<RocksNodeId>> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
@@ -455,7 +456,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
         snapshot: Box<SnapshotDataOf<TypeConfig>>,
-    ) -> Result<(), StorageError<RocksNodeId>> {
+    ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },
             "decoding snapshot for installation"
@@ -485,7 +486,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         Ok(())
     }
 
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<RocksNodeId>> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, StorageError<TypeConfig>> {
         let x = self
             .db
             .get_cf(self.db.cf_handle("sm_meta").unwrap(), "snapshot")
@@ -525,7 +526,7 @@ pub async fn new<P: AsRef<Path>>(db_path: P) -> (RocksLogStore, RocksStateMachin
     (RocksLogStore { db: db.clone() }, RocksStateMachine::new(db).await)
 }
 
-fn read_logs_err(e: impl Error + 'static) -> StorageError<RocksNodeId> {
+fn read_logs_err(e: impl Error + 'static) -> StorageError<TypeConfig> {
     StorageError::IO {
         source: StorageIOError::read_logs(&e),
     }

--- a/stores/rocksstore/src/test.rs
+++ b/stores/rocksstore/src/test.rs
@@ -4,14 +4,13 @@ use openraft::StorageError;
 use tempfile::TempDir;
 
 use crate::RocksLogStore;
-use crate::RocksNodeId;
 use crate::RocksStateMachine;
 use crate::TypeConfig;
 
 struct RocksBuilder {}
 
 impl StoreBuilder<TypeConfig, RocksLogStore, RocksStateMachine, TempDir> for RocksBuilder {
-    async fn build(&self) -> Result<(TempDir, RocksLogStore, RocksStateMachine), StorageError<RocksNodeId>> {
+    async fn build(&self) -> Result<(TempDir, RocksLogStore, RocksStateMachine), StorageError<TypeConfig>> {
         let td = TempDir::new().expect("couldn't create temp dir");
         let (log_store, sm) = crate::new(td.path()).await;
         Ok((td, log_store, sm))
@@ -37,7 +36,7 @@ impl StoreBuilder<TypeConfig, RocksLogStore, RocksStateMachine, TempDir> for Roc
 /// }
 /// ```
 #[test]
-pub fn test_rocks_store() -> Result<(), StorageError<RocksNodeId>> {
+pub fn test_rocks_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(RocksBuilder {})?;
     Ok(())
 }

--- a/stores/sledstore/src/test.rs
+++ b/stores/sledstore/src/test.rs
@@ -5,14 +5,13 @@ use openraft::testing::Suite;
 use openraft::StorageError;
 use tempfile::TempDir;
 
-use crate::ExampleNodeId;
 use crate::SledStore;
 use crate::TypeConfig;
 
 struct SledBuilder {}
 
 #[test]
-pub fn test_sled_store() -> Result<(), StorageError<ExampleNodeId>> {
+pub fn test_sled_store() -> Result<(), StorageError<TypeConfig>> {
     Suite::test_all(SledBuilder {})
 }
 
@@ -20,7 +19,7 @@ type LogStore = Arc<SledStore>;
 type StateMachine = Arc<SledStore>;
 
 impl StoreBuilder<TypeConfig, LogStore, StateMachine, TempDir> for SledBuilder {
-    async fn build(&self) -> Result<(TempDir, LogStore, StateMachine), StorageError<ExampleNodeId>> {
+    async fn build(&self) -> Result<(TempDir, LogStore, StateMachine), StorageError<TypeConfig>> {
         let td = TempDir::new().expect("couldn't create temp dir");
 
         let db: sled::Db = sled::open(td.path()).unwrap();


### PR DESCRIPTION

## Changelog

##### Change: use RaftTypeConfig to replace NID

- `StorageError<NID>` to `StorageError<C>`
- `StorageIOError<NID>` to `StorageIOError<C>`
- `ErrorSubject<NID>` to `ErrorSubject<C>`
- `DefensiveError<NID>` to `DefensiveError<C>`
- `Violation<NID>` to `Violation<C>`
- `SnapshotSignature<NID>` to `SnapshotSignature<C>`
- `ChangeMembers<NID, N>` to `ChangeMembers<C>`
- `LogIdList<NID>` to `LogIdList<C>`

Upgrade tip:

Replace `StorageError<NID>` with `StorageError<C>`, such as:
```diff
-  async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<NodeId>>
+  async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<TypeConfig>>
```

Types to replace:

- `StorageError<NID>` to `StorageError<C>`
- `StorageIOError<NID>` to `StorageIOError<C>`
- `ErrorSubject<NID>` to `ErrorSubject<C>`
- `DefensiveError<NID>` to `DefensiveError<C>`
- `Violation<NID>` to `Violation<C>`
- `SnapshotSignature<NID>` to `SnapshotSignature<C>`
- `ChangeMembers<NID, N>` to `ChangeMembers<C>`
- `LogIdList<NID>` to `LogIdList<C>`


##### Refactor: use RaftTypeConfig to replace NID

- `ReplicationSessionId<NID>` to `ReplicationSessionId<C>`
- `LeaderQuorumSet<NID>` to `LeaderQuorumSet<C>`
- `Condition<NID>` to `Condition<C>`
- `ProgressEntry<NID>` to `ProgressEntry<C>`


##### Chore: add `since` to new methods

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1148)
<!-- Reviewable:end -->
