### PR TITLE
fix: reset progress when heartbeat response indicates conflict

### DIFF
--- a/openraft/src/core/heartbeat/errors/mod.rs
+++ b/openraft/src/core/heartbeat/errors/mod.rs
@@ -1,0 +1,5 @@
+mod raft_core_closed;
+mod stopped;
+
+pub(crate) use raft_core_closed::RaftCoreClosed;
+pub(crate) use stopped::Stopped;

--- a/openraft/src/core/heartbeat/errors/raft_core_closed.rs
+++ b/openraft/src/core/heartbeat/errors/raft_core_closed.rs
@@ -1,0 +1,3 @@
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("RaftCore closed receiver")]
+pub(crate) struct RaftCoreClosed;

--- a/openraft/src/core/heartbeat/errors/stopped.rs
+++ b/openraft/src/core/heartbeat/errors/stopped.rs
@@ -1,0 +1,10 @@
+use crate::core::heartbeat::errors::raft_core_closed::RaftCoreClosed;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum Stopped {
+    #[error("HeartbeatWorkerStopped: {0}")]
+    RaftCoreClosed(#[from] RaftCoreClosed),
+
+    #[error("HeartbeatWorkerStopped: received shutdown signal")]
+    ReceivedShutdown,
+}

--- a/openraft/src/core/heartbeat/mod.rs
+++ b/openraft/src/core/heartbeat/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod errors;
 pub(crate) mod event;
 pub(crate) mod handle;
 pub(crate) mod worker;

--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -6,11 +6,16 @@ use futures::FutureExt;
 
 use crate::async_runtime::watch::WatchReceiver;
 use crate::async_runtime::MpscUnboundedSender;
+use crate::core::heartbeat::errors::RaftCoreClosed;
+use crate::core::heartbeat::errors::Stopped;
 use crate::core::heartbeat::event::HeartbeatEvent;
 use crate::core::notification::Notification;
 use crate::network::v2::RaftNetworkV2;
 use crate::network::RPCOption;
 use crate::raft::AppendEntriesRequest;
+use crate::raft::AppendEntriesResponse;
+use crate::replication::response::ReplicationResult;
+use crate::replication::Progress;
 use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::WatchReceiverOf;
@@ -59,14 +64,19 @@ where
     C: RaftTypeConfig,
     N: RaftNetworkV2<C>,
 {
-    pub(crate) async fn run(mut self, mut rx_shutdown: OneshotReceiverOf<C, ()>) {
+    pub(crate) async fn run(self, rx_shutdown: OneshotReceiverOf<C, ()>) {
+        let res = self.do_run(rx_shutdown).await;
+        tracing::info!("HeartbeatWorker finished with result: {:?}", res);
+    }
+
+    pub(crate) async fn do_run(mut self, mut rx_shutdown: OneshotReceiverOf<C, ()>) -> Result<(), Stopped> {
         loop {
             tracing::debug!("{} is waiting for a new heartbeat event.", self);
 
             futures::select! {
                 _ = (&mut rx_shutdown).fuse() => {
                     tracing::info!("{} is shutdown.", self);
-                    return;
+                    return Err(Stopped::ReceivedShutdown);
                 },
                 _ = self.rx.changed().fuse() => {},
             }
@@ -83,7 +93,9 @@ where
 
             let payload = AppendEntriesRequest {
                 vote: heartbeat.session_id.leader_vote.clone().into_vote(),
-                prev_log_id: None,
+                // Use committed log id as prev_log_id to detect follower state reversion.
+                // prev_log_id == None does not conflict.
+                prev_log_id: heartbeat.committed.clone(),
                 leader_commit: heartbeat.committed.clone(),
                 entries: vec![],
             };
@@ -92,22 +104,65 @@ where
             tracing::debug!("{} sent a heartbeat: {}, result: {:?}", self, heartbeat, res);
 
             match res {
-                Ok(Ok(_)) => {
-                    let res = self.tx_notification.send(Notification::HeartbeatProgress {
+                Ok(Ok(x)) => {
+                    let response: AppendEntriesResponse<C> = x;
+
+                    match response {
+                        AppendEntriesResponse::Success => {}
+                        AppendEntriesResponse::PartialSuccess(_matching) => {}
+                        AppendEntriesResponse::HigherVote(vote) => {
+                            tracing::debug!(
+                                "seen a higher vote({vote}) from {}; when:(sending heartbeat)",
+                                self.target
+                            );
+
+                            let noti = Notification::HigherVote {
+                                target: self.target.clone(),
+                                higher: vote,
+                                leader_vote: heartbeat.session_id.committed_vote(),
+                            };
+
+                            self.send_notification(noti, "Seeing higher Vote")?;
+                        }
+                        AppendEntriesResponse::Conflict => {
+                            let conflict = heartbeat.committed.unwrap();
+
+                            let noti = Notification::ReplicationProgress {
+                                has_payload: false,
+                                progress: Progress {
+                                    session_id: heartbeat.session_id.clone(),
+                                    target: self.target.clone(),
+                                    result: Ok(ReplicationResult(Err(conflict))),
+                                },
+                            };
+
+                            self.send_notification(noti, "Seeing conflict")?;
+                        }
+                    }
+
+                    let noti = Notification::HeartbeatProgress {
                         session_id: heartbeat.session_id.clone(),
                         sending_time: heartbeat.time,
                         target: self.target.clone(),
-                    });
+                    };
 
-                    if res.is_err() {
-                        tracing::error!("{} failed to send a heartbeat progress to RaftCore. quit", self);
-                        return;
-                    }
+                    self.send_notification(noti, "send HeartbeatProgress")?;
                 }
                 _ => {
                     tracing::warn!("{} failed to send a heartbeat: {:?}", self, res);
                 }
             }
         }
+    }
+
+    fn send_notification(&self, notification: Notification<C>, when: impl fmt::Display) -> Result<(), RaftCoreClosed> {
+        let res = self.tx_notification.send(notification);
+
+        if let Err(e) = res {
+            let notification = e.0;
+            tracing::error!("{self} failed to send {notification} to RaftCore; when:({when})");
+            return Err(RaftCoreClosed);
+        }
+        Ok(())
     }
 }

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -50,7 +50,13 @@ where C: RaftTypeConfig
     LocalIO { io_id: IOId<C> },
 
     /// Result of executing a command sent from network worker.
-    ReplicationProgress { progress: replication::Progress<C> },
+    ReplicationProgress {
+        /// If this progress from RPC with payload.
+        ///
+        /// `has_payload`: contain payload and should reset `inflight` state if conflict.
+        has_payload: bool,
+        progress: replication::Progress<C>,
+    },
 
     HeartbeatProgress {
         session_id: ReplicationSessionId<C>,
@@ -105,8 +111,9 @@ where C: RaftTypeConfig
             }
             Self::StorageError { error } => write!(f, "StorageError: {}", error),
             Self::LocalIO { io_id } => write!(f, "IOFlushed: {}", io_id),
-            Self::ReplicationProgress { progress } => {
-                write!(f, "{}", progress)
+            Self::ReplicationProgress { has_payload, progress } => {
+                let payload = if *has_payload { "no-payload" } else { "has-payload" };
+                write!(f, "{payload}: {}", progress)
             }
             Self::HeartbeatProgress {
                 session_id: leader_vote,

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1399,7 +1399,7 @@ where
                 }
             }
 
-            Notification::ReplicationProgress { progress } => {
+            Notification::ReplicationProgress { has_payload, progress } => {
                 // If vote or membership changes, ignore the message.
                 // There is chance delayed message reports a wrong state.
                 if self.does_replication_session_match(&progress.session_id, "ReplicationProgress") {
@@ -1407,7 +1407,7 @@ where
 
                     // replication_handler() won't panic because:
                     // The leader is still valid because progress.session_id.leader_vote does not change.
-                    self.engine.replication_handler().update_progress(progress.target, progress.result);
+                    self.engine.replication_handler().update_progress(progress.target, progress.result, has_payload);
                 }
             }
 

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -79,7 +79,7 @@ fn test_update_conflicting() -> anyhow::Result<()> {
     pe.inflight = inflight_logs(5, 10);
 
     let engine_config = EngineConfig::new_default(1);
-    pe.new_updater(&engine_config).update_conflicting(5);
+    pe.new_updater(&engine_config).update_conflicting(5, true);
 
     assert_eq!(Inflight::None, pe.inflight);
     assert_eq!(&Some(log_id(3)), pe.borrow());

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -10,7 +10,6 @@ use validit::Validate;
 use crate::display_ext::DisplayOptionExt;
 use crate::log_id_range::LogIdRange;
 use crate::type_config::alias::LogIdOf;
-use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
 /// The inflight data being transmitting from leader to a follower/learner.
@@ -130,16 +129,12 @@ where C: RaftTypeConfig
     }
 
     /// Update inflight state when a conflicting log id is responded by a follower/learner.
-    pub(crate) fn conflict(&mut self, conflict: u64) {
+    pub(crate) fn conflict(&mut self, _conflict: u64) {
         match self {
             Inflight::None => {
                 unreachable!("no inflight data")
             }
-            Inflight::Logs { log_id_range: logs } => {
-                // if prev_log_id==None, it will never conflict
-                debug_assert_eq!(Some(conflict), logs.prev.index());
-                *self = Inflight::None
-            }
+            Inflight::Logs { log_id_range: _ } => *self = Inflight::None,
             Inflight::Snapshot { last_log_id: _ } => {
                 unreachable!("sending snapshot should not conflict");
             }

--- a/openraft/src/progress/inflight/tests.rs
+++ b/openraft/src/progress/inflight/tests.rs
@@ -126,24 +126,6 @@ fn test_inflight_conflict() -> anyhow::Result<()> {
 
     {
         let res = std::panic::catch_unwind(|| {
-            let mut f = Inflight::<UTConfig>::logs(Some(log_id(5)), Some(log_id(10)));
-            f.conflict(4);
-        });
-        tracing::info!("res: {:?}", res);
-        assert!(res.is_err(), "non-matching conflict < prev_log_id");
-    }
-
-    {
-        let res = std::panic::catch_unwind(|| {
-            let mut f = Inflight::<UTConfig>::logs(Some(log_id(5)), Some(log_id(10)));
-            f.conflict(6);
-        });
-        tracing::info!("res: {:?}", res);
-        assert!(res.is_err(), "non-matching conflict > prev_log_id");
-    }
-
-    {
-        let res = std::panic::catch_unwind(|| {
             let mut f = Inflight::<UTConfig>::snapshot(Some(log_id(5)));
             f.conflict(5);
         });

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -10,3 +10,4 @@ mod t50_append_entries_backoff_rejoin;
 mod t51_append_entries_too_large;
 mod t60_feature_loosen_follower_log_revert;
 mod t61_allow_follower_log_revert;
+mod t62_follower_clear_restart_recover;

--- a/tests/tests/replication/t62_follower_clear_restart_recover.rs
+++ b/tests/tests/replication/t62_follower_clear_restart_recover.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::ut_harness;
+use crate::fixtures::MemLogStore;
+use crate::fixtures::MemRaft;
+use crate::fixtures::MemStateMachine;
+use crate::fixtures::RaftRouter;
+
+/// Test follower restart after state cleared to be able to recovery.
+///
+/// A 3-nodes cluster follower loses all state on restart,
+/// then the leader should be able to discover its state loss via heartbeat and recover it.
+///
+/// This is meant to address the issue a `conflict` response for a heartbeat does not reset the
+/// transmission progress.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn follower_clear_restart_recover() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            allow_log_reversion: Some(true),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.enable_saving_committed = false;
+
+    tracing::info!("--- bring up cluster of 3 node");
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- stop node-1");
+    {
+        let (n1, _log, _sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(1).unwrap();
+        n1.shutdown().await?;
+    }
+
+    tracing::info!(log_index, "--- restart node-1 with empty log and sm");
+    router.new_raft_node(1).await;
+
+    tracing::info!(
+        log_index,
+        "--- trigger heartbeat on node-0 to let it discover the state loss on node-1"
+    );
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.trigger().heartbeat().await?;
+
+        let n1 = router.get_raft_handle(&1)?;
+        n1.wait(timeout()).log_index(Some(log_index), "should recovered").await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### fix: reset progress when heartbeat response indicates conflict

With `allow_log_reversion` enabled:

Before this fix, `RaftCore` ignored `conflict` messages from `Heartbeat` RPCs,
preventing leaders from discovering follower state changes. When a follower's
state reverted and responded with a conflict message, the leader wouldn't
retransmit necessary data to the follower.

This commit ensures `conflict` responses are always processed properly and
progress is reset to trigger data retransmission to the follower.

In this commit, a `Heartbeat` message uses `committed` log id as the
`prev_log_id` to detect Follower state reversion.


- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1389)
<!-- Reviewable:end -->
