### PR TITLE
Refactor: Use stored lease in `RaftState.vote` for election decisions

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -304,7 +304,7 @@ where C: RaftTypeConfig
 
         if local_leased_vote.is_committed() {
             // Current leader lease has not yet expired, reject voting request
-            if !local_leased_vote.is_expired(now) {
+            if !local_leased_vote.is_expired(now, Duration::from_millis(0)) {
                 tracing::info!(
                     "reject vote-request: leader lease has not yet expire: {}",
                     local_leased_vote.time_info(now)

--- a/openraft/src/utime.rs
+++ b/openraft/src/utime.rs
@@ -129,9 +129,11 @@ impl<T, I: Instant> Leased<T, I> {
         self.lease = Duration::default();
     }
 
-    pub(crate) fn is_expired(&self, now: I) -> bool {
+    /// Checks if the value is expired based on the provided `now` timestamp.
+    /// An additional `timeout` parameter can be used to extend the lease under various situations.
+    pub(crate) fn is_expired(&self, now: I, timeout: Duration) -> bool {
         match self.last_update {
-            Some(utime) => now > utime + self.lease,
+            Some(utime) => now > utime + self.lease + timeout,
             None => true,
         }
     }


### PR DESCRIPTION

## Changelog

##### Refactor: Use stored lease in `RaftState.vote` for election decisions

This commit modifies the election process within the Raft algorithm to
consider the lease duration stored in `RaftState.vote` when determining
whether a follower or candidate should initiate an election to become
the new leader. Previously, this decision was based solely on a static
configuration value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1215)
<!-- Reviewable:end -->
