### PR TITLE
Fix: minimal versions check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ tracing-futures = "0.2.4"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 validit = { version = "0.2.2" }
 
+# make minimal versions happy
+rust_decimal = "1.15"
+
 [workspace]
 
 resolver = "2"

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -33,6 +33,9 @@ tracing         = { workspace = true }
 tracing-futures = { workspace = true }
 validit         = { workspace = true }
 
+# make minimal versions happy
+rust_decimal    = { workspace = true }
+
 
 [dev-dependencies]
 anyhow             = { workspace = true }


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

This is a tiny fix for minimal versions. I stumbled about this issue when testing with the latest `openraft:0.9.15` when executing in my pipeline:

```
cargo minimal-versions check --workspace
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1237)
<!-- Reviewable:end -->
