### PR TITLE
change: separate ResponderBuilder trait from Responder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ all: test defensive_test send_delay_test check_all
 
 check_all: lint fmt doc unused_dep typos
 
+basic_check:
+	cargo fmt
+	cargo test --lib
+	cargo test --test '*'
+	cargo clippy --no-deps --all-targets -- -D warnings
+	RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --all --no-deps
+
 defensive_test:
 	OPENRAFT_STORE_DEFENSIVE=on cargo test
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -470,10 +470,10 @@ where
     /// The result of applying it to state machine is sent to `resp_tx`, if it is not `None`.
     /// The calling side may not receive a result from `resp_tx`, if raft is shut down.
     ///
-    /// The responder `R` for `resp_tx` is either [`RaftTypeConfig::Responder`]
-    /// (application-defined) or [`OneshotResponder`] (general-purpose); the former is for
-    /// application-defined entries like user data, the latter is for membership configuration
-    /// changes.
+    /// The responder `resp_tx` is either Responder type of
+    /// [`RaftTypeConfig::ResponderBuilder`] (application-defined) or [`OneshotResponder`]
+    /// (general-purpose); the former is for application-defined entries like user data, the
+    /// latter is for membership configuration changes.
     #[tracing::instrument(level = "debug", skip_all, fields(id = display(&self.id)))]
     pub fn write_entry(&mut self, entry: C::Entry, resp_tx: Option<OneshotOrUserDefined<C>>) {
         tracing::debug!(payload = display(&entry), "write_entry");

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -183,7 +183,7 @@ mod tests {
         type Entry = crate::Entry<Self>;
         type SnapshotData = Cursor<Vec<u8>>;
         type AsyncRuntime = TokioRuntime;
-        type Responder = crate::impls::OneshotResponder<Self>;
+        type ResponderBuilder = crate::impls::OneshotResponder<Self>;
     }
 
     #[tokio::test]

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -85,7 +85,7 @@ impl openraft::RaftTypeConfig for TypeConfig {
     type NodeId       = u64;
     type Node         = openraft::impls::BasicNode;
     type Entry        = openraft::impls::Entry<TypeConfig>;
-    type Responder    = openraft::impls::OneshotResponder<TypeConfig>,
+    type ResponderBuilder = openraft::impls::OneshotResponder<TypeConfig>,
     type AsyncRuntime = openraft::impls::TokioRuntime;
     type SnapshotData = Cursor<Vec<u8>>;
 }
@@ -96,7 +96,7 @@ impl openraft::RaftTypeConfig for TypeConfig {
 > - `Node` is the node type that contains the node's address, etc., which implements [`Node`] trait.
 > - `Entry` is the log entry type that will be stored in the raft log,
 >   which includes the payload and log id, which implements [`RaftEntry`] trait.
-> - `Responder` is the type that will be used to respond to the client, which implements [`Responder`] trait.
+> - `ResponderBuilder` is the type that will be used to create a Responder to send response to the client, which implements [`ResponderBuilder`] trait.
 > - `AsyncRuntime` is the async runtime that will be used to run the raft instance, which implements [`AsyncRuntime`] trait.
 > - `SnapshotData` is the type that will be used to store the snapshot data.
 
@@ -416,7 +416,7 @@ Additionally, two test scripts for setting up a cluster are available:
 [`RaftEntry`]:                          `crate::entry::RaftEntry`
 [`Node`]:                               `crate::node::Node`
 [`NodeId`]:                             `crate::node::NodeId`
-[`Responder`]:                          `crate::raft::responder::Responder`
+[`ResponderBuilder`]:                   `crate::raft::responder::ResponderBuilder`
 
 [`TokioRuntime`]:                       `crate::impls::TokioRuntime`
 [`OneshotResponder`]:                   `crate::impls::OneshotResponder`

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -39,6 +39,7 @@ use crate::raft::AppendEntriesResponse;
 use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
+use crate::raft::message::ClientWriteResult;
 use crate::raft::responder::Responder;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
@@ -250,14 +251,15 @@ where C: RaftTypeConfig
     ///
     /// If `tx` is None, no response will be sent.
     ///
-    /// The `tx` is a [`Responder`] instance, but it does not have to be the [`C::Responder`].
-    /// The generic `R` allows any responder type to be used, while [`C::Responder`] is specifically
-    /// designed for client write operations.
+    /// The `tx` is a [`Responder`] instance, but it does not have to be the built responder from
+    /// [`C::ResponderBuilder`]. The generic `R` allows any responder type to be used, while the
+    /// responder built from [`C::ResponderBuilder`] is specifically designed for client write
+    /// operations.
     ///
-    /// [`C::Responder`]: RaftTypeConfig::Responder
+    /// [`C::ResponderBuilder`]: RaftTypeConfig::ResponderBuilder
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn get_leader_handler_or_reject<R>(&mut self, tx: Option<R>) -> Option<(LeaderHandler<C>, Option<R>)>
-    where R: Responder<C> {
+    where R: Responder<ClientWriteResult<C>> {
         let res = self.leader_handler();
         let forward_err = match res {
             Ok(lh) => {

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -45,7 +45,7 @@ where N: Node + Ord
     type Entry = crate::impls::Entry<Self>;
     type SnapshotData = Cursor<Vec<u8>>;
     type AsyncRuntime = TokioRuntime;
-    type Responder = crate::impls::OneshotResponder<Self>;
+    type ResponderBuilder = crate::impls::OneshotResponder<Self>;
 }
 
 /// Builds a log id, for testing purposes.

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -14,9 +14,9 @@ use crate::raft::ClientWriteResponse;
 use crate::raft::ClientWriteResult;
 use crate::raft::linearizable_read::Linearizer;
 use crate::raft::raft_inner::RaftInner;
-use crate::raft::responder::Responder;
+use crate::raft::responder::ResponderBuilder;
 use crate::type_config::TypeConfigExt;
-use crate::type_config::alias::ResponderOf;
+use crate::type_config::alias::ResponderBuilderOf;
 use crate::type_config::alias::ResponderReceiverOf;
 
 /// Provides application-facing APIs for interacting with the Raft system.
@@ -68,7 +68,7 @@ where C: RaftTypeConfig
     #[since(version = "0.10.0")]
     #[tracing::instrument(level = "debug", skip(self, app_data))]
     pub(crate) async fn client_write_ff(&self, app_data: C::D) -> Result<ResponderReceiverOf<C>, Fatal<C>> {
-        let (app_data, tx, rx) = ResponderOf::<C>::from_app_data(app_data);
+        let (tx, rx) = ResponderBuilderOf::<C>::build(&app_data);
 
         self.inner.send_msg(RaftMsg::ClientWriteRequest { app_data, tx }).await?;
 

--- a/openraft/src/raft/declare_raft_types_test.rs
+++ b/openraft/src/raft/declare_raft_types_test.rs
@@ -23,7 +23,7 @@ declare_raft_types!(
         Vote = crate::impls::Vote<Self>,
         SnapshotData = Cursor<Vec<u8>>,
         AsyncRuntime = TokioRuntime,
-        Responder = crate::impls::OneshotResponder<Self>,
+        ResponderBuilder = crate::impls::OneshotResponder<Self>,
 );
 
 declare_raft_types!(

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -1,6 +1,6 @@
 //! Implement blocking-mode write operations for Raft.
 //! Blocking-mode write API blocks until the write operation is completed,
-//! where [`RaftTypeConfig::Responder`] is a [`OneshotResponder`].
+//! where [`RaftTypeConfig::ResponderBuilder`] is a [`OneshotResponder`].
 
 use crate::ChangeMembers;
 use crate::Raft;

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -119,11 +119,11 @@ use crate::vote::raft_vote::RaftVoteExt;
 ///        Node         = openraft::BasicNode,
 ///        Term         = u64,
 ///        LeaderId     = openraft::impls::leader_id_adv::LeaderId<Self>,
-///        Vote         = openraft::impls::Vote<Self>,
-///        Entry        = openraft::Entry<Self>,
-///        SnapshotData = Cursor<Vec<u8>>,
-///        Responder    = openraft::impls::OneshotResponder<Self>,
-///        AsyncRuntime = openraft::TokioRuntime,
+///        Vote           = openraft::impls::Vote<Self>,
+///        Entry          = openraft::Entry<Self>,
+///        SnapshotData   = Cursor<Vec<u8>>,
+///        ResponderBuilder = openraft::impls::OneshotResponder<Self>,
+///        AsyncRuntime   = openraft::TokioRuntime,
 /// );
 /// ```
 ///
@@ -134,11 +134,11 @@ use crate::vote::raft_vote::RaftVoteExt;
 /// - `Node`:         `::openraft::impls::BasicNode`
 /// - `Term`:         `u64`
 /// - `LeaderId`:     `::openraft::impls::leader_id_adv::LeaderId<Self>`
-/// - `Vote`:         `::openraft::impls::Vote<Self>`
-/// - `Entry`:        `::openraft::impls::Entry<Self>`
-/// - `SnapshotData`: `Cursor<Vec<u8>>`
-/// - `Responder`:    `::openraft::impls::OneshotResponder<Self>`
-/// - `AsyncRuntime`: `::openraft::impls::TokioRuntime`
+/// - `Vote`:           `::openraft::impls::Vote<Self>`
+/// - `Entry`:          `::openraft::impls::Entry<Self>`
+/// - `SnapshotData`:   `Cursor<Vec<u8>>`
+/// - `ResponderBuilder`: `::openraft::impls::OneshotResponder<Self>`
+/// - `AsyncRuntime`:   `::openraft::impls::TokioRuntime`
 ///
 /// For example, to declare with only `D` and `R` types:
 /// ```ignore
@@ -183,11 +183,11 @@ macro_rules! declare_raft_types {
                 (Node         , , $crate::impls::BasicNode                     ),
                 (Term         , , u64                                          ),
                 (LeaderId     , , $crate::impls::leader_id_adv::LeaderId<Self> ),
-                (Vote         , , $crate::impls::Vote<Self>                    ),
-                (Entry        , , $crate::impls::Entry<Self>                   ),
-                (SnapshotData , , std::io::Cursor<Vec<u8>>                     ),
-                (Responder    , , $crate::impls::OneshotResponder<Self>        ),
-                (AsyncRuntime , , $crate::impls::TokioRuntime                  ),
+                (Vote           , , $crate::impls::Vote<Self>                    ),
+                (Entry          , , $crate::impls::Entry<Self>                   ),
+                (SnapshotData   , , std::io::Cursor<Vec<u8>>                     ),
+                (ResponderBuilder , , $crate::impls::OneshotResponder<Self>        ),
+                (AsyncRuntime   , , $crate::impls::TokioRuntime                  ),
             );
 
         }

--- a/openraft/src/raft/responder/builder.rs
+++ b/openraft/src/raft/responder/builder.rs
@@ -1,0 +1,34 @@
+//! Builder trait for creating Responders.
+
+use crate::OptionalSend;
+use crate::raft::responder::Responder;
+
+/// A trait for building [`Responder`] instances from source data.
+///
+/// This trait separates the construction logic from the behavior of a responder.
+/// Different implementations can build responders from different sources:
+/// - `()` for responders that need no context
+/// - Application data for responders that need request context
+/// - Custom types for responders that need other context
+///
+/// # Type Parameters
+///
+/// - `T`: The type of data needed to build the responder
+/// - `R`: The type of result that the responder will send
+///
+/// [`Responder`]: crate::raft::responder::Responder
+pub trait ResponderBuilder<T, R = ()>: OptionalSend {
+    /// The type of responder this builder creates.
+    type Responder: Responder<R> + OptionalSend;
+
+    /// An optional receiver to receive the result sent by `RaftCore`.
+    ///
+    /// If the application does not need to wait for the response, it can be `()`.
+    type Receiver;
+
+    /// Build a new responder and its receiver from the source data.
+    ///
+    /// Returns a tuple of (responder, receiver) where the responder will be sent to
+    /// RaftCore and the receiver can be used to wait for the response.
+    fn build(src: &T) -> (Self::Responder, Self::Receiver);
+}

--- a/openraft/src/raft/responder/either.rs
+++ b/openraft/src/raft/responder/either.rs
@@ -2,6 +2,7 @@ use crate::RaftTypeConfig;
 use crate::impls::OneshotResponder;
 use crate::raft::ClientWriteResult;
 use crate::raft::responder::Responder;
+use crate::type_config::alias::ResponderOf;
 
 /// Either an oneshot responder or a user-defined responder.
 ///
@@ -10,10 +11,10 @@ pub(crate) enum OneshotOrUserDefined<C>
 where C: RaftTypeConfig
 {
     Oneshot(OneshotResponder<C>),
-    UserDefined(C::Responder),
+    UserDefined(ResponderOf<C>),
 }
 
-impl<C> Responder<C> for OneshotOrUserDefined<C>
+impl<C> Responder<ClientWriteResult<C>> for OneshotOrUserDefined<C>
 where C: RaftTypeConfig
 {
     fn send(self, res: ClientWriteResult<C>) {
@@ -21,12 +22,5 @@ where C: RaftTypeConfig
             Self::Oneshot(responder) => responder.send(res),
             Self::UserDefined(responder) => responder.send(res),
         }
-    }
-
-    type Receiver = ();
-
-    fn from_app_data(_app_data: <C as RaftTypeConfig>::D) -> (<C as RaftTypeConfig>::D, Self, Self::Receiver)
-    where Self: Sized {
-        unimplemented!("OneshotOrUserDefined is just a wrapper and does not support building from app_data")
     }
 }

--- a/openraft/src/raft/responder/mod.rs
+++ b/openraft/src/raft/responder/mod.rs
@@ -1,40 +1,30 @@
 //! API to consumer a response when a client write request is completed.
 
+pub(crate) mod builder;
 pub(crate) mod either;
 pub(crate) mod impls;
+pub use builder::ResponderBuilder;
 pub use impls::OneshotResponder;
 
 use crate::OptionalSend;
-use crate::RaftTypeConfig;
-use crate::raft::message::ClientWriteResult;
 
-/// A trait that lets `RaftCore` send the response or an error of a client write request back to the
-/// client or to somewhere else.
+/// A trait that lets `RaftCore` send a result back to the client or to somewhere else.
 ///
-/// It is created for each request [`AppData`] and is sent to `RaftCore`.
-/// Once the request is completed,
-/// the `RaftCore` sends the result [`ClientWriteResult`] via it.
+/// This is a generic abstraction for sending results of any type `T`.
+/// It is created for each request and is sent to `RaftCore`.
+/// Once the request is completed, the `RaftCore` sends the result via it.
 /// The implementation of the trait then forwards the response to the application.
-/// There could optionally be a receiver to wait for the response.
 ///
-/// Usually an implementation of [`Responder`] is a oneshot channel Sender,
-/// and [`Responder::Receiver`] is a oneshot channel Receiver.
+/// Usually an implementation of [`Responder`] is a oneshot channel Sender.
 ///
-/// [`AppData`]: `crate::AppData`
-pub trait Responder<C>: OptionalSend + 'static
-where C: RaftTypeConfig
-{
-    /// An optional receiver to receive the result sent by `RaftCore`.
-    ///
-    /// If the application does not need to wait for the response, it can be `()`.
-    type Receiver;
-
-    /// Build a new instance from the application request.
-    fn from_app_data(app_data: C::D) -> (C::D, Self, Self::Receiver)
-    where Self: Sized;
-
+/// See [`ResponderBuilder`] for constructing responders and their receivers.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of value to send through this responder
+pub trait Responder<T>: OptionalSend + 'static {
     /// Send result when the request has been completed.
     ///
-    /// This method is called by the `RaftCore` once the request has been applied to state machine.
-    fn send(self, result: ClientWriteResult<C>);
+    /// This method is called by the `RaftCore` once the request has been processed.
+    fn send(self, result: T);
 }


### PR DESCRIPTION
## Changelog

##### change: separate ResponderBuilder trait from Responder
Extract construction logic from the Responder trait into a new
ResponderBuilder trait, and rename the associated type from
`RaftTypeConfig::Responder` to `RaftTypeConfig::ResponderBuilder`
to improve clarity and separation of concerns.

The Responder trait previously mixed two responsibilities: building
responder instances from application data and sending results back to
clients. This refactoring splits these concerns into two focused traits:

- `Responder<T>`: Generic behavior trait for sending results of type T.
  The trait is now generic over the result type rather than being tied
  to RaftTypeConfig, making it reusable for different result types.

- `ResponderBuilder<T, R>`: Construction trait for building responders
  from source data of type T that will send results of type R. The
  builder creates both the responder and an optional receiver.

Renaming `RaftTypeConfig::Responder` to `ResponderBuilder` clarifies
that this associated type is specifically a builder for write operation
responders, avoiding naming confusion with the ResponderBuilder trait
itself.

Type aliases updated accordingly:
- `ResponderReceiverOf<C>` renamed to `ResponderReceiverOf<C>`
- New alias `ResponderBuilderOf<C>` added for the builder type
- New alias `ResponderOf<C>` added for the built responder type

Upgrade tip:

Replace `RaftTypeConfig::Responder` with `RaftTypeConfig::ResponderBuilder`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1421)
<!-- Reviewable:end -->
