### PR TITLE
Refactor: remove `replication::Response::StorageError`

### DIFF
--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -39,14 +39,14 @@ where C: RaftTypeConfig
         // membership_log_id: Option<LogId<C::NodeId>>,
     },
 
-    /// A storage error occurred in the local store.
+    /// [`StorageError`] error has taken place locally(not on remote node),
+    /// and [`RaftCore`](`crate::core::RaftCore`) needs to shutdown.
     StorageError { error: StorageError<C> },
 
     /// Completion of an IO operation to local store.
     LocalIO { io_id: IOId<C> },
 
     /// Result of executing a command sent from network worker.
-    // TODO: remove StorageError from replication::Response, use Notify::StorageError instead
     Network { response: replication::Response<C> },
 
     /// Result of executing a command sent from state machine worker.

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -173,7 +173,6 @@ where C: RaftTypeConfig
 
         if let Some(prev_committed) = self.state.update_committed(&committed) {
             self.output.push_command(Command::Commit {
-                // TODO(xp): when restart, commit is reset to None. Use last_applied instead.
                 already_committed: prev_committed,
                 upto: committed.unwrap(),
             });
@@ -269,7 +268,7 @@ where C: RaftTypeConfig
     /// It returns an `Option<Condition<C>>` indicating the next action:
     /// - `Some(Condition::StateMachineCommand { command_seq })` if the snapshot will be installed.
     ///   Further commands that depend on snapshot state should use this condition so that these
-    ///   command block until the condition is satisfied(`RaftCore` receives a `Notify`).
+    ///   command block until the condition is satisfied(`RaftCore` receives a `Notification`).
     /// - Otherwise `None` if the snapshot will not be installed (e.g., if it is not newer than the
     ///   current state).
     #[tracing::instrument(level = "debug", skip_all)]

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -275,10 +275,7 @@ where
                         ReplicationError::StorageError(error) => {
                             tracing::error!(error=%error, "error replication to target={}", self.target);
 
-                            // TODO: report this error
-                            let _ = self.tx_raft_core.send(Notification::Network {
-                                response: Response::StorageError { error },
-                            });
+                            let _ = self.tx_raft_core.send(Notification::StorageError { error });
                             return Ok(());
                         }
                         ReplicationError::RPCError(err) => {

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -8,7 +8,6 @@ use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
-use crate::StorageError;
 use crate::Vote;
 
 /// The response of replication command.
@@ -47,11 +46,6 @@ where C: RaftTypeConfig
         session_id: ReplicationSessionId<C>,
     },
 
-    /// [`StorageError`] error has taken place locally(not on remote node) when replicating, and
-    /// [`RaftCore`](`crate::core::RaftCore`) needs to shutdown. Sent by a replication task
-    /// [`crate::replication::ReplicationCore`].
-    StorageError { error: StorageError<C> },
-
     /// ReplicationCore has seen a higher `vote`.
     /// Sent by a replication task `ReplicationCore`.
     HigherVote {
@@ -89,8 +83,6 @@ where C: RaftTypeConfig
                     session_id
                 )
             }
-
-            Self::StorageError { error } => write!(f, "replication::StorageError: {}", error),
 
             Self::HigherVote {
                 target,

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -76,7 +76,7 @@ where C: RaftTypeConfig
         }
     }
 
-    /// Figure out the error subject and verb from the kind of response `Notify`.
+    /// Figure out the error subject and verb from the kind of response `Notification`.
     fn make_storage_error(&self, e: io::Error) -> StorageError<C> {
         match &self.notification {
             Notification::VoteResponse { .. } => StorageError::from_io_error(ErrorSubject::Vote, ErrorVerb::Write, e),


### PR DESCRIPTION

## Changelog

##### Refactor: remove `replication::Response::StorageError`

Whne a `StorageError` occurs locally during replication,
the `RaftCore` has to be shutdown at once. in this case, just send a
generic notification `Notification::StorageError`. There is no need for
`replication::Response` to contain `StorageError`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1186)
<!-- Reviewable:end -->
