### PR TITLE
change: Require AppData to impl Debug and Display

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -1,6 +1,7 @@
 mod test;
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::io::Cursor;
 use std::ops::RangeBounds;
@@ -31,6 +32,12 @@ use tokio::sync::RwLock;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ClientRequest {}
+
+impl fmt::Display for ClientRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ClientRequest {{}}")
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ClientResponse {}

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_set_request.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_set_request.rs
@@ -1,0 +1,10 @@
+use std::fmt;
+use std::fmt::Formatter;
+
+use crate::protobuf as pb;
+
+impl fmt::Display for pb::SetRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "SetRequest {{ key: {}, value: {} }}", self.key, self.value)
+    }
+}

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/mod.rs
@@ -7,6 +7,7 @@ mod impl_entry;
 mod impl_leader_id;
 mod impl_log_id;
 mod impl_membership;
+mod impl_set_request;
 mod impl_snapshot_request;
 mod impl_vote;
 mod impl_vote_request;

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -17,6 +18,14 @@ pub type LogStore = mem_log::LogStore<TypeConfig>;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
     Set { key: String, value: String },
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Request::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
 }
 
 impl Request {

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -19,6 +20,14 @@ pub type LogStore = mem_log::LogStore<TypeConfig>;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
     Set { key: String, value: String },
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Request::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
 }
 
 impl Request {

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::io::Cursor;
 use std::marker::PhantomData;
@@ -23,6 +24,14 @@ pub enum Request {
         value: String,
         _p: PhantomData<*const ()>,
     },
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Request::Set { key, value, .. } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
 }
 
 impl Request {

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::io::Cursor;
 use std::sync::atomic::AtomicU64;
@@ -32,6 +33,14 @@ pub type LogStore = mem_log::LogStore<TypeConfig>;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
     Set { key: String, value: String },
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Request::Set { key, value, .. } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
 }
 
 /**

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::io::Cursor;
 use std::path::Path;
@@ -31,6 +32,14 @@ use crate::TypeConfig;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
     Set { key: String, value: String },
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Request::Set { key, value, .. } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
 }
 
 /**

--- a/examples/rocksstore/src/lib.rs
+++ b/examples/rocksstore/src/lib.rs
@@ -11,6 +11,7 @@ pub mod log_store;
 #[cfg(test)]
 mod test;
 
+use std::fmt;
 use std::fmt::Debug;
 use std::fs;
 use std::io::Cursor;
@@ -58,6 +59,14 @@ openraft::declare_raft_types!(
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RocksRequest {
     Set { key: String, value: String },
+}
+
+impl fmt::Display for RocksRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RocksRequest::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
 }
 
 /**

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -173,7 +173,7 @@ mod tests {
     #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
     pub(crate) struct TickUTConfig {}
     impl RaftTypeConfig for TickUTConfig {
-        type D = ();
+        type D = u64;
         type R = ();
         type NodeId = u64;
         type Node = ();

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -35,7 +35,7 @@ impl<N> Copy for UTConfig<N> {}
 impl<N> RaftTypeConfig for UTConfig<N>
 where N: Node + Ord
 {
-    type D = ();
+    type D = u64;
     type R = ();
     type NodeId = u64;
     type Node = N;

--- a/openraft/src/feature_serde_test.rs
+++ b/openraft/src/feature_serde_test.rs
@@ -4,8 +4,9 @@ mod serde_enabled {
     use crate::AppDataResponse;
     use crate::OptionalSerde;
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(derive_more::Display)]
     struct SerdeEnabled {
         i: u32,
     }
@@ -51,7 +52,8 @@ mod serde_disabled {
     use crate::AppDataResponse;
     use crate::OptionalSerde;
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
+    #[derive(derive_more::Display)]
     struct SerdeDisabled {
         #[allow(dead_code)]
         i: u32,

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -75,6 +75,8 @@ pub mod vote;
 #[cfg(test)]
 mod feature_serde_test;
 
+use std::fmt;
+
 pub use anyerror;
 pub use anyerror::AnyError;
 pub use openraft_macros::add_async_trait;
@@ -148,9 +150,9 @@ pub use crate::vote::Vote;
 /// ## Note
 ///
 /// The trait is automatically implemented for all types that satisfy its supertraits.
-pub trait AppData: OptionalFeatures + 'static {}
+pub trait AppData: OptionalFeatures + fmt::Debug + fmt::Display + 'static {}
 
-impl<T> AppData for T where T: OptionalFeatures + 'static {}
+impl<T> AppData for T where T: OptionalFeatures + fmt::Debug + fmt::Display + 'static {}
 
 /// A trait defining application-specific response data.
 ///

--- a/openraft/src/raft/declare_raft_types_test.rs
+++ b/openraft/src/raft/declare_raft_types_test.rs
@@ -13,7 +13,7 @@ declare_raft_types!(
         Node = (),
 
         /// This is AppData
-        D = (),
+        D = u64,
         #[allow(dead_code)]
         #[allow(dead_code)]
         R = (),
@@ -38,7 +38,7 @@ declare_raft_types!(
 
 declare_raft_types!(
     WithoutR:
-        D = (),
+        D = u64,
         NodeId = u64,
         Node = (),
         Entry = crate::Entry<Self>,

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -142,7 +142,7 @@ mod tests {
         use crate::declare_raft_types;
         use crate::vote::leader_id_std::LeaderId;
 
-        declare_raft_types!(TC: D=(),R=(),LeaderId=LeaderId<TC>);
+        declare_raft_types!(TC: D=u64,R=(),LeaderId=LeaderId<TC>);
 
         #[cfg(feature = "serde")]
         #[test]

--- a/stores/memstore/Cargo.toml
+++ b/stores/memstore/Cargo.toml
@@ -16,6 +16,7 @@ repository    = { workspace = true }
 [dependencies]
 openraft = { path= "../../openraft", version = "0.10.0", features=["serde", "type-alias"] }
 
+derive_more     = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }
 tokio           = { workspace = true }

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -42,6 +42,8 @@ use tokio::time::Duration;
 /// Conceptually, for demo purposes, this represents an update to a client's status info,
 /// returning the previously recorded status.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(derive_more::Display)]
+#[display("ClientRequest{{client:{}, serial:{}, status:{}}}", client, serial, status)]
 pub struct ClientRequest {
     /// The ID of the client which has sent the request.
     pub client: String,


### PR DESCRIPTION

## Changelog

##### change: Require AppData to impl Debug and Display
This enables better debugging and logging by displaying actual application
data in entry payloads, rather than just showing "normal" for all entries.
The change updates Debug/Display implementations to include app data content
and adds corresponding tests.

Upgrade tip:

Implement `Debug` and `Display` for `RaftTypeConfig::D: AppData`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1436)
<!-- Reviewable:end -->
