### PR TITLE
chore: InstallSnapshot use LogIOId instead of IOId

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1548,15 +1548,15 @@ where
 
                         self.engine.on_building_snapshot_done(meta);
                     }
-                    sm::Response::InstallSnapshot((io_id, meta)) => {
+                    sm::Response::InstallSnapshot((log_io_id, meta)) => {
                         tracing::info!(
-                            "sm::StateMachine command done: InstallSnapshot: {}, io_id: {}: {}",
+                            "sm::StateMachine command done: InstallSnapshot: {}, log_io_id: {}: {}",
                             meta.display(),
-                            io_id,
+                            log_io_id,
                             func_name!()
                         );
 
-                        self.engine.state.log_progress_mut().flush(io_id);
+                        self.engine.state.log_progress_mut().flush(IOId::Log(log_io_id));
 
                         if let Some(meta) = meta {
                             let st = self.engine.state.io_state_mut();

--- a/openraft/src/core/sm/response.rs
+++ b/openraft/src/core/sm/response.rs
@@ -6,7 +6,7 @@ use crate::StorageError;
 use crate::core::ApplyResult;
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::display_result::DisplayResultExt;
-use crate::raft_state::IOId;
+use crate::raft_state::io_state::log_io_id::LogIOId;
 use crate::storage::SnapshotMeta;
 
 /// The Ok part of a state machine command result.
@@ -23,7 +23,7 @@ where C: RaftTypeConfig
     /// When finishing installing a snapshot.
     ///
     /// It does not return any value to RaftCore.
-    InstallSnapshot((IOId<C>, Option<SnapshotMeta<C>>)),
+    InstallSnapshot((LogIOId<C>, Option<SnapshotMeta<C>>)),
 
     /// Send back applied result to RaftCore.
     Apply(ApplyResult<C>),

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -122,7 +122,10 @@ where
                     self.get_snapshot(tx).await?;
                     // GetSnapshot does not respond to RaftCore
                 }
-                Command::InstallFullSnapshot { io_id, snapshot } => {
+                Command::InstallFullSnapshot {
+                    log_io_id: io_id,
+                    snapshot,
+                } => {
                     tracing::info!("{}: install complete snapshot", func_name!());
 
                     let meta = snapshot.meta.clone();

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -17,6 +17,7 @@ use crate::engine::LogIdList;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::raft_state::IOId;
+use crate::raft_state::io_state::log_io_id::LogIOId;
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
 use crate::type_config::TypeConfigExt;
@@ -165,7 +166,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: Cursor::new(vec![0u8]),
                 },
-                IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6))),
+                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6))),
             )),
             Command::PurgeLog { upto: log_id(4, 1, 6) },
         ],
@@ -251,7 +252,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: Cursor::new(vec![0u8]),
                 },
-                IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(5, 1, 6)))
+                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(5, 1, 6)))
             )),
             Command::PurgeLog { upto: log_id(5, 1, 6) },
         ],
@@ -311,7 +312,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
                     },
                     snapshot: Cursor::new(vec![0u8]),
                 },
-                IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(100, 1, 100)))
+                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(100, 1, 100)))
             )),
             Command::PurgeLog {
                 upto: log_id(100, 1, 100)

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -16,7 +16,7 @@ use crate::engine::Respond;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::raft::SnapshotResponse;
-use crate::raft_state::IOId;
+use crate::raft_state::io_state::log_io_id::LogIOId;
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
 use crate::type_config::TypeConfigExt;
@@ -153,7 +153,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: Cursor::new(vec![0u8]),
                 },
-                IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6)))
+                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6)))
             )),
             Command::PurgeLog { upto: log_id(4, 1, 6) },
             Command::Respond {

--- a/openraft/src/raft_state/io_state/log_io_id.rs
+++ b/openraft/src/raft_state/io_state/log_io_id.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::RaftTypeConfig;
 use crate::display_ext::DisplayOptionExt;
+use crate::raft_state::io_state::IOId;
 use crate::type_config::alias::LogIdOf;
 use crate::vote::committed::CommittedVote;
 
@@ -48,5 +49,14 @@ where C: RaftTypeConfig
 {
     pub(crate) fn new(committed_vote: CommittedVote<C>, log_id: Option<LogIdOf<C>>) -> Self {
         Self { committed_vote, log_id }
+    }
+
+    /// Return the last log id included in this io operation.
+    pub(crate) fn last_log_id(&self) -> Option<&LogIdOf<C>> {
+        self.log_id.as_ref()
+    }
+
+    pub(crate) fn to_io_id(&self) -> IOId<C> {
+        IOId::Log(self.clone())
     }
 }


### PR DESCRIPTION

## Changelog

##### chore: InstallSnapshot use LogIOId instead of IOId
IOId includes two kinds of IO: save-vote IO and append-entries io, but
InstallSnapshot does not involve save-vote IO, but just increase the
last-log-id cursor. Therefore we shoulduse `LogIOId` to replace `IOI`
used in InstallSnapshot command and response.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1432)
<!-- Reviewable:end -->
