### PR TITLE
Refactor: Move Log Reading to State Machine Worker

### DIFF
--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -271,7 +271,7 @@ where C: RaftTypeConfig
 
         let engine = Engine::new(state, eng_config);
 
-        let sm_handle = worker::Worker::spawn(state_machine, tx_notify.clone());
+        let sm_handle = worker::Worker::spawn(state_machine, log_store.get_log_reader().await, tx_notify.clone());
 
         let core: RaftCore<C, N, LS> = RaftCore {
             id,


### PR DESCRIPTION

## Changelog

##### Refactor: Move Log Reading to State Machine Worker

This commit optimizes the process of applying log entries to the state
machine by moving the log reading responsibilities from `RaftCore` to
the state machine worker.

The state machine worker runs in a separate task, ensuring that the
`RaftCore` main task is not blocked by applying log entries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1154)
<!-- Reviewable:end -->
