### PR TITLE
Dep: Require tokio 1.22 for WeakUnboundedSender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0.57"
 syn = "2.0"
 tempfile = { version = "3.4.0" }
 thiserror = "1.0.49"
-tokio = { version="1.8", default-features=false, features=["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version="1.22", default-features=false, features=["io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = { version = "0.1.40" }
 tracing-appender = "0.2.0"
 tracing-futures = "0.2.4"


### PR DESCRIPTION

## Changelog

##### Dep: Require tokio 1.22 for WeakUnboundedSender

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1165)
<!-- Reviewable:end -->
