### PR TITLE
Refactor: Add Leader Lease Duration into `RaftState.vote`

### DIFF
--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 
@@ -9,7 +10,7 @@ use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
-use crate::utime::UTime;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -27,7 +28,11 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
-    eng.state.vote = UTime::new(UTConfig::<()>::now(), Vote::new_committed(2, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.state.committed = Some(log_id(1, 1, 1));
     eng.state.membership_state = MembershipState::new(
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -1,5 +1,6 @@
 use std::io::Cursor;
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -13,12 +14,12 @@ use crate::engine::LogIdList;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
+use crate::type_config::TypeConfigExt;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::Snapshot;
 use crate::SnapshotMeta;
 use crate::StoredMembership;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m12() -> Membership<UTConfig> {
@@ -33,7 +34,11 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
-    eng.state.vote.update(TokioInstant::now(), Vote::new_committed(2, 1));
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.state.committed = Some(log_id(4, 1, 5));
     eng.state.log_ids = LogIdList::new(vec![
         //
@@ -179,7 +184,11 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
         let mut eng = Engine::<UTConfig>::testing_default(0);
         eng.state.enable_validation(false); // Disable validation for incomplete state
 
-        eng.state.vote.update(TokioInstant::now(), Vote::new_committed(2, 1));
+        eng.state.vote.update(
+            UTConfig::<()>::now(),
+            Duration::from_millis(500),
+            Vote::new_committed(2, 1),
+        );
         eng.state.committed = Some(log_id(2, 1, 3));
         eng.state.log_ids = LogIdList::new(vec![
             //

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 
@@ -9,7 +10,7 @@ use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
-use crate::utime::UTime;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -33,7 +34,11 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;
-    eng.state.vote = UTime::new(UTConfig::<()>::now(), Vote::new_committed(2, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.state.log_ids = LogIdList::new(vec![
         log_id(2, 1, 2), //
         log_id(4, 1, 4),

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 
@@ -7,7 +8,7 @@ use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
-use crate::utime::UTime;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
@@ -28,7 +29,11 @@ fn m34() -> Membership<UTConfig> {
 fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
     eng.config.id = 2;
-    eng.state.vote = UTime::new(UTConfig::<()>::now(), Vote::new_committed(2, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.state.membership_state = MembershipState::new(
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 #[allow(unused_imports)]
@@ -19,14 +20,14 @@ use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::testing::blank_ent;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::vote::CommittedLeaderId;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::LogId;
 use crate::Membership;
 use crate::MembershipState;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m01() -> Membership<UTConfig> {
@@ -52,7 +53,11 @@ fn eng() -> Engine<UTConfig> {
 
     eng.config.id = 1;
     eng.state.committed = Some(log_id(0, 1, 0));
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(3, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(3, 1),
+    );
     eng.state.log_ids.append(log_id(1, 1, 1));
     eng.state.log_ids.append(log_id(2, 1, 3));
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
+++ b/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 #[allow(unused_imports)]
@@ -11,11 +12,11 @@ use pretty_assertions::assert_str_eq;
 use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m01() -> Membership<UTConfig> {
@@ -32,7 +33,11 @@ fn eng() -> Engine<UTConfig> {
 
     eng.config.id = 1;
     eng.state.committed = Some(log_id(0, 1, 0));
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(3, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(3, 1),
+    );
     eng.state.log_ids.append(log_id(1, 1, 1));
     eng.state.log_ids.append(log_id(2, 1, 3));
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 #[allow(unused_imports)]
@@ -14,11 +15,11 @@ use crate::engine::Engine;
 use crate::progress::Inflight;
 use crate::progress::Progress;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m01() -> Membership<UTConfig> {
@@ -35,7 +36,11 @@ fn eng() -> Engine<UTConfig> {
 
     eng.config.id = 1;
     eng.state.committed = Some(log_id(0, 1, 0));
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(3, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(3, 1),
+    );
     eng.state.log_ids.append(log_id(1, 1, 1));
     eng.state.log_ids.append(log_id(2, 1, 3));
     eng.state.membership_state = MembershipState::new(

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -13,13 +14,13 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
 use crate::LogId;
 use crate::Membership;
 use crate::MembershipState;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m01() -> Membership<UTConfig> {
@@ -49,7 +50,11 @@ fn eng() -> Engine<UTConfig> {
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),
     );
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(6, 2));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(6, 2),
+    );
     eng.state.server_state = eng.calc_server_state();
     eng
 }

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -10,11 +11,11 @@ use crate::progress::Inflight;
 use crate::progress::Progress;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m01() -> Membership<UTConfig> {
@@ -30,7 +31,11 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 2;
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(2, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.state.membership_state = MembershipState::new(
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m123())),

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -14,10 +15,9 @@ use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
 use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
-use crate::utime::UTime;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m01() -> Membership<UTConfig> {
@@ -34,7 +34,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 0;
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
+    eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
     eng.state.server_state = ServerState::Candidate;
     eng.state
         .membership_state

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -13,10 +14,10 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::testing::log_id;
 use crate::type_config::alias::EntryOf;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m01() -> Membership<UTConfig> {
@@ -28,7 +29,11 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 1;
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(2, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.state.server_state = ServerState::Candidate;
     eng.state
         .membership_state

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -11,7 +11,8 @@ use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::error::RejectVoteRequest;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::TokioInstant;
@@ -26,7 +27,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 0;
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
+    eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
     eng.state.server_state = ServerState::Candidate;
     eng.state
         .membership_state
@@ -39,7 +40,11 @@ fn eng() -> Engine<UTConfig> {
 #[test]
 fn test_handle_message_vote_reject_smaller_vote() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.vote = UTime::new(TokioInstant::now(), Vote::new_committed(2, 1));
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.testing_new_leader();
 
     let resp = eng.vote_handler().update_vote(&Vote::new(1, 2));

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -139,14 +139,17 @@ where C: RaftTypeConfig
 
         // Grant the vote
 
+        // TODO: Leader decide the lease.
+        let leader_lease = self.config.timer_config.leader_lease;
+
         if vote > self.state.vote_ref() {
             tracing::info!("vote is changing from {} to {}", self.state.vote_ref(), vote);
 
-            self.state.vote.update(C::now(), *vote);
+            self.state.vote.update(C::now(), leader_lease, *vote);
             self.state.accept_io(IOId::new(*vote));
             self.output.push_command(Command::SaveVote { vote: *vote });
         } else {
-            self.state.vote.touch(C::now());
+            self.state.vote.touch(C::now(), leader_lease);
         }
 
         // Update vote related timer and lease.

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -16,13 +17,13 @@ use crate::progress::Inflight;
 use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
 use crate::Entry;
 use crate::LogId;
 use crate::Membership;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m12() -> Membership<UTConfig> {
@@ -47,7 +48,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.state.server_state = ServerState::Follower;
-        eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
+        eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));
@@ -68,7 +69,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.config.id = 1;
-        eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
+        eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));
@@ -101,7 +102,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.config.id = 1;
-        eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
+        eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
         eng.state.log_ids = LogIdList::new(vec![log_id(3, 1, 3)]);
         eng.state
             .membership_state
@@ -140,7 +141,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.config.id = 1;
-        eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
+        eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m1234())));
@@ -176,7 +177,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
     {
         let mut eng = eng();
         eng.config.id = 1;
-        eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(2, 1));
+        eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
@@ -13,12 +15,12 @@ use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::vote::CommittedLeaderId;
 use crate::Entry;
 use crate::LogId;
 use crate::Membership;
-use crate::TokioInstant;
 use crate::Vote;
 
 #[test]
@@ -148,7 +150,7 @@ fn test_initialize() -> anyhow::Result<()> {
     tracing::info!("--- not allowed because of vote");
     {
         let mut eng = eng();
-        eng.state.vote = UTime::new(TokioInstant::now(), Vote::new(0, 1));
+        eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(0, 1));
 
         assert_eq!(
             Err(InitializeError::NotAllowed(NotAllowed {

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -18,7 +19,6 @@ use crate::Membership;
 use crate::Snapshot;
 use crate::SnapshotMeta;
 use crate::StoredMembership;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn m12() -> Membership<UTConfig> {
@@ -33,7 +33,11 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
-    eng.state.vote.update(TokioInstant::now(), Vote::new_committed(2, 1));
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
     eng.state.committed = Some(log_id(4, 1, 5));
     eng.state.log_ids = LogIdList::new(vec![
         //

--- a/openraft/src/instant.rs
+++ b/openraft/src/instant.rs
@@ -47,6 +47,16 @@ pub trait Instant:
             Duration::from_secs(0)
         }
     }
+
+    /// Returns the amount of time elapsed from another instant to this one, or zero duration if
+    /// that instant is later than this one.
+    fn saturating_duration_since(&self, earlier: Self) -> Duration {
+        if *self > earlier {
+            *self - earlier
+        } else {
+            Duration::from_secs(0)
+        }
+    }
 }
 
 pub type TokioInstant = tokio::time::Instant;

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -7,7 +7,7 @@ use validit::Validate;
 use crate::engine::LogIdList;
 use crate::error::ForwardToLeader;
 use crate::log_id::RaftLogId;
-use crate::utime::UTime;
+use crate::utime::Leased;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
@@ -49,7 +49,7 @@ pub struct RaftState<C>
 where C: RaftTypeConfig
 {
     /// The vote state of this node.
-    pub(crate) vote: UTime<Vote<C::NodeId>, InstantOf<C>>,
+    pub(crate) vote: Leased<Vote<C::NodeId>, InstantOf<C>>,
 
     /// The LogId of the last log committed(AKA applied) to the state machine.
     ///
@@ -90,7 +90,7 @@ where C: RaftTypeConfig
 {
     fn default() -> Self {
         Self {
-            vote: UTime::default(),
+            vote: Leased::default(),
             committed: None,
             purged_next: 0,
             log_ids: LogIdList::default(),
@@ -193,7 +193,7 @@ where C: RaftTypeConfig
 
     /// Return the last updated time of the vote.
     pub fn vote_last_modified(&self) -> Option<InstantOf<C>> {
-        self.vote.utime()
+        self.vote.last_update()
     }
 
     pub(crate) fn is_initialized(&self) -> bool {

--- a/openraft/src/raft_state/tests/forward_to_leader_test.rs
+++ b/openraft/src/raft_state/tests/forward_to_leader_test.rs
@@ -1,18 +1,19 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreemap;
 use maplit::btreeset;
 
 use crate::engine::testing::UTConfig;
 use crate::error::ForwardToLeader;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
 use crate::LogId;
 use crate::Membership;
 use crate::MembershipState;
 use crate::RaftState;
-use crate::TokioInstant;
 use crate::Vote;
 
 fn log_id(term: u64, index: u64) -> LogId<u64> {
@@ -29,7 +30,7 @@ fn m12() -> Membership<UTConfig> {
 #[test]
 fn test_forward_to_leader_vote_not_committed() {
     let rs = RaftState::<UTConfig> {
-        vote: UTime::new(TokioInstant::now(), Vote::new(1, 2)),
+        vote: Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(1, 2)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -43,7 +44,11 @@ fn test_forward_to_leader_vote_not_committed() {
 #[test]
 fn test_forward_to_leader_not_a_member() {
     let rs = RaftState::<UTConfig> {
-        vote: UTime::new(TokioInstant::now(), Vote::new_committed(1, 3)),
+        vote: Leased::new(
+            UTConfig::<()>::now(),
+            Duration::from_millis(500),
+            Vote::new_committed(1, 3),
+        ),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
@@ -59,7 +64,11 @@ fn test_forward_to_leader_has_leader() {
     let m123 = || Membership::<UTConfig<u64>>::new(vec![btreeset! {1,2}], btreemap! {1=>4,2=>5,3=>6});
 
     let rs = RaftState::<UTConfig<u64>> {
-        vote: UTime::new(TokioInstant::now(), Vote::new_committed(1, 3)),
+        vote: Leased::new(
+            UTConfig::<()>::now(),
+            Duration::from_millis(500),
+            Vote::new_committed(1, 3),
+        ),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),
             Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),

--- a/openraft/src/raft_state/tests/is_initialized_test.rs
+++ b/openraft/src/raft_state/tests/is_initialized_test.rs
@@ -1,9 +1,11 @@
+use std::time::Duration;
+
 use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::testing::log_id;
-use crate::utime::UTime;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
 use crate::RaftState;
-use crate::TokioInstant;
 use crate::Vote;
 
 #[test]
@@ -18,7 +20,7 @@ fn test_is_initialized() {
     // Vote is set but is default
     {
         let rs = RaftState::<UTConfig> {
-            vote: UTime::new(TokioInstant::now(), Vote::default()),
+            vote: Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::default()),
             ..Default::default()
         };
 
@@ -28,7 +30,7 @@ fn test_is_initialized() {
     // Vote is non-default value
     {
         let rs = RaftState::<UTConfig> {
-            vote: UTime::new(TokioInstant::now(), Vote::new(1, 2)),
+            vote: Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(1, 2)),
             ..Default::default()
         };
 

--- a/openraft/src/testing/suite.rs
+++ b/openraft/src/testing/suite.rs
@@ -435,7 +435,11 @@ where
     pub async fn get_initial_state_without_init(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
         let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
         let mut want = RaftState::<C>::default();
-        want.vote.update(initial.vote.utime().unwrap(), Vote::default());
+        want.vote.update(
+            initial.vote.last_update().unwrap(),
+            Duration::default(),
+            Vote::default(),
+        );
         want.io_state.io_progress.accept(IOId::new(Vote::default()));
         want.io_state.io_progress.submit(IOId::new(Vote::default()));
         want.io_state.io_progress.flush(IOId::new(Vote::default()));


### PR DESCRIPTION

## Changelog

##### Refactor: Add Leader Lease Duration into `RaftState.vote`

This commit enhances the management of leader lease durations by
integrating them directly into the `RaftState.vote` structure.
Previously, the leader lease was managed separately as a configuration
parameter, and `RaftState.vote` only recorded the timestamp of the last
received `AppendEntries` RPC.

- Store the lease duration together with the last update time in
  `RaftState.vote`, we simplify the process of expiration checking and
  improve the clarity of state logging.

- Dynamic Lease Management: This integration allows the lease duration
  to be reset dynamically, which is particularly useful when a
  leadership transfer is scheduled. This capability ensures that the
  leader's expiration can be immediately considered without delay.

- Runtime Adjustments: Leaders can now adjust their lease durations
  at runtime as needed, without requiring a configuration update. This
  flexibility supports more responsive and adaptable leadership
  management within the Raft cluster.

- Rename `UTime` to `Leased` and add field `lease` and related methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1212)
<!-- Reviewable:end -->
