### PR TITLE
Refactor: Send heartbeat with dedicated workers

### DIFF
--- a/openraft/src/core/heartbeat/event.rs
+++ b/openraft/src/core/heartbeat/event.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+
+use crate::display_ext::DisplayInstantExt;
+use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::InstantOf;
+use crate::vote::CommittedVote;
+use crate::LogId;
+use crate::RaftTypeConfig;
+
+/// The information for broadcasting a heartbeat.
+#[derive(Debug, Clone, Copy)]
+#[derive(PartialEq, Eq)]
+pub struct HeartbeatEvent<C>
+where C: RaftTypeConfig
+{
+    /// The timestamp when this heartbeat is sent.
+    ///
+    /// The Leader use this sending time to calculate the quorum acknowledge time, but not the
+    /// receiving timestamp.
+    pub(crate) time: InstantOf<C>,
+
+    /// The vote of the Leader that submit this heartbeat.
+    ///
+    /// The response that matches this vote is considered as a valid response.
+    /// Otherwise, it is considered as an outdated response and will be ignored.
+    pub(crate) leader_vote: CommittedVote<C>,
+
+    /// The last known committed log id of the Leader.
+    ///
+    /// When there are no new logs to replicate, the Leader sends a heartbeat to replicate committed
+    /// log id to followers to update their committed log id.
+    pub(crate) committed: Option<LogId<C::NodeId>>,
+}
+
+impl<C> HeartbeatEvent<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(time: InstantOf<C>, leader_vote: CommittedVote<C>, committed: Option<LogId<C::NodeId>>) -> Self {
+        Self {
+            time,
+            leader_vote,
+            committed,
+        }
+    }
+}
+
+impl<C> fmt::Display for HeartbeatEvent<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "(time={}, leader_vote: {}, committed: {})",
+            self.time.display(),
+            self.leader_vote,
+            self.committed.display()
+        )
+    }
+}

--- a/openraft/src/core/heartbeat/handle.rs
+++ b/openraft/src/core/heartbeat/handle.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tracing::Instrument;
+use tracing::Level;
+use tracing::Span;
+
+use crate::async_runtime::watch::WatchSender;
+use crate::core::heartbeat::event::HeartbeatEvent;
+use crate::core::heartbeat::worker::HeartbeatWorker;
+use crate::core::notification::Notification;
+use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::MpscUnboundedSenderOf;
+use crate::type_config::alias::OneshotSenderOf;
+use crate::type_config::alias::WatchReceiverOf;
+use crate::type_config::alias::WatchSenderOf;
+use crate::type_config::TypeConfigExt;
+use crate::Config;
+use crate::RaftNetworkFactory;
+use crate::RaftTypeConfig;
+
+pub(crate) struct HeartbeatWorkersHandle<C>
+where C: RaftTypeConfig
+{
+    pub(crate) id: C::NodeId,
+
+    pub(crate) config: Arc<Config>,
+
+    /// Inform the heartbeat task to broadcast heartbeat message.
+    ///
+    /// A Leader will periodically update this value to trigger sending heartbeat messages.
+    pub(crate) tx: WatchSenderOf<C, Option<HeartbeatEvent<C>>>,
+
+    /// The receiving end of heartbeat command.
+    ///
+    /// A separate task will have a clone of this receiver to receive and execute heartbeat command.
+    pub(crate) rx: WatchReceiverOf<C, Option<HeartbeatEvent<C>>>,
+
+    pub(crate) workers: BTreeMap<C::NodeId, (OneshotSenderOf<C, ()>, JoinHandleOf<C, ()>)>,
+}
+
+impl<C> HeartbeatWorkersHandle<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(id: C::NodeId, config: Arc<Config>) -> Self {
+        let (tx, rx) = C::watch_channel(None);
+
+        Self {
+            id,
+            config,
+            tx,
+            rx,
+            workers: Default::default(),
+        }
+    }
+
+    pub(crate) fn broadcast(&self, event: HeartbeatEvent<C>) {
+        tracing::debug!("id={} send_heartbeat {}", self.id, event);
+        let _ = self.tx.send(Some(event));
+    }
+
+    pub(crate) async fn spawn_workers<NF>(
+        &mut self,
+        network_factory: &mut NF,
+        tx_notification: &MpscUnboundedSenderOf<C, Notification<C>>,
+        targets: impl IntoIterator<Item = (C::NodeId, C::Node)>,
+    ) where
+        NF: RaftNetworkFactory<C>,
+    {
+        for (target, node) in targets {
+            tracing::debug!("id={} spawn HeartbeatWorker target={}", self.id, target);
+            let network = network_factory.new_client(target, &node).await;
+
+            let worker = HeartbeatWorker {
+                id: self.id,
+                rx: self.rx.clone(),
+                network,
+                target,
+                node,
+                config: self.config.clone(),
+                tx_notification: tx_notification.clone(),
+            };
+
+            let span = tracing::span!(parent: &Span::current(), Level::DEBUG, "heartbeat", id=display(self.id), target=display(target));
+
+            let (tx_shutdown, rx_shutdown) = C::oneshot();
+
+            let worker_handle = C::spawn(worker.run(rx_shutdown).instrument(span));
+            self.workers.insert(target, (tx_shutdown, worker_handle));
+        }
+    }
+
+    pub(crate) fn shutdown(&mut self) {
+        self.workers.clear();
+        tracing::info!("id={} HeartbeatWorker are shutdown", self.id);
+    }
+}

--- a/openraft/src/core/heartbeat/mod.rs
+++ b/openraft/src/core/heartbeat/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod event;
+pub(crate) mod handle;
+pub(crate) mod worker;

--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -1,0 +1,114 @@
+use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::FutureExt;
+
+use crate::async_runtime::watch::WatchReceiver;
+use crate::async_runtime::MpscUnboundedSender;
+use crate::core::heartbeat::event::HeartbeatEvent;
+use crate::core::notification::Notification;
+use crate::network::v2::RaftNetworkV2;
+use crate::network::RPCOption;
+use crate::raft::AppendEntriesRequest;
+use crate::type_config::alias::MpscUnboundedSenderOf;
+use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::alias::WatchReceiverOf;
+use crate::type_config::TypeConfigExt;
+use crate::Config;
+use crate::RaftTypeConfig;
+
+/// A dedicate worker sending heartbeat to a specific follower.
+pub struct HeartbeatWorker<C, N>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkV2<C>,
+{
+    pub(crate) id: C::NodeId,
+
+    /// The receiver will be changed when a new heartbeat is needed to be sent.
+    pub(crate) rx: WatchReceiverOf<C, Option<HeartbeatEvent<C>>>,
+
+    pub(crate) network: N,
+
+    pub(crate) target: C::NodeId,
+
+    #[allow(dead_code)]
+    pub(crate) node: C::Node,
+
+    pub(crate) config: Arc<Config>,
+
+    /// For sending back result to the [`RaftCore`].
+    ///
+    /// [`RaftCore`]: crate::core::RaftCore
+    pub(crate) tx_notification: MpscUnboundedSenderOf<C, Notification<C>>,
+}
+
+impl<C, N> fmt::Display for HeartbeatWorker<C, N>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkV2<C>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HeartbeatWorker(id={}, target={})", self.id, self.target)
+    }
+}
+
+impl<C, N> HeartbeatWorker<C, N>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkV2<C>,
+{
+    pub(crate) async fn run(mut self, mut rx_shutdown: OneshotReceiverOf<C, ()>) {
+        loop {
+            tracing::debug!("{} is waiting for a new heartbeat event.", self);
+
+            futures::select! {
+                _ = (&mut rx_shutdown).fuse() => {
+                    tracing::info!("{} is shutdown.", self);
+                    return;
+                },
+                _ = self.rx.changed().fuse() => {},
+            }
+
+            let heartbeat = *self.rx.borrow_watched();
+
+            // None is the initial value of the WatchReceiver, ignore it.
+            let Some(heartbeat) = heartbeat else {
+                continue;
+            };
+
+            let timeout = Duration::from_millis(self.config.heartbeat_interval);
+            let option = RPCOption::new(timeout);
+
+            let payload = AppendEntriesRequest {
+                vote: *heartbeat.leader_vote.deref(),
+                prev_log_id: None,
+                leader_commit: heartbeat.committed,
+                entries: vec![],
+            };
+
+            let res = C::timeout(timeout, self.network.append_entries(payload, option)).await;
+            tracing::debug!("{} sent a heartbeat: {}, result: {:?}", self, heartbeat, res);
+
+            match res {
+                Ok(Ok(_)) => {
+                    let res = self.tx_notification.send(Notification::HeartbeatProgress {
+                        leader_vote: heartbeat.leader_vote,
+                        sending_time: heartbeat.time,
+                        target: self.target,
+                    });
+
+                    if res.is_err() {
+                        tracing::error!("{} failed to send a heartbeat progress to RaftCore. quit", self);
+                        return;
+                    }
+                }
+                _ => {
+                    tracing::warn!("{} failed to send a heartbeat: {:?}", self, res);
+                }
+            }
+        }
+    }
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -5,6 +5,7 @@
 //! storage or forward messages to other raft nodes.
 
 pub(crate) mod balancer;
+pub(crate) mod heartbeat;
 pub(crate) mod notification;
 mod raft_core;
 pub(crate) mod raft_msg;

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -1,9 +1,12 @@
 use std::fmt;
 
 use crate::core::sm;
+use crate::display_ext::DisplayInstantExt;
 use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
 use crate::replication;
+use crate::type_config::alias::InstantOf;
+use crate::vote::CommittedVote;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::Vote;
@@ -48,6 +51,12 @@ where C: RaftTypeConfig
 
     /// Result of executing a command sent from network worker.
     ReplicationProgress { progress: replication::Progress<C> },
+
+    HeartbeatProgress {
+        leader_vote: CommittedVote<C>,
+        sending_time: InstantOf<C>,
+        target: C::NodeId,
+    },
 
     /// Result of executing a command sent from state machine worker.
     StateMachine { command_result: sm::CommandResult<C> },
@@ -98,6 +107,19 @@ where C: RaftTypeConfig
             Self::LocalIO { io_id } => write!(f, "IOFlushed: {}", io_id),
             Self::ReplicationProgress { progress } => {
                 write!(f, "{}", progress)
+            }
+            Self::HeartbeatProgress {
+                leader_vote,
+                sending_time,
+                target,
+            } => {
+                write!(
+                    f,
+                    "HeartbeatProgress: target={}, leader_vote: {}, sending_time: {}",
+                    target,
+                    leader_vote,
+                    sending_time.display(),
+                )
             }
             Self::StateMachine { command_result } => {
                 write!(f, "{}", command_result)

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -47,7 +47,7 @@ where C: RaftTypeConfig
     LocalIO { io_id: IOId<C> },
 
     /// Result of executing a command sent from network worker.
-    Network { response: replication::Response<C> },
+    ReplicationProgress { progress: replication::Progress<C> },
 
     /// Result of executing a command sent from state machine worker.
     StateMachine { command_result: sm::CommandResult<C> },
@@ -96,8 +96,8 @@ where C: RaftTypeConfig
             }
             Self::StorageError { error } => write!(f, "StorageError: {}", error),
             Self::LocalIO { io_id } => write!(f, "IOFlushed: {}", io_id),
-            Self::Network { response } => {
-                write!(f, "{}", response)
+            Self::ReplicationProgress { progress } => {
+                write!(f, "{}", progress)
             }
             Self::StateMachine { command_result } => {
                 write!(f, "{}", command_result)

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -1,5 +1,4 @@
 use crate::engine::handler::replication_handler::ReplicationHandler;
-use crate::engine::handler::replication_handler::SendNone;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
@@ -92,13 +91,15 @@ where C: RaftTypeConfig
             rh.append_membership(&log_id, &m);
         }
 
-        rh.initiate_replication(SendNone::False);
+        rh.initiate_replication();
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn send_heartbeat(&mut self) -> () {
-        let mut rh = self.replication_handler();
-        rh.initiate_replication(SendNone::True);
+        self.output.push_command(Command::BroadcastHeartbeat {
+            leader_vote: self.leader.committed_vote,
+            committed: self.state.committed().copied(),
+        });
     }
 
     /// Get the log id for a linearizable read.

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -2,18 +2,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-#[allow(unused_imports)]
 use pretty_assertions::assert_eq;
-#[allow(unused_imports)]
-use pretty_assertions::assert_ne;
-#[allow(unused_imports)]
-use pretty_assertions::assert_str_eq;
 
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
-use crate::progress::Inflight;
-use crate::progress::Progress;
 use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
@@ -63,47 +56,31 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
         eng.leader_handler()?.send_heartbeat();
         assert_eq!(
             vec![
-                Command::Replicate {
-                    target: 2,
-                    req: Inflight::logs(None, Some(log_id(2, 1, 3))).with_id(1),
-                },
-                Command::Replicate {
-                    target: 3,
-                    req: Inflight::logs(None, Some(log_id(2, 1, 3))).with_id(1),
+                //
+                Command::BroadcastHeartbeat {
+                    leader_vote: Vote::new(3, 1).into_committed(),
+                    committed: Some(log_id(0, 1, 0))
                 },
             ],
             eng.output.take_commands()
         );
     }
 
-    // No RPC will be sent if there are inflight RPC
+    // Heartbeat will be resent
     {
         eng.output.clear_commands();
         eng.leader_handler()?.send_heartbeat();
-        assert!(eng.output.take_commands().is_empty());
+        assert_eq!(
+            vec![
+                //
+                Command::BroadcastHeartbeat {
+                    leader_vote: Vote::new(3, 1).into_committed(),
+                    committed: Some(log_id(0, 1, 0))
+                },
+            ],
+            eng.output.take_commands()
+        );
     }
-
-    // No data to send, sending a heartbeat is to send empty RPC:
-    {
-        let l = eng.leader_handler()?;
-        let _ = l.leader.progress.update_with(&2, |ent| ent.update_matching(1, Some(log_id(2, 1, 3))).unwrap());
-        let _ = l.leader.progress.update_with(&3, |ent| ent.update_matching(1, Some(log_id(2, 1, 3))).unwrap());
-    }
-    eng.output.clear_commands();
-    eng.leader_handler()?.send_heartbeat();
-    assert_eq!(
-        vec![
-            Command::Replicate {
-                target: 2,
-                req: Inflight::logs(Some(log_id(2, 1, 3)), Some(log_id(2, 1, 3))).with_id(1),
-            },
-            Command::Replicate {
-                target: 3,
-                req: Inflight::logs(Some(log_id(2, 1, 3)), Some(log_id(2, 1, 3))).with_id(1),
-            },
-        ],
-        eng.output.take_commands()
-    );
 
     Ok(())
 }

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use crate::core::raft_msg::ResultSender;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::handler::replication_handler::ReplicationHandler;
-use crate::engine::handler::replication_handler::SendNone;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::Command;
 use crate::engine::Condition;
@@ -208,7 +207,7 @@ where C: RaftTypeConfig
             self.leader_handler()
                 .leader_append_entries(vec![C::Entry::new_blank(LogId::<C::NodeId>::default())]);
         } else {
-            self.replication_handler().initiate_replication(SendNone::False);
+            self.replication_handler().initiate_replication();
         }
     }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -51,6 +51,7 @@ use crate::base::BoxFuture;
 use crate::base::BoxOnce;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
+use crate::core::heartbeat::handle::HeartbeatWorkersHandle;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::replication_lag;
@@ -297,6 +298,7 @@ where C: RaftTypeConfig
 
             replications: Default::default(),
 
+            heartbeat_handle: HeartbeatWorkersHandle::new(id, config.clone()),
             tx_api: tx_api.clone(),
             rx_api,
 

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -87,7 +87,7 @@ where C: RaftTypeConfig
             }
             Notification::HigherVote { .. }
             | Notification::StorageError { .. }
-            | Notification::Network { .. }
+            | Notification::ReplicationProgress { .. }
             | Notification::StateMachine { .. }
             | Notification::Tick { .. } => {
                 unreachable!("Unexpected notification: {}", self.notification)

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -88,6 +88,7 @@ where C: RaftTypeConfig
             Notification::HigherVote { .. }
             | Notification::StorageError { .. }
             | Notification::ReplicationProgress { .. }
+            | Notification::HeartbeatProgress { .. }
             | Notification::StateMachine { .. }
             | Notification::Tick { .. } => {
                 unreachable!("Unexpected notification: {}", self.notification)

--- a/openraft/src/type_config/async_runtime/mod.rs
+++ b/openraft/src/type_config/async_runtime/mod.rs
@@ -63,7 +63,7 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     /// The timeout error type.
     type TimeoutError: Debug + Display + OptionalSend;
 
-    /// The timeout type used by [`Self::timeout`] and [`Self::timeout_at`] that enables the user
+    /// The timeout type used by [`Self::timeout`] that enables the user
     /// to await the outcome of a [`Future`].
     type Timeout<R, T: Future<Output = R> + OptionalSend>: Future<Output = Result<R, Self::TimeoutError>> + OptionalSend;
 
@@ -79,14 +79,8 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     /// Wait until `duration` has elapsed.
     fn sleep(duration: Duration) -> Self::Sleep;
 
-    /// Wait until `deadline` is reached.
-    fn sleep_until(deadline: Self::Instant) -> Self::Sleep;
-
     /// Require a [`Future`] to complete before the specified duration has elapsed.
     fn timeout<R, F: Future<Output = R> + OptionalSend>(duration: Duration, future: F) -> Self::Timeout<R, F>;
-
-    /// Require a [`Future`] to complete before the specified instant in time.
-    fn timeout_at<R, F: Future<Output = R> + OptionalSend>(deadline: Self::Instant, future: F) -> Self::Timeout<R, F>;
 
     /// Check if the [`Self::JoinError`] is `panic`.
     fn is_panic(join_error: &Self::JoinError) -> bool;

--- a/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
+++ b/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
@@ -50,18 +50,8 @@ impl AsyncRuntime for TokioRuntime {
     }
 
     #[inline]
-    fn sleep_until(deadline: Self::Instant) -> Self::Sleep {
-        tokio::time::sleep_until(deadline)
-    }
-
-    #[inline]
     fn timeout<R, F: Future<Output = R> + OptionalSend>(duration: Duration, future: F) -> Self::Timeout<R, F> {
         tokio::time::timeout(duration, future)
-    }
-
-    #[inline]
-    fn timeout_at<R, F: Future<Output = R> + OptionalSend>(deadline: Self::Instant, future: F) -> Self::Timeout<R, F> {
-        tokio::time::timeout_at(deadline, future)
     }
 
     #[inline]

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -45,7 +45,8 @@ pub trait TypeConfigExt: RaftTypeConfig {
 
     /// Wait until `deadline` is reached.
     fn sleep_until(deadline: InstantOf<Self>) -> SleepOf<Self> {
-        AsyncRuntimeOf::<Self>::sleep_until(deadline)
+        let duration = deadline.saturating_duration_since(Self::now());
+        AsyncRuntimeOf::<Self>::sleep(duration)
     }
 
     /// Require a [`Future`] to complete before the specified duration has elapsed.
@@ -58,7 +59,8 @@ pub trait TypeConfigExt: RaftTypeConfig {
         deadline: InstantOf<Self>,
         future: F,
     ) -> TimeoutOf<Self, R, F> {
-        AsyncRuntimeOf::<Self>::timeout_at(deadline, future)
+        let duration = deadline.saturating_duration_since(Self::now());
+        AsyncRuntimeOf::<Self>::timeout(duration, future)
     }
 
     // Synchronization methods


### PR DESCRIPTION

## Changelog

##### Refactor: Send heartbeat with dedicated workers

Heavy AppendEntries traffic can block heartbeat messages. For example,
future AppendEntries in stream RPC may not receive a response indicating
a follower is alive. In such cases, the leader might time out to extend
its lease, and be considered partitioned from the cluster.

This commit moves heartbeat broadcasting to separate tasks that won't be
blocked by AppendEntries. This ensures the leader can always be
acknowledged with the liveness of followers.


##### Refactor: simplify HigherVote notification

`HigherVote` can be sent directly to Notification channel.
replication::Response does not need `HigherVote` variant any more.
And `Response` is renamed to `Progress`


##### Refactor: Move `sleep_until()` and `timeout_at()` out of `AsyncRuntime` trait

The `sleep_until()` and `timeout_at()` functions can be automatically
derived from `sleep()` and `timeout()`. This change removes the need for
applications to implement these functions for the `AsyncRuntime` trait.
They are now provided by `TypeConfigExt`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1224)
<!-- Reviewable:end -->
