### PR TITLE
Refactor: Send heartbeat with dedicated workers

### DIFF
--- a/openraft/src/core/heartbeat/event.rs
+++ b/openraft/src/core/heartbeat/event.rs
@@ -1,0 +1,64 @@
+use std::fmt;
+
+use crate::display_ext::DisplayInstantExt;
+use crate::display_ext::DisplayOptionExt;
+use crate::replication::ReplicationSessionId;
+use crate::type_config::alias::InstantOf;
+use crate::LogId;
+use crate::RaftTypeConfig;
+
+/// The information for broadcasting a heartbeat.
+#[derive(Debug, Clone, Copy)]
+#[derive(PartialEq, Eq)]
+pub struct HeartbeatEvent<C>
+where C: RaftTypeConfig
+{
+    /// The timestamp when this heartbeat is sent.
+    ///
+    /// The Leader use this sending time to calculate the quorum acknowledge time, but not the
+    /// receiving timestamp.
+    pub(crate) time: InstantOf<C>,
+
+    /// The vote of the Leader that submit this heartbeat and the log id of the cluster config.
+    ///
+    /// The response that matches this session id is considered as a valid response.
+    /// Otherwise, it is considered as an outdated response from older leader or older cluster
+    /// membership config and will be ignored.
+    pub(crate) session_id: ReplicationSessionId<C>,
+
+    /// The last known committed log id of the Leader.
+    ///
+    /// When there are no new logs to replicate, the Leader sends a heartbeat to replicate committed
+    /// log id to followers to update their committed log id.
+    pub(crate) committed: Option<LogId<C::NodeId>>,
+}
+
+impl<C> HeartbeatEvent<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(
+        time: InstantOf<C>,
+        session_id: ReplicationSessionId<C>,
+        committed: Option<LogId<C::NodeId>>,
+    ) -> Self {
+        Self {
+            time,
+            session_id,
+            committed,
+        }
+    }
+}
+
+impl<C> fmt::Display for HeartbeatEvent<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "(time={}, leader_vote: {}, committed: {})",
+            self.time.display(),
+            self.session_id,
+            self.committed.display()
+        )
+    }
+}

--- a/openraft/src/core/heartbeat/handle.rs
+++ b/openraft/src/core/heartbeat/handle.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tracing::Instrument;
+use tracing::Level;
+use tracing::Span;
+
+use crate::async_runtime::watch::WatchSender;
+use crate::core::heartbeat::event::HeartbeatEvent;
+use crate::core::heartbeat::worker::HeartbeatWorker;
+use crate::core::notification::Notification;
+use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::MpscUnboundedSenderOf;
+use crate::type_config::alias::OneshotSenderOf;
+use crate::type_config::alias::WatchReceiverOf;
+use crate::type_config::alias::WatchSenderOf;
+use crate::type_config::TypeConfigExt;
+use crate::Config;
+use crate::RaftNetworkFactory;
+use crate::RaftTypeConfig;
+
+pub(crate) struct HeartbeatWorkersHandle<C>
+where C: RaftTypeConfig
+{
+    pub(crate) id: C::NodeId,
+
+    pub(crate) config: Arc<Config>,
+
+    /// Inform the heartbeat task to broadcast heartbeat message.
+    ///
+    /// A Leader will periodically update this value to trigger sending heartbeat messages.
+    pub(crate) tx: WatchSenderOf<C, Option<HeartbeatEvent<C>>>,
+
+    /// The receiving end of heartbeat command.
+    ///
+    /// A separate task will have a clone of this receiver to receive and execute heartbeat command.
+    pub(crate) rx: WatchReceiverOf<C, Option<HeartbeatEvent<C>>>,
+
+    pub(crate) workers: BTreeMap<C::NodeId, (OneshotSenderOf<C, ()>, JoinHandleOf<C, ()>)>,
+}
+
+impl<C> HeartbeatWorkersHandle<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(id: C::NodeId, config: Arc<Config>) -> Self {
+        let (tx, rx) = C::watch_channel(None);
+
+        Self {
+            id,
+            config,
+            tx,
+            rx,
+            workers: Default::default(),
+        }
+    }
+
+    pub(crate) fn broadcast(&self, event: HeartbeatEvent<C>) {
+        tracing::debug!("id={} send_heartbeat {}", self.id, event);
+        let _ = self.tx.send(Some(event));
+    }
+
+    pub(crate) async fn spawn_workers<NF>(
+        &mut self,
+        network_factory: &mut NF,
+        tx_notification: &MpscUnboundedSenderOf<C, Notification<C>>,
+        targets: impl IntoIterator<Item = (C::NodeId, C::Node)>,
+    ) where
+        NF: RaftNetworkFactory<C>,
+    {
+        for (target, node) in targets {
+            tracing::debug!("id={} spawn HeartbeatWorker target={}", self.id, target);
+            let network = network_factory.new_client(target, &node).await;
+
+            let worker = HeartbeatWorker {
+                id: self.id,
+                rx: self.rx.clone(),
+                network,
+                target,
+                node,
+                config: self.config.clone(),
+                tx_notification: tx_notification.clone(),
+            };
+
+            let span = tracing::span!(parent: &Span::current(), Level::DEBUG, "heartbeat", id=display(self.id), target=display(target));
+
+            let (tx_shutdown, rx_shutdown) = C::oneshot();
+
+            let worker_handle = C::spawn(worker.run(rx_shutdown).instrument(span));
+            self.workers.insert(target, (tx_shutdown, worker_handle));
+        }
+    }
+
+    pub(crate) fn shutdown(&mut self) {
+        self.workers.clear();
+        tracing::info!("id={} HeartbeatWorker are shutdown", self.id);
+    }
+}

--- a/openraft/src/core/heartbeat/mod.rs
+++ b/openraft/src/core/heartbeat/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod event;
+pub(crate) mod handle;
+pub(crate) mod worker;

--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -1,0 +1,114 @@
+use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::FutureExt;
+
+use crate::async_runtime::watch::WatchReceiver;
+use crate::async_runtime::MpscUnboundedSender;
+use crate::core::heartbeat::event::HeartbeatEvent;
+use crate::core::notification::Notification;
+use crate::network::v2::RaftNetworkV2;
+use crate::network::RPCOption;
+use crate::raft::AppendEntriesRequest;
+use crate::type_config::alias::MpscUnboundedSenderOf;
+use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::alias::WatchReceiverOf;
+use crate::type_config::TypeConfigExt;
+use crate::Config;
+use crate::RaftTypeConfig;
+
+/// A dedicate worker sending heartbeat to a specific follower.
+pub struct HeartbeatWorker<C, N>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkV2<C>,
+{
+    pub(crate) id: C::NodeId,
+
+    /// The receiver will be changed when a new heartbeat is needed to be sent.
+    pub(crate) rx: WatchReceiverOf<C, Option<HeartbeatEvent<C>>>,
+
+    pub(crate) network: N,
+
+    pub(crate) target: C::NodeId,
+
+    #[allow(dead_code)]
+    pub(crate) node: C::Node,
+
+    pub(crate) config: Arc<Config>,
+
+    /// For sending back result to the [`RaftCore`].
+    ///
+    /// [`RaftCore`]: crate::core::RaftCore
+    pub(crate) tx_notification: MpscUnboundedSenderOf<C, Notification<C>>,
+}
+
+impl<C, N> fmt::Display for HeartbeatWorker<C, N>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkV2<C>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HeartbeatWorker(id={}, target={})", self.id, self.target)
+    }
+}
+
+impl<C, N> HeartbeatWorker<C, N>
+where
+    C: RaftTypeConfig,
+    N: RaftNetworkV2<C>,
+{
+    pub(crate) async fn run(mut self, mut rx_shutdown: OneshotReceiverOf<C, ()>) {
+        loop {
+            tracing::debug!("{} is waiting for a new heartbeat event.", self);
+
+            futures::select! {
+                _ = (&mut rx_shutdown).fuse() => {
+                    tracing::info!("{} is shutdown.", self);
+                    return;
+                },
+                _ = self.rx.changed().fuse() => {},
+            }
+
+            let heartbeat: Option<HeartbeatEvent<C>> = *self.rx.borrow_watched();
+
+            // None is the initial value of the WatchReceiver, ignore it.
+            let Some(heartbeat) = heartbeat else {
+                continue;
+            };
+
+            let timeout = Duration::from_millis(self.config.heartbeat_interval);
+            let option = RPCOption::new(timeout);
+
+            let payload = AppendEntriesRequest {
+                vote: *heartbeat.session_id.leader_vote.deref(),
+                prev_log_id: None,
+                leader_commit: heartbeat.committed,
+                entries: vec![],
+            };
+
+            let res = C::timeout(timeout, self.network.append_entries(payload, option)).await;
+            tracing::debug!("{} sent a heartbeat: {}, result: {:?}", self, heartbeat, res);
+
+            match res {
+                Ok(Ok(_)) => {
+                    let res = self.tx_notification.send(Notification::HeartbeatProgress {
+                        session_id: heartbeat.session_id,
+                        sending_time: heartbeat.time,
+                        target: self.target,
+                    });
+
+                    if res.is_err() {
+                        tracing::error!("{} failed to send a heartbeat progress to RaftCore. quit", self);
+                        return;
+                    }
+                }
+                _ => {
+                    tracing::warn!("{} failed to send a heartbeat: {:?}", self, res);
+                }
+            }
+        }
+    }
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -5,6 +5,7 @@
 //! storage or forward messages to other raft nodes.
 
 pub(crate) mod balancer;
+pub(crate) mod heartbeat;
 pub(crate) mod notification;
 mod raft_core;
 pub(crate) mod raft_msg;

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use crate::core::raft_msg::ResultSender;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::handler::replication_handler::ReplicationHandler;
-use crate::engine::handler::replication_handler::SendNone;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::Command;
 use crate::engine::Condition;
@@ -208,7 +207,7 @@ where C: RaftTypeConfig
             self.leader_handler()
                 .leader_append_entries(vec![C::Entry::new_blank(LogId::<C::NodeId>::default())]);
         } else {
-            self.replication_handler().initiate_replication(SendNone::False);
+            self.replication_handler().initiate_replication();
         }
     }
 

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -9,7 +9,6 @@ use validit::Validate;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::log_id_range::LogIdRange;
-use crate::replication::request_id::RequestId;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
@@ -115,11 +114,11 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn is_my_id(&self, res_id: RequestId) -> bool {
+    pub(crate) fn is_my_id(&self, res_id: u64) -> bool {
         match self {
             Inflight::None => false,
-            Inflight::Logs { id, .. } => RequestId::AppendEntries { id: *id } == res_id,
-            Inflight::Snapshot { id, .. } => RequestId::Snapshot { id: *id } == res_id,
+            Inflight::Logs { id, .. } => *id == res_id,
+            Inflight::Snapshot { id, .. } => *id == res_id,
         }
     }
 

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -7,6 +7,12 @@ use crate::RaftTypeConfig;
 use crate::Vote;
 
 /// An RPC sent by a cluster leader to replicate log entries (§5.3), and as a heartbeat (§5.2).
+///
+/// In Openraft a heartbeat [`AppendEntriesRequest`] message could have `prev_log_id=None` and
+/// `entries` empty. Which means: to append nothing at the very beginning position on the Follower,
+/// which is always valid. Because `prev_log_id` is used to assert `entries` to be consecutive with
+/// the previous log entries, and `prev_log_id=None` is the very beginning position and there are no
+/// previous log entries.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct AppendEntriesRequest<C: RaftTypeConfig> {

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -51,6 +51,7 @@ use crate::base::BoxFuture;
 use crate::base::BoxOnce;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
+use crate::core::heartbeat::handle::HeartbeatWorkersHandle;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::replication_lag;
@@ -297,6 +298,7 @@ where C: RaftTypeConfig
 
             replications: Default::default(),
 
+            heartbeat_handle: HeartbeatWorkersHandle::new(id, config.clone()),
             tx_api: tx_api.clone(),
             rx_api,
 

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -30,11 +30,12 @@ use crate::Vote;
 /// But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft
 /// core believe node `c` already has `log_id=1`, and commit it.
 #[derive(Debug, Clone, Copy)]
+#[derive(PartialEq, Eq)]
 pub(crate) struct ReplicationSessionId<C>
 where C: RaftTypeConfig
 {
     /// The Leader or Candidate this replication belongs to.
-    pub(crate) vote: CommittedVote<C>,
+    pub(crate) leader_vote: CommittedVote<C>,
 
     /// The log id of the membership log this replication works for.
     pub(crate) membership_log_id: Option<LogId<C::NodeId>>,
@@ -44,7 +45,12 @@ impl<C> Display for ReplicationSessionId<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.vote, self.membership_log_id.display())
+        write!(
+            f,
+            "(leader_vote:{}, membership_log_id:{})",
+            self.leader_vote,
+            self.membership_log_id.display()
+        )
     }
 }
 
@@ -53,12 +59,12 @@ where C: RaftTypeConfig
 {
     pub(crate) fn new(vote: CommittedVote<C>, membership_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self {
-            vote,
+            leader_vote: vote,
             membership_log_id,
         }
     }
 
     pub(crate) fn vote_ref(&self) -> &Vote<C::NodeId> {
-        &self.vote
+        &self.leader_vote
     }
 }

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -1,136 +1,74 @@
 use std::fmt;
 
-use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplayResultExt;
-use crate::replication::request_id::RequestId;
 use crate::replication::ReplicationSessionId;
-use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// The response of replication command.
+///
+/// Update the `matched` log id of a replication target.
+/// Sent by a replication task `ReplicationCore`.
 #[derive(Debug)]
-pub(crate) enum Response<C>
+pub(crate) struct Progress<C>
 where C: RaftTypeConfig
 {
-    // /// Logs that are submitted to append has been persisted to disk.
-    // LogPersisted {},
-    /// Update the `matched` log id of a replication target.
-    /// Sent by a replication task `ReplicationCore`.
-    Progress {
-        /// The ID of the target node for which the match index is to be updated.
-        target: C::NodeId,
+    /// The ID of the target node for which the match index is to be updated.
+    pub(crate) target: C::NodeId,
 
-        /// The id of the subject that submit this replication action.
-        request_id: RequestId,
+    /// The id of the subject that submit this replication action.
+    pub(crate) request_id: u64,
 
-        /// The request by this leader has been successfully handled by the target node,
-        /// or an error in string.
-        ///
-        /// A successful result can still be log matching or log conflicting.
-        /// In either case, the request is considered accepted, i.e., this leader is still valid to
-        /// the target node.
-        ///
-        /// The result also track the time when this request is sent.
-        result: Result<ReplicationResult<C>, String>,
+    /// The request by this leader has been successfully handled by the target node,
+    /// or an error in string.
+    ///
+    /// A successful result can still be log matching or log conflicting.
+    /// In either case, the request is considered accepted, i.e., this leader is still valid to
+    /// the target node.
+    ///
+    /// The result also track the time when this request is sent.
+    pub(crate) result: Result<ReplicationResult<C>, String>,
 
-        /// In which session this message is sent.
-        ///
-        /// This session id identifies a certain leader(by vote) that is replicating to a certain
-        /// group of nodes.
-        ///
-        /// A message should be discarded if it does not match the present vote and
-        /// membership_log_id.
-        session_id: ReplicationSessionId<C>,
-    },
-
-    /// ReplicationCore has seen a higher `vote`.
-    /// Sent by a replication task `ReplicationCore`.
-    HigherVote {
-        /// The ID of the target node from which the new term was observed.
-        target: C::NodeId,
-
-        /// The higher vote observed.
-        higher: Vote<C::NodeId>,
-
-        /// Which state(a Leader or Candidate) sent this message
-        sender_vote: Vote<C::NodeId>,
-        // TODO: need this?
-        // /// The cluster this replication works for.
-        // membership_log_id: Option<LogId<C::NodeId>>,
-    },
+    /// In which session this message is sent.
+    ///
+    /// This session id identifies a certain leader(by vote) that is replicating to a certain
+    /// group of nodes.
+    ///
+    /// A message should be discarded if it does not match the present vote and
+    /// membership_log_id.
+    pub(crate) session_id: ReplicationSessionId<C>,
 }
 
-impl<C> fmt::Display for Response<C>
+impl<C> fmt::Display for Progress<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Progress {
-                target,
-                request_id,
-                result,
-                session_id,
-            } => {
-                write!(
-                    f,
-                    "replication::Progress: target={}, request_id: {}, result: {}, session_id: {}",
-                    target,
-                    request_id,
-                    result.display(),
-                    session_id
-                )
-            }
-
-            Self::HigherVote {
-                target,
-                higher,
-                sender_vote,
-            } => {
-                write!(
-                    f,
-                    "replication::Seen a higher vote: target={}, higher: {}, sender_vote: {}",
-                    target, higher, sender_vote
-                )
-            }
-        }
+        write!(
+            f,
+            "replication::Progress: target={}, request_id: {}, result: {}, session_id: {}",
+            self.target,
+            self.request_id,
+            self.result.display(),
+            self.session_id
+        )
     }
 }
 
 /// Result of an append-entries replication
+///
+/// Ok for matching, Err for conflict.
 #[derive(Clone, Debug)]
-pub(crate) struct ReplicationResult<C: RaftTypeConfig> {
-    /// The timestamp when this request is sent.
-    ///
-    /// It is used to update the lease for leader.
-    pub(crate) sending_time: InstantOf<C>,
-
-    /// Ok for matching, Err for conflict.
-    pub(crate) result: Result<Option<LogIdOf<C>>, LogIdOf<C>>,
-}
+pub(crate) struct ReplicationResult<C: RaftTypeConfig>(pub(crate) Result<Option<LogIdOf<C>>, LogIdOf<C>>);
 
 impl<C> fmt::Display for ReplicationResult<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{sending_time:{}, result:", self.sending_time.display())?;
-
-        match &self.result {
-            Ok(matching) => write!(f, "Match:{}", matching.display())?,
-            Err(conflict) => write!(f, "Conflict:{}", conflict)?,
+        match &self.0 {
+            Ok(matching) => write!(f, "(Match:{})", matching.display()),
+            Err(conflict) => write!(f, "(Conflict:{})", conflict),
         }
-
-        write!(f, "}}")
-    }
-}
-
-impl<C> ReplicationResult<C>
-where C: RaftTypeConfig
-{
-    pub(crate) fn new(sending_time: InstantOf<C>, result: Result<Option<LogIdOf<C>>, LogIdOf<C>>) -> Self {
-        Self { sending_time, result }
     }
 }
 
@@ -139,18 +77,17 @@ mod tests {
     use crate::engine::testing::UTConfig;
     use crate::replication::response::ReplicationResult;
     use crate::testing::log_id;
-    use crate::type_config::TypeConfigExt;
 
     #[test]
     fn test_replication_result_display() {
         // NOTE that with single-term-leader, log id is `1-3`
 
-        let result = ReplicationResult::<UTConfig>::new(UTConfig::<()>::now(), Ok(Some(log_id(1, 2, 3))));
-        let want = format!(", result:Match:{}}}", log_id(1, 2, 3));
+        let result = ReplicationResult::<UTConfig>(Ok(Some(log_id(1, 2, 3))));
+        let want = format!("(Match:{})", log_id(1, 2, 3));
         assert!(result.to_string().ends_with(&want), "{}", result.to_string());
 
-        let result = ReplicationResult::<UTConfig>::new(UTConfig::<()>::now(), Err(log_id(1, 2, 3)));
-        let want = format!(", result:Conflict:{}}}", log_id(1, 2, 3));
+        let result = ReplicationResult::<UTConfig>(Err(log_id(1, 2, 3)));
+        let want = format!("(Conflict:{})", log_id(1, 2, 3));
         assert!(result.to_string().ends_with(&want), "{}", result.to_string());
     }
 }

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -87,7 +87,8 @@ where C: RaftTypeConfig
             }
             Notification::HigherVote { .. }
             | Notification::StorageError { .. }
-            | Notification::Network { .. }
+            | Notification::ReplicationProgress { .. }
+            | Notification::HeartbeatProgress { .. }
             | Notification::StateMachine { .. }
             | Notification::Tick { .. } => {
                 unreachable!("Unexpected notification: {}", self.notification)


### PR DESCRIPTION
## Changelog

##### Refactor: Send heartbeat with dedicated workers

Heavy AppendEntries traffic can block heartbeat messages. For example,
future AppendEntries in stream RPC may not receive a response indicating
a follower is alive. In such cases, the leader might time out to extend
its lease, and be considered partitioned from the cluster.

This commit moves heartbeat broadcasting to separate tasks that won't be
blocked by AppendEntries. This ensures the leader can always be
acknowledged with the liveness of followers.

Separate log progress notification and clock progress notification:
When ReplicationCore successfully finished one RPC to Follower/Learner,
it informs the RaftCore to update log progress and clock(heartbeat) progress.
This commit split these two informations into two `Notification`
variants, in order to make progress handling more clear.

Another improvement is to ignore a heartbeat progress if it is sent with
an older cluster membership config. Because a follower can be removed
and re-added, the obsolete heartbeat progress is invalid. This check is
done by remembering the membership log id in the `HeartbeatEvent`.

`HigherVote` can be sent directly to Notification channel.
replication::Response does not need `HigherVote` variant any more.
And `Response` is renamed to `Progress`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1225)
<!-- Reviewable:end -->
