### PR TITLE
Test: allow deprecated std::panic::PanicInfo in example tests

### DIFF
--- a/examples/raft-kv-memstore-network-v2/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-network-v2/tests/cluster/test_cluster.rs
@@ -1,5 +1,6 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
+#[allow(deprecated)] // since nightly 1.82
 use std::panic::PanicInfo;
 use std::time::Duration;
 
@@ -12,6 +13,7 @@ use tokio::task;
 use tokio::task::LocalSet;
 use tracing_subscriber::EnvFilter;
 
+#[allow(deprecated)] // PanicInfo deprecated since nightly 1.82
 pub fn log_panic(panic: &PanicInfo) {
     let backtrace = format!("{:?}", Backtrace::force_capture());
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/tests/cluster/test_cluster.rs
@@ -1,6 +1,7 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+#[allow(deprecated)] // since nightly 1.82
 use std::panic::PanicInfo;
 use std::time::Duration;
 
@@ -13,6 +14,7 @@ use tokio::task;
 use tokio::task::LocalSet;
 use tracing_subscriber::EnvFilter;
 
+#[allow(deprecated)] // PanicInfo deprecated since nightly 1.82
 pub fn log_panic(panic: &PanicInfo) {
     let backtrace = format!("{:?}", Backtrace::force_capture());
 

--- a/examples/raft-kv-memstore-singlethreaded/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-singlethreaded/tests/cluster/test_cluster.rs
@@ -1,6 +1,7 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+#[allow(deprecated)] // since nightly 1.82
 use std::panic::PanicInfo;
 use std::time::Duration;
 
@@ -21,6 +22,7 @@ use tokio::task;
 use tokio::task::LocalSet;
 use tracing_subscriber::EnvFilter;
 
+#[allow(deprecated)] // PanicInfo deprecated since nightly 1.82
 pub fn log_panic(panic: &PanicInfo) {
     let backtrace = format!("{:?}", Backtrace::force_capture());
 

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -1,5 +1,6 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
+#[allow(deprecated)] // since nightly 1.82
 use std::panic::PanicInfo;
 use std::thread;
 use std::time::Duration;
@@ -13,6 +14,7 @@ use raft_kv_memstore::store::Request;
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
 
+#[allow(deprecated)] // PanicInfo deprecated since nightly 1.82
 pub fn log_panic(panic: &PanicInfo) {
     let backtrace = {
         format!("{:?}", Backtrace::force_capture())

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -1,5 +1,6 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
+#[allow(deprecated)] // since nightly 1.82
 use std::panic::PanicInfo;
 use std::thread;
 use std::time::Duration;
@@ -13,6 +14,7 @@ use raft_kv_rocksdb::Node;
 use tokio::runtime::Handle;
 use tracing_subscriber::EnvFilter;
 
+#[allow(deprecated)] // PanicInfo deprecated since nightly 1.82
 pub fn log_panic(panic: &PanicInfo) {
     let backtrace = { format!("{:?}", Backtrace::force_capture()) };
 


### PR DESCRIPTION
### What does this PR do

Rust nightly 1.82 renamed `std::panic::PanicInfo` to `std::panic::PanicHookInfo` and [mark the old name deprecated](https://doc.rust-lang.org/nightly/std/panic/type.PanicInfo.html), this change is currently exclusive to nightly toolchain 1.82.0 and higher.

Based on our [discussion](https://github.com/datafuselabs/openraft/pull/1177#issuecomment-2241954264), allow them.



**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1188)
<!-- Reviewable:end -->
