### PR TITLE
Change: rename `AsyncOneshotSendExt` to `OneshotSender`, remove `TokioOneShotSender`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -20,7 +20,7 @@ use tracing::Instrument;
 use tracing::Level;
 use tracing::Span;
 
-use crate::async_runtime::AsyncOneshotSendExt;
+use crate::async_runtime::OneshotSender;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
 use crate::core::balancer::Balancer;

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -1,6 +1,6 @@
 use tokio::sync::mpsc;
 
-use crate::async_runtime::AsyncOneshotSendExt;
+use crate::async_runtime::OneshotSender;
 use crate::core::notify::Notify;
 use crate::core::raft_msg::ResultSender;
 use crate::core::sm::handle::Handle;

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -1,6 +1,7 @@
+use std::fmt;
 use std::fmt::Debug;
 
-use crate::async_runtime::AsyncOneshotSendExt;
+use crate::async_runtime::OneshotSender;
 use crate::core::sm;
 use crate::engine::CommandKind;
 use crate::error::Infallible;
@@ -244,7 +245,6 @@ where C: RaftTypeConfig
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct ValueSender<C, T>
 where
     T: Debug + PartialEq + Eq + OptionalSend,
@@ -252,6 +252,16 @@ where
 {
     value: T,
     tx: OneshotSenderOf<C, T>,
+}
+
+impl<C, T> Debug for ValueSender<C, T>
+where
+    T: Debug + PartialEq + Eq + OptionalSend,
+    C: RaftTypeConfig,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ValueSender").field("value", &self.value).finish()
+    }
 }
 
 impl<C, T> PartialEq for ValueSender<C, T>

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -47,7 +47,7 @@ use tracing::trace_span;
 use tracing::Instrument;
 use tracing::Level;
 
-use crate::async_runtime::AsyncOneshotSendExt;
+use crate::async_runtime::OneshotSender;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
 use crate::core::command_state::CommandState;

--- a/openraft/src/raft/responder/impls.rs
+++ b/openraft/src/raft/responder/impls.rs
@@ -1,4 +1,4 @@
-use crate::async_runtime::AsyncOneshotSendExt;
+use crate::async_runtime::OneshotSender;
 use crate::raft::message::ClientWriteResult;
 use crate::raft::responder::Responder;
 use crate::type_config::alias::OneshotReceiverOf;

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -4,7 +4,7 @@ use std::io;
 
 use tokio::sync::oneshot;
 
-use crate::async_runtime::AsyncOneshotSendExt;
+use crate::async_runtime::OneshotSender;
 use crate::raft_state::io_state::log_io_id::LogIOId;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::LogId;

--- a/openraft/src/timer/timeout_test.rs
+++ b/openraft/src/timer/timeout_test.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tokio::time::Instant;
 
-use crate::async_runtime::AsyncOneshotSendExt;
 use crate::timer::timeout::RaftTimer;
 use crate::timer::Timeout;
 use crate::AsyncRuntime;


### PR DESCRIPTION

## Changelog

##### Change: rename `AsyncOneshotSendExt` to `OneshotSender`, remove `TokioOneShotSender`

**Removal of `TokioOneShotSender`:** Previously,
`TokioOneShotSender(tokio::sync::oneshot::Sender)` was used to
implement `Debug` for a oneshot sender. Given that `Debug`
implementation is not a mandatory requirement, `TokioOneShotSender` is
no longer necessary and has been removed.

**Rename `AsyncOneshotSendExt` to `OneshotSender`:** The renaming
reflects a more streamlined and intuitive naming convention.

Upgrade tip:

- rename `AsyncOneshotSendExt` to `OneshotSender`

---

- `AsyncOneshotSendExt` and `TokioOneShotSender` are introduced in #1026

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1157)
<!-- Reviewable:end -->
