### PR TITLE
Feature: store heartbeat metric in RaftMetrics and RaftDataMetrics

### DIFF
--- a/openraft/src/display_ext.rs
+++ b/openraft/src/display_ext.rs
@@ -1,10 +1,14 @@
 //! Implement [`std::fmt::Display`] for types such as `Option<T>` and slice `&[T]`.
 
+pub(crate) mod display_btreemap_opt_value;
 pub(crate) mod display_instant;
 pub(crate) mod display_option;
 pub(crate) mod display_result;
 pub(crate) mod display_slice;
 
+pub(crate) use display_btreemap_opt_value::DisplayBTreeMapOptValue;
+#[allow(unused_imports)]
+pub(crate) use display_btreemap_opt_value::DisplayBtreeMapOptValueExt;
 #[allow(unused_imports)]
 pub(crate) use display_instant::DisplayInstant;
 pub(crate) use display_instant::DisplayInstantExt;

--- a/openraft/src/display_ext/display_btreemap_opt_value.rs
+++ b/openraft/src/display_ext/display_btreemap_opt_value.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use super::DisplayOption;
+
+/// Implement `Display` for `BTreeMap<K, Option<V>>` if `K` and `V` are `Display`.
+///
+/// It formats a key-value pair in a string like "{key}:{opt_value}", and
+/// concatenates the key-value pairs with comma.
+///
+/// For how to format the `opt_value`, see [`DisplayOption`].
+pub(crate) struct DisplayBTreeMapOptValue<'a, K: fmt::Display, V: fmt::Display>(pub &'a BTreeMap<K, Option<V>>);
+
+impl<'a, K: fmt::Display, V: fmt::Display> fmt::Display for DisplayBTreeMapOptValue<'a, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.0.len();
+        for (idx, (key, value)) in self.0.iter().enumerate() {
+            write!(f, "{}:{}", key, DisplayOption(value))?;
+            if idx + 1 != len {
+                write!(f, ",")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(unused)]
+pub(crate) trait DisplayBtreeMapOptValueExt<'a, K: fmt::Display, V: fmt::Display> {
+    fn display(&'a self) -> DisplayBTreeMapOptValue<'a, K, V>;
+}
+
+impl<K, V> DisplayBtreeMapOptValueExt<'_, K, V> for BTreeMap<K, Option<V>>
+where
+    K: fmt::Display,
+    V: fmt::Display,
+{
+    fn display(&self) -> DisplayBTreeMapOptValue<K, V> {
+        DisplayBTreeMapOptValue(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_btreemap_opt_value() {
+        let map = (1..=3).map(|num| (num, Some(num))).collect::<BTreeMap<_, _>>();
+        let display = DisplayBTreeMapOptValue(&map);
+
+        assert_eq!(display.to_string(), "1:1,2:2,3:3");
+    }
+
+    #[test]
+    fn test_display_empty_map() {
+        let map = BTreeMap::<i32, Option<i32>>::new();
+        let display = DisplayBTreeMapOptValue(&map);
+
+        assert_eq!(display.to_string(), "");
+    }
+
+    #[test]
+    fn test_display_btreemap_opt_value_with_1_item() {
+        let map = (1..=1).map(|num| (num, Some(num))).collect::<BTreeMap<_, _>>();
+        let display = DisplayBTreeMapOptValue(&map);
+
+        assert_eq!(display.to_string(), "1:1");
+    }
+
+    #[test]
+    fn test_display_btreemap_opt_value_with_none() {
+        let mut map = BTreeMap::new();
+        map.insert(1, Some(1));
+        map.insert(2, None);
+        map.insert(3, Some(3));
+        let display = DisplayBTreeMapOptValue(&map);
+
+        assert_eq!(display.to_string(), "1:1,2:None,3:3");
+    }
+}

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -50,3 +50,6 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::NodeIdOf;
 
 pub(crate) type ReplicationMetrics<C> = BTreeMap<NodeIdOf<C>, Option<LogIdOf<C>>>;
+/// Heartbeat metrics, a mapping between a node's ID and milliseconds since the
+/// last acknowledged heartbeat or replication to this node.
+pub(crate) type HeartbeatMetrics<C> = BTreeMap<NodeIdOf<C>, Option<u64>>;

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -262,6 +262,7 @@ where C: RaftTypeConfig {
         current_leader: None,
         millis_since_quorum_ack: None,
         membership_config: Arc::new(StoredMembership::new(None, Membership::new(vec![btreeset! {}], None))),
+        heartbeat: None,
 
         snapshot: None,
         replication: None,

--- a/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
+++ b/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::type_config::TypeConfigExt;
 use openraft::Config;
+use openraft_memstore::TypeConfig;
 #[allow(unused_imports)]
 use pretty_assertions::assert_eq;
 #[allow(unused_imports)]
@@ -61,6 +63,77 @@ async fn server_metrics_and_data_metrics() -> Result<()> {
         server_metrics_1,
         server_metrics_2
     );
+    Ok(())
+}
+
+/// Test if heartbeat metrics work
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn heartbeat_metrics() -> Result<()> {
+    // Setup test dependencies.
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            heartbeat_interval: 50,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let leader = router.get_raft_handle(&0)?;
+
+    tracing::info!(log_index, "--- trigger heartbeat; heartbeat metrics refreshes");
+    let refreshed_node1;
+    let refreshed_node2;
+    {
+        leader.trigger().heartbeat().await?;
+        let metrics = leader
+            .wait(timeout())
+            .metrics(
+                |metrics| {
+                    let heartbeat = metrics
+                        .heartbeat
+                        .as_ref()
+                        .expect("expect heartbeat to be Some as metrics come from the leader node");
+                    let node1 = heartbeat.get(&1).unwrap().unwrap();
+                    let node2 = heartbeat.get(&2).unwrap().unwrap();
+
+                    (node1 < 100) && (node2 < 100)
+                },
+                "millis_since_quorum_ack refreshed",
+            )
+            .await?;
+
+        let heartbeat = metrics
+            .heartbeat
+            .as_ref()
+            .expect("expect heartbeat to be Some as metrics come from the leader node");
+        refreshed_node1 = heartbeat.get(&1).unwrap().unwrap();
+        refreshed_node2 = heartbeat.get(&2).unwrap().unwrap();
+    }
+
+    tracing::info!(log_index, "--- sleep 500 ms, the interval should extend");
+    {
+        TypeConfig::sleep(Duration::from_millis(500)).await;
+
+        let metrics = leader.metrics();
+        let metrics_ref = metrics.borrow();
+        let heartbeat = metrics_ref
+            .heartbeat
+            .as_ref()
+            .expect("expect heartbeat to be Some as metrics come from the leader node");
+
+        let greater_node1 = heartbeat.get(&1).unwrap().unwrap();
+        let greater_node2 = heartbeat.get(&2).unwrap().unwrap();
+
+        assert!(greater_node1 > refreshed_node1);
+        assert!(greater_node2 > refreshed_node2);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

Will check the above stuff when this PR is no longer a draft:)

-----
# What does this PR do

This PR attempts to implement the metric discussed in [this thread][link], 
adding the `heartbeat` information (time of the last replication or heartbeat) to
`RaftDataMetrics` and `RaftMetrics` so that users can subscribe to it.

[link]: https://github.com/datafuselabs/openraft/discussions/1174#discussioncomment-10079172

It is a draft PR as I want to ensure it looks basically correct, then I will
try to add tests, code documents, and polish interfaces.

# How it is implemented

For the time type, I used `RaftTypeConfig::AsyncRuntime::Instant` as it is used 
widely.

And I found the last applied log ID is stored in `struct ProcessEntry`, so I 
stored this time information there as well. When a response to a replication 
request is received, the replication handler will update it in 
`ReplicationHandler::update_matching()` using the `sending_time` of the replication
result.

And these metrics will be sent to the tokio watch channel in `RaftCore::report_metrics()`.

# Unsolved problems/Questions

There are several unsolved problems with this PR, which I want to discuss with
the maintainer before taking any further actions.

1. The `serde::{Deserialize, Serialize}` bounds
   
   `RaftDataMetris` and `RaftMetrics` need to satisfy these bounds when the `serde`
   feature of Openraft is enabled, but neither `std::time::Instant` nor 
   `tokio::time::Instant` does this.

2. Should we use the `result.sending_time`, or we should let the follower pass
   the time when it receives the replication request? The later seems more 
   accurate.

3. Tests

   Looks like most unit tests (related to replication) use special human-made 
   log ID to emulate specific cases, should this time info be done similarly?
   I guess no as it is not that important compared to the log ID.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1177)
<!-- Reviewable:end -->
