### PR TITLE
Refactor: log significant events with `Display`

### DIFF
--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -75,9 +75,13 @@ where C: RaftTypeConfig
             Self::VoteResponse {
                 target,
                 resp,
-                sender_vote: vote,
+                sender_vote,
             } => {
-                write!(f, "VoteResponse: from: {}: {}, res-vote: {}", target, resp, vote)
+                write!(
+                    f,
+                    "VoteResponse: from target={}, to sender_vote: {}, {}",
+                    target, sender_vote, resp
+                )
             }
             Self::HigherVote {
                 ref target,
@@ -91,12 +95,12 @@ where C: RaftTypeConfig
                 )
             }
             Self::StorageError { error } => write!(f, "StorageError: {}", error),
-            Self::LocalIO { io_id } => write!(f, "LocalIO({}) done", io_id),
+            Self::LocalIO { io_id } => write!(f, "{}", io_id),
             Self::Network { response } => {
-                write!(f, "Replication command done: {}", response)
+                write!(f, "{}", response)
             }
             Self::StateMachine { command_result } => {
-                write!(f, "StateMachine command done: {:?}", command_result)
+                write!(f, "{}", command_result)
             }
             Self::Tick { i } => {
                 write!(f, "Tick {}", i)

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -125,7 +125,7 @@ where C: RaftTypeConfig
             }
             RaftMsg::ChangeMembership { changes, retain, .. } => {
                 // TODO: avoid using Debug
-                write!(f, "ChangeMembership: members: {:?}, retain: {}", changes, retain,)
+                write!(f, "ChangeMembership: {:?}, retain: {}", changes, retain,)
             }
             RaftMsg::ExternalCoreRequest { .. } => write!(f, "External Request"),
             RaftMsg::ExternalCommand { cmd } => {

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
@@ -19,11 +20,19 @@ where C: RaftTypeConfig
 impl<C> Debug for Command<C>
 where C: RaftTypeConfig
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("StateMachineCommand")
             .field("seq", &self.seq)
             .field("payload", &self.payload)
             .finish()
+    }
+}
+
+impl<C> fmt::Display for Command<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "sm::Command: seq: {}, payload: {}", self.seq, self.payload)
     }
 }
 
@@ -115,12 +124,30 @@ where C: RaftTypeConfig
 impl<C> Debug for CommandPayload<C>
 where C: RaftTypeConfig
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             CommandPayload::BuildSnapshot => write!(f, "BuildSnapshot"),
             CommandPayload::GetSnapshot { .. } => write!(f, "GetSnapshot"),
             CommandPayload::InstallFullSnapshot { snapshot } => {
                 write!(f, "InstallFullSnapshot: meta: {:?}", snapshot.meta)
+            }
+            CommandPayload::BeginReceivingSnapshot { .. } => {
+                write!(f, "BeginReceivingSnapshot")
+            }
+            CommandPayload::Apply { first, last } => write!(f, "Apply: [{},{}]", first, last),
+        }
+    }
+}
+
+impl<C> fmt::Display for CommandPayload<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CommandPayload::BuildSnapshot => write!(f, "BuildSnapshot"),
+            CommandPayload::GetSnapshot { .. } => write!(f, "GetSnapshot"),
+            CommandPayload::InstallFullSnapshot { snapshot } => {
+                write!(f, "InstallFullSnapshot: meta: {}", snapshot.meta)
             }
             CommandPayload::BeginReceivingSnapshot { .. } => {
                 write!(f, "BeginReceivingSnapshot")

--- a/openraft/src/core/sm/response.rs
+++ b/openraft/src/core/sm/response.rs
@@ -1,5 +1,10 @@
+use std::fmt;
+use std::fmt::Formatter;
+
 use crate::core::sm::command::CommandSeq;
 use crate::core::ApplyResult;
+use crate::display_ext::display_result::DisplayResultExt;
+use crate::display_ext::DisplayOptionExt;
 use crate::RaftTypeConfig;
 use crate::SnapshotMeta;
 use crate::StorageError;
@@ -21,6 +26,24 @@ where C: RaftTypeConfig
     Apply(ApplyResult<C>),
 }
 
+impl<C> fmt::Display for Response<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BuildSnapshot(meta) => {
+                write!(f, "BuildSnapshot({})", meta)
+            }
+            Self::InstallSnapshot(meta) => {
+                write!(f, "InstallSnapshot({})", meta.display())
+            }
+            Self::Apply(result) => {
+                write!(f, "{}", result)
+            }
+        }
+    }
+}
+
 /// Container of result of a command.
 #[derive(Debug)]
 pub(crate) struct CommandResult<C>
@@ -29,6 +52,19 @@ where C: RaftTypeConfig
     #[allow(dead_code)]
     pub(crate) command_seq: CommandSeq,
     pub(crate) result: Result<Response<C>, StorageError<C>>,
+}
+
+impl<C> fmt::Display for CommandResult<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "sm::Result(command_seq:{}, {})",
+            self.command_seq,
+            self.result.display()
+        )
+    }
 }
 
 impl<C> CommandResult<C>

--- a/openraft/src/display_ext.rs
+++ b/openraft/src/display_ext.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod display_instant;
 pub(crate) mod display_option;
+pub(crate) mod display_result;
 pub(crate) mod display_slice;
 
 #[allow(unused_imports)]
@@ -9,5 +10,8 @@ pub(crate) use display_instant::DisplayInstant;
 pub(crate) use display_instant::DisplayInstantExt;
 pub(crate) use display_option::DisplayOption;
 pub(crate) use display_option::DisplayOptionExt;
+#[allow(unused_imports)]
+pub(crate) use display_result::DisplayResult;
+pub(crate) use display_result::DisplayResultExt;
 pub(crate) use display_slice::DisplaySlice;
 pub(crate) use display_slice::DisplaySliceExt;

--- a/openraft/src/display_ext/display_result.rs
+++ b/openraft/src/display_ext/display_result.rs
@@ -1,0 +1,53 @@
+use std::fmt;
+
+/// Implement `Display` for `Result<T,E>` if T and E are `Display`.
+///
+/// It outputs `"Ok(...)"` or `"Err(...)"`.
+pub(crate) struct DisplayResult<'a, T: fmt::Display, E: fmt::Display>(pub &'a Result<T, E>);
+
+impl<'a, T, E> fmt::Display for DisplayResult<'a, T, E>
+where
+    T: fmt::Display,
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Ok(ok) => {
+                write!(f, "Ok({})", ok)
+            }
+            Err(err) => {
+                write!(f, "Err({})", err)
+            }
+        }
+    }
+}
+
+pub(crate) trait DisplayResultExt<'a, T: fmt::Display, E: fmt::Display> {
+    fn display(&'a self) -> DisplayResult<'a, T, E>;
+}
+
+impl<T, E> DisplayResultExt<'_, T, E> for Result<T, E>
+where
+    T: fmt::Display,
+    E: fmt::Display,
+{
+    fn display(&self) -> DisplayResult<T, E> {
+        DisplayResult(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_result() {
+        let result: Result<i32, &str> = Ok(42);
+        let display_result = DisplayResult(&result);
+        assert_eq!(format!("{}", display_result), "Ok(42)");
+
+        let result: Result<i32, &str> = Err("error");
+        let display_result = DisplayResult(&result);
+        assert_eq!(format!("{}", display_result), "Err(error)");
+    }
+}

--- a/openraft/src/display_ext/display_slice.rs
+++ b/openraft/src/display_ext/display_slice.rs
@@ -40,12 +40,19 @@ impl<'a, T: fmt::Display, const MAX: usize> fmt::Display for DisplaySlice<'a, T,
 
 pub(crate) trait DisplaySliceExt<'a, T: fmt::Display> {
     fn display(&'a self) -> DisplaySlice<'a, T>;
+
+    /// Display at most `MAX` elements.
+    fn display_n<const MAX: usize>(&'a self) -> DisplaySlice<'a, T, MAX>;
 }
 
 impl<T> DisplaySliceExt<'_, T> for [T]
 where T: fmt::Display
 {
     fn display(&self) -> DisplaySlice<T> {
+        DisplaySlice(self)
+    }
+
+    fn display_n<const MAX: usize>(&'_ self) -> DisplaySlice<'_, T, MAX> {
         DisplaySlice(self)
     }
 }

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -11,6 +11,7 @@ use pretty_assertions::assert_str_eq;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::ReplicationProgress;
 use crate::entry::RaftEntry;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
@@ -248,7 +249,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
                 ]
             },
             Command::RebuildReplicationStreams {
-                targets: vec![(2, ProgressEntry::empty(7))]
+                targets: vec![ReplicationProgress(2, ProgressEntry::empty(7))]
             },
             Command::Replicate {
                 target: 2,

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -8,6 +8,7 @@ use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::engine::ReplicationProgress;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
@@ -79,8 +80,11 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
         vec![
             //
             Command::RebuildReplicationStreams {
-                targets: vec![(3, ProgressEntry::empty(0)), (4, ProgressEntry::empty(0))], /* node-2 is leader,
-                                                                                            * won't be removed */
+                targets: vec![
+                    ReplicationProgress(3, ProgressEntry::empty(0)),
+                    ReplicationProgress(4, ProgressEntry::empty(0))
+                ], /* node-2 is leader,
+                    * won't be removed */
             }
         ],
         eng.output.take_commands()

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -4,6 +4,7 @@ use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::engine::ReplicationProgress;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
@@ -319,7 +320,7 @@ where C: RaftTypeConfig
                 // Reset and resend(by self.send_to_all()) replication requests.
                 prog_entry.inflight = Inflight::None;
 
-                targets.push((*target, *prog_entry));
+                targets.push(ReplicationProgress(*target, *prog_entry));
             }
         }
         self.output.push_command(Command::RebuildReplicationStreams { targets });

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -33,6 +33,7 @@ mod engine_config;
 mod engine_impl;
 mod engine_output;
 mod log_id_list;
+mod replication_progress;
 
 pub(crate) mod handler;
 pub(crate) mod time_state;
@@ -61,3 +62,4 @@ pub(crate) use engine_config::EngineConfig;
 pub(crate) use engine_impl::Engine;
 pub(crate) use engine_output::EngineOutput;
 pub use log_id_list::LogIdList;
+pub(crate) use replication_progress::ReplicationProgress;

--- a/openraft/src/engine/replication_progress.rs
+++ b/openraft/src/engine/replication_progress.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+use crate::progress::entry::ProgressEntry;
+use crate::RaftTypeConfig;
+
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct ReplicationProgress<C: RaftTypeConfig>(pub C::NodeId, pub ProgressEntry<C>);
+
+impl<C> fmt::Display for ReplicationProgress<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ReplicationProgress({}={})", self.0, self.1)
+    }
+}

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -9,6 +9,7 @@ use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::engine::ReplicationProgress;
 use crate::entry::RaftEntry;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
@@ -201,7 +202,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
         assert_eq!(
             vec![
                 Command::RebuildReplicationStreams {
-                    targets: vec![(2, ProgressEntry::empty(1))]
+                    targets: vec![ReplicationProgress(2, ProgressEntry::empty(1))]
                 },
                 Command::SaveVote {
                     vote: Vote::new_committed(2, 1)

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -7,6 +7,7 @@ use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
+use crate::engine::ReplicationProgress;
 use crate::entry::RaftEntry;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
@@ -61,7 +62,7 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
         vec![
             //
             Command::RebuildReplicationStreams {
-                targets: vec![(3, ProgressEntry {
+                targets: vec![ReplicationProgress(3, ProgressEntry {
                     matching: None,
                     curr_inflight_id: 0,
                     inflight: Inflight::None,
@@ -106,7 +107,7 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
         vec![
             //
             Command::RebuildReplicationStreams {
-                targets: vec![(3, ProgressEntry {
+                targets: vec![ReplicationProgress(3, ProgressEntry {
                     matching: None,
                     curr_inflight_id: 0,
                     inflight: Inflight::None,

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -42,7 +42,7 @@ impl<NID: NodeId> RaftLogId<NID> for LogId<NID> {
 
 impl<NID: NodeId> Display for LogId<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}-{}", self.leader_id, self.index)
+        write!(f, "{}.{}", self.leader_id, self.index)
     }
 }
 

--- a/openraft/src/raft_state/io_state/append_log_io_id.rs
+++ b/openraft/src/raft_state/io_state/append_log_io_id.rs
@@ -33,7 +33,7 @@ impl<C> fmt::Display for AppendLogIOId<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "by({}):{}", self.committed_vote, self.log_id)
+        write!(f, "by:{}, {}", self.committed_vote, self.log_id)
     }
 }
 

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
+use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
+use crate::display_ext::DisplayResultExt;
 use crate::replication::request_id::RequestId;
 use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::InstantOf;
@@ -80,12 +82,15 @@ where C: RaftTypeConfig
             } => {
                 write!(
                     f,
-                    "UpdateReplicationProgress: target: {}, id: {}, result: {:?}, session_id: {}",
-                    target, request_id, result, session_id
+                    "replication::Progress: target={}, request_id: {}, result: {}, session_id: {}",
+                    target,
+                    request_id,
+                    result.display(),
+                    session_id
                 )
             }
 
-            Self::StorageError { error } => write!(f, "ReplicationStorageError: {}", error),
+            Self::StorageError { error } => write!(f, "replication::StorageError: {}", error),
 
             Self::HigherVote {
                 target,
@@ -94,7 +99,7 @@ where C: RaftTypeConfig
             } => {
                 write!(
                     f,
-                    "Seen a higher vote: target: {}, vote: {}, server_state_vote: {}",
+                    "replication::Seen a higher vote: target={}, higher: {}, sender_vote: {}",
                     target, higher, sender_vote
                 )
             }
@@ -118,7 +123,7 @@ impl<C> fmt::Display for ReplicationResult<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{time:{:?}, result:", self.sending_time)?;
+        write!(f, "{{sending_time:{}, result:", self.sending_time.display())?;
 
         match &self.result {
             Ok(matching) => write!(f, "Match:{}", matching.display())?,

--- a/openraft/src/summary.rs
+++ b/openraft/src/summary.rs
@@ -86,15 +86,15 @@ mod tests {
         use crate::MessageSummary;
 
         let lid = crate::testing::log_id(1, 2, 3);
-        assert_eq!("T1-N2-3", lid.to_string());
-        assert_eq!("T1-N2-3", lid.summary());
-        assert_eq!("Some(T1-N2-3)", Some(&lid).summary());
-        assert_eq!("Some(T1-N2-3)", Some(lid).summary());
+        assert_eq!("T1-N2.3", lid.to_string());
+        assert_eq!("T1-N2.3", lid.summary());
+        assert_eq!("Some(T1-N2.3)", Some(&lid).summary());
+        assert_eq!("Some(T1-N2.3)", Some(lid).summary());
 
         let slc = vec![lid, lid];
-        assert_eq!("T1-N2-3,T1-N2-3", slc.as_slice().summary());
+        assert_eq!("T1-N2.3,T1-N2.3", slc.as_slice().summary());
 
         let slc = vec![&lid, &lid];
-        assert_eq!("T1-N2-3,T1-N2-3", slc.as_slice().summary());
+        assert_eq!("T1-N2.3,T1-N2.3", slc.as_slice().summary());
     }
 }

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -44,13 +44,9 @@ impl<NID: NodeId> std::fmt::Display for Vote<NID> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}:{}",
+            "<{}:{}>",
             self.leader_id,
-            if self.is_committed() {
-                "committed"
-            } else {
-                "uncommitted"
-            }
+            if self.is_committed() { "Q" } else { "-" }
         )
     }
 }


### PR DESCRIPTION
## Changelog

##### Refactor: log significant events with `Display`

This commit refines our logging strategy by utilizing the `Display`
trait instead of `Debug` for significant events. This change is aimed at
producing logs that are easier to read and understand.

Three kinds of significant events are logged at DEBUG level:

- `input`: the `RaftMsg`s received by `RaftCore`, such as client-write
  or AppendEntries request from the Leader.

- `cmd`: the `Command` outputted by `Engine` to execute by storage or
  network layer, such as `AppendInputEntries` or `ReplicateCommitted`.

- `notify`: the `Notification`s received by `RaftCore` from storage or
  network.

Example significant event logs:
```
RAFT_event id=0     cmd: Commit: seq: 5, (T1-N0.4, T1-N0.5]
RAFT_event id=1   input: AppendEntries: vote=<T1-N0:Q>, prev_log_id=T1-N0.5, leader_commit=T1-N0.5, entries=[]
RAFT_event id=0  notify: sm::Result(command_seq:5, Ok(ApplyResult([5, 6), last_applied=T1-N0.5, entries=[T1-N0.5])))
RAFT_event id=0   input: ClientWriteRequest
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1173)
<!-- Reviewable:end -->
