### PR TITLE
Refactor: Introduce `CommittedVote` Type to Enhance Vote Handling

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1507,7 +1508,7 @@ where
         // - Otherwise, it is sent by a Candidate, we check against the current in progress voting state.
         let my_vote = if sender_vote.is_committed() {
             let l = self.engine.leader.as_ref();
-            l.map(|x| x.vote)
+            l.map(|x| *x.vote.deref())
         } else {
             // If it finished voting, Candidate's vote is None.
             let candidate = self.engine.candidate_ref();

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -754,14 +754,12 @@ where C: RaftTypeConfig
             Some(x) => x,
         };
 
-        // This leader is not accepted by a quorum yet.
-        // Not a valid leader.
-        //
-        // Note that leading state is separated from local RaftState(which is used by the `Acceptor` part),
-        // and do not consider the vote in the local RaftState.
-        if !leader.vote.is_committed() {
-            return Err(self.state.forward_to_leader());
-        }
+        debug_assert!(
+            *leader.vote_ref() >= *self.state.vote_ref(),
+            "leader.vote({}) >= state.vote({})",
+            leader.vote_ref(),
+            self.state.vote_ref()
+        );
 
         Ok(LeaderHandler {
             config: &mut self.config,

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -67,29 +67,10 @@ where C: RaftTypeConfig
             }
         }
 
-        // TODO: In future implementations with asynchronous IO,
-        //       ensure logs are not written until the vote is committed
-        //       to maintain consistency.
-        //       ---
-        //       Currently, IO requests to `RaftLogStorage` are executed
-        //       within the `RaftCore` task. This means an `AppendLog` request
-        //       won't be submitted to `RaftLogStorage` until `save_vote()` completes,
-        //       which ensures consistency.
-        //       ---
-        //       However, when `RaftLogStorage` is moved to a separate task,
-        //       `RaftCore` will communicate with `RaftLogStorage` via a channel.
-        //       This change could result in `AppendLog` requests being submitted
-        //       before the previous `save_vote()` request is finished.
-        //       ---
-        //       This scenario creates a risk where a log entry becomes visible and
-        //       is replicated by `ReplicationCore` to other nodes before the vote
-        //       is flushed to disk. If the vote isn't flushed and the server restarts,
-        //       the vote could revert to a previous state. This could allow a new leader
-        //       to be elected with a smaller vote (term), breaking consistency.
         self.output.push_command(Command::AppendInputEntries {
             // A leader should always use the leader's vote.
             // It is allowed to be different from local vote.
-            vote: self.leader.vote,
+            vote: *self.leader.vote,
             entries,
         });
 

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -186,7 +186,7 @@ where C: RaftTypeConfig
                 // TODO: this is not gonna happen,
                 //       because `self.leader`(previous `internal_server_state`)
                 //       does not include Candidate any more.
-                l.vote = *self.state.vote_ref();
+                l.vote = self.state.vote_ref().into_committed();
                 self.server_state_handler().update_server_state_if_changed();
                 return;
             }

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -105,10 +105,9 @@ where
     pub(crate) fn into_leader(self) -> Leader<C, QS> {
         // Mark the vote as committed, i.e., being granted and saved by a quorum.
         let vote = {
-            let mut vote = *self.vote_ref();
+            let vote = *self.vote_ref();
             debug_assert!(!vote.is_committed());
-            vote.commit();
-            vote
+            vote.into_committed()
         };
 
         let last_leader_log_ids = self.last_log_id().copied().into_iter().collect::<Vec<_>>();

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -383,7 +383,7 @@ where C: RaftTypeConfig
         let last_leader_log_ids = self.log_ids.by_last_leader();
 
         Leader::new(
-            *self.vote_ref(),
+            self.vote_ref().into_committed(),
             em.to_quorum_set(),
             em.learner_ids(),
             last_leader_log_ids,

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::vote::CommittedVote;
 use crate::LogId;
 use crate::RaftTypeConfig;
 use crate::Vote;
@@ -33,7 +34,7 @@ pub(crate) struct ReplicationSessionId<C>
 where C: RaftTypeConfig
 {
     /// The Leader or Candidate this replication belongs to.
-    pub(crate) vote: Vote<C::NodeId>,
+    pub(crate) vote: CommittedVote<C>,
 
     /// The log id of the membership log this replication works for.
     pub(crate) membership_log_id: Option<LogId<C::NodeId>>,
@@ -50,7 +51,7 @@ where C: RaftTypeConfig
 impl<C> ReplicationSessionId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: Vote<C::NodeId>, membership_log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub(crate) fn new(vote: CommittedVote<C>, membership_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self {
             vote,
             membership_log_id,

--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+use std::ops::Deref;
+
+use crate::type_config::alias::NodeIdOf;
+use crate::CommittedLeaderId;
+use crate::RaftTypeConfig;
+use crate::Vote;
+
+/// Represents a committed Vote that has been accepted by a quorum.
+///
+/// The inner `Vote`'s attribute `committed` is always set to `true`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
+pub(crate) struct CommittedVote<C>
+where C: RaftTypeConfig
+{
+    vote: Vote<NodeIdOf<C>>,
+}
+
+impl<C> CommittedVote<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(mut vote: Vote<NodeIdOf<C>>) -> Self {
+        vote.committed = true;
+        Self { vote }
+    }
+    pub(crate) fn committed_leader_id(&self) -> CommittedLeaderId<C::NodeId> {
+        self.leader_id().to_committed()
+    }
+}
+
+impl<C> Deref for CommittedVote<C>
+where C: RaftTypeConfig
+{
+    type Target = Vote<NodeIdOf<C>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.vote
+    }
+}
+
+impl<C> fmt::Display for CommittedVote<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.vote.fmt(f)
+    }
+}

--- a/openraft/src/vote/mod.rs
+++ b/openraft/src/vote/mod.rs
@@ -1,7 +1,9 @@
+pub(crate) mod committed;
 mod leader_id;
 #[allow(clippy::module_inception)]
 mod vote;
 
+pub(crate) use committed::CommittedVote;
 pub use leader_id::CommittedLeaderId;
 pub use leader_id::LeaderId;
 pub use vote::Vote;


### PR DESCRIPTION

## Changelog

##### Refactor: Introduce `CommittedVote` Type to Enhance Vote Handling

This commit introduces a new type, `CommittedVote`, which represents a
committed vote. This enhancement is aimed at ensuring that only
committed votes are considered valid for the leader's status.

By using the `CommittedVote` type, we can eliminate several runtime
assertion checks previously required to verify the commitment status of
votes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1149)
<!-- Reviewable:end -->
