### PR TITLE
Feature: add absolute timestamp `RaftMetrics::last_quorum_acked`

### DIFF
--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -1,4 +1,6 @@
+use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
+use crate::display_ext::DisplayResultExt;
 use crate::engine::handler::log_handler::LogHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::Command;
@@ -147,7 +149,7 @@ where C: RaftTypeConfig
     /// accepted.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn update_leader_clock(&mut self, node_id: C::NodeId, t: InstantOf<C>) {
-        tracing::debug!(target = display(node_id), t = debug(t), "{}", func_name!());
+        tracing::debug!(target = display(node_id), t = display(t.display()), "{}", func_name!());
 
         let granted = *self
             .leader
@@ -156,7 +158,7 @@ where C: RaftTypeConfig
             .expect("it should always update existing progress");
 
         tracing::debug!(
-            granted = debug(granted),
+            granted = display(granted.as_ref().map(|x| x.display()).display()),
             clock_progress = debug(&self.leader.clock_progress),
             "granted leader vote clock after updating"
         );
@@ -267,7 +269,7 @@ where C: RaftTypeConfig
         tracing::debug!(
             target = display(target),
             request_id = display(request_id),
-            result = debug(&repl_res),
+            result = display(repl_res.display()),
             progress = display(&self.leader.progress),
             "{}",
             func_name!()

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use crate::core::raft_msg::ResultSender;
+use crate::display_ext::DisplayInstantExt;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::handler::replication_handler::ReplicationHandler;
 use crate::engine::handler::replication_handler::SendNone;
@@ -150,7 +151,7 @@ where C: RaftTypeConfig
 
         // Update vote related timer and lease.
 
-        tracing::debug!(now = debug(C::now()), "{}", func_name!());
+        tracing::debug!(now = display(C::now().display()), "{}", func_name!());
 
         self.update_internal_server_state();
 

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -232,8 +232,6 @@ where C: RaftTypeConfig
     #[error(transparent)]
     Closed(#[from] ReplicationClosed),
 
-    // TODO(xp): two sub type: StorageError / TransportError
-    // TODO(xp): a sub error for just append_entries()
     #[error(transparent)]
     StorageError(#[from] StorageError<C>),
 

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -32,6 +32,7 @@ mod raft_metrics;
 mod wait;
 
 mod metric_display;
+mod serde_instant;
 mod wait_condition;
 #[cfg(test)]
 mod wait_test;
@@ -42,6 +43,7 @@ pub use metric::Metric;
 pub use raft_metrics::RaftDataMetrics;
 pub use raft_metrics::RaftMetrics;
 pub use raft_metrics::RaftServerMetrics;
+pub use serde_instant::SerdeInstant;
 pub use wait::Wait;
 pub use wait::WaitError;
 pub(crate) use wait_condition::Condition;

--- a/openraft/src/metrics/serde_instant.rs
+++ b/openraft/src/metrics/serde_instant.rs
@@ -1,0 +1,185 @@
+use std::fmt;
+use std::fmt::Formatter;
+use std::ops::Deref;
+
+use crate::display_ext::DisplayInstantExt;
+use crate::Instant;
+
+/// A wrapper for [`Instant`] that supports serialization and deserialization.
+///
+/// This struct serializes an `Instant` into a i64 which is the number of non-leap-nanoseconds since
+/// January 1, 1970 UTC.
+///
+/// Note: Serialization and deserialization are not perfectly accurate and can be indeterministic,
+/// resulting in minor variations each time. These deviations(could be smaller or greater) are
+/// typically less than a microsecond (10^-6 seconds).
+#[derive(Debug, Clone, Copy)]
+#[derive(PartialEq, Eq)]
+#[derive(PartialOrd, Ord)]
+pub struct SerdeInstant<I>
+where I: Instant
+{
+    inner: I,
+}
+
+impl<I> Deref for SerdeInstant<I>
+where I: Instant
+{
+    type Target = I;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<I> From<I> for SerdeInstant<I>
+where I: Instant
+{
+    fn from(inner: I) -> Self {
+        Self { inner }
+    }
+}
+
+impl<I> fmt::Display for SerdeInstant<I>
+where I: Instant
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.inner.display().fmt(f)
+    }
+}
+
+impl<I> SerdeInstant<I>
+where I: Instant
+{
+    pub fn new(inner: I) -> Self {
+        Self { inner }
+    }
+
+    pub fn into_inner(self) -> I {
+        self.inner
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use std::fmt;
+    use std::marker::PhantomData;
+    use std::time::SystemTime;
+
+    use chrono::DateTime;
+    use chrono::Utc;
+    use serde::de;
+    use serde::de::Visitor;
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serialize;
+    use serde::Serializer;
+
+    use super::SerdeInstant;
+    use crate::Instant;
+
+    impl<I> Serialize for SerdeInstant<I>
+    where I: Instant
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer {
+            // Convert Instant to SystemTime
+            let system_time = {
+                let sys_now = SystemTime::now();
+                let now = I::now();
+
+                if now >= self.inner {
+                    let d = now - self.inner;
+                    sys_now - d
+                } else {
+                    let d = self.inner - now;
+                    sys_now + d
+                }
+            };
+
+            let datetime: DateTime<Utc> = system_time.into();
+
+            let nano = datetime.timestamp_nanos_opt().ok_or(serde::ser::Error::custom("time out of range"))?;
+
+            serializer.serialize_u64(nano as u64)
+        }
+    }
+
+    impl<'de, I> Deserialize<'de> for SerdeInstant<I>
+    where I: Instant
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de> {
+            struct InstantVisitor<II: Instant>(PhantomData<II>);
+
+            impl<'de, II: Instant> Visitor<'de> for InstantVisitor<II> {
+                type Value = SerdeInstant<II>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    write!(formatter, "an u64 generated with Datetime::timestamp_nanos_opt()",)
+                }
+
+                fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+                where E: de::Error {
+                    let datetime = DateTime::from_timestamp_nanos(value as i64);
+
+                    let system_time: SystemTime = datetime.with_timezone(&Utc).into();
+
+                    // Calculate the `Instant` from the current time
+                    let sys_now = SystemTime::now();
+                    let now = II::now();
+                    let instant = if system_time > sys_now {
+                        now + (system_time.duration_since(sys_now).unwrap())
+                    } else {
+                        now - (sys_now.duration_since(system_time).unwrap())
+                    };
+                    Ok(SerdeInstant { inner: instant })
+                }
+            }
+
+            deserializer.deserialize_u64(InstantVisitor::<I>(Default::default()))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::time::Duration;
+
+        use super::SerdeInstant;
+        use crate::engine::testing::UTConfig;
+        use crate::type_config::alias::InstantOf;
+        use crate::type_config::TypeConfigExt;
+
+        #[test]
+        fn test_serde_instant() {
+            let now = UTConfig::<()>::now();
+            let serde_instant = SerdeInstant::new(now);
+            let json = serde_json::to_string(&serde_instant).unwrap();
+            println!("json: {}", json);
+            println!("Now: {:?}", now);
+
+            let deserialized: SerdeInstant<InstantOf<UTConfig>> = serde_json::from_str(&json).unwrap();
+            println!("Des: {:?}", *deserialized);
+
+            // Convert Instant to SerdeInstant is inaccurate.
+            if now > *deserialized {
+                assert!((now - *deserialized) < Duration::from_millis(5));
+            } else {
+                assert!((*deserialized - now) < Duration::from_millis(5));
+            }
+
+            // Test serialization format
+
+            let nano = "1721829051211301916";
+            let deserialized: SerdeInstant<InstantOf<UTConfig>> = serde_json::from_str(nano).unwrap();
+            let serialized = serde_json::to_string(&deserialized).unwrap();
+
+            assert_eq!(
+                nano[0..nano.len() - 6],
+                serialized[0..serialized.len() - 6],
+                "compare upto milli seconds: {}",
+                &nano[0..nano.len() - 6]
+            );
+        }
+    }
+}

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -249,6 +249,7 @@ pub(crate) type InitResult<C> = (RaftMetrics<C>, Wait<C>, WatchSenderOf<C, RaftM
 /// Returns init metrics, Wait, and the tx to send an updated metrics.
 fn init_wait_test<C>() -> InitResult<C>
 where C: RaftTypeConfig {
+    #[allow(deprecated)]
     let init = RaftMetrics {
         running_state: Ok(()),
         id: NodeIdOf::<C>::default(),
@@ -261,6 +262,7 @@ where C: RaftTypeConfig {
 
         current_leader: None,
         millis_since_quorum_ack: None,
+        last_quorum_acked: None,
         membership_config: Arc::new(StoredMembership::new(None, Membership::new(vec![btreeset! {}], None))),
         heartbeat: None,
 

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplaySliceExt;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Progress;
@@ -9,7 +10,6 @@ use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::CommittedVote;
-use crate::Instant;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftLogId;
@@ -192,11 +192,11 @@ where
 
         // Safe unwrap: voted_for() is always non-None in Openraft
         let node_id = self.committed_vote.leader_id().voted_for().unwrap();
-        let now = Instant::now();
+        let now = C::now();
 
         tracing::debug!(
             leader_id = display(node_id),
-            now = debug(now),
+            now = display(now.display()),
             "{}: update with leader's local time, before retrieving quorum acked clock",
             func_name!()
         );

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -29,6 +29,7 @@ use crate::async_runtime::MpscUnboundedWeakSender;
 use crate::config::Config;
 use crate::core::notification::Notification;
 use crate::core::sm::handle::SnapshotReader;
+use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
 use crate::error::HigherVote;
 use crate::error::PayloadTooLarge;
@@ -425,7 +426,7 @@ where
         // Send the payload.
         tracing::debug!(
             payload = display(&payload),
-            now = debug(leader_time),
+            now = display(leader_time.display()),
             "start sending append_entries, timeout: {:?}",
             self.config.heartbeat_interval
         );

--- a/scripts/check.kdl
+++ b/scripts/check.kdl
@@ -21,17 +21,14 @@ layout {
             pane {
                 command "cargo"
                 args "test" "--lib"
-                close_on_exit true
             }
             pane {
                 command "cargo"
                 args "test" "--test" "*"
-                close_on_exit true
             }
             pane {
                 command "cargo"
                 args "clippy" "--no-deps" "--all-targets" "--" "-D" "warnings"
-                close_on_exit true
             }
         }
         // status-bar

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -132,8 +132,10 @@ pub fn init_global_tracing(app_name: &str, dir: &str, level: &str) -> WorkerGuar
 }
 
 pub fn set_panic_hook() {
-    std::panic::set_hook(Box::new(|panic| {
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic| {
         log_panic(panic);
+        prev_hook(panic);
     }));
 }
 
@@ -150,22 +152,17 @@ pub fn log_panic(panic: &PanicInfo) {
         }
     };
 
-    eprintln!("{}", panic);
-
     if let Some(location) = panic.location() {
         tracing::error!(
-            message = %panic,
+            message = %panic.to_string().replace('\n', " "),
             backtrace = %backtrace,
             panic.file = location.file(),
             panic.line = location.line(),
             panic.column = location.column(),
         );
-        eprintln!("{}:{}:{}", location.file(), location.line(), location.column());
     } else {
-        tracing::error!(message = %panic, backtrace = %backtrace);
+        tracing::error!(message = %panic.to_string().replace('\n', " "), backtrace = %backtrace);
     }
-
-    eprintln!("{}", backtrace);
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/tests/tests/metrics/t10_leader_last_ack.rs
+++ b/tests/tests/metrics/t10_leader_last_ack.rs
@@ -14,6 +14,7 @@ use crate::fixtures::RaftRouter;
 /// from RaftMetrics and RaftServerMetrics.
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
+#[allow(deprecated)]
 async fn leader_last_ack_3_nodes() -> Result<()> {
     let heartbeat_interval = 50; // ms
     let config = Arc::new(
@@ -100,6 +101,7 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
         let got = n0
             .wait(timeout())
             .metrics(
+                #[allow(deprecated)]
                 |x| x.millis_since_quorum_ack < Some(100),
                 "millis_since_quorum_ack refreshed again",
             )
@@ -114,6 +116,109 @@ async fn leader_last_ack_3_nodes() -> Result<()> {
 /// from RaftMetrics and RaftServerMetrics.
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
+async fn leader_last_ack_3_nodes_abs_time() -> Result<()> {
+    let heartbeat_interval = 50; // ms
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            heartbeat_interval,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    // Wait a short while so that all events finished.
+    // Upon receiving a replication Response, it wakes up RaftCore and flush the metrics again.
+    // This cause the last_quorum_acked to be updated.
+    TypeConfig::sleep(Duration::from_millis(100)).await;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let last_acked = n0.metrics().borrow().last_quorum_acked;
+    assert!(last_acked.as_deref() <= Some(&TypeConfig::now()));
+
+    {
+        let last_acked = n0.data_metrics().borrow().last_quorum_acked;
+        assert!(last_acked.as_deref() <= Some(&TypeConfig::now()));
+    }
+
+    tracing::info!(log_index, "--- sleep 500 ms, the `last_quorum_acked` should not change");
+    {
+        TypeConfig::sleep(Duration::from_millis(500)).await;
+
+        let acked2 = n0.metrics().borrow().last_quorum_acked;
+        println!("greater: {:?}", acked2);
+        assert_eq!(acked2, last_acked);
+    }
+
+    let n0 = router.get_raft_handle(&0)?;
+
+    tracing::info!(log_index, "--- heartbeat; last_quorum_acked refreshes");
+    {
+        let now = TypeConfig::now();
+
+        n0.trigger().heartbeat().await?;
+        n0.wait(timeout())
+            .metrics(
+                |x| x.last_quorum_acked.as_deref() >= Some(&now),
+                "last_quorum_acked refreshed",
+            )
+            .await?;
+    }
+
+    tracing::info!(log_index, "--- sleep and heartbeat again; last_quorum_acked refreshes");
+    {
+        TypeConfig::sleep(Duration::from_millis(500)).await;
+
+        let now = TypeConfig::now();
+        n0.trigger().heartbeat().await?;
+
+        n0.wait(timeout())
+            .metrics(
+                |x| x.last_quorum_acked.as_deref() >= Some(&now),
+                "last_quorum_acked refreshed again",
+            )
+            .await?;
+    }
+
+    tracing::info!(log_index, "--- remove node 1 and node 2");
+    {
+        router.remove_node(1);
+        router.remove_node(2);
+    }
+
+    tracing::info!(
+        log_index,
+        "--- sleep and heartbeat again; last_quorum_acked does not refresh"
+    );
+    {
+        TypeConfig::sleep(Duration::from_millis(500)).await;
+
+        let now = TypeConfig::now();
+        n0.trigger().heartbeat().await?;
+
+        let got = n0
+            .wait(timeout())
+            .metrics(
+                |x| x.last_quorum_acked.as_deref() >= Some(&now),
+                "last_quorum_acked refreshed again",
+            )
+            .await;
+        assert!(got.is_err(), "last_quorum_acked does not refresh");
+    }
+
+    Ok(())
+}
+
+/// Get the last timestamp when a leader is acknowledged by a quorum,
+/// from RaftMetrics and RaftServerMetrics.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+#[allow(deprecated)]
 async fn leader_last_ack_1_node() -> Result<()> {
     let config = Arc::new(
         Config {
@@ -137,6 +242,20 @@ async fn leader_last_ack_1_node() -> Result<()> {
     {
         let millis = n0.data_metrics().borrow().millis_since_quorum_ack;
         assert_eq!(millis, Some(0), "it is always acked for single leader");
+    }
+
+    let last_acked = n0.metrics().borrow().last_quorum_acked;
+    assert!(
+        last_acked.unwrap().elapsed() < Duration::from_millis(100),
+        "it is always acked for single leader"
+    );
+
+    {
+        let last_acked = n0.metrics().borrow().last_quorum_acked;
+        assert!(
+            last_acked.unwrap().elapsed() < Duration::from_millis(100),
+            "it is always acked for single leader"
+        );
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Feature: add absolute timestamp `RaftMetrics::last_quorum_acked`

`RaftMetrics::last_quorum_acked` is the absolute timestamp of the most
recent time point that is accepted by a quorum via `AppendEntries` RPC.
This field is a wrapped `Instant` type: `SerdeInstant` which support
serde for `Instant`. This field is added as a replacement of
`millis_since_quorum_ack`, which is a relative time.

`SerdeInstant` serialize `Instant` into a string formatted as
"%Y-%m-%dT%H:%M:%S%.9f%z", e.g., "2024-07-24T04:07:32.567025000+0000".

Note: Serialization and deserialization are not perfectly accurate and
can be indeterministic, resulting in minor variations each time. These
deviations(could be smaller or greater) are typically less than a
microsecond (10^-6 seconds).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1197)
<!-- Reviewable:end -->
