### PR TITLE
Change: Openraft does not require `Clone` for `WatchSender`

### DIFF
--- a/openraft/src/type_config/async_runtime/watch/mod.rs
+++ b/openraft/src/type_config/async_runtime/watch/mod.rs
@@ -16,7 +16,7 @@ pub trait Watch: Sized + OptionalSend {
     fn channel<T: OptionalSend + OptionalSync>(init: T) -> (Self::Sender<T>, Self::Receiver<T>);
 }
 
-pub trait WatchSender<W, T>: OptionalSend + Clone
+pub trait WatchSender<W, T>: OptionalSend
 where
     W: Watch,
     T: OptionalSend + OptionalSync,


### PR DESCRIPTION

## Changelog

##### Change: Openraft does not require `Clone` for `WatchSender`

- `WatchSender` is added in: 1b4ec53df2c548757607261e88287a2fd6cb5131

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1171)
<!-- Reviewable:end -->
