### PR TITLE
refactor: replace const generic with dynamic field in DisplaySlice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,14 @@ guide:
 
 lint:
 	cargo fmt
-	cargo fmt --manifest-path examples/memstore/Cargo.toml
+	cargo fmt --manifest-path examples/mem-log/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-singlethreaded/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-rocksdb/Cargo.toml
 	cargo clippy --no-deps --all-targets -- -D warnings
-	cargo clippy --no-deps --manifest-path examples/memstore/Cargo.toml                               --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path examples/mem-log/Cargo.toml                               --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml            --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-singlethreaded/Cargo.toml        --all-targets -- -D warnings

--- a/openraft/src/change_members.rs
+++ b/openraft/src/change_members.rs
@@ -109,7 +109,10 @@ where C: RaftTypeConfig
                 write!(f, "ReplaceAllNodes({})", nodes.display())
             }
             ChangeMembers::Batch(changes) => {
-                write!(f, "Batch({})", DisplaySlice::<_, 1024>(changes.as_slice()))
+                write!(f, "Batch({})", DisplaySlice {
+                    slice: changes.as_slice(),
+                    max: 1024
+                })
             }
         }
     }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1712,7 +1712,10 @@ where
                 entries,
             } => {
                 let last_log_id = entries.last().unwrap().log_id();
-                tracing::debug!("AppendInputEntries: {}", DisplaySlice::<_>(&entries),);
+                tracing::debug!("AppendInputEntries: {}", DisplaySlice {
+                    slice: &entries,
+                    max: 5
+                });
 
                 let io_id = IOId::new_log_io(vote, Some(last_log_id));
                 let notify = Notification::LocalIO { io_id: io_id.clone() };

--- a/openraft/src/display_ext/display_slice.rs
+++ b/openraft/src/display_ext/display_slice.rs
@@ -2,19 +2,30 @@ use std::fmt;
 
 /// Implement `Display` for `&[T]` if T is `Display`.
 ///
-/// It outputs at most `MAX` elements, excluding those from the 5th to the second-to-last one:
-/// - `DisplaySlice(&[1,2,3,4,5,6])` outputs: `"[1,2,3,4,...,6]"`.
-pub(crate) struct DisplaySlice<'a, T: fmt::Display, const MAX: usize = 5>(pub &'a [T]);
+/// It outputs at most `max` elements, excluding those from the 5th to the second-to-last one:
+/// - `DisplaySlice { slice: &[1,2,3,4,5,6], max: 5 }` outputs: `"[1,2,3,4,..,6]"`.
+pub(crate) struct DisplaySlice<'a, T: fmt::Display> {
+    pub slice: &'a [T],
+    pub max: usize,
+}
 
-impl<T: fmt::Display, const MAX: usize> fmt::Display for DisplaySlice<'_, T, MAX> {
+impl<'a, T: fmt::Display> DisplaySlice<'a, T> {
+    /// Set the maximum number of elements to display.
+    #[allow(unused)]
+    pub fn limit(mut self, max: usize) -> Self {
+        self.max = max;
+        self
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for DisplaySlice<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let slice = self.0;
-        let len = slice.len();
+        let len = self.slice.len();
 
         write!(f, "[")?;
 
-        if len > MAX {
-            for (i, t) in slice[..(MAX - 1)].iter().enumerate() {
+        if len > self.max {
+            for (i, t) in self.slice[..(self.max - 1)].iter().enumerate() {
                 if i > 0 {
                     write!(f, ",")?;
                 }
@@ -23,9 +34,9 @@ impl<T: fmt::Display, const MAX: usize> fmt::Display for DisplaySlice<'_, T, MAX
             }
 
             write!(f, ",..,")?;
-            write!(f, "{}", slice.last().unwrap())?;
+            write!(f, "{}", self.slice.last().unwrap())?;
         } else {
-            for (i, t) in slice.iter().enumerate() {
+            for (i, t) in self.slice.iter().enumerate() {
                 if i > 0 {
                     write!(f, ",")?;
                 }
@@ -41,41 +52,70 @@ impl<T: fmt::Display, const MAX: usize> fmt::Display for DisplaySlice<'_, T, MAX
 pub(crate) trait DisplaySliceExt<'a, T: fmt::Display> {
     fn display(&'a self) -> DisplaySlice<'a, T>;
 
-    /// Display at most `MAX` elements.
-    fn display_n<const MAX: usize>(&'a self) -> DisplaySlice<'a, T, MAX>;
+    /// Display at most `max` elements.
+    fn display_n(&'a self, max: usize) -> DisplaySlice<'a, T> {
+        self.display().limit(max)
+    }
 }
 
 impl<T> DisplaySliceExt<'_, T> for [T]
 where T: fmt::Display
 {
     fn display(&self) -> DisplaySlice<T> {
-        DisplaySlice(self)
-    }
-
-    fn display_n<const MAX: usize>(&'_ self) -> DisplaySlice<'_, T, MAX> {
-        DisplaySlice(self)
+        DisplaySlice { slice: self, max: 5 }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::display_ext::DisplaySlice;
-
     #[test]
     fn test_display_slice() {
-        let a = vec![1, 2, 3, 4];
-        assert_eq!("[1,2,3,4]", DisplaySlice::<_>(&a).to_string());
+        use crate::display_ext::DisplaySliceExt;
 
-        let a = vec![1, 2, 3, 4, 5];
-        assert_eq!("[1,2,3,4,5]", DisplaySlice::<_>(&a).to_string());
+        let a = [1, 2, 3, 4];
+        assert_eq!("[1,2,3,4]", a.display().to_string());
 
-        let a = vec![1, 2, 3, 4, 5, 6];
-        assert_eq!("[1,2,3,4,..,6]", DisplaySlice::<_>(&a).to_string());
+        let a = [1, 2, 3, 4, 5];
+        assert_eq!("[1,2,3,4,5]", a.display().to_string());
 
-        let a = vec![1, 2, 3, 4, 5, 6, 7];
-        assert_eq!("[1,2,3,4,..,7]", DisplaySlice::<_>(&a).to_string());
+        let a = [1, 2, 3, 4, 5, 6];
+        assert_eq!("[1,2,3,4,..,6]", a.display().to_string());
 
-        let a = vec![1, 2, 3, 4, 5, 6, 7];
-        assert_eq!("[1,..,7]", DisplaySlice::<_, 2>(&a).to_string());
+        let a = [1, 2, 3, 4, 5, 6, 7];
+        assert_eq!("[1,2,3,4,..,7]", a.display().to_string());
+
+        let a = [1, 2, 3, 4, 5, 6, 7];
+        assert_eq!("[1,..,7]", a.display().limit(2).to_string());
+    }
+
+    #[test]
+    fn test_display_slice_limit() {
+        use crate::display_ext::DisplaySliceExt;
+
+        let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        // Default max: 5
+        assert_eq!("[1,2,3,4,..,10]", a.display().to_string());
+
+        // Change max to 3
+        assert_eq!("[1,2,..,10]", a.display().limit(3).to_string());
+
+        // Change max to 8
+        assert_eq!("[1,2,3,4,5,6,7,..,10]", a.display().limit(8).to_string());
+
+        // Change max to larger than length
+        assert_eq!("[1,2,3,4,5,6,7,8,9,10]", a.display().limit(20).to_string());
+    }
+
+    #[test]
+    fn test_display_slice_display_n() {
+        use crate::display_ext::DisplaySliceExt;
+
+        let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        // display_n should use the default implementation
+        assert_eq!("[1,2,..,10]", a.display_n(3).to_string());
+        assert_eq!("[1,2,3,4,5,6,7,..,10]", a.display_n(8).to_string());
+        assert_eq!("[1,2,3,4,5,6,7,8,9,10]", a.display_n(20).to_string());
     }
 }

--- a/openraft/src/docs/faq/faq-toc.md
+++ b/openraft/src/docs/faq/faq-toc.md
@@ -8,7 +8,7 @@
   * [How to minimize error logging when a follower is offline](#how-to-minimize-error-logging-when-a-follower-is-offline)
   * [How to detect which nodes are currently down or unreachable?](#how-to-detect-which-nodes-are-currently-down-or-unreachable)
 - [Node management](#node-management)
-  * [How to customize snapshot building policy?](#how-to-customize-snapshot-building-policy)
+  * [How to customize snapshot-building policy?](#how-to-customize-snapshot-building-policy)
 - [Cluster management](#cluster-management)
   * [How to initialize a cluster?](#how-to-initialize-a-cluster)
   * [Are there any issues with running a single node service?](#are-there-any-issues-with-running-a-single-node-service)

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -171,7 +171,7 @@ where C: RaftTypeConfig
             }
             Command::BroadcastTransferLeader { req } => write!(f, "TransferLeader: {}", req),
             Command::RebuildReplicationStreams { targets } => {
-                write!(f, "RebuildReplicationStreams: {}", targets.display_n::<10>())
+                write!(f, "RebuildReplicationStreams: {}", targets.display_n(10))
             }
             Command::SaveVote { vote } => write!(f, "SaveVote: {}", vote),
             Command::SendVote { vote_req } => write!(f, "SendVote: {}", vote_req),

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -51,7 +51,10 @@ where C: RaftTypeConfig
             self.vote,
             self.prev_log_id.display(),
             self.leader_commit.display(),
-            DisplaySlice::<_>(self.entries.as_slice())
+            DisplaySlice {
+                slice: self.entries.as_slice(),
+                max: 5
+            }
         )
     }
 }


### PR DESCRIPTION

## Changelog

##### refactor: replace const generic with dynamic field in DisplaySlice
Replace const generic parameter MAX with a dynamic `max` field in
`DisplaySlice` to provide runtime flexibility for controlling the number
of displayed elements.

Change `DisplaySlice` from tuple struct to standard struct with named
fields `slice` and `max`. Add `limit()` method to modify `max` value at
runtime. Provide default implementation for `display_n()` trait method
that calls `display().limit(max)`.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1416)
<!-- Reviewable:end -->
