### PR TITLE
Doc: explain default types used by `RaftTypeConfig` in getting-started.md

### DIFF
--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -26,7 +26,7 @@ openraft::declare_raft_types!(
         D = Request,
         R = Response,
         // In this example, snapshot is a path pointing to a file stored in shared storage.
-        SnapshotData = String,
+        SnapshotData = String
 );
 
 pub type LogStore = store::LogStore;


### PR DESCRIPTION

## Changelog

##### Doc: explain default types used by `RaftTypeConfig` in getting-started.md

- Fix: #1168

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1181)
<!-- Reviewable:end -->
