### PR TITLE
Refactor: `RaftMetrics::heartbeat` stores last-acked timestamp instead of duration since last ack

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -526,16 +526,7 @@ where
             let replication = Some(replication_prog.iter().map(|(id, p)| (*id, *p.borrow())).collect());
 
             let clock_prog = &leader.clock_progress;
-            let heartbeat = Some(
-                clock_prog
-                    .iter()
-                    .map(|(id, opt_t)| {
-                        let millis_since_last_ack = opt_t.map(|t| t.elapsed().as_millis() as u64);
-
-                        (*id, millis_since_last_ack)
-                    })
-                    .collect(),
-            );
+            let heartbeat = Some(clock_prog.iter().map(|(id, opt_t)| (*id, opt_t.map(SerdeInstant::new))).collect());
 
             (replication, heartbeat)
         } else {

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -50,8 +50,9 @@ pub(crate) use wait_condition::Condition;
 
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::NodeIdOf;
+use crate::type_config::alias::SerdeInstantOf;
 
 pub(crate) type ReplicationMetrics<C> = BTreeMap<NodeIdOf<C>, Option<LogIdOf<C>>>;
 /// Heartbeat metrics, a mapping between a node's ID and milliseconds since the
 /// last acknowledged heartbeat or replication to this node.
-pub(crate) type HeartbeatMetrics<C> = BTreeMap<NodeIdOf<C>, Option<u64>>;
+pub(crate) type HeartbeatMetrics<C> = BTreeMap<NodeIdOf<C>, Option<SerdeInstantOf<C>>>;

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -9,6 +9,7 @@ use crate::metrics::HeartbeatMetrics;
 use crate::metrics::ReplicationMetrics;
 use crate::metrics::SerdeInstant;
 use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::SerdeInstantOf;
 use crate::Instant;
 use crate::LogId;
 use crate::RaftTypeConfig;
@@ -90,7 +91,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// lost synchronization with the cluster.
     /// An older value may suggest a higher probability of the leader being partitioned from the
     /// cluster.
-    pub last_quorum_acked: Option<SerdeInstant<InstantOf<C>>>,
+    pub last_quorum_acked: Option<SerdeInstantOf<C>>,
 
     /// The current membership config of the cluster.
     pub membership_config: Arc<StoredMembership<C>>,

--- a/openraft/src/metrics/serde_instant.rs
+++ b/openraft/src/metrics/serde_instant.rs
@@ -147,7 +147,7 @@ mod serde_impl {
 
         use super::SerdeInstant;
         use crate::engine::testing::UTConfig;
-        use crate::type_config::alias::InstantOf;
+        use crate::type_config::alias::SerdeInstantOf;
         use crate::type_config::TypeConfigExt;
 
         #[test]
@@ -158,7 +158,7 @@ mod serde_impl {
             println!("json: {}", json);
             println!("Now: {:?}", now);
 
-            let deserialized: SerdeInstant<InstantOf<UTConfig>> = serde_json::from_str(&json).unwrap();
+            let deserialized: SerdeInstantOf<UTConfig> = serde_json::from_str(&json).unwrap();
             println!("Des: {:?}", *deserialized);
 
             // Convert Instant to SerdeInstant is inaccurate.
@@ -171,7 +171,7 @@ mod serde_impl {
             // Test serialization format
 
             let nano = "1721829051211301916";
-            let deserialized: SerdeInstant<InstantOf<UTConfig>> = serde_json::from_str(nano).unwrap();
+            let deserialized: SerdeInstantOf<UTConfig> = serde_json::from_str(nano).unwrap();
             let serialized = serde_json::to_string(&deserialized).unwrap();
 
             assert_eq!(

--- a/openraft/src/progress/bench/vec_progress_update.rs
+++ b/openraft/src/progress/bench/vec_progress_update.rs
@@ -11,7 +11,7 @@ use crate::quorum::Joint;
 fn progress_update_01234_567(b: &mut Bencher) {
     let membership: Vec<Vec<u64>> = vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7]];
     let quorum_set = Joint::from(membership);
-    let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, 0..=7, 0);
+    let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, 0..=7, || 0);
 
     let mut id = 0u64;
     let mut values = [0, 1, 2, 3, 4, 5, 6, 7];

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -69,7 +69,7 @@ where
             starting_time,
             vote,
             last_log_id,
-            progress: VecProgress::new(quorum_set.clone(), [], false),
+            progress: VecProgress::new(quorum_set.clone(), [], || false),
             quorum_set,
             learner_ids: learner_ids.into_iter().collect::<Vec<_>>(),
         }

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -114,12 +114,10 @@ where
             next_heartbeat: C::now(),
             last_log_id,
             noop_log_id,
-            progress: VecProgress::new(
-                quorum_set.clone(),
-                learner_ids.iter().copied(),
-                ProgressEntry::empty(last_log_id.next_index()),
-            ),
-            clock_progress: VecProgress::new(quorum_set, learner_ids, None),
+            progress: VecProgress::new(quorum_set.clone(), learner_ids.iter().copied(), || {
+                ProgressEntry::empty(last_log_id.next_index())
+            }),
+            clock_progress: VecProgress::new(quorum_set, learner_ids, || None),
         };
 
         // Update progress for this Leader.

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -5,6 +5,7 @@
 use maplit::btreemap;
 
 use crate::core::raft_msg::RaftMsg;
+use crate::display_ext::DisplayResult;
 use crate::error::ClientWriteError;
 use crate::error::RaftError;
 use crate::raft::message::ClientWriteResult;
@@ -165,7 +166,10 @@ where C: RaftTypeConfig<Responder = OneshotResponder<C>>
             )
             .await;
 
-        tracing::info!(wait_res = debug(&wait_res), "waiting for replication to new learner");
+        tracing::info!(
+            wait_res = display(DisplayResult(&wait_res)),
+            "waiting for replication to new learner"
+        );
 
         Ok(resp)
     }

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -142,4 +142,5 @@ pub mod alias {
     pub type VoteOf<C> = crate::Vote<NodeIdOf<C>>;
     pub type LeaderIdOf<C> = crate::LeaderId<NodeIdOf<C>>;
     pub type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<NodeIdOf<C>>;
+    pub type SerdeInstantOf<C> = crate::metrics::SerdeInstant<InstantOf<C>>;
 }


### PR DESCRIPTION

## Changelog

##### Refactor: `RaftMetrics::heartbeat` stores last-acked timestamp instead of duration since last ack

Other changes: Display human readable Instant in log

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1202)
<!-- Reviewable:end -->
