### PR TITLE
Refactor: Move `sleep_until()` and `timeout_at()` out of `AsyncRuntime` trait

### DIFF
--- a/openraft/src/type_config/async_runtime/mod.rs
+++ b/openraft/src/type_config/async_runtime/mod.rs
@@ -63,7 +63,7 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     /// The timeout error type.
     type TimeoutError: Debug + Display + OptionalSend;
 
-    /// The timeout type used by [`Self::timeout`] and [`Self::timeout_at`] that enables the user
+    /// The timeout type used by [`Self::timeout`] that enables the user
     /// to await the outcome of a [`Future`].
     type Timeout<R, T: Future<Output = R> + OptionalSend>: Future<Output = Result<R, Self::TimeoutError>> + OptionalSend;
 
@@ -79,14 +79,8 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     /// Wait until `duration` has elapsed.
     fn sleep(duration: Duration) -> Self::Sleep;
 
-    /// Wait until `deadline` is reached.
-    fn sleep_until(deadline: Self::Instant) -> Self::Sleep;
-
     /// Require a [`Future`] to complete before the specified duration has elapsed.
     fn timeout<R, F: Future<Output = R> + OptionalSend>(duration: Duration, future: F) -> Self::Timeout<R, F>;
-
-    /// Require a [`Future`] to complete before the specified instant in time.
-    fn timeout_at<R, F: Future<Output = R> + OptionalSend>(deadline: Self::Instant, future: F) -> Self::Timeout<R, F>;
 
     /// Check if the [`Self::JoinError`] is `panic`.
     fn is_panic(join_error: &Self::JoinError) -> bool;

--- a/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
+++ b/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
@@ -50,18 +50,8 @@ impl AsyncRuntime for TokioRuntime {
     }
 
     #[inline]
-    fn sleep_until(deadline: Self::Instant) -> Self::Sleep {
-        tokio::time::sleep_until(deadline)
-    }
-
-    #[inline]
     fn timeout<R, F: Future<Output = R> + OptionalSend>(duration: Duration, future: F) -> Self::Timeout<R, F> {
         tokio::time::timeout(duration, future)
-    }
-
-    #[inline]
-    fn timeout_at<R, F: Future<Output = R> + OptionalSend>(deadline: Self::Instant, future: F) -> Self::Timeout<R, F> {
-        tokio::time::timeout_at(deadline, future)
     }
 
     #[inline]

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -45,7 +45,8 @@ pub trait TypeConfigExt: RaftTypeConfig {
 
     /// Wait until `deadline` is reached.
     fn sleep_until(deadline: InstantOf<Self>) -> SleepOf<Self> {
-        AsyncRuntimeOf::<Self>::sleep_until(deadline)
+        let duration = deadline.saturating_duration_since(Self::now());
+        AsyncRuntimeOf::<Self>::sleep(duration)
     }
 
     /// Require a [`Future`] to complete before the specified duration has elapsed.
@@ -58,7 +59,8 @@ pub trait TypeConfigExt: RaftTypeConfig {
         deadline: InstantOf<Self>,
         future: F,
     ) -> TimeoutOf<Self, R, F> {
-        AsyncRuntimeOf::<Self>::timeout_at(deadline, future)
+        let duration = deadline.saturating_duration_since(Self::now());
+        AsyncRuntimeOf::<Self>::timeout(duration, future)
     }
 
     // Synchronization methods


### PR DESCRIPTION

## Changelog

##### Refactor: Move `sleep_until()` and `timeout_at()` out of `AsyncRuntime` trait

The `sleep_until()` and `timeout_at()` functions can be automatically
derived from `sleep()` and `timeout()`. This change removes the need for
applications to implement these functions for the `AsyncRuntime` trait.
They are now provided by `TypeConfigExt`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1223)
<!-- Reviewable:end -->
