### PR TITLE
Fix: (0.10) Clarify that receiving an equal vote does not grant leadership.

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1676,7 +1676,7 @@ where
                 let _ = self.tx_notification.send(Notification::VoteResponse {
                     target: self.id,
                     // last_log_id is not used when sending VoteRequest to local node
-                    resp: VoteResponse::new(vote, None),
+                    resp: VoteResponse::new(vote, None, true),
                     sender_vote: vote,
                 });
             }

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -25,8 +25,8 @@ fn m01() -> Membership<UTConfig> {
 }
 
 /// Make a sample VoteResponse
-fn mk_res() -> Result<VoteResponse<UTConfig>, Infallible> {
-    Ok::<VoteResponse<UTConfig>, Infallible>(VoteResponse::new(Vote::new(2, 1), None))
+fn mk_res(granted: bool) -> Result<VoteResponse<UTConfig>, Infallible> {
+    Ok::<VoteResponse<UTConfig>, Infallible>(VoteResponse::new(Vote::new(2, 1), None, granted))
 }
 
 fn eng() -> Engine<UTConfig> {
@@ -50,7 +50,7 @@ fn test_accept_vote_reject_smaller_vote() -> anyhow::Result<()> {
     eng.output.take_commands();
 
     let (tx, _rx) = UTConfig::<()>::oneshot();
-    let resp = eng.vote_handler().accept_vote(&Vote::new(1, 2), tx, |_state, _err| mk_res());
+    let resp = eng.vote_handler().accept_vote(&Vote::new(1, 2), tx, |_state, _err| mk_res(false));
 
     assert!(resp.is_none());
 
@@ -62,7 +62,7 @@ fn test_accept_vote_reject_smaller_vote() -> anyhow::Result<()> {
                 when: Some(Condition::IOFlushed {
                     io_id: IOId::new(Vote::new(2, 1))
                 }),
-                resp: Respond::new(mk_res(), tx)
+                resp: Respond::new(mk_res(false), tx)
             },
         ],
         eng.output.take_commands()
@@ -78,7 +78,7 @@ fn test_accept_vote_granted_greater_vote() -> anyhow::Result<()> {
     eng.output.take_commands();
 
     let (tx, _rx) = UTConfig::<()>::oneshot();
-    let resp = eng.vote_handler().accept_vote(&Vote::new(3, 3), tx, |_state, _err| mk_res());
+    let resp = eng.vote_handler().accept_vote(&Vote::new(3, 3), tx, |_state, _err| mk_res(true));
 
     assert!(resp.is_some());
 

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -42,7 +42,6 @@ where C: RaftTypeConfig
     pub(crate) config: &'st mut EngineConfig<C>,
     pub(crate) state: &'st mut RaftState<C>,
     pub(crate) output: &'st mut EngineOutput<C>,
-    pub(crate) last_seen_vote: &'st mut Vote<C::NodeId>,
     pub(crate) leader: &'st mut LeaderState<C>,
     pub(crate) candidate: &'st mut CandidateState<C>,
 }
@@ -90,27 +89,6 @@ where C: RaftTypeConfig
         Some(tx)
     }
 
-    /// Update the `last_seen_vote` to a greater value.
-    ///
-    /// Return the replaced value if it is updated.
-    /// Return None if not updated.
-    pub(crate) fn update_last_seen(&mut self, vote: &Vote<C::NodeId>) -> Option<Vote<C::NodeId>> {
-        tracing::debug!(
-            "about to update last_seen_vote from {} to {}",
-            self.last_seen_vote,
-            vote
-        );
-
-        if vote >= self.last_seen_vote {
-            tracing::info!("updated last_seen_vote from {} to {}", self.last_seen_vote, vote);
-            let last = *self.last_seen_vote;
-            *self.last_seen_vote = *vote;
-            Some(last)
-        } else {
-            None
-        }
-    }
-
     /// Check and update the local vote and related state for every message received.
     ///
     /// This is used by all incoming event, such as the three RPC append-entries, vote,
@@ -124,8 +102,6 @@ where C: RaftTypeConfig
     /// This method also implies calling [`Self::update_last_seen`].
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn update_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), RejectVoteRequest<C>> {
-        self.update_last_seen(vote);
-
         // Partial ord compare:
         // Vote does not have to be total ord.
         // `!(a >= b)` does not imply `a < b`.

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -87,7 +87,6 @@ fn test_elect_single_node_elect_again() -> anyhow::Result<()> {
             Duration::from_millis(500),
             Vote::new_committed(1, 2),
         );
-        eng.last_seen_vote = *eng.state.vote_ref();
         eng.testing_new_leader();
         eng.candidate_mut().map(|candidate| candidate.grant_by(&1));
 

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -53,7 +53,7 @@ fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
         last_log_id: Some(log_id(2, 1, 3)),
     });
 
-    assert_eq!(VoteResponse::new(Vote::new_committed(2, 1), None), resp);
+    assert_eq!(VoteResponse::new(Vote::new_committed(2, 1), None, false), resp);
 
     assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
     assert!(eng.leader.is_none());
@@ -74,7 +74,7 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
         last_log_id: None,
     });
 
-    assert_eq!(VoteResponse::new(Vote::new(2, 1), None), resp);
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), None, false), resp);
 
     assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
     assert!(eng.leader.is_none());
@@ -96,7 +96,7 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
         last_log_id: Some(log_id(1, 1, 3)),
     });
 
-    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3))), resp);
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3)), false), resp);
 
     assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
     assert!(eng.leader.is_none());
@@ -123,7 +123,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
         last_log_id: Some(log_id(2, 1, 3)),
     });
 
-    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3))), resp);
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3)), true), resp);
 
     assert_eq!(Vote::new(2, 1), *eng.state.vote_ref());
     assert!(eng.leader.is_none());
@@ -150,7 +150,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     });
 
     // respond the updated vote.
-    assert_eq!(VoteResponse::new(Vote::new(3, 1), Some(log_id(2, 1, 3))), resp);
+    assert_eq!(VoteResponse::new(Vote::new(3, 1), Some(log_id(2, 1, 3)), true), resp);
 
     assert_eq!(Vote::new(3, 1), *eng.state.vote_ref());
     assert!(eng.leader.is_none());

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -36,12 +36,12 @@ where C: RaftTypeConfig
 pub struct VoteResponse<C: RaftTypeConfig> {
     /// vote after a node handling vote-request.
     /// Thus `resp.vote >= req.vote` always holds.
+    ///
+    /// `vote` that equals the candidate.vote does not mean the vote is granted.
+    /// The `vote` may be updated when a previous Leader sees a higher vote.
     pub vote: Vote<C::NodeId>,
 
-    /// Previously, it is true if a node accepted and saved the VoteRequest.
-    /// Now, it is no longer used and is always false.
-    /// If `vote` is the same as the Candidate, the Vote is granted.
-    #[deprecated(note = "use new() and is_granted_to() instead", since = "0.10.0")]
+    /// It is true if a node accepted and saved the VoteRequest.
     pub vote_granted: bool,
 
     /// The last log id stored on the remote voter.
@@ -51,11 +51,10 @@ pub struct VoteResponse<C: RaftTypeConfig> {
 impl<C> VoteResponse<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: impl Borrow<Vote<C::NodeId>>, last_log_id: Option<LogId<C::NodeId>>) -> Self {
-        #[allow(deprecated)]
+    pub fn new(vote: impl Borrow<Vote<C::NodeId>>, last_log_id: Option<LogId<C::NodeId>>, granted: bool) -> Self {
         Self {
             vote: *vote.borrow(),
-            vote_granted: false,
+            vote_granted: granted,
             last_log_id: last_log_id.map(|x| *x.borrow()),
         }
     }


### PR DESCRIPTION

## Changelog

##### Fix: (0.10) Clarify that receiving an equal vote does not grant leadership.

A node's `vote` may be updated when a leader observes a higher vote.
In such cases, the leader updates its local vote and steps down.
However, this vote update does not imply that the node accepts the
higher vote as valid for leadership, as it has not yet compared their
logs.

In this commit, re-enable `VoteResponse.vote_granted` to indicate a vote
is granted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1220)
<!-- Reviewable:end -->
