### PR TITLE
Doc: Add example explaining why `LogIOId` must be `(CommittedLeaderId, LogId)`

### DIFF
--- a/openraft/src/raft_state/io_state/io_id.rs
+++ b/openraft/src/raft_state/io_state/io_id.rs
@@ -11,7 +11,7 @@ use crate::LogId;
 use crate::RaftTypeConfig;
 use crate::Vote;
 
-/// An ID to uniquely identify an monotonic increasing io operation to [`RaftLogStorage`].
+/// An ID to uniquely identify a monotonic increasing io operation to [`RaftLogStorage`].
 ///
 /// Not all IO to [`RaftLogStorage`] are included by this struct:
 /// only the IOs make progress in the raft log are included.

--- a/openraft/src/raft_state/io_state/log_io_id.rs
+++ b/openraft/src/raft_state/io_state/log_io_id.rs
@@ -17,6 +17,9 @@ use crate::RaftTypeConfig;
 /// It is monotonic increasing because:
 /// - Leader id increase monotonically in the entire cluster.
 /// - Leader propose or replicate log entries in order.
+///
+/// See: [LogId Appended Multiple
+/// Times](crate::docs::protocol::replication::log_replication#logid-appended-multiple-times).
 #[derive(Debug, Clone, Copy)]
 #[derive(PartialEq, Eq)]
 #[derive(PartialOrd, Ord)]


### PR DESCRIPTION

## Changelog

##### Doc: Add example explaining why `LogIOId` must be `(CommittedLeaderId, LogId)`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1195)
<!-- Reviewable:end -->
