### PR TITLE
fix: bug in 0.10.0: remove duplicated SaveCommittedAndApply

### DIFF
--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -7,7 +7,6 @@ use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
 use crate::Vote;
-use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
@@ -76,13 +75,9 @@ fn test_following_handler_commit_entries_ge_accepted() -> anyhow::Result<()> {
         ),
         eng.state.membership_state
     );
-    assert_eq!(
-        vec![Command::SaveCommittedAndApply {
-            already_applied: Some(log_id(1, 1, 1)),
-            upto: log_id(1, 1, 2),
-        }],
-        eng.output.take_commands()
-    );
+    assert_eq!(0, eng.output.take_commands().len());
+    assert_eq!(Some(&log_id(1, 1, 2)), eng.state.io_state.apply_progress.accepted());
+    assert_eq!(None, eng.state.io_state.apply_progress.submitted());
 
     Ok(())
 }
@@ -103,16 +98,9 @@ fn test_following_handler_commit_entries_le_accepted() -> anyhow::Result<()> {
         ),
         eng.state.membership_state
     );
-    assert_eq!(
-        vec![
-            //
-            Command::SaveCommittedAndApply {
-                already_applied: Some(log_id(1, 1, 1)),
-                upto: log_id(2, 1, 3)
-            },
-        ],
-        eng.output.take_commands()
-    );
+    assert_eq!(0, eng.output.take_commands().len());
+    assert_eq!(Some(&log_id(2, 1, 3)), eng.state.io_state.apply_progress.accepted());
+    assert_eq!(None, eng.state.io_state.apply_progress.submitted());
 
     Ok(())
 }

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -172,12 +172,7 @@ where C: RaftTypeConfig
             func_name!()
         );
 
-        if let Some(prev_committed) = self.state.update_committed(&committed) {
-            self.output.push_command(Command::SaveCommittedAndApply {
-                already_applied: prev_committed,
-                upto: committed.unwrap(),
-            });
-        }
+        self.state.update_committed(&committed);
     }
 
     /// Delete log entries since log index `since`, inclusive, when the log at `since` is found


### PR DESCRIPTION

## Changelog

##### fix: bug in 0.10.0: remove duplicated SaveCommittedAndApply
in previous commit 842cd796414eac12965862b657ebfe899db9e933,
FollowerHandler should not build a SaveCommittedAndApply command,
because next_progress_driven_command will generate this command
automatically.

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1431)
<!-- Reviewable:end -->
