### PR TITLE
refactor: example/rocksstore: improve error handling and async operations

### DIFF
--- a/examples/rocksstore/src/log_store.rs
+++ b/examples/rocksstore/src/log_store.rs
@@ -169,7 +169,6 @@ where C: RaftTypeConfig<AsyncRuntime = TokioRuntime>
     where I: IntoIterator<Item = EntryOf<C>> + Send {
         for entry in entries {
             let id = id_to_bin(entry.index());
-            assert_eq!(bin_to_id(&id), entry.index());
             self.db
                 .put_cf(
                     self.cf_logs(),
@@ -198,7 +197,7 @@ where C: RaftTypeConfig<AsyncRuntime = TokioRuntime>
         tracing::debug!("truncate: [{:?}, +oo)", log_id);
 
         let from = id_to_bin(log_id.index());
-        let to = id_to_bin(0xff_ff_ff_ff_ff_ff_ff_ff);
+        let to = id_to_bin(u64::MAX);
         self.db.delete_range_cf(self.cf_logs(), &from, &to).map_err(|e| StorageError::write_logs(&e))?;
 
         // Truncating does not need to be persisted.

--- a/examples/rocksstore/src/test.rs
+++ b/examples/rocksstore/src/test.rs
@@ -11,8 +11,8 @@ struct RocksBuilder {}
 
 impl StoreBuilder<TypeConfig, RocksLogStore<TypeConfig>, RocksStateMachine, TempDir> for RocksBuilder {
     async fn build(&self) -> Result<(TempDir, RocksLogStore<TypeConfig>, RocksStateMachine), StorageError<TypeConfig>> {
-        let td = TempDir::new().expect("couldn't create temp dir");
-        let (log_store, sm) = crate::new(td.path()).await;
+        let td = TempDir::new().map_err(|e| StorageError::read(&e))?;
+        let (log_store, sm) = crate::new(td.path()).await.map_err(|e| StorageError::read(&e))?;
         Ok((td, log_store, sm))
     }
 }


### PR DESCRIPTION

## Changelog

##### refactor: example/rocksstore: improve error handling and async operations
Replace `unwrap()` calls with proper error handling throughout the
rocksstore implementation. The public `new()` function now returns
`Result<_, io::Error>` instead of panicking, making it easier for
applications to handle initialization failures gracefully.

Replace `spawn()` with `spawn_blocking()` for WAL flush operations in
state machine snapshot installation. This ensures blocking I/O runs on
the blocking thread pool instead of the async executor.

Remove unnecessary `data.clone()` calls when constructing snapshots
to avoid redundant allocations. Use `u64::MAX` constant instead of
hex literal for better readability. Remove redundant assertion in
`append()` method.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1424)
<!-- Reviewable:end -->
