### PR TITLE
Chore: mark StorageIOError as deprecated

### DIFF
--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -106,7 +106,6 @@ where C: RaftTypeConfig
     /// inclusive.
     TruncateLog { since: LogId<C::NodeId> },
 
-    // TODO(1): current it is only used to replace BuildSnapshot, InstallSnapshot, CancelSnapshot.
     /// A command send to state machine worker [`sm::worker::Worker`].
     ///
     /// The runtime(`RaftCore`) will just forward this command to [`sm::worker::Worker`].

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -235,9 +235,6 @@ where C: RaftTypeConfig
     ///
     /// This node then becomes raft-follower or raft-learner.
     pub(crate) fn become_following(&mut self) {
-        // TODO: entering following needs to check last-log-id on other node to decide the election
-        // timeout.
-
         debug_assert!(
             self.state.vote_ref().leader_id().voted_for() != Some(self.config.id)
                 || !self.state.membership_state.effective().membership().is_voter(&self.config.id),

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -113,6 +113,7 @@ pub use crate::storage::StorageHelper;
 pub use crate::storage_error::ErrorSubject;
 pub use crate::storage_error::ErrorVerb;
 pub use crate::storage_error::StorageError;
+#[allow(deprecated)]
 pub use crate::storage_error::StorageIOError;
 pub use crate::storage_error::ToStorageResult;
 pub use crate::summary::MessageSummary;

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -84,6 +84,7 @@ impl fmt::Display for ErrorVerb {
 }
 
 /// Backward compatible with old application using `StorageIOError`
+#[deprecated(note = "use StorageError instead", since = "0.10.0")]
 pub type StorageIOError<C> = StorageError<C>;
 
 impl<C> StorageError<C>


### PR DESCRIPTION

## Changelog

##### Chore: mark StorageIOError as deprecated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1187)
<!-- Reviewable:end -->
