### PR TITLE
Doc: update doc of Leader::assign_doc_ids()

### DIFF
--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -148,10 +148,6 @@ where
 
     /// Assign log ids to the entries.
     ///
-    /// Return `()` if successful.
-    /// Otherwise, return `Err(current_vote)` if this Leader is not yet established(by being
-    /// accepted by a quorum).
-    ///
     /// This method update the `self.last_log_id`.
     pub(crate) fn assign_log_ids<'a, LID: RaftLogId<C::NodeId> + 'a>(
         &mut self,


### PR DESCRIPTION
### What does this PR do

`Leader::assign_doc_ids()` no longer has a return value since #1143, so updates the doc.

**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1201)
<!-- Reviewable:end -->
