### PR TITLE
Refactor: Remove `LeaderData` from `RaftCore`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -710,7 +710,7 @@ where
     {
         tracing::debug!("append_to_log");
 
-        let (tx, rx) = C::AsyncRuntime::oneshot();
+        let (tx, rx) = C::oneshot();
         let log_io_id = LogIOId::new(vote, Some(last_log_id));
 
         let callback = LogFlushed::new(log_io_id, tx);
@@ -1622,7 +1622,7 @@ where
                 self.log_store.purge(upto).await?;
                 self.engine.state.io_state_mut().update_purged(Some(upto));
             }
-            Command::DeleteConflictLog { since } => {
+            Command::TruncateLog { since } => {
                 self.log_store.truncate(since).await?;
 
                 // Inform clients waiting for logs to be applied.

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -92,7 +92,7 @@ where C: RaftTypeConfig
 
     /// Delete logs that conflict with the leader from a follower/learner since log id `since`,
     /// inclusive.
-    DeleteConflictLog { since: LogId<C::NodeId> },
+    TruncateLog { since: LogId<C::NodeId> },
 
     // TODO(1): current it is only used to replace BuildSnapshot, InstallSnapshot, CancelSnapshot.
     /// A command send to state machine worker [`sm::worker::Worker`].
@@ -135,7 +135,7 @@ where
             (Command::SaveVote { vote },                       Command::SaveVote { vote: b })                                                  => vote == b,
             (Command::SendVote { vote_req },                   Command::SendVote { vote_req: b }, )                                            => vote_req == b,
             (Command::PurgeLog { upto },                       Command::PurgeLog { upto: b })                                                  => upto == b,
-            (Command::DeleteConflictLog { since },             Command::DeleteConflictLog { since: b }, )                                      => since == b,
+            (Command::TruncateLog { since },             Command::TruncateLog { since: b }, )                                      => since == b,
             (Command::Respond { when, resp: send },            Command::Respond { when: b_when, resp: b })                                     => send == b && when == b_when,
             (Command::StateMachine { command },                Command::StateMachine { command: b })                                           => command == b,
             _ => false,
@@ -158,7 +158,7 @@ where C: RaftTypeConfig
             Command::AppendInputEntries { .. }        => CommandKind::Log,
             Command::SaveVote { .. }                  => CommandKind::Log,
             Command::PurgeLog { .. }                  => CommandKind::Log,
-            Command::DeleteConflictLog { .. }         => CommandKind::Log,
+            Command::TruncateLog { .. }         => CommandKind::Log,
 
             Command::ReplicateCommitted { .. }        => CommandKind::Network,
             Command::Replicate { .. }                 => CommandKind::Network,
@@ -187,7 +187,7 @@ where C: RaftTypeConfig
             Command::SaveVote { .. }                  => None,
             Command::SendVote { .. }                  => None,
             Command::PurgeLog { .. }                  => None,
-            Command::DeleteConflictLog { .. }         => None,
+            Command::TruncateLog { .. }         => None,
             Command::Respond { when, .. }             => when.as_ref(),
             // TODO(1): 
             Command::StateMachine { .. }              => None,

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -32,6 +32,7 @@ use crate::error::NotInMembers;
 use crate::error::RejectAppendEntries;
 use crate::proposer::leader_state::CandidateState;
 use crate::proposer::Candidate;
+use crate::proposer::Leader;
 use crate::proposer::LeaderQuorumSet;
 use crate::proposer::LeaderState;
 use crate::raft::responder::Responder;
@@ -244,6 +245,14 @@ where C: RaftTypeConfig
         });
 
         self.server_state_handler().update_server_state_if_changed();
+    }
+
+    pub(crate) fn leader_ref(&self) -> Option<&Leader<C, LeaderQuorumSet<C>>> {
+        self.leader.as_deref()
+    }
+
+    pub(crate) fn leader_mut(&mut self) -> Option<&mut Leader<C, LeaderQuorumSet<C>>> {
+        self.leader.as_deref_mut()
     }
 
     pub(crate) fn candidate_ref(&self) -> Option<&Candidate<C, LeaderQuorumSet<C>>> {
@@ -799,7 +808,6 @@ where C: RaftTypeConfig
         ServerStateHandler {
             config: &self.config,
             state: &mut self.state,
-            output: &mut self.output,
         }
     }
     pub(crate) fn establish_handler(&mut self) -> EstablishHandler<C> {

--- a/openraft/src/engine/engine_output.rs
+++ b/openraft/src/engine/engine_output.rs
@@ -47,8 +47,6 @@ where C: RaftTypeConfig
                 tracing::debug!("next_seq: {}", seq);
                 command.set_seq(seq);
             }
-            Command::BecomeLeader => {}
-            Command::QuitLeader => {}
             Command::AppendInputEntries { .. } => {}
             Command::ReplicateCommitted { .. } => {}
             Command::Commit { .. } => {}

--- a/openraft/src/engine/engine_output.rs
+++ b/openraft/src/engine/engine_output.rs
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
             Command::SaveVote { .. } => {}
             Command::SendVote { .. } => {}
             Command::PurgeLog { .. } => {}
-            Command::DeleteConflictLog { .. } => {}
+            Command::TruncateLog { .. } => {}
             Command::Respond { .. } => {}
         }
         self.commands.push_back(cmd)

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -222,7 +222,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::DeleteConflictLog { since: log_id(2, 1, 4) },
+            Command::TruncateLog { since: log_id(2, 1, 4) },
             Command::from(
                 sm::Command::install_full_snapshot(Snapshot {
                     meta: SnapshotMeta {

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -360,7 +360,6 @@ where C: RaftTypeConfig
         ServerStateHandler {
             config: self.config,
             state: self.state,
-            output: self.output,
         }
     }
 }

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -197,7 +197,7 @@ where C: RaftTypeConfig
         };
 
         self.state.log_ids.truncate(since);
-        self.output.push_command(Command::DeleteConflictLog { since: since_log_id });
+        self.output.push_command(Command::TruncateLog { since: since_log_id });
 
         let changed = self.state.membership_state.truncate(since);
         if let Some(_c) = changed {

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -65,7 +65,7 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::DeleteConflictLog { since: log_id(2, 1, 3) },
+            Command::TruncateLog { since: log_id(2, 1, 3) },
         ],
         eng.output.take_commands()
     );
@@ -91,7 +91,7 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
 
     assert_eq!(
-        vec![Command::DeleteConflictLog { since: log_id(4, 1, 4) }],
+        vec![Command::TruncateLog { since: log_id(4, 1, 4) }],
         eng.output.take_commands()
     );
 
@@ -107,7 +107,7 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
     assert_eq!(Some(&log_id(4, 1, 4)), eng.state.last_log_id());
     assert_eq!(&[log_id(2, 1, 2), log_id(4, 1, 4)], eng.state.log_ids.key_log_ids());
     assert_eq!(
-        vec![Command::DeleteConflictLog { since: log_id(4, 1, 5) }],
+        vec![Command::TruncateLog { since: log_id(4, 1, 5) }],
         eng.output.take_commands()
     );
 
@@ -126,7 +126,7 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(
-        vec![Command::DeleteConflictLog { since: log_id(4, 1, 6) }],
+        vec![Command::TruncateLog { since: log_id(4, 1, 6) }],
         eng.output.take_commands()
     );
 
@@ -181,7 +181,7 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::DeleteConflictLog { since: log_id(4, 1, 4) },
+            Command::TruncateLog { since: log_id(4, 1, 4) },
         ],
         eng.output.take_commands()
     );

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -1,6 +1,4 @@
-use crate::engine::Command;
 use crate::engine::EngineConfig;
-use crate::engine::EngineOutput;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::ServerState;
@@ -14,7 +12,6 @@ where C: RaftTypeConfig
 {
     pub(crate) config: &'st EngineConfig<C>,
     pub(crate) state: &'st mut RaftState<C>,
-    pub(crate) output: &'st mut EngineOutput<C>,
 }
 
 impl<'st, C> ServerStateHandler<'st, C>
@@ -41,10 +38,8 @@ where C: RaftTypeConfig
 
         if !was_leader && is_leader {
             tracing::info!(id = display(self.config.id), "become leader");
-            self.output.push_command(Command::BecomeLeader);
         } else if was_leader && !is_leader {
             tracing::info!(id = display(self.config.id), "quit leader");
-            self.output.push_command(Command::QuitLeader);
         } else {
             // nothing to do
         }

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -4,7 +4,6 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::engine::testing::UTConfig;
-use crate::engine::Command;
 use crate::engine::Engine;
 use crate::testing::log_id;
 use crate::utime::UTime;
@@ -47,18 +46,10 @@ fn test_update_server_state_if_changed() -> anyhow::Result<()> {
     {
         assert_eq!(ServerState::Leader, ssh.state.server_state);
 
-        ssh.output.clear_commands();
         ssh.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 100));
         ssh.update_server_state_if_changed();
 
         assert_eq!(ServerState::Follower, ssh.state.server_state);
-        assert_eq!(
-            vec![
-                //
-                Command::QuitLeader,
-            ],
-            ssh.output.take_commands()
-        );
     }
 
     // TODO(3): add more test,

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -234,7 +234,6 @@ where C: RaftTypeConfig
         ServerStateHandler {
             config: self.config,
             state: self.state,
-            output: self.output,
         }
     }
 

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -157,7 +157,7 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::DeleteConflictLog { since: log_id(1, 1, 2) },
+            Command::TruncateLog { since: log_id(1, 1, 2) },
         ],
         eng.output.take_commands()
     );
@@ -197,7 +197,7 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::DeleteConflictLog { since: log_id(1, 1, 2) },
+            Command::TruncateLog { since: log_id(1, 1, 2) },
             Command::AppendInputEntries {
                 vote: Vote::new_committed(2, 1),
                 entries: vec![blank_ent(2, 1, 2)]
@@ -291,7 +291,7 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::DeleteConflictLog { since: log_id(2, 1, 3) },
+            Command::TruncateLog { since: log_id(2, 1, 3) },
             Command::AppendInputEntries {
                 vote: Vote::new_committed(2, 1),
                 entries: vec![Entry::new_membership(log_id(3, 1, 3), m34())]

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -206,7 +206,6 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
                 Command::SaveVote {
                     vote: Vote::new_committed(2, 1)
                 },
-                Command::BecomeLeader,
                 Command::AppendInputEntries {
                     vote: Vote::new_committed(2, 1),
                     entries: vec![Entry::<UTConfig>::new_blank(log_id(2, 1, 1))],

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -56,7 +56,6 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::BecomeLeader,
             Command::RebuildReplicationStreams {
                 targets: vec![(3, ProgressEntry {
                     matching: None,
@@ -101,7 +100,6 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::BecomeLeader,
             Command::RebuildReplicationStreams {
                 targets: vec![(3, ProgressEntry {
                     matching: None,

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -7,6 +7,7 @@ use crate::progress::VecProgress;
 use crate::quorum::QuorumSet;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::TypeConfigExt;
 use crate::vote::CommittedVote;
 use crate::Instant;
 use crate::LogId;
@@ -38,6 +39,9 @@ where C: RaftTypeConfig
     ///
     /// `self.voting` may be in progress requesting vote for a higher vote.
     pub(crate) vote: CommittedVote<C>,
+
+    /// The time to send next heartbeat.
+    pub(crate) next_heartbeat: InstantOf<C>,
 
     last_log_id: Option<LogIdOf<C>>,
 
@@ -108,6 +112,7 @@ where
 
         Self {
             vote,
+            next_heartbeat: C::now(),
             last_log_id,
             noop_log_id,
             progress: VecProgress::new(

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -287,7 +287,6 @@ where C: RaftTypeConfig
             client_resp_channels: BTreeMap::new(),
 
             replications: Default::default(),
-            leader_data: None,
 
             tx_api: tx_api.clone(),
             rx_api,


### PR DESCRIPTION

## Changelog

##### Refactor: Remove `LeaderData` from `RaftCore`

`LeaderData` stores heartbeat time which is now stored in `Engine.leader`.

Remove `Command::BecomeLeader` and `Command::QuitLeader`.


##### Refactor: rename Command::DeleteConflictLog to TruncateLog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1151)
<!-- Reviewable:end -->
