### PR TITLE
Feature: `AsyncRuntime::MpscUnbounded` to abstract mpsc channels

### DIFF
--- a/openraft/src/core/sm/handle.rs
+++ b/openraft/src/core/sm/handle.rs
@@ -1,9 +1,12 @@
 //! State machine control handle
 
-use tokio::sync::mpsc;
-
+use crate::async_runtime::MpscUnboundedSender;
+use crate::async_runtime::MpscUnboundedWeakSender;
+use crate::async_runtime::SendError;
 use crate::core::sm;
 use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::MpscUnboundedSenderOf;
+use crate::type_config::alias::MpscUnboundedWeakSenderOf;
 use crate::type_config::TypeConfigExt;
 use crate::RaftTypeConfig;
 use crate::Snapshot;
@@ -12,7 +15,7 @@ use crate::Snapshot;
 pub(crate) struct Handle<C>
 where C: RaftTypeConfig
 {
-    pub(in crate::core::sm) cmd_tx: mpsc::UnboundedSender<sm::Command<C>>,
+    pub(in crate::core::sm) cmd_tx: MpscUnboundedSenderOf<C, sm::Command<C>>,
 
     #[allow(dead_code)]
     pub(in crate::core::sm) join_handle: JoinHandleOf<C, ()>,
@@ -21,7 +24,7 @@ where C: RaftTypeConfig
 impl<C> Handle<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn send(&mut self, cmd: sm::Command<C>) -> Result<(), mpsc::error::SendError<sm::Command<C>>> {
+    pub(crate) fn send(&mut self, cmd: sm::Command<C>) -> Result<(), SendError<sm::Command<C>>> {
         tracing::debug!("sending command to state machine worker: {:?}", cmd);
         self.cmd_tx.send(cmd)
     }
@@ -43,7 +46,7 @@ where C: RaftTypeConfig
     /// It is weak because the [`Worker`] watches the close event of this channel for shutdown.
     ///
     /// [`Worker`]: sm::worker::Worker
-    cmd_tx: mpsc::WeakUnboundedSender<sm::Command<C>>,
+    cmd_tx: MpscUnboundedWeakSenderOf<C, sm::Command<C>>,
 }
 
 impl<C> SnapshotReader<C>

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -40,13 +40,13 @@ pub use message::InstallSnapshotResponse;
 pub use message::SnapshotResponse;
 pub use message::VoteRequest;
 pub use message::VoteResponse;
-use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tracing::trace_span;
 use tracing::Instrument;
 use tracing::Level;
 
+use crate::async_runtime::MpscUnboundedSender;
 use crate::async_runtime::OneshotSender;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
@@ -239,8 +239,8 @@ where C: RaftTypeConfig
         LS: RaftLogStorage<C>,
         SM: RaftStateMachine<C>,
     {
-        let (tx_api, rx_api) = mpsc::unbounded_channel();
-        let (tx_notify, rx_notify) = mpsc::unbounded_channel();
+        let (tx_api, rx_api) = C::mpsc_unbounded();
+        let (tx_notify, rx_notify) = C::mpsc_unbounded();
         let (tx_metrics, rx_metrics) = watch::channel(RaftMetrics::new_initial(id));
         let (tx_data_metrics, rx_data_metrics) = watch::channel(RaftDataMetrics::default());
         let (tx_server_metrics, rx_server_metrics) = watch::channel(RaftServerMetrics::default());

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -3,11 +3,11 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tracing::Level;
 
+use crate::async_runtime::MpscUnboundedSender;
 use crate::config::RuntimeConfig;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::core::raft_msg::RaftMsg;
@@ -17,6 +17,7 @@ use crate::error::RaftError;
 use crate::metrics::RaftDataMetrics;
 use crate::metrics::RaftServerMetrics;
 use crate::raft::core_state::CoreState;
+use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::AsyncRuntime;
@@ -34,7 +35,7 @@ where C: RaftTypeConfig
     pub(in crate::raft) config: Arc<Config>,
     pub(in crate::raft) runtime_config: Arc<RuntimeConfig>,
     pub(in crate::raft) tick_handle: TickHandle<C>,
-    pub(in crate::raft) tx_api: mpsc::UnboundedSender<RaftMsg<C>>,
+    pub(in crate::raft) tx_api: MpscUnboundedSenderOf<C, RaftMsg<C>>,
     pub(in crate::raft) rx_metrics: watch::Receiver<RaftMetrics<C>>,
     pub(in crate::raft) rx_data_metrics: watch::Receiver<RaftDataMetrics<C>>,
     pub(in crate::raft) rx_server_metrics: watch::Receiver<RaftServerMetrics<C>>,

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -9,6 +9,7 @@ pub(crate) mod util;
 use std::fmt::Debug;
 
 pub use async_runtime::AsyncRuntime;
+pub use async_runtime::MpscUnbounded;
 pub use async_runtime::OneshotSender;
 pub use util::TypeConfigExt;
 
@@ -93,6 +94,7 @@ pub trait RaftTypeConfig:
 ///
 /// [`type-alias`]: crate::docs::feature_flags#feature-flag-type-alias
 pub mod alias {
+    use crate::async_runtime::MpscUnbounded;
     use crate::raft::responder::Responder;
     use crate::type_config::AsyncRuntime;
     use crate::RaftTypeConfig;
@@ -118,6 +120,13 @@ pub mod alias {
     pub type OneshotSenderOf<C, T> = <Rt<C> as AsyncRuntime>::OneshotSender<T>;
     pub type OneshotReceiverErrorOf<C> = <Rt<C> as AsyncRuntime>::OneshotReceiverError;
     pub type OneshotReceiverOf<C, T> = <Rt<C> as AsyncRuntime>::OneshotReceiver<T>;
+    pub type MpscUnboundedOf<C> = <Rt<C> as AsyncRuntime>::MpscUnbounded;
+
+    type Mpsc<C> = MpscUnboundedOf<C>;
+
+    pub type MpscUnboundedSenderOf<C, T> = <Mpsc<C> as MpscUnbounded>::Sender<T>;
+    pub type MpscUnboundedReceiverOf<C, T> = <Mpsc<C> as MpscUnbounded>::Receiver<T>;
+    pub type MpscUnboundedWeakSenderOf<C, T> = <Mpsc<C> as MpscUnbounded>::WeakSender<T>;
 
     // Usually used types
     pub type LogIdOf<C> = crate::LogId<NodeIdOf<C>>;

--- a/openraft/src/type_config/async_runtime/impls/tokio_runtime.rs
+++ b/openraft/src/type_config/async_runtime/impls/tokio_runtime.rs
@@ -1,6 +1,10 @@
 use std::future::Future;
 use std::time::Duration;
 
+use tokio::sync::mpsc;
+
+use crate::async_runtime::mpsc_unbounded;
+use crate::async_runtime::mpsc_unbounded::MpscUnbounded;
 use crate::type_config::OneshotSender;
 use crate::AsyncRuntime;
 use crate::OptionalSend;
@@ -74,11 +78,67 @@ impl AsyncRuntime for TokioRuntime {
         let (tx, rx) = tokio::sync::oneshot::channel();
         (tx, rx)
     }
+
+    type MpscUnbounded = TokioMpscUnbounded;
 }
 
 impl<T> OneshotSender<T> for tokio::sync::oneshot::Sender<T> {
     #[inline]
     fn send(self, t: T) -> Result<(), T> {
         self.send(t)
+    }
+}
+
+pub struct TokioMpscUnbounded;
+
+impl MpscUnbounded for TokioMpscUnbounded {
+    type Sender<T: OptionalSend> = mpsc::UnboundedSender<T>;
+    type Receiver<T: OptionalSend> = mpsc::UnboundedReceiver<T>;
+    type WeakSender<T: OptionalSend> = mpsc::WeakUnboundedSender<T>;
+
+    /// Creates an unbounded mpsc channel for communicating between asynchronous
+    /// tasks without backpressure.
+    fn channel<T: OptionalSend>() -> (Self::Sender<T>, Self::Receiver<T>) {
+        mpsc::unbounded_channel()
+    }
+}
+
+impl<T> mpsc_unbounded::MpscUnboundedSender<TokioMpscUnbounded, T> for mpsc::UnboundedSender<T>
+where T: OptionalSend
+{
+    #[inline]
+    fn send(&self, msg: T) -> Result<(), mpsc_unbounded::SendError<T>> {
+        self.send(msg).map_err(|e| mpsc_unbounded::SendError(e.0))
+    }
+
+    #[inline]
+    fn downgrade(&self) -> <TokioMpscUnbounded as MpscUnbounded>::WeakSender<T> {
+        self.downgrade()
+    }
+}
+
+impl<T> mpsc_unbounded::MpscUnboundedReceiver<T> for mpsc::UnboundedReceiver<T>
+where T: OptionalSend
+{
+    #[inline]
+    async fn recv(&mut self) -> Option<T> {
+        self.recv().await
+    }
+
+    #[inline]
+    fn try_recv(&mut self) -> Result<T, mpsc_unbounded::TryRecvError> {
+        self.try_recv().map_err(|e| match e {
+            mpsc::error::TryRecvError::Empty => mpsc_unbounded::TryRecvError::Empty,
+            mpsc::error::TryRecvError::Disconnected => mpsc_unbounded::TryRecvError::Disconnected,
+        })
+    }
+}
+
+impl<T> mpsc_unbounded::MpscUnboundedWeakSender<TokioMpscUnbounded, T> for mpsc::WeakUnboundedSender<T>
+where T: OptionalSend
+{
+    #[inline]
+    fn upgrade(&self) -> Option<<TokioMpscUnbounded as MpscUnbounded>::Sender<T>> {
+        self.upgrade()
     }
 }

--- a/openraft/src/type_config/async_runtime/mod.rs
+++ b/openraft/src/type_config/async_runtime/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod impls {
 
     pub use tokio_runtime::TokioRuntime;
 }
+pub mod mpsc_unbounded;
 mod oneshot;
 
 use std::fmt::Debug;
@@ -15,6 +16,12 @@ use std::fmt::Display;
 use std::future::Future;
 use std::time::Duration;
 
+pub use mpsc_unbounded::MpscUnbounded;
+pub use mpsc_unbounded::MpscUnboundedReceiver;
+pub use mpsc_unbounded::MpscUnboundedSender;
+pub use mpsc_unbounded::MpscUnboundedWeakSender;
+pub use mpsc_unbounded::SendError;
+pub use mpsc_unbounded::TryRecvError;
 pub use oneshot::OneshotSender;
 
 use crate::Instant;
@@ -107,4 +114,6 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     /// Each handle can be used on separate tasks.
     fn oneshot<T>() -> (Self::OneshotSender<T>, Self::OneshotReceiver<T>)
     where T: OptionalSend;
+
+    type MpscUnbounded: MpscUnbounded;
 }

--- a/openraft/src/type_config/async_runtime/mpsc_unbounded/mod.rs
+++ b/openraft/src/type_config/async_runtime/mpsc_unbounded/mod.rs
@@ -1,0 +1,69 @@
+mod send_error;
+mod try_recv_error;
+
+pub use send_error::SendError;
+pub use try_recv_error::TryRecvError;
+
+use crate::OptionalSend;
+use crate::OptionalSync;
+
+pub trait MpscUnbounded: Sized + OptionalSend {
+    type Sender<T: OptionalSend>: MpscUnboundedSender<Self, T>;
+    type Receiver<T: OptionalSend>: MpscUnboundedReceiver<T>;
+    type WeakSender<T: OptionalSend>: MpscUnboundedWeakSender<Self, T>;
+
+    fn channel<T: OptionalSend>() -> (Self::Sender<T>, Self::Receiver<T>);
+}
+
+/// Send values to the associated [`MpscUnboundedReceiver`].
+pub trait MpscUnboundedSender<MU, T>: OptionalSend + OptionalSync + Clone
+where
+    MU: MpscUnbounded,
+    T: OptionalSend,
+{
+    /// Attempts to send a message without blocking.
+    ///
+    /// If the receive half of the channel is closed, this
+    /// function returns an error. The error includes the value passed to `send`.
+    fn send(&self, msg: T) -> Result<(), SendError<T>>;
+
+    /// Converts the [`MpscUnboundedSender`] to a [`MpscUnboundedWeakSender`] that does not count
+    /// towards RAII semantics, i.e. if all `Sender` instances of the
+    /// channel were dropped and only `WeakSender` instances remain,
+    /// the channel is closed.
+    fn downgrade(&self) -> MU::WeakSender<T>;
+}
+
+/// Receive values from the associated [`MpscUnboundedSender`].
+pub trait MpscUnboundedReceiver<T>: OptionalSend + OptionalSync {
+    /// Receives the next value for this receiver.
+    ///
+    /// This method returns `None` if the channel has been closed and there are
+    /// no remaining messages in the channel's buffer.
+    fn recv(&mut self) -> impl std::future::Future<Output = Option<T>> + OptionalSend;
+
+    /// Tries to receive the next value for this receiver.
+    ///
+    /// This method returns the [`TryRecvError::Empty`] error if the channel is currently
+    /// empty, but there are still outstanding senders.
+    ///
+    /// This method returns the [`TryRecvError::Disconnected`] error if the channel is
+    /// currently empty, and there are no outstanding senders.
+    fn try_recv(&mut self) -> Result<T, TryRecvError>;
+}
+
+/// A sender that does not prevent the channel from being closed.
+///
+/// If all [`MpscUnboundedSender`] instances of a channel were dropped and only
+/// `WeakSender` instances remain, the channel is closed.
+pub trait MpscUnboundedWeakSender<MU, T>: OptionalSend + OptionalSync + Clone
+where
+    MU: MpscUnbounded,
+    T: OptionalSend,
+{
+    /// Tries to convert a [`MpscUnboundedWeakSender`] into an [`MpscUnboundedSender`].
+    ///
+    /// This will return `Some` if there are other `Sender` instances alive and
+    /// the channel wasn't previously dropped, otherwise `None` is returned.
+    fn upgrade(&self) -> Option<MU::Sender<T>>;
+}

--- a/openraft/src/type_config/async_runtime/mpsc_unbounded/send_error.rs
+++ b/openraft/src/type_config/async_runtime/mpsc_unbounded/send_error.rs
@@ -1,0 +1,19 @@
+use std::fmt;
+
+/// Error returned by the `Sender`.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub struct SendError<T>(pub T);
+
+impl<T> fmt::Debug for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendError").finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Display for SendError<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "channel closed")
+    }
+}
+
+impl<T> std::error::Error for SendError<T> {}

--- a/openraft/src/type_config/async_runtime/mpsc_unbounded/try_recv_error.rs
+++ b/openraft/src/type_config/async_runtime/mpsc_unbounded/try_recv_error.rs
@@ -1,0 +1,23 @@
+use std::fmt;
+
+/// Error returned by `try_recv`.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum TryRecvError {
+    /// This **channel** is currently empty, but the **Sender**(s) have not yet
+    /// disconnected, so data may yet become available.
+    Empty,
+    /// The **channel**'s sending half has become disconnected, and there will
+    /// never be any more data received on it.
+    Disconnected,
+}
+
+impl fmt::Display for TryRecvError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            TryRecvError::Empty => "receiving on an empty channel".fmt(fmt),
+            TryRecvError::Disconnected => "receiving on a closed channel".fmt(fmt),
+        }
+    }
+}
+
+impl std::error::Error for TryRecvError {}

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -3,9 +3,13 @@ use std::time::Duration;
 
 use openraft_macros::since;
 
+use crate::async_runtime::MpscUnbounded;
 use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::MpscUnboundedOf;
+use crate::type_config::alias::MpscUnboundedReceiverOf;
+use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::SleepOf;
@@ -57,6 +61,16 @@ pub trait TypeConfigExt: RaftTypeConfig {
     fn oneshot<T>() -> (OneshotSenderOf<Self, T>, OneshotReceiverOf<Self, T>)
     where T: OptionalSend {
         AsyncRuntimeOf::<Self>::oneshot()
+    }
+
+    /// Creates an unbounded mpsc channel for communicating between asynchronous
+    /// tasks without backpressure.
+    ///
+    /// This is just a wrapper of
+    /// [`AsyncRuntime::MpscUnbounded::channel()`](`crate::async_runtime::MpscUnbounded::channel`).
+    fn mpsc_unbounded<T>() -> (MpscUnboundedSenderOf<Self, T>, MpscUnboundedReceiverOf<Self, T>)
+    where T: OptionalSend {
+        MpscUnboundedOf::<Self>::channel()
     }
 
     // Task methods


### PR DESCRIPTION
## Changelog

##### Feature: `AsyncRuntime::MpscUnbounded` to abstract mpsc channels

- Part of: #1013

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1159)
<!-- Reviewable:end -->
