### PR TITLE
Feature: Add MPSC channel to AsyncRuntime

### DIFF
--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -95,6 +95,7 @@ pub trait RaftTypeConfig:
 /// [`type-alias`]: crate::docs::feature_flags#feature-flag-type-alias
 pub mod alias {
     use crate::async_runtime::watch;
+    use crate::async_runtime::Mpsc;
     use crate::async_runtime::MpscUnbounded;
     use crate::async_runtime::Oneshot;
     use crate::raft::responder::Responder;
@@ -125,13 +126,23 @@ pub mod alias {
     pub type OneshotReceiverErrorOf<C> = <OneshotOf<C> as Oneshot>::ReceiverError;
     pub type OneshotReceiverOf<C, T> = <OneshotOf<C> as Oneshot>::Receiver<T>;
 
+    pub type MpscOf<C> = <Rt<C> as AsyncRuntime>::Mpsc;
+
+    // MPSC bounded
+    type MpscB<C> = MpscOf<C>;
+
+    pub type MpscSenderOf<C, T> = <MpscB<C> as Mpsc>::Sender<T>;
+    pub type MpscReceiverOf<C, T> = <MpscB<C> as Mpsc>::Receiver<T>;
+    pub type MpscWeakSenderOf<C, T> = <MpscB<C> as Mpsc>::WeakSender<T>;
+
     pub type MpscUnboundedOf<C> = <Rt<C> as AsyncRuntime>::MpscUnbounded;
 
-    type Mpsc<C> = MpscUnboundedOf<C>;
+    // MPSC unbounded
+    type MpscUB<C> = MpscUnboundedOf<C>;
 
-    pub type MpscUnboundedSenderOf<C, T> = <Mpsc<C> as MpscUnbounded>::Sender<T>;
-    pub type MpscUnboundedReceiverOf<C, T> = <Mpsc<C> as MpscUnbounded>::Receiver<T>;
-    pub type MpscUnboundedWeakSenderOf<C, T> = <Mpsc<C> as MpscUnbounded>::WeakSender<T>;
+    pub type MpscUnboundedSenderOf<C, T> = <MpscUB<C> as MpscUnbounded>::Sender<T>;
+    pub type MpscUnboundedReceiverOf<C, T> = <MpscUB<C> as MpscUnbounded>::Receiver<T>;
+    pub type MpscUnboundedWeakSenderOf<C, T> = <MpscUB<C> as MpscUnbounded>::WeakSender<T>;
 
     pub type WatchOf<C> = <Rt<C> as AsyncRuntime>::Watch;
     pub type WatchSenderOf<C, T> = <WatchOf<C> as watch::Watch>::Sender<T>;

--- a/openraft/src/type_config/async_runtime/mod.rs
+++ b/openraft/src/type_config/async_runtime/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod tokio_impls {
     mod tokio_runtime;
     pub use tokio_runtime::TokioRuntime;
 }
+pub mod mpsc;
 pub mod mpsc_unbounded;
 pub mod mutex;
 pub mod oneshot;
@@ -19,6 +20,10 @@ use std::fmt::Display;
 use std::future::Future;
 use std::time::Duration;
 
+pub use mpsc::Mpsc;
+pub use mpsc::MpscReceiver;
+pub use mpsc::MpscSender;
+pub use mpsc::MpscWeakSender;
 pub use mpsc_unbounded::MpscUnbounded;
 pub use mpsc_unbounded::MpscUnboundedReceiver;
 pub use mpsc_unbounded::MpscUnboundedSender;
@@ -98,6 +103,8 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     /// This is a per-thread instance, which cannot be shared across threads or
     /// sent to another thread.
     fn thread_rng() -> Self::ThreadLocalRng;
+
+    type Mpsc: Mpsc;
 
     type MpscUnbounded: MpscUnbounded;
 

--- a/openraft/src/type_config/async_runtime/mpsc/mod.rs
+++ b/openraft/src/type_config/async_runtime/mpsc/mod.rs
@@ -1,0 +1,73 @@
+use std::future::Future;
+
+use base::OptionalSend;
+use base::OptionalSync;
+
+/// mpsc shares the same error types as mpsc_unbounded
+pub use super::mpsc_unbounded::SendError;
+pub use super::mpsc_unbounded::TryRecvError;
+use crate::base;
+
+/// Multi-producer, single-consumer channel.
+pub trait Mpsc: Sized + OptionalSend {
+    type Sender<T: OptionalSend>: MpscSender<Self, T>;
+    type Receiver<T: OptionalSend>: MpscReceiver<T>;
+    type WeakSender<T: OptionalSend>: MpscWeakSender<Self, T>;
+
+    /// Creates a bounded mpsc channel for communicating between asynchronous tasks with
+    /// backpressure.
+    fn channel<T: OptionalSend>(buffer: usize) -> (Self::Sender<T>, Self::Receiver<T>);
+}
+
+/// Send values to the associated [`MpscReceiver`].
+pub trait MpscSender<MU, T>: OptionalSend + OptionalSync + Clone
+where
+    MU: Mpsc,
+    T: OptionalSend,
+{
+    /// Attempts to send a message, blocks if there is no capacity.
+    ///
+    /// If the receiving half of the channel is closed, this
+    /// function returns an error. The error includes the value passed to `send`.
+    fn send(&self, msg: T) -> impl Future<Output = Result<(), SendError<T>>> + OptionalSend;
+
+    /// Converts the [`MpscSender`] to a [`MpscWeakSender`] that does not count
+    /// towards RAII semantics, i.e. if all `Sender` instances of the
+    /// channel were dropped and only `WeakSender` instances remain,
+    /// the channel is closed.
+    fn downgrade(&self) -> MU::WeakSender<T>;
+}
+
+/// Receive values from the associated [`MpscSender`].
+pub trait MpscReceiver<T>: OptionalSend + OptionalSync {
+    /// Receives the next value for this receiver.
+    ///
+    /// This method returns `None` if the channel has been closed and there are
+    /// no remaining messages in the channel's buffer.
+    fn recv(&mut self) -> impl Future<Output = Option<T>> + OptionalSend;
+
+    /// Tries to receive the next value for this receiver.
+    ///
+    /// This method returns the [`TryRecvError::Empty`] error if the channel is currently
+    /// empty, but there are still outstanding senders.
+    ///
+    /// This method returns the [`TryRecvError::Disconnected`] error if the channel is
+    /// currently empty, and there are no outstanding senders.
+    fn try_recv(&mut self) -> Result<T, TryRecvError>;
+}
+
+/// A sender that does not prevent the channel from being closed.
+///
+/// If all [`MpscSender`] instances of a channel were dropped and only
+/// `WeakSender` instances remain, the channel is closed.
+pub trait MpscWeakSender<MU, T>: OptionalSend + OptionalSync + Clone
+where
+    MU: Mpsc,
+    T: OptionalSend,
+{
+    /// Tries to convert a [`MpscWeakSender`] into an [`MpscSender`].
+    ///
+    /// This will return `Some` if there are other `Sender` instances alive and
+    /// the channel wasn't previously dropped, otherwise `None` is returned.
+    fn upgrade(&self) -> Option<MU::Sender<T>>;
+}

--- a/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
+++ b/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
@@ -74,6 +74,7 @@ impl AsyncRuntime for TokioRuntime {
         rand::thread_rng()
     }
 
+    type Mpsc = mpsc_impl::TokioMpsc;
     type MpscUnbounded = TokioMpscUnbounded;
     type Watch = TokioWatch;
     type Oneshot = TokioOneshot;
@@ -131,6 +132,75 @@ where T: OptionalSend
     #[inline]
     fn upgrade(&self) -> Option<<TokioMpscUnbounded as MpscUnbounded>::Sender<T>> {
         self.upgrade()
+    }
+}
+
+mod mpsc_impl {
+    use std::future::Future;
+
+    use futures::TryFutureExt;
+    use tokio::sync::mpsc;
+
+    use crate::async_runtime::Mpsc;
+    use crate::async_runtime::MpscReceiver;
+    use crate::async_runtime::MpscSender;
+    use crate::async_runtime::MpscWeakSender;
+    use crate::async_runtime::SendError;
+    use crate::async_runtime::TryRecvError;
+    use crate::OptionalSend;
+
+    pub struct TokioMpsc;
+
+    impl Mpsc for TokioMpsc {
+        type Sender<T: OptionalSend> = mpsc::Sender<T>;
+        type Receiver<T: OptionalSend> = mpsc::Receiver<T>;
+        type WeakSender<T: OptionalSend> = mpsc::WeakSender<T>;
+
+        /// Creates a bounded mpsc channel for communicating between asynchronous
+        /// tasks with backpressure.
+        fn channel<T: OptionalSend>(buffer: usize) -> (Self::Sender<T>, Self::Receiver<T>) {
+            mpsc::channel(buffer)
+        }
+    }
+
+    impl<T> MpscSender<TokioMpsc, T> for mpsc::Sender<T>
+    where T: OptionalSend
+    {
+        #[inline]
+        fn send(&self, msg: T) -> impl Future<Output = Result<(), SendError<T>>> + OptionalSend {
+            self.send(msg).map_err(|e| SendError(e.0))
+        }
+
+        #[inline]
+        fn downgrade(&self) -> <TokioMpsc as Mpsc>::WeakSender<T> {
+            self.downgrade()
+        }
+    }
+
+    impl<T> MpscReceiver<T> for mpsc::Receiver<T>
+    where T: OptionalSend
+    {
+        #[inline]
+        fn recv(&mut self) -> impl Future<Output = Option<T>> + OptionalSend {
+            self.recv()
+        }
+
+        #[inline]
+        fn try_recv(&mut self) -> Result<T, TryRecvError> {
+            self.try_recv().map_err(|e| match e {
+                mpsc::error::TryRecvError::Empty => TryRecvError::Empty,
+                mpsc::error::TryRecvError::Disconnected => TryRecvError::Disconnected,
+            })
+        }
+    }
+
+    impl<T> MpscWeakSender<TokioMpsc, T> for mpsc::WeakSender<T>
+    where T: OptionalSend
+    {
+        #[inline]
+        fn upgrade(&self) -> Option<<TokioMpsc as Mpsc>::Sender<T>> {
+            self.upgrade()
+        }
     }
 }
 

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -5,11 +5,15 @@ use openraft_macros::since;
 
 use crate::async_runtime::mutex::Mutex;
 use crate::async_runtime::watch::Watch;
+use crate::async_runtime::Mpsc;
 use crate::async_runtime::MpscUnbounded;
 use crate::async_runtime::Oneshot;
 use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::MpscOf;
+use crate::type_config::alias::MpscReceiverOf;
+use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::MpscUnboundedOf;
 use crate::type_config::alias::MpscUnboundedReceiverOf;
 use crate::type_config::alias::MpscUnboundedSenderOf;
@@ -70,6 +74,16 @@ pub trait TypeConfigExt: RaftTypeConfig {
     fn oneshot<T>() -> (OneshotSenderOf<Self, T>, OneshotReceiverOf<Self, T>)
     where T: OptionalSend {
         OneshotOf::<Self>::channel()
+    }
+
+    /// Creates a mpsc channel for communicating between asynchronous
+    /// tasks with backpressure.
+    ///
+    /// This is just a wrapper of
+    /// [`AsyncRuntime::Mpsc::channel()`](`crate::async_runtime::Mpsc::channel`).
+    fn mpsc<T>(buffer: usize) -> (MpscSenderOf<Self, T>, MpscReceiverOf<Self, T>)
+    where T: OptionalSend {
+        MpscOf::<Self>::channel(buffer)
     }
 
     /// Creates an unbounded mpsc channel for communicating between asynchronous

--- a/rt-monoio/Cargo.toml
+++ b/rt-monoio/Cargo.toml
@@ -18,6 +18,9 @@ repository = "https://github.com/datafuselabs/openraft"
 openraft = { path = "../openraft", version = "0.10.0", default-features = false, features = ["singlethreaded"] }
 
 rand = "0.8"
-tokio = { version = "1.22", features = ["sync"] }
-monoio = "0.2.3"
+
+futures = { version = "0.3" }
 local-sync = "0.1.1"
+
+monoio = "0.2.3"
+tokio = { version = "1.22", features = ["sync"] }

--- a/rt-monoio/src/lib.rs
+++ b/rt-monoio/src/lib.rs
@@ -86,7 +86,8 @@ impl AsyncRuntime for MonoioRuntime {
         rand::thread_rng()
     }
 
-    type MpscUnbounded = mpsc_mod::TokioMpscUnbounded;
+    type Mpsc = mpsc_mod::MonoioMpsc;
+    type MpscUnbounded = mpsc_unbounded_mod::TokioMpscUnbounded;
     type Watch = watch_mod::TokioWatch;
     type Oneshot = oneshot_mod::MonoioOneshot;
     type Mutex<T: OptionalSend + 'static> = mutex_mod::TokioMutex<T>;
@@ -203,7 +204,104 @@ mod oneshot_mod {
 
 // Put the wrapper types in a private module to make them `pub` but not
 // exposed to the user.
+/// MPSC channel is implemented with tokio MPSC channels.
+///
+/// Tokio MPSC channel are runtime independent.
 mod mpsc_mod {
+    //! MPSC channel wrapper types and their trait impl.
+
+    use std::future::Future;
+
+    use futures::TryFutureExt;
+    use openraft::async_runtime::Mpsc;
+    use openraft::async_runtime::MpscReceiver;
+    use openraft::async_runtime::MpscSender;
+    use openraft::async_runtime::MpscWeakSender;
+    use openraft::async_runtime::SendError;
+    use openraft::async_runtime::TryRecvError;
+    use openraft::OptionalSend;
+    use tokio::sync::mpsc as tokio_mpsc;
+
+    pub struct MonoioMpsc;
+
+    pub struct MonoioMpscSender<T>(tokio_mpsc::Sender<T>);
+
+    impl<T> Clone for MonoioMpscSender<T> {
+        #[inline]
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    pub struct MonoioMpscReceiver<T>(tokio_mpsc::Receiver<T>);
+
+    pub struct MonoioMpscWeakSender<T>(tokio_mpsc::WeakSender<T>);
+
+    impl<T> Clone for MonoioMpscWeakSender<T> {
+        #[inline]
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl Mpsc for MonoioMpsc {
+        type Sender<T: OptionalSend> = MonoioMpscSender<T>;
+        type Receiver<T: OptionalSend> = MonoioMpscReceiver<T>;
+        type WeakSender<T: OptionalSend> = MonoioMpscWeakSender<T>;
+
+        #[inline]
+        fn channel<T: OptionalSend>(buffer: usize) -> (Self::Sender<T>, Self::Receiver<T>) {
+            let (tx, rx) = tokio_mpsc::channel(buffer);
+            let tx_wrapper = MonoioMpscSender(tx);
+            let rx_wrapper = MonoioMpscReceiver(rx);
+
+            (tx_wrapper, rx_wrapper)
+        }
+    }
+
+    impl<T> MpscSender<MonoioMpsc, T> for MonoioMpscSender<T>
+    where T: OptionalSend
+    {
+        #[inline]
+        fn send(&self, msg: T) -> impl Future<Output = Result<(), SendError<T>>> {
+            self.0.send(msg).map_err(|e| SendError(e.0))
+        }
+
+        #[inline]
+        fn downgrade(&self) -> <MonoioMpsc as Mpsc>::WeakSender<T> {
+            let inner = self.0.downgrade();
+            MonoioMpscWeakSender(inner)
+        }
+    }
+
+    impl<T> MpscReceiver<T> for MonoioMpscReceiver<T> {
+        #[inline]
+        fn recv(&mut self) -> impl Future<Output = Option<T>> {
+            self.0.recv()
+        }
+
+        #[inline]
+        fn try_recv(&mut self) -> Result<T, TryRecvError> {
+            self.0.try_recv().map_err(|e| match e {
+                tokio_mpsc::error::TryRecvError::Empty => TryRecvError::Empty,
+                tokio_mpsc::error::TryRecvError::Disconnected => TryRecvError::Disconnected,
+            })
+        }
+    }
+
+    impl<T> MpscWeakSender<MonoioMpsc, T> for MonoioMpscWeakSender<T>
+    where T: OptionalSend
+    {
+        #[inline]
+        fn upgrade(&self) -> Option<<MonoioMpsc as Mpsc>::Sender<T>> {
+            self.0.upgrade().map(MonoioMpscSender)
+        }
+    }
+}
+
+// Put the wrapper types in a private module to make them `pub` but not
+// exposed to the user.
+mod mpsc_unbounded_mod {
     //! Unbounded MPSC channel wrapper types and their trait impl.
 
     use openraft::type_config::async_runtime::mpsc_unbounded;


### PR DESCRIPTION

## Changelog

##### Feature: Add MPSC channel to AsyncRuntime

`AsyncRuntime` trait defines the async-runtime such as tokio to run
Openraft. This commit add MPSC abstraction to `AsyncRuntime` and
MPSC implementations to tokio based runtime and monoio based runtime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1233)
<!-- Reviewable:end -->
