### PR TITLE
refactor: replace Debug with Display for RaftMsg formatting

### DIFF
--- a/openraft/src/change_members.rs
+++ b/openraft/src/change_members.rs
@@ -1,7 +1,11 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::fmt;
 
 use crate::RaftTypeConfig;
+use crate::display_ext::DisplayBTreeMapDebugValueExt;
+use crate::display_ext::DisplayBTreeSetExt;
+use crate::display_ext::DisplaySlice;
 
 /// Defines various actions to change the membership, including adding or removing learners or
 /// voters.
@@ -72,5 +76,41 @@ where
     fn from(r: I) -> Self {
         let ids = r.into_iter().collect::<BTreeSet<C::NodeId>>();
         ChangeMembers::ReplaceAllVoters(ids)
+    }
+}
+
+impl<C> fmt::Display for ChangeMembers<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChangeMembers::AddVoterIds(ids) => {
+                write!(f, "AddVoterIds({})", ids.display())
+            }
+            ChangeMembers::AddVoters(nodes) => {
+                write!(f, "AddVoters({})", nodes.display())
+            }
+            ChangeMembers::RemoveVoters(ids) => {
+                write!(f, "RemoveVoters({})", ids.display())
+            }
+            ChangeMembers::ReplaceAllVoters(ids) => {
+                write!(f, "ReplaceAllVoters({})", ids.display())
+            }
+            ChangeMembers::AddNodes(nodes) => {
+                write!(f, "AddNodes({})", nodes.display())
+            }
+            ChangeMembers::SetNodes(nodes) => {
+                write!(f, "SetNodes({})", nodes.display())
+            }
+            ChangeMembers::RemoveNodes(ids) => {
+                write!(f, "RemoveNodes({})", ids.display())
+            }
+            ChangeMembers::ReplaceAllNodes(nodes) => {
+                write!(f, "ReplaceAllNodes({})", nodes.display())
+            }
+            ChangeMembers::Batch(changes) => {
+                write!(f, "Batch({})", DisplaySlice::<_, 1024>(changes.as_slice()))
+            }
+        }
     }
 }

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -6,6 +6,7 @@ use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::base::BoxOnce;
 use crate::core::raft_msg::external_command::ExternalCommand;
+use crate::display_ext::DisplayBTreeMapDebugValueExt;
 use crate::error::CheckIsLeaderError;
 use crate::error::Infallible;
 use crate::error::InitializeError;
@@ -120,7 +121,6 @@ where C: RaftTypeConfig
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RaftMsg::AppendEntries { rpc, .. } => {
-                // TODO: avoid using summary()
                 write!(f, "AppendEntries: {}", rpc)
             }
             RaftMsg::RequestVote { rpc, .. } => {
@@ -137,12 +137,10 @@ where C: RaftTypeConfig
                 write!(f, "CheckIsLeaderRequest with read policy: {}", read_policy)
             }
             RaftMsg::Initialize { members, .. } => {
-                // TODO: avoid using Debug
-                write!(f, "Initialize: {:?}", members)
+                write!(f, "Initialize: {}", members.display())
             }
             RaftMsg::ChangeMembership { changes, retain, .. } => {
-                // TODO: avoid using Debug
-                write!(f, "ChangeMembership: {:?}, retain: {}", changes, retain,)
+                write!(f, "ChangeMembership: {}, retain: {}", changes, retain)
             }
             RaftMsg::ExternalCoreRequest { .. } => write!(f, "External Request"),
             RaftMsg::HandleTransferLeader { from, to } => {

--- a/openraft/src/display_ext.rs
+++ b/openraft/src/display_ext.rs
@@ -1,14 +1,29 @@
 //! Implement [`std::fmt::Display`] for types such as `Option<T>` and slice `&[T]`.
 
+pub(crate) mod display_btreemap;
+pub(crate) mod display_btreemap_debug_value;
 pub(crate) mod display_btreemap_opt_value;
+pub(crate) mod display_btreeset;
 pub(crate) mod display_instant;
 pub(crate) mod display_option;
 pub(crate) mod display_result;
 pub(crate) mod display_slice;
 
+#[allow(unused_imports)]
+pub(crate) use display_btreemap::DisplayBTreeMap;
+#[allow(unused_imports)]
+pub(crate) use display_btreemap::DisplayBTreeMapExt;
+#[allow(unused_imports)]
+pub(crate) use display_btreemap_debug_value::DisplayBTreeMapDebugValue;
+#[allow(unused_imports)]
+pub(crate) use display_btreemap_debug_value::DisplayBTreeMapDebugValueExt;
 pub(crate) use display_btreemap_opt_value::DisplayBTreeMapOptValue;
 #[allow(unused_imports)]
 pub(crate) use display_btreemap_opt_value::DisplayBtreeMapOptValueExt;
+#[allow(unused_imports)]
+pub(crate) use display_btreeset::DisplayBTreeSet;
+#[allow(unused_imports)]
+pub(crate) use display_btreeset::DisplayBTreeSetExt;
 #[allow(unused_imports)]
 pub(crate) use display_instant::DisplayInstant;
 pub(crate) use display_instant::DisplayInstantExt;

--- a/openraft/src/display_ext/display_btreemap.rs
+++ b/openraft/src/display_ext/display_btreemap.rs
@@ -1,0 +1,66 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Implement `Display` for `BTreeMap<K, V>` if `K` and `V` are `Display`.
+///
+/// It formats a key-value pair in a string like "{key}:{value}" and
+/// concatenates the key-value pairs with comma.
+pub(crate) struct DisplayBTreeMap<'a, K: fmt::Display, V: fmt::Display>(pub &'a BTreeMap<K, V>);
+
+impl<K: fmt::Display, V: fmt::Display> fmt::Display for DisplayBTreeMap<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.0.len();
+        for (idx, (key, value)) in self.0.iter().enumerate() {
+            write!(f, "{}:{}", key, value)?;
+            if idx + 1 != len {
+                write!(f, ",")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(unused)]
+pub(crate) trait DisplayBTreeMapExt<'a, K: fmt::Display, V: fmt::Display> {
+    fn display(&'a self) -> DisplayBTreeMap<'a, K, V>;
+}
+
+impl<K, V> DisplayBTreeMapExt<'_, K, V> for BTreeMap<K, V>
+where
+    K: fmt::Display,
+    V: fmt::Display,
+{
+    fn display(&self) -> DisplayBTreeMap<K, V> {
+        DisplayBTreeMap(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_btreemap() {
+        let map = (1..=3).map(|num| (num, num)).collect::<BTreeMap<_, _>>();
+        let display = DisplayBTreeMap(&map);
+
+        assert_eq!(display.to_string(), "1:1,2:2,3:3");
+    }
+
+    #[test]
+    fn test_display_empty_map() {
+        let map = BTreeMap::<i32, i32>::new();
+        let display = DisplayBTreeMap(&map);
+
+        assert_eq!(display.to_string(), "");
+    }
+
+    #[test]
+    fn test_display_btreemap_with_1_item() {
+        let map = (1..=1).map(|num| (num, num)).collect::<BTreeMap<_, _>>();
+        let display = DisplayBTreeMap(&map);
+
+        assert_eq!(display.to_string(), "1:1");
+    }
+}

--- a/openraft/src/display_ext/display_btreemap_debug_value.rs
+++ b/openraft/src/display_ext/display_btreemap_debug_value.rs
@@ -1,0 +1,66 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Implement `Display` for `BTreeMap<K, V>` if `K` is `Display` and `V` is `Debug`.
+///
+/// It formats a key-value pair in a string like "{key}:{value:?}" and
+/// concatenates the key-value pairs with comma.
+pub(crate) struct DisplayBTreeMapDebugValue<'a, K: fmt::Display, V: fmt::Debug>(pub &'a BTreeMap<K, V>);
+
+impl<K: fmt::Display, V: fmt::Debug> fmt::Display for DisplayBTreeMapDebugValue<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.0.len();
+        for (idx, (key, value)) in self.0.iter().enumerate() {
+            write!(f, "{}:{:?}", key, value)?;
+            if idx + 1 != len {
+                write!(f, ",")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(unused)]
+pub(crate) trait DisplayBTreeMapDebugValueExt<'a, K: fmt::Display, V: fmt::Debug> {
+    fn display(&'a self) -> DisplayBTreeMapDebugValue<'a, K, V>;
+}
+
+impl<K, V> DisplayBTreeMapDebugValueExt<'_, K, V> for BTreeMap<K, V>
+where
+    K: fmt::Display,
+    V: fmt::Debug,
+{
+    fn display(&self) -> DisplayBTreeMapDebugValue<K, V> {
+        DisplayBTreeMapDebugValue(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_btreemap_debug_value() {
+        let map = (1..=3).map(|num| (num, num)).collect::<BTreeMap<_, _>>();
+        let display = DisplayBTreeMapDebugValue(&map);
+
+        assert_eq!(display.to_string(), "1:1,2:2,3:3");
+    }
+
+    #[test]
+    fn test_display_empty_map() {
+        let map = BTreeMap::<i32, i32>::new();
+        let display = DisplayBTreeMapDebugValue(&map);
+
+        assert_eq!(display.to_string(), "");
+    }
+
+    #[test]
+    fn test_display_btreemap_debug_value_with_1_item() {
+        let map = (1..=1).map(|num| (num, num)).collect::<BTreeMap<_, _>>();
+        let display = DisplayBTreeMapDebugValue(&map);
+
+        assert_eq!(display.to_string(), "1:1");
+    }
+}

--- a/openraft/src/display_ext/display_btreeset.rs
+++ b/openraft/src/display_ext/display_btreeset.rs
@@ -1,0 +1,63 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+/// Implement `Display` for `BTreeSet<T>` if `T` is `Display`.
+///
+/// It formats elements as a comma-separated list enclosed in brackets.
+pub(crate) struct DisplayBTreeSet<'a, T: fmt::Display>(pub &'a BTreeSet<T>);
+
+impl<T: fmt::Display> fmt::Display for DisplayBTreeSet<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        let len = self.0.len();
+        for (idx, item) in self.0.iter().enumerate() {
+            write!(f, "{}", item)?;
+            if idx + 1 != len {
+                write!(f, ",")?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+
+#[allow(unused)]
+pub(crate) trait DisplayBTreeSetExt<'a, T: fmt::Display> {
+    fn display(&'a self) -> DisplayBTreeSet<'a, T>;
+}
+
+impl<T> DisplayBTreeSetExt<'_, T> for BTreeSet<T>
+where T: fmt::Display
+{
+    fn display(&self) -> DisplayBTreeSet<T> {
+        DisplayBTreeSet(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_btreeset() {
+        let set = (1..=3).collect::<BTreeSet<_>>();
+        let display = DisplayBTreeSet(&set);
+
+        assert_eq!(display.to_string(), "[1,2,3]");
+    }
+
+    #[test]
+    fn test_display_empty_set() {
+        let set = BTreeSet::<i32>::new();
+        let display = DisplayBTreeSet(&set);
+
+        assert_eq!(display.to_string(), "[]");
+    }
+
+    #[test]
+    fn test_display_btreeset_with_1_item() {
+        let set = (1..=1).collect::<BTreeSet<_>>();
+        let display = DisplayBTreeSet(&set);
+
+        assert_eq!(display.to_string(), "[1]");
+    }
+}


### PR DESCRIPTION

## Changelog

##### refactor: replace Debug with Display for RaftMsg formatting
Replace Debug formatting with Display in `RaftMsg` and implement Display
trait for `ChangeMembers` to improve log message readability. The change
removes Debug's verbose output in favor of cleaner, more concise Display
formatting.

Add three new display helper modules to support allocation-free Display
implementations:

- `DisplayBTreeMap`: formats `BTreeMap<K,V>` as "key:value,..." when
  both K and V implement Display

- `DisplayBTreeMapDebugValue`: formats `BTreeMap<K,V>` as
  "key:value,..." when K implements Display and V implements Debug

- `DisplayBTreeSet`: formats `BTreeSet<T>` as "[item,...]" when T
  implements Display

Update `RaftMsg::Initialize` to use `members.display()` instead of
`{:?}` formatting and `RaftMsg::ChangeMembership` to format `changes`
with Display instead of Debug. Remove TODO comments about avoiding Debug
formatting as the issue is now resolved.

All Display implementations iterate directly over collections without
intermediate allocations, ensuring zero-cost formatting in log paths.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1415)
<!-- Reviewable:end -->
