### PR TITLE
Feature: Transfer Leader

### DIFF
--- a/openraft/src/core/raft_msg/external_command.rs
+++ b/openraft/src/core/raft_msg/external_command.rs
@@ -33,6 +33,9 @@ pub(crate) enum ExternalCommand<C: RaftTypeConfig> {
     /// [`max_in_snapshot_log_to_keep`]: `crate::Config::max_in_snapshot_log_to_keep`
     PurgeLog { upto: u64 },
 
+    /// Submit a command to inform RaftCore to transfer leadership to the specified node.
+    TriggerTransferLeader { to: C::NodeId },
+
     /// Send a [`sm::Command`] to [`sm::worker::Worker`].
     /// This command is run in the sm task.
     StateMachineCommand { sm_cmd: sm::Command<C> },
@@ -65,6 +68,9 @@ where C: RaftTypeConfig
             }
             ExternalCommand::PurgeLog { upto } => {
                 write!(f, "PurgeLog[..={}]", upto)
+            }
+            ExternalCommand::TriggerTransferLeader { to } => {
+                write!(f, "TriggerTransferLeader: to {}", to)
             }
             ExternalCommand::StateMachineCommand { sm_cmd } => {
                 write!(f, "StateMachineCommand: {}", sm_cmd)

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -99,7 +99,7 @@ where C: RaftTypeConfig
     ///
     /// If this node is `to`, reset Leader lease and start election.
     /// Otherwise, just reset Leader lease so that the node `to` can become Leader.
-    TransferLeader {
+    HandleTransferLeader {
         /// The vote of the Leader that is transferring the leadership.
         from: Vote<C::NodeId>,
         /// The assigned node to be the next Leader.
@@ -140,7 +140,7 @@ where C: RaftTypeConfig
                 write!(f, "ChangeMembership: {:?}, retain: {}", changes, retain,)
             }
             RaftMsg::ExternalCoreRequest { .. } => write!(f, "External Request"),
-            RaftMsg::TransferLeader { from, to } => {
+            RaftMsg::HandleTransferLeader { from, to } => {
                 write!(f, "TransferLeader: from_leader: vote={}, to: {}", from, to)
             }
             RaftMsg::ExternalCommand { cmd } => {

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -279,7 +279,7 @@ where C: RaftTypeConfig
         tracing::info!(
             my_vote = display(&**local_leased_vote),
             my_last_log_id = display(self.state.last_log_id().display()),
-            lease = display(local_leased_vote.time_info(now)),
+            lease = display(local_leased_vote.display_lease_info(now)),
             "Engine::handle_vote_req"
         );
 
@@ -288,7 +288,7 @@ where C: RaftTypeConfig
             if !local_leased_vote.is_expired(now, Duration::from_millis(0)) {
                 tracing::info!(
                     "reject vote-request: leader lease has not yet expire: {}",
-                    local_leased_vote.time_info(now)
+                    local_leased_vote.display_lease_info(now)
                 );
 
                 return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().copied(), false);
@@ -604,6 +604,21 @@ where C: RaftTypeConfig
 
         self.log_handler().update_purge_upto(log_id);
         self.try_purge_log();
+    }
+
+    pub(crate) fn trigger_transfer_leader(&mut self, to: C::NodeId) {
+        tracing::info!(to = display(to), "{}", func_name!());
+
+        let Some((mut lh, _)) = self.get_leader_handler_or_reject(None) else {
+            tracing::info!(
+                to = display(to),
+                "{}: this node is not a Leader, ignore transfer Leader",
+                func_name!()
+            );
+            return;
+        };
+
+        lh.transfer_leader(to);
     }
 }
 

--- a/openraft/src/engine/handler/leader_handler/transfer_leader_test.rs
+++ b/openraft/src/engine/handler/leader_handler/transfer_leader_test.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+#[allow(unused_imports)]
+use pretty_assertions::assert_eq;
+#[allow(unused_imports)]
+use pretty_assertions::assert_ne;
+#[allow(unused_imports)]
+use pretty_assertions::assert_str_eq;
+
+use crate::engine::testing::UTConfig;
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::raft::TransferLeaderRequest;
+use crate::testing::log_id;
+use crate::type_config::TypeConfigExt;
+use crate::utime::Leased;
+use crate::EffectiveMembership;
+use crate::Membership;
+use crate::MembershipState;
+use crate::Vote;
+
+fn m23() -> Membership<UTConfig> {
+    Membership::<UTConfig>::new(vec![btreeset! {2,3}], btreeset! {1,2,3})
+}
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(0);
+    eng.state.enable_validation(false); // Disable validation for incomplete state
+
+    eng.config.id = 1;
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(3, 1),
+    );
+    eng.state.log_ids.append(log_id(1, 1, 1));
+    eng.state.log_ids.append(log_id(2, 1, 3));
+    eng.state.membership_state = MembershipState::new(
+        Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m23())),
+        Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),
+    );
+    eng.testing_new_leader();
+    eng.state.server_state = eng.calc_server_state();
+
+    eng
+}
+
+#[test]
+fn test_leader_send_heartbeat() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.output.take_commands();
+
+    let mut lh = eng.leader_handler()?;
+
+    lh.transfer_leader(2);
+
+    assert_eq!(lh.leader.transfer_to, Some(2));
+
+    let lease_info = lh.state.vote.lease_info();
+    assert_eq!(lease_info.1, Duration::default());
+    assert_eq!(lease_info.2, false);
+
+    assert_eq!(
+        vec![
+            //
+            Command::BroadcastTransferLeader {
+                req: TransferLeaderRequest::new(Vote::new_committed(3, 1), 2, Some(log_id(2, 1, 3))),
+            },
+        ],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -98,8 +98,6 @@ where C: RaftTypeConfig
     ///
     /// Note: This method does not check last-log-id. handle-vote-request has to deal with
     /// last-log-id itself.
-    ///
-    /// This method also implies calling [`Self::update_last_seen`].
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn update_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), RejectVoteRequest<C>> {
         // Partial ord compare:

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -458,6 +458,9 @@ impl fmt::Display for PayloadTooLarge {
             RPCTypes::InstallSnapshot => {
                 write!(f, "bytes:{}", self.bytes_hint)?;
             }
+            RPCTypes::TransferLeader => {
+                unreachable!("TransferLeader rpc should not have payload")
+            }
         }
         write!(f, ")")?;
 

--- a/openraft/src/error/streaming_error.rs
+++ b/openraft/src/error/streaming_error.rs
@@ -64,6 +64,20 @@ impl<C: RaftTypeConfig> From<StreamingError<C, Fatal<C>>> for ReplicationError<C
     }
 }
 
+impl<C: RaftTypeConfig> From<RPCError<C>> for StreamingError<C> {
+    fn from(value: RPCError<C>) -> Self {
+        match value {
+            RPCError::Timeout(e) => StreamingError::Timeout(e),
+            RPCError::Unreachable(e) => StreamingError::Unreachable(e),
+            RPCError::PayloadTooLarge(_e) => {
+                unreachable!("PayloadTooLarge should not be converted to StreamingError")
+            }
+            RPCError::Network(e) => StreamingError::Network(e),
+            RPCError::RemoteError(e) => StreamingError::RemoteError(e),
+        }
+    }
+}
+
 impl<C: RaftTypeConfig> From<StreamingError<C>> for ReplicationError<C> {
     fn from(e: StreamingError<C>) -> Self {
         match e {

--- a/openraft/src/network/rpc_type.rs
+++ b/openraft/src/network/rpc_type.rs
@@ -8,6 +8,7 @@ pub enum RPCTypes {
     Vote,
     AppendEntries,
     InstallSnapshot,
+    TransferLeader,
 }
 
 impl fmt::Display for RPCTypes {

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -34,6 +34,15 @@ use crate::RaftTypeConfig;
 pub(crate) struct Leader<C, QS: QuorumSet<C::NodeId>>
 where C: RaftTypeConfig
 {
+    /// Whether this Leader is marked as transferring to another node.
+    ///
+    /// Proposing is disabled when Leader has been transferring to another node.
+    /// Indicates whether the current Leader is in the process of transferring leadership to another
+    /// node.
+    ///
+    /// Leadership transfers disable proposing new logs.
+    pub(crate) transfer_to: Option<C::NodeId>,
+
     /// The vote this leader works in.
     ///
     /// `self.voting` may be in progress requesting vote for a higher vote.
@@ -110,6 +119,7 @@ where
         let last_log_id = last_leader_log_id.last().copied();
 
         let mut leader = Self {
+            transfer_to: None,
             committed_vote: vote,
             next_heartbeat: C::now(),
             last_log_id,
@@ -144,6 +154,14 @@ where
         &self.committed_vote
     }
 
+    pub(crate) fn mark_transfer(&mut self, to: C::NodeId) {
+        self.transfer_to = Some(to);
+    }
+
+    pub(crate) fn get_transfer_to(&self) -> Option<&C::NodeId> {
+        self.transfer_to.as_ref()
+    }
+
     /// Assign log ids to the entries.
     ///
     /// This method update the `self.last_log_id`.
@@ -151,6 +169,8 @@ where
         &mut self,
         entries: impl IntoIterator<Item = &'a mut LID>,
     ) {
+        debug_assert!(self.transfer_to.is_none(), "leader is disabled to propose new log");
+
         let committed_leader_id = self.committed_vote.committed_leader_id();
 
         let first = LogId::new(committed_leader_id, self.last_log_id().next_index());

--- a/openraft/src/raft/message/mod.rs
+++ b/openraft/src/raft/message/mod.rs
@@ -5,6 +5,7 @@
 
 mod append_entries;
 mod install_snapshot;
+mod transfer_leader;
 mod vote;
 
 mod client_write;
@@ -16,5 +17,6 @@ pub use client_write::ClientWriteResult;
 pub use install_snapshot::InstallSnapshotRequest;
 pub use install_snapshot::InstallSnapshotResponse;
 pub use install_snapshot::SnapshotResponse;
+pub use transfer_leader::TransferLeaderRequest;
 pub use vote::VoteRequest;
 pub use vote::VoteResponse;

--- a/openraft/src/raft/message/transfer_leader.rs
+++ b/openraft/src/raft/message/transfer_leader.rs
@@ -1,0 +1,56 @@
+use std::fmt;
+
+use crate::display_ext::DisplayOptionExt;
+use crate::LogId;
+use crate::RaftTypeConfig;
+use crate::Vote;
+
+#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub struct TransferLeaderRequest<C>
+where C: RaftTypeConfig
+{
+    /// The vote of the Leader that is transferring the leadership.
+    pub(crate) from: Vote<C::NodeId>,
+
+    /// The assigned node to be the next Leader.
+    pub(crate) to: C::NodeId,
+
+    /// The last log id the `to` node should at least have to become Leader.
+    pub(crate) last_log_id: Option<LogId<C::NodeId>>,
+}
+
+impl<C> TransferLeaderRequest<C>
+where C: RaftTypeConfig
+{
+    pub fn new(from: Vote<C::NodeId>, to: C::NodeId, last_log_id: Option<LogId<C::NodeId>>) -> Self {
+        Self { from, to, last_log_id }
+    }
+
+    pub fn from(&self) -> &Vote<C::NodeId> {
+        &self.from
+    }
+
+    pub fn to(&self) -> &C::NodeId {
+        &self.to
+    }
+
+    pub fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+        self.last_log_id.as_ref()
+    }
+}
+
+impl<C> fmt::Display for TransferLeaderRequest<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "(from={}, to={}, last_log_id={})",
+            self.from,
+            self.to,
+            self.last_log_id.display()
+        )
+    }
+}

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -77,4 +77,13 @@ where C: RaftTypeConfig
     pub async fn purge_log(&self, upto: u64) -> Result<(), Fatal<C>> {
         self.raft_inner.send_external_command(ExternalCommand::PurgeLog { upto }, "purge_log").await
     }
+
+    /// Submit a command to inform RaftCore to transfer leadership to the specified node.
+    ///
+    /// If this node is not a Leader, it is just ignored.
+    pub async fn transfer_leader(&self, to: C::NodeId) -> Result<(), Fatal<C>> {
+        self.raft_inner
+            .send_external_command(ExternalCommand::TriggerTransferLeader { to }, "transfer_leader")
+            .await
+    }
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -350,6 +350,9 @@ where
                 // TODO: handle too large
                 tracing::error!("InstallSnapshot RPC is too large, but it is not supported yet");
             }
+            RPCTypes::TransferLeader => {
+                unreachable!("TransferLeader RPC should not be too large")
+            }
         }
     }
 

--- a/openraft/src/utime.rs
+++ b/openraft/src/utime.rs
@@ -80,15 +80,21 @@ impl<T, I: Instant> Leased<T, I> {
         self.last_update
     }
 
+    /// Return a tuple of the last updated time, lease duration, and whether the lease is enabled.
+    #[allow(dead_code)]
+    pub(crate) fn lease_info(&self) -> (Option<I>, Duration, bool) {
+        (self.last_update, self.lease, self.lease_enabled)
+    }
+
     /// Return a Display instance that shows the last updated time and lease duration relative to
     /// `now`.
-    pub(crate) fn time_info(&self, now: I) -> impl fmt::Display + '_ {
-        struct DisplayTimeInfo<'a, T, I: Instant> {
+    pub(crate) fn display_lease_info(&self, now: I) -> impl fmt::Display + '_ {
+        struct DisplayLeaseInfo<'a, T, I: Instant> {
             now: I,
             leased: &'a Leased<T, I>,
         }
 
-        impl<'a, T, I> fmt::Display for DisplayTimeInfo<'a, T, I>
+        impl<'a, T, I> fmt::Display for DisplayLeaseInfo<'a, T, I>
         where I: Instant
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -113,7 +119,7 @@ impl<T, I: Instant> Leased<T, I> {
             }
         }
 
-        DisplayTimeInfo { now, leased: self }
+        DisplayLeaseInfo { now, leased: self }
     }
 
     /// Consumes this object and returns the inner data.

--- a/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::VoteRequest;
 use openraft::CommittedLeaderId;

--- a/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
+++ b/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::log_id;

--- a/tests/tests/client_api/t14_transfer_leader.rs
+++ b/tests/tests/client_api/t14_transfer_leader.rs
@@ -2,14 +2,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
+use openraft::raft::TransferLeaderRequest;
 use openraft::Config;
 use openraft::ServerState;
 
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 
-/// Call [`transfer_leader`](openraft::raft::Raft::transfer_leader) on every non-leader node to
-/// force establish a new leader.
+/// Test handling of transfer leader request.
+///
+/// Call [`handle_transfer_leader`](openraft::raft::Raft::handle_transfer_leader) on every
+/// non-leader node to force establish a new leader.
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
 async fn transfer_leader() -> anyhow::Result<()> {
@@ -35,10 +38,12 @@ async fn transfer_leader() -> anyhow::Result<()> {
     let leader_vote = metrics.vote;
     let last_log_id = metrics.last_applied;
 
+    let req = TransferLeaderRequest::new(leader_vote, 2, last_log_id);
+
     tracing::info!("--- transfer Leader from 0 to 2");
     {
-        n1.transfer_leader(leader_vote, 2, last_log_id).await?;
-        n2.transfer_leader(leader_vote, 2, last_log_id).await?;
+        n1.handle_transfer_leader(req.clone()).await?;
+        n2.handle_transfer_leader(req.clone()).await?;
 
         n2.wait(timeout()).state(ServerState::Leader, "node-2 become leader").await?;
         n0.wait(timeout()).state(ServerState::Follower, "node-0 become follower").await?;
@@ -46,8 +51,10 @@ async fn transfer_leader() -> anyhow::Result<()> {
 
     tracing::info!("--- can NOT transfer Leader from 2 to 0 with an old vote");
     {
-        n0.transfer_leader(leader_vote, 0, last_log_id).await?;
-        n1.transfer_leader(leader_vote, 0, last_log_id).await?;
+        let req = TransferLeaderRequest::new(leader_vote, 0, last_log_id);
+
+        n0.handle_transfer_leader(req.clone()).await?;
+        n1.handle_transfer_leader(req.clone()).await?;
 
         let n0_res = n0
             .wait(Some(Duration::from_millis(1_000)))
@@ -55,6 +62,43 @@ async fn transfer_leader() -> anyhow::Result<()> {
             .await;
 
         assert!(n0_res.is_err());
+    }
+
+    Ok(())
+}
+
+/// Test trigger transfer leader on the Leader.
+///
+/// Call [`trigger().transfer_leader()`](openraft::raft::trigger::Trigger::transfer_leader) on the
+/// Leader node to force establish a new leader.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn trigger_transfer_leader() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            election_timeout_min: 150,
+            election_timeout_max: 300,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let _log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+    let n2 = router.get_raft_handle(&2)?;
+
+    tracing::info!("--- trigger transfer Leader from 0 to 2");
+    {
+        n0.trigger().transfer_leader(2).await?;
+
+        n2.wait(timeout()).state(ServerState::Leader, "node-2 become leader").await?;
+        n0.wait(timeout()).state(ServerState::Follower, "node-0 become follower").await?;
+        n1.wait(timeout()).state(ServerState::Follower, "node-1 become follower").await?;
     }
 
     Ok(())

--- a/tests/tests/snapshot_building/t10_build_snapshot.rs
+++ b/tests/tests/snapshot_building/t10_build_snapshot.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::RaftLogStorageExt;

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;

--- a/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
-use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::StorageHelper;


### PR DESCRIPTION

## Changelog

##### Feature: Transfer Leader

Call `Raft.trigger().transfer_leader(to)` to inform the raft node to
transfer its leadership to Node `to`.

This feature is enabled only when: the application uses `RaftNetworkV2`
and implements the `RaftNetworkV2::transfer_leader()` methods. This method
provides a default implementation that returns an `Unreachable`, and
such an error will be just ignored.

Application upgrading Openraft from older version does not need to modify any
codes, unless TransferLeader is required.

Upgrade tip:

Implement `RaftNetworkV2::transfer_leader()` to send the
`TransferLeaderRequest` to the target node.
The target node that receives this request should then pass it to
`Raft::transfer_leader()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1221)
<!-- Reviewable:end -->
