### PR TITLE
Refactor: Automate Initialization of Leader Progress and Replication

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -15,7 +15,6 @@ use crate::engine::handler::following_handler::FollowingHandler;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::handler::log_handler::LogHandler;
 use crate::engine::handler::replication_handler::ReplicationHandler;
-use crate::engine::handler::replication_handler::SendNone;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::handler::vote_handler::VoteHandler;
@@ -158,17 +157,10 @@ where C: RaftTypeConfig
             self.state.membership_state.effective().is_voter(&self.config.id)
         );
 
+        // TODO: replace all the following codes with one update_internal_server_state;
         // Previously it is a leader. restore it as leader at once
         if self.state.is_leader(&self.config.id) {
             self.vote_handler().update_internal_server_state();
-
-            let mut rh = self.replication_handler();
-
-            // Restore the progress about the local log
-            rh.update_local_progress(rh.state.last_log_id().copied());
-
-            rh.initiate_replication(SendNone::False);
-
             return;
         }
 

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -110,7 +110,7 @@ where
 
         let last_log_id = last_leader_log_id.last().copied();
 
-        Self {
+        let mut leader = Self {
             vote,
             next_heartbeat: C::now(),
             last_log_id,
@@ -121,7 +121,14 @@ where
                 ProgressEntry::empty(last_log_id.next_index()),
             ),
             clock_progress: VecProgress::new(quorum_set, learner_ids, None),
-        }
+        };
+
+        // Update progress for this Leader.
+        // Note that Leader not being a voter is allowed.
+        let leader_node_id = vote.leader_id().voted_for().unwrap();
+        let _ = leader.progress.update(&leader_node_id, ProgressEntry::new(last_log_id));
+
+        leader
     }
 
     pub(crate) fn noop_log_id(&self) -> Option<&LogIdOf<C>> {


### PR DESCRIPTION

## Changelog

##### Refactor: Automate Initialization of Leader Progress and Replication

This commit enhances the initialization process of a `Leader` instance
by automating the setup of progress information and replication streams.
Previously, these tasks were manually performed by the caller after the
leader's creation, which could lead to inconsistencies or additional
complexity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1166)
<!-- Reviewable:end -->
