### PR TITLE
Doc: mention is_initialized() in initialize()'s doc

### DIFF
--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -643,7 +643,9 @@ where C: RaftTypeConfig
     /// in Learner state — as if either of those constraints are false, it indicates that the
     /// cluster is already formed and in motion. If `InitializeError::NotAllowed` is returned
     /// from this function, it is safe to ignore, as it simply indicates that the cluster is
-    /// already up and running, which is ultimately the goal of this function.
+    /// already up and running, which is ultimately the goal of this function. You can check
+    /// if the cluster is initialized with [`Raft::is_initialized()`] and then avoid re-initialize
+    /// it in case you want to get rid of this error.
     ///
     /// This command will work for single-node or multi-node cluster formation. This command
     /// should be called with all discovered nodes which need to be part of cluster, and as such


### PR DESCRIPTION
Mention that one can check if a cluster is initialized using `Raft::is_initialized()` in the document of `Raft::initialize()` in case someone want to get rid of that `InitializeError::NotAllowed` error.

**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1190)
<!-- Reviewable:end -->
