### PR TITLE
Chore: don't gate mod testing with feat tokio-rt

### DIFF
--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -62,7 +62,6 @@ pub mod metrics;
 pub mod network;
 pub mod raft;
 pub mod storage;
-#[cfg(feature = "tokio-rt")]
 pub mod testing;
 pub mod type_config;
 


### PR DESCRIPTION
### What does this PR do

Since the log test suite is rt-agnostic now, we should no longer gate it with feature `tokio-rt`. This tiny patch should be included in #1227, sorry for missing it.

**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1228)
<!-- Reviewable:end -->
