### PR TITLE
Refactor: split `Command::Commit` into `SaveCommitted` and `Apply`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1714,12 +1714,13 @@ where
                     let _ = node.tx_repl.send(Replicate::Committed(committed));
                 }
             }
-            Command::Commit {
+            Command::SaveCommitted { committed } => {
+                self.log_store.save_committed(Some(committed)).await?;
+            }
+            Command::Apply {
                 already_committed,
                 upto,
             } => {
-                self.log_store.save_committed(Some(upto)).await?;
-
                 let first = self.engine.state.get_log_id(already_committed.next_index()).unwrap();
                 self.apply_to_state_machine(first, upto).await?;
             }

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -77,10 +77,15 @@ fn test_following_handler_commit_entries_ge_accepted() -> anyhow::Result<()> {
         eng.state.membership_state
     );
     assert_eq!(
-        vec![Command::Commit {
-            already_committed: Some(log_id(1, 1, 1)),
-            upto: log_id(1, 1, 2),
-        }],
+        vec![
+            Command::SaveCommitted {
+                committed: log_id(1, 1, 2)
+            },
+            Command::Apply {
+                already_committed: Some(log_id(1, 1, 1)),
+                upto: log_id(1, 1, 2),
+            }
+        ],
         eng.output.take_commands()
     );
 
@@ -106,7 +111,10 @@ fn test_following_handler_commit_entries_le_accepted() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::Commit {
+            Command::SaveCommitted {
+                committed: log_id(2, 1, 3)
+            },
+            Command::Apply {
                 already_committed: Some(log_id(1, 1, 1)),
                 upto: log_id(2, 1, 3)
             },

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -172,7 +172,11 @@ where C: RaftTypeConfig
         );
 
         if let Some(prev_committed) = self.state.update_committed(&committed) {
-            self.output.push_command(Command::Commit {
+            self.output.push_command(Command::SaveCommitted {
+                committed: committed.unwrap(),
+            });
+
+            self.output.push_command(Command::Apply {
                 already_committed: prev_committed,
                 upto: committed.unwrap(),
             });

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -233,7 +233,11 @@ where C: RaftTypeConfig
                 committed: self.state.committed().copied(),
             });
 
-            self.output.push_command(Command::Commit {
+            self.output.push_command(Command::SaveCommitted {
+                committed: self.state.committed().copied().unwrap(),
+            });
+
+            self.output.push_command(Command::Apply {
                 already_committed: prev_committed,
                 upto: self.state.committed().copied().unwrap(),
             });

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -106,7 +106,10 @@ fn test_update_matching() -> anyhow::Result<()> {
                 Command::ReplicateCommitted {
                     committed: Some(log_id(2, 1, 1))
                 },
-                Command::Commit {
+                Command::SaveCommitted {
+                    committed: log_id(2, 1, 1)
+                },
+                Command::Apply {
                     already_committed: None,
                     upto: log_id(2, 1, 1)
                 }
@@ -125,7 +128,10 @@ fn test_update_matching() -> anyhow::Result<()> {
                 Command::ReplicateCommitted {
                     committed: Some(log_id(2, 1, 3))
                 },
-                Command::Commit {
+                Command::SaveCommitted {
+                    committed: log_id(2, 1, 3)
+                },
+                Command::Apply {
                     already_committed: Some(log_id(2, 1, 1)),
                     upto: log_id(2, 1, 3)
                 }

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -37,6 +37,7 @@ pub use message::InstallSnapshotResponse;
 pub use message::SnapshotResponse;
 pub use message::VoteRequest;
 pub use message::VoteResponse;
+use openraft_macros::since;
 use tracing::trace_span;
 use tracing::Instrument;
 use tracing::Level;
@@ -807,6 +808,7 @@ where C: RaftTypeConfig
     ///     async move { sm.last_applied().await }
     /// }).await?;
     /// ```
+    #[since(version = "0.10.0")]
     pub async fn with_state_machine<F, SM, V>(&self, func: F) -> Result<Result<V, InvalidStateMachineType>, Fatal<C>>
     where
         SM: RaftStateMachine<C>,
@@ -849,6 +851,7 @@ where C: RaftTypeConfig
     /// destroyed right away and not called at all.
     ///
     /// If the input `SM` is different from the one in `RaftCore`, it just silently ignores it.
+    #[since(version = "0.10.0")]
     pub fn external_state_machine_request<F, SM>(&self, req: F)
     where
         SM: 'static,


### PR DESCRIPTION

## Changelog

##### Refactor: split `Command::Commit` into `SaveCommitted` and `Apply`