### PR TITLE
improve: implement non-blocking Respond queue

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -659,15 +659,25 @@ where
         let res = self.engine.initialize(entry);
 
         // If there is an error, respond at once.
-        // Otherwise, wait until the membership config log at index 0 to be flushed to disk.
+        // Otherwise, wait for the initialization log to be applied to state machine.
         let condition = if res.is_err() {
             None
         } else {
-            // There is no Leader yet therefore use [`Condition::LogFlushed`] instead of
-            // [`Condition::IOFlushed`].
-            Some(Condition::LogFlushed {
-                log_id: self.engine.state.last_log_id().cloned(),
-            })
+            // Wait for the initialization log to be flushed, not applied.
+            //
+            // Because committing a log entry requires a leader, the first leader may or may not be able to
+            // established, for example, there are already other nodes in the cluster with more logs.
+            //
+            // Thus, initialization should never wait for to apply of the initialization log.
+            //
+            // When adding new learners after initialization, we should not wait for the log to be applied.
+            // But this introduces an issue, if the client send a change membership at once after
+            // initialization, it may receive a InProgress error:
+            // `"InProgress": { "committed": null, "membership_log_id": { "leader_id": { "term": 0,
+            //             "node_id": 0 }, "index": 0 } }`
+            // TODO: change-membership should check leadership or wait for leader to establish?
+            let last_log_id = self.engine.state.last_log_id().cloned();
+            last_log_id.map(|log_id| Condition::LogFlushed { log_id })
         };
         self.engine.output.push_command(Command::Respond {
             when: condition,
@@ -862,29 +872,66 @@ where
             tracing::debug!("queued commands: end...");
         }
 
+        self.send_satisfied_responds();
+
         while let Some(cmd) = self.engine.output.pop_command() {
             let res = self.run_command(cmd).await?;
 
-            if let Some(cmd) = res {
-                tracing::debug!(
-                    "RAFT_stats id={:<2}    cmd: postpone command: {}, pending: {}",
-                    self.id,
-                    cmd,
-                    self.engine.output.len()
-                );
-                self.engine.output.postpone_command(cmd);
+            let Some(cmd) = res else {
+                // cmd executed. Process next
+                continue;
+            };
 
-                if tracing::enabled!(Level::DEBUG) {
-                    for c in self.engine.output.iter_commands().take(8) {
-                        tracing::debug!("postponed, first 8 queued commands: {:?}", c);
-                    }
-                }
+            // cmd is returned, means it can not be executed now, postpone it.
 
-                return Ok(());
+            tracing::debug!(
+                "RAFT_stats id={:<2}    cmd: postpone command: {}, pending: {}",
+                self.id,
+                cmd,
+                self.engine.output.len()
+            );
+
+            if self.engine.output.postpone_command(cmd).is_ok() {
+                continue;
             }
+
+            // cmd is put back to the front of the queue. quit the loop
+
+            if tracing::enabled!(Level::DEBUG) {
+                for c in self.engine.output.iter_commands().take(8) {
+                    tracing::debug!("postponed, first 8 queued commands: {:?}", c);
+                }
+            }
+            return Ok(());
         }
 
         Ok(())
+    }
+
+    /// Send responds whose waiting conditions are satisfied.
+    ///
+    /// Responds are queued when their waiting conditions (log flushed, applied, snapshot built)
+    /// are not yet met. This method drains all responds whose conditions are now satisfied.
+    pub(crate) fn send_satisfied_responds(&mut self) {
+        let io_state = self.engine.state.io_state();
+
+        tracing::debug!(
+            "RAFT_stats id={:<2}    cmd: send satisfied responds: log_io: {}, apply: {}, snapshot: {}",
+            self.id,
+            io_state.log_progress.flushed().display(),
+            io_state.apply_progress.flushed().display(),
+            io_state.snapshot.flushed().display(),
+        );
+
+        for (phase, respond) in self.engine.output.pending_responds.drain_satisfied(io_state) {
+            tracing::debug!(
+                "RAFT_stats id={:<2}    cmd: send respond waiting for {}: {}",
+                self.id,
+                phase,
+                respond
+            );
+            respond.send();
+        }
     }
 
     /// Run an event handling loop
@@ -1648,52 +1695,11 @@ where
         tracing::debug!("condition: {:?}", condition);
 
         if let Some(condition) = condition {
-            match condition {
-                Condition::IOFlushed { io_id } => {
-                    let curr = self.engine.state.log_progress().flushed();
-                    if curr < Some(&io_id) {
-                        tracing::debug!(
-                            "io_id: {} has not yet flushed, currently flushed: {} postpone cmd: {}",
-                            io_id,
-                            curr.display(),
-                            cmd
-                        );
-                        return Ok(Some(cmd));
-                    }
-                }
-                Condition::LogFlushed { log_id } => {
-                    let curr = self.engine.state.log_progress().flushed();
-                    let curr = curr.and_then(|x| x.last_log_id());
-                    if curr < log_id.as_ref() {
-                        tracing::debug!(
-                            "log_id: {} has not yet flushed, currently flushed: {} postpone cmd: {}",
-                            log_id.display(),
-                            curr.display(),
-                            cmd
-                        );
-                        return Ok(Some(cmd));
-                    }
-                }
-                Condition::Applied { log_id } => {
-                    if self.engine.state.io_applied() < log_id.as_ref() {
-                        tracing::debug!(
-                            "log_id: {} has not yet applied, postpone cmd: {}",
-                            log_id.display(),
-                            cmd
-                        );
-                        return Ok(Some(cmd));
-                    }
-                }
-                Condition::Snapshot { log_id } => {
-                    if self.engine.state.io_state().snapshot() < log_id.as_ref() {
-                        tracing::debug!(
-                            "log_id: {} has not yet been in snapshot, postpone cmd: {}",
-                            log_id.display(),
-                            cmd
-                        );
-                        return Ok(Some(cmd));
-                    }
-                }
+            if condition.is_met(&self.engine.state.io_state) {
+                // continue run the command
+            } else {
+                tracing::debug!("{} is not yet met, postpone cmd: {}", condition, cmd);
+                return Ok(Some(cmd));
             }
         }
 

--- a/openraft/src/engine/command_kind.rs
+++ b/openraft/src/engine/command_kind.rs
@@ -11,6 +11,8 @@ pub(crate) enum CommandKind {
     Network,
     /// State machine IO command
     StateMachine,
-    /// RaftCore main thread command
+    /// Command handled by RaftCore main thread.
     Main,
+    /// Respond to caller. Can be executed in parallel with other commands.
+    Respond,
 }

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -134,7 +134,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         Some(Condition::Snapshot {
-            log_id: Some(log_id(4, 1, 6))
+            log_id: log_id(4, 1, 6)
         }),
         cond
     );
@@ -219,7 +219,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
 
     assert_eq!(
         Some(Condition::Snapshot {
-            log_id: Some(log_id(5, 1, 6))
+            log_id: log_id(5, 1, 6)
         }),
         cond
     );
@@ -277,7 +277,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
 
     assert_eq!(
         Some(Condition::Snapshot {
-            log_id: Some(log_id(100, 1, 100))
+            log_id: log_id(100, 1, 100)
         }),
         cond
     );
@@ -339,7 +339,7 @@ fn test_install_snapshot_update_accepted() -> anyhow::Result<()> {
 
     assert_eq!(
         Some(Condition::Snapshot {
-            log_id: Some(log_id(100, 1, 100))
+            log_id: log_id(100, 1, 100)
         }),
         cond
     );

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -325,7 +325,7 @@ where C: RaftTypeConfig
         self.log_handler().purge_log();
 
         Some(Condition::Snapshot {
-            log_id: Some(snap_last_log_id),
+            log_id: snap_last_log_id,
         })
     }
 

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -32,11 +32,13 @@ mod engine_config;
 mod engine_impl;
 mod engine_output;
 mod replication_progress;
+mod respond_command;
 
 pub(crate) mod command;
 pub(crate) mod handler;
 pub(crate) mod leader_log_ids;
 pub(crate) mod log_id_list;
+pub(crate) mod pending_responds;
 pub(crate) mod time_state;
 
 #[cfg(test)]

--- a/openraft/src/engine/pending_responds.rs
+++ b/openraft/src/engine/pending_responds.rs
@@ -1,0 +1,380 @@
+use std::collections::VecDeque;
+use std::fmt;
+
+use crate::LogId;
+use crate::RaftTypeConfig;
+use crate::engine::Respond;
+use crate::engine::respond_command::PendingRespond;
+use crate::raft_state::IOId;
+use crate::raft_state::io_state::IOState;
+
+/// Queues of pending responds waiting for IO conditions to be satisfied.
+#[derive(Debug, Default)]
+pub(crate) struct PendingResponds<C>
+where C: RaftTypeConfig
+{
+    /// Responds waiting for log IO to be flushed to storage.
+    pub(crate) on_log_io: VecDeque<PendingRespond<C, IOId<C>>>,
+
+    /// Responds waiting for log entries to be flushed to storage.
+    pub(crate) on_log_flush: VecDeque<PendingRespond<C, LogId<C>>>,
+
+    /// Responds waiting for log entries to be applied to state machine.
+    pub(crate) on_apply: VecDeque<PendingRespond<C, LogId<C>>>,
+
+    /// Responds waiting for snapshot to be built.
+    pub(crate) on_snapshot: VecDeque<PendingRespond<C, LogId<C>>>,
+}
+
+impl<C> PendingResponds<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            on_log_io: VecDeque::with_capacity(capacity),
+            on_log_flush: VecDeque::with_capacity(capacity),
+            on_apply: VecDeque::with_capacity(capacity),
+            on_snapshot: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    /// Drain all satisfied responds based on the current IO state.
+    ///
+    /// Returns an iterator that yields all responds whose conditions are met by the provided
+    /// IO state. The responds are removed from their respective queues as they are yielded.
+    pub(crate) fn drain_satisfied<'a>(&'a mut self, io_state: &'a IOState<C>) -> DrainSatisfied<'a, C> {
+        DrainSatisfied {
+            pending_responds: self,
+            io_state,
+            phase: DrainPhase::LogIO,
+        }
+    }
+}
+
+/// Pop the first respond from the queue if the actual value satisfies the pending condition.
+pub(crate) fn pop_if_satisfied<C, V>(queue: &mut VecDeque<PendingRespond<C, V>>, actual: &V) -> Option<Respond<C>>
+where
+    C: RaftTypeConfig,
+    V: PartialOrd,
+{
+    let front_item = queue.front()?;
+
+    if actual >= front_item.wait_for() {
+        return queue.pop_front().map(|p| p.into_respond());
+    }
+    None
+}
+
+/// Iterator that drains satisfied responds from pending queues.
+///
+/// Iterates through all phases (LogIO, LogFlush, Apply, Snapshot) and yields responds
+/// whose waiting conditions are satisfied by the current IO state.
+pub(crate) struct DrainSatisfied<'a, C>
+where C: RaftTypeConfig
+{
+    pending_responds: &'a mut PendingResponds<C>,
+    io_state: &'a IOState<C>,
+    phase: DrainPhase,
+}
+
+/// Phases for draining satisfied responds from pending queues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DrainPhase {
+    /// Draining responds waiting for log IO to be flushed.
+    LogIO,
+    /// Draining responds waiting for log entries to be flushed.
+    LogFlush,
+    /// Draining responds waiting for log entries to be applied.
+    Apply,
+    /// Draining responds waiting for snapshot to be built.
+    Snapshot,
+    /// All phases completed.
+    Done,
+}
+
+impl fmt::Display for DrainPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DrainPhase::LogIO => write!(f, "log_io"),
+            DrainPhase::LogFlush => write!(f, "log_flush"),
+            DrainPhase::Apply => write!(f, "apply"),
+            DrainPhase::Snapshot => write!(f, "snapshot"),
+            DrainPhase::Done => write!(f, "done"),
+        }
+    }
+}
+
+impl<'a, C> Iterator for DrainSatisfied<'a, C>
+where C: RaftTypeConfig
+{
+    type Item = (DrainPhase, Respond<C>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.phase {
+                DrainPhase::LogIO => {
+                    if let Some(flushed) = self.io_state.log_progress.flushed() {
+                        if let Some(respond) = pop_if_satisfied(&mut self.pending_responds.on_log_io, flushed) {
+                            return Some((self.phase, respond));
+                        }
+                    }
+                    self.phase = DrainPhase::LogFlush;
+                }
+                DrainPhase::LogFlush => {
+                    if let Some(flushed) = self.io_state.log_progress.flushed() {
+                        if let Some(log_id) = flushed.last_log_id() {
+                            if let Some(respond) = pop_if_satisfied(&mut self.pending_responds.on_log_flush, log_id) {
+                                return Some((self.phase, respond));
+                            }
+                        }
+                    }
+                    self.phase = DrainPhase::Apply;
+                }
+                DrainPhase::Apply => {
+                    if let Some(applied) = self.io_state.apply_progress.flushed() {
+                        if let Some(respond) = pop_if_satisfied(&mut self.pending_responds.on_apply, applied) {
+                            return Some((self.phase, respond));
+                        }
+                    }
+                    self.phase = DrainPhase::Snapshot;
+                }
+                DrainPhase::Snapshot => {
+                    if let Some(snapshot) = self.io_state.snapshot.flushed() {
+                        if let Some(respond) = pop_if_satisfied(&mut self.pending_responds.on_snapshot, snapshot) {
+                            return Some((self.phase, respond));
+                        }
+                    }
+                    self.phase = DrainPhase::Done;
+                }
+                DrainPhase::Done => {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use validit::Valid;
+
+    use super::*;
+    use crate::AsyncRuntime;
+    use crate::LogId;
+    use crate::Vote;
+    use crate::engine::Respond;
+    use crate::engine::respond_command::PendingRespond;
+    use crate::engine::testing::UTConfig;
+    use crate::engine::testing::log_id;
+    use crate::impls::TokioRuntime;
+    use crate::raft::VoteResponse;
+    use crate::raft_state::IOId;
+    use crate::raft_state::io_state::IOState;
+    use crate::raft_state::io_state::io_progress::IOProgress;
+    use crate::type_config::async_runtime::oneshot::Oneshot;
+
+    type TestIOId = IOId<UTConfig>;
+    type TestLogId = LogId<UTConfig>;
+
+    fn new_respond() -> Respond<UTConfig> {
+        let (tx, _rx) = <TokioRuntime as AsyncRuntime>::Oneshot::channel();
+        Respond::new(VoteResponse::new(Vote::new(1, 1), None, false), tx)
+    }
+
+    fn new_io_state(
+        log_io: Option<TestIOId>,
+        applied: Option<TestLogId>,
+        snapshot: Option<TestLogId>,
+    ) -> IOState<UTConfig> {
+        let vote = Vote::new(1, 1);
+        let mut io_state = IOState::new(&vote, applied, snapshot, None, false);
+        if let Some(id) = log_io {
+            io_state.log_progress = Valid::new(IOProgress::new_synchronized(Some(id), "log", false));
+        }
+        io_state
+    }
+
+    #[test]
+    fn test_pop_if_satisfied() {
+        let mut queue = VecDeque::new();
+        queue.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+        queue.push_back(PendingRespond::new(log_id(1, 1, 5), new_respond()));
+
+        assert!(pop_if_satisfied(&mut queue, &log_id(1, 1, 2)).is_none());
+        assert_eq!(queue.len(), 2);
+
+        assert!(pop_if_satisfied(&mut queue, &log_id(1, 1, 3)).is_some());
+        assert_eq!(queue.len(), 1);
+
+        assert!(pop_if_satisfied(&mut queue, &log_id(1, 1, 10)).is_some());
+        assert_eq!(queue.len(), 0);
+
+        assert!(pop_if_satisfied(&mut queue, &log_id(1, 1, 10)).is_none());
+    }
+
+    #[test]
+    fn test_drain_satisfied_empty_queues() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        let io_state = new_io_state(None, None, None);
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 0);
+    }
+
+    #[test]
+    fn test_drain_satisfied_all_unsatisfied() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 5), new_respond()));
+        pending.on_apply.push_back(PendingRespond::new(log_id(1, 1, 5), new_respond()));
+
+        let io_state = new_io_state(None, None, None);
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 0);
+        assert_eq!(pending.on_log_flush.len(), 1);
+        assert_eq!(pending.on_apply.len(), 1);
+    }
+
+    #[test]
+    fn test_drain_satisfied_log_io() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        let io_id = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 3)));
+        pending.on_log_io.push_back(PendingRespond::new(io_id, new_respond()));
+
+        let flushed_io_id = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 5)));
+        let io_state = new_io_state(Some(flushed_io_id), None, None);
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].0, DrainPhase::LogIO);
+        assert_eq!(pending.on_log_io.len(), 0);
+    }
+
+    #[test]
+    fn test_drain_satisfied_log_flush() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+
+        let flushed_io_id = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 5)));
+        let io_state = new_io_state(Some(flushed_io_id), None, None);
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].0, DrainPhase::LogFlush);
+        assert_eq!(pending.on_log_flush.len(), 0);
+    }
+
+    #[test]
+    fn test_drain_satisfied_apply() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        pending.on_apply.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+
+        let io_state = new_io_state(None, Some(log_id(1, 1, 5)), None);
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].0, DrainPhase::Apply);
+        assert_eq!(pending.on_apply.len(), 0);
+    }
+
+    #[test]
+    fn test_drain_satisfied_snapshot() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        pending.on_snapshot.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+
+        let io_state = new_io_state(None, None, Some(log_id(1, 1, 5)));
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].0, DrainPhase::Snapshot);
+        assert_eq!(pending.on_snapshot.len(), 0);
+    }
+
+    #[test]
+    fn test_drain_satisfied_multiple_phases() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        let io_id = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 3)));
+        pending.on_log_io.push_back(PendingRespond::new(io_id, new_respond()));
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+        pending.on_apply.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+        pending.on_snapshot.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+
+        let flushed_io_id = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 5)));
+        let io_state = new_io_state(Some(flushed_io_id), Some(log_id(1, 1, 5)), Some(log_id(1, 1, 5)));
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 4);
+        assert_eq!(collected[0].0, DrainPhase::LogIO);
+        assert_eq!(collected[1].0, DrainPhase::LogFlush);
+        assert_eq!(collected[2].0, DrainPhase::Apply);
+        assert_eq!(collected[3].0, DrainPhase::Snapshot);
+    }
+
+    #[test]
+    fn test_drain_satisfied_partial_satisfaction() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 5), new_respond()));
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 7), new_respond()));
+
+        let flushed_io_id = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 5)));
+        let io_state = new_io_state(Some(flushed_io_id), None, None);
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 2);
+        assert_eq!(pending.on_log_flush.len(), 1);
+    }
+
+    #[test]
+    fn test_drain_satisfied_multiple_items_per_phase() {
+        let mut pending = PendingResponds::<UTConfig>::new(10);
+
+        let io_id1 = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 2)));
+        let io_id2 = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 3)));
+        let io_id3 = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 7)));
+        pending.on_log_io.push_back(PendingRespond::new(io_id1, new_respond()));
+        pending.on_log_io.push_back(PendingRespond::new(io_id2, new_respond()));
+        pending.on_log_io.push_back(PendingRespond::new(io_id3, new_respond()));
+
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 2), new_respond()));
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 4), new_respond()));
+        pending.on_log_flush.push_back(PendingRespond::new(log_id(1, 1, 8), new_respond()));
+
+        pending.on_apply.push_back(PendingRespond::new(log_id(1, 1, 2), new_respond()));
+        pending.on_apply.push_back(PendingRespond::new(log_id(1, 1, 4), new_respond()));
+        pending.on_apply.push_back(PendingRespond::new(log_id(1, 1, 9), new_respond()));
+
+        pending.on_snapshot.push_back(PendingRespond::new(log_id(1, 1, 3), new_respond()));
+        pending.on_snapshot.push_back(PendingRespond::new(log_id(1, 1, 10), new_respond()));
+
+        let flushed_io_id = TestIOId::new_log_io(Default::default(), Some(log_id(1, 1, 5)));
+        let io_state = new_io_state(Some(flushed_io_id), Some(log_id(1, 1, 5)), Some(log_id(1, 1, 5)));
+
+        let collected: Vec<_> = pending.drain_satisfied(&io_state).collect();
+        assert_eq!(collected.len(), 8);
+
+        assert_eq!(collected[0].0, DrainPhase::LogIO);
+        assert_eq!(collected[1].0, DrainPhase::LogIO);
+        assert_eq!(collected[2].0, DrainPhase::LogFlush);
+        assert_eq!(collected[3].0, DrainPhase::LogFlush);
+        assert_eq!(collected[4].0, DrainPhase::LogFlush);
+        assert_eq!(collected[5].0, DrainPhase::Apply);
+        assert_eq!(collected[6].0, DrainPhase::Apply);
+        assert_eq!(collected[7].0, DrainPhase::Snapshot);
+
+        assert_eq!(pending.on_log_io.len(), 1);
+        assert_eq!(pending.on_log_flush.len(), 1);
+        assert_eq!(pending.on_apply.len(), 1);
+        assert_eq!(pending.on_snapshot.len(), 1);
+    }
+
+    #[test]
+    fn test_drain_phase_display() {
+        assert_eq!(format!("{}", DrainPhase::LogIO), "log_io");
+        assert_eq!(format!("{}", DrainPhase::LogFlush), "log_flush");
+        assert_eq!(format!("{}", DrainPhase::Apply), "apply");
+        assert_eq!(format!("{}", DrainPhase::Snapshot), "snapshot");
+        assert_eq!(format!("{}", DrainPhase::Done), "done");
+    }
+}

--- a/openraft/src/engine/respond_command.rs
+++ b/openraft/src/engine/respond_command.rs
@@ -1,0 +1,30 @@
+use crate::RaftTypeConfig;
+use crate::engine::Respond;
+
+/// A respond waiting for an IO condition to be satisfied.
+///
+/// Stores the expected progress value that must be reached before sending the respond.
+#[derive(Debug)]
+pub(crate) struct PendingRespond<C, V>
+where C: RaftTypeConfig
+{
+    /// The expected progress value that must be reached before sending the respond.
+    wait_for: V,
+    respond: Respond<C>,
+}
+
+impl<C, V> PendingRespond<C, V>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(wait_for: V, respond: Respond<C>) -> Self {
+        Self { wait_for, respond }
+    }
+
+    pub(crate) fn wait_for(&self) -> &V {
+        &self.wait_for
+    }
+
+    pub(crate) fn into_respond(self) -> Respond<C> {
+        self.respond
+    }
+}

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -158,7 +158,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
             Command::PurgeLog { upto: log_id(4, 1, 6) },
             Command::Respond {
                 when: Some(Condition::Snapshot {
-                    log_id: Some(log_id(4, 1, 6))
+                    log_id: log_id(4, 1, 6)
                 }),
                 resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
             },


### PR DESCRIPTION

## Changelog

##### improve: implement non-blocking Respond queue
Introduce a separate queue system for pending responds to prevent
blocking the main command queue. Responds are now queued based on
their waiting conditions (log IO flushed, log applied, snapshot
built) and sent when conditions are satisfied.

Add `PendingResponds` struct with four queues (`on_log_io`,
`on_log_flush`, `on_apply`, `on_snapshot`) to hold responds
waiting for different IO completion events. Implement
`drain_satisfied()` iterator that checks current IO state and
yields responds whose conditions are met.

Add `send_satisfied_responds()` method to `RaftCore` that
periodically checks and sends all satisfied responds. This method
is called in the command processing loop to ensure responds are
sent promptly when conditions become satisfied.

Simplify condition checking by adding `Condition::is_met()` method
that encapsulates the logic for checking if IO state satisfies a
condition. Remove duplicated condition checking code from
`run_command()`.

Change `Condition` enum variants to use non-optional `LogId` values
since conditions always require specific log IDs to wait for.
Update `Condition::Display` to show threshold comparisons using
">=" operator for clarity.

Add `CommandKind::Respond` variant to classify respond commands
separately, enabling parallel execution with other command types.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1427)
<!-- Reviewable:end -->
