### PR TITLE
refactor: grpc-example: eliminate code duplication

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/bin/main.rs
+++ b/examples/raft-kv-memstore-grpc/src/bin/main.rs
@@ -1,17 +1,5 @@
-use std::sync::Arc;
-
 use clap::Parser;
-use openraft::Config;
-use raft_kv_memstore_grpc::grpc::app_service::AppServiceImpl;
-use raft_kv_memstore_grpc::grpc::raft_service::RaftServiceImpl;
-use raft_kv_memstore_grpc::network::Network;
-use raft_kv_memstore_grpc::protobuf::app_service_server::AppServiceServer;
-use raft_kv_memstore_grpc::protobuf::raft_service_server::RaftServiceServer;
-use raft_kv_memstore_grpc::typ::Raft;
-use raft_kv_memstore_grpc::LogStore;
-use raft_kv_memstore_grpc::StateMachineStore;
-use tonic::transport::Server;
-use tracing::info;
+use raft_kv_memstore_grpc::app::start_raft_app;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -35,40 +23,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Parse the parameters passed by arguments.
     let options = Opt::parse();
-    let node_id = options.id;
-    let addr = options.addr;
 
-    // Create a configuration for the raft instance.
-    let config = Arc::new(
-        Config {
-            heartbeat_interval: 500,
-            election_timeout_min: 1500,
-            election_timeout_max: 3000,
-            ..Default::default()
-        }
-        .validate()?,
-    );
-
-    // Create stores and network
-    let log_store = LogStore::default();
-    let state_machine_store = Arc::new(StateMachineStore::default());
-    let network = Network {};
-
-    // Create Raft instance
-    let raft = Raft::new(node_id, config.clone(), network, log_store, state_machine_store.clone()).await?;
-
-    // Create the management service with raft instance
-    let internal_service = RaftServiceImpl::new(raft.clone());
-    let api_service = AppServiceImpl::new(raft, state_machine_store);
-
-    // Start server
-    let server_future = Server::builder()
-        .add_service(RaftServiceServer::new(internal_service))
-        .add_service(AppServiceServer::new(api_service))
-        .serve(addr.parse()?);
-
-    info!("Node {node_id} starting server at {addr}");
-    server_future.await?;
-
-    Ok(())
+    start_raft_app(options.id, options.addr).await
 }

--- a/examples/raft-kv-memstore-grpc/src/grpc/app_service.rs
+++ b/examples/raft-kv-memstore-grpc/src/grpc/app_service.rs
@@ -110,16 +110,7 @@ impl AppService for AppServiceImpl {
         let req = request.into_inner();
 
         // Convert nodes into required format
-        let nodes_map: BTreeMap<u64, pb::Node> = req
-            .nodes
-            .into_iter()
-            .map(|node| {
-                (node.node_id, pb::Node {
-                    rpc_addr: node.rpc_addr,
-                    node_id: node.node_id,
-                })
-            })
-            .collect();
+        let nodes_map: BTreeMap<u64, pb::Node> = req.nodes.into_iter().map(|node| (node.node_id, node)).collect();
 
         // Initialize the cluster
         let result = self


### PR DESCRIPTION

## Changelog

##### refactor: grpc-example: eliminate code duplication
Refactor raft-kv-memstore-grpc example to remove duplicate code
and improve maintainability. The main binary contained nearly
identical initialization logic to `app::start_raft_app()`,
and network operations repeated channel creation code three times.

Changes:
- Simplify `bin/main.rs` from 74 lines to 28 lines by delegating
  to `app::start_raft_app()` instead of duplicating initialization
- Extract `NetworkConnection::create_channel()` helper to eliminate
  duplicate channel creation across `append_entries()`, `vote()`,
  and `full_snapshot()` methods
- Extract `NetworkConnection::send_snapshot_chunks()` to separate
  chunking logic from `full_snapshot()` flow control
- Extract `StateMachineStore::generate_snapshot_id()` to isolate
  ID generation logic in `build_snapshot()`
- Simplify node mapping in `app_service::init()` by removing
  redundant field copies from identical structs

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1435)
<!-- Reviewable:end -->
