### PR TITLE
Doc: update doc of heartbeat metric

### DIFF
--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -53,6 +53,6 @@ use crate::type_config::alias::NodeIdOf;
 use crate::type_config::alias::SerdeInstantOf;
 
 pub(crate) type ReplicationMetrics<C> = BTreeMap<NodeIdOf<C>, Option<LogIdOf<C>>>;
-/// Heartbeat metrics, a mapping between a node's ID and milliseconds since the
-/// last acknowledged heartbeat or replication to this node.
+/// Heartbeat metrics, a mapping between a node's ID and the time of the last
+/// acknowledged heartbeat or replication to this node.
 pub(crate) type HeartbeatMetrics<C> = BTreeMap<NodeIdOf<C>, Option<SerdeInstantOf<C>>>;

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -98,11 +98,12 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
 
     /// Heartbeat metrics. It is Some() only when this node is leader.
     ///
-    /// This field records a mapping between a node's ID and milliseconds since
-    /// the last acknowledged heartbeat or replication to this node.
+    /// This field records a mapping between a node's ID and the time of the
+    /// last acknowledged heartbeat or replication to this node.
     ///
-    /// This duration can be used by applications to guess if a follwer/learner
-    /// node is offline, longer duration suggests higher possibility of that.
+    /// This duration since the recorded time can be used by applications to
+    /// guess if a follwer/learner node is offline, longer duration suggests
+    /// higher possibility of that.
     pub heartbeat: Option<HeartbeatMetrics<C>>,
 
     // ---
@@ -227,11 +228,12 @@ pub struct RaftDataMetrics<C: RaftTypeConfig> {
 
     /// Heartbeat metrics. It is Some() only when this node is leader.
     ///
-    /// This field records a mapping between a node's ID and milliseconds since
-    /// the last acknowledged heartbeat or replication to this node.
+    /// This field records a mapping between a node's ID and the time of the
+    /// last acknowledged heartbeat or replication to this node.
     ///
-    /// This duration can be used by applications to guess if a follwer/learner
-    /// node is offline, longer duration suggests higher possibility of that.
+    /// This duration since the recorded time can be used by applications to
+    /// guess if a follwer/learner node is offline, longer duration suggests
+    /// higher possibility of that.
     pub heartbeat: Option<HeartbeatMetrics<C>>,
 }
 


### PR DESCRIPTION
### What does this PR do

Updates the doc of the `heartbeat` field of `RaftMetrics` and `RaftDataMetrics` as we store the timestamp itself rather than the duration since the last acknowledged heartbeat/replication timestamp since #1202.


**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/openraft/1241)
<!-- Reviewable:end -->
