### PR TITLE
chore: move `Entry` implementation to separate files

### DIFF
--- a/openraft/src/entry/entry.rs
+++ b/openraft/src/entry/entry.rs
@@ -1,0 +1,103 @@
+use std::fmt;
+
+use crate::EntryPayload;
+use crate::Membership;
+use crate::RaftTypeConfig;
+use crate::entry::RaftEntry;
+use crate::entry::RaftPayload;
+use crate::type_config::alias::CommittedLeaderIdOf;
+use crate::type_config::alias::LogIdOf;
+
+/// A Raft log entry.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub struct Entry<C>
+where C: RaftTypeConfig
+{
+    /// The log ID uniquely identifying this entry.
+    pub log_id: LogIdOf<C>,
+
+    /// This entry's payload.
+    pub payload: EntryPayload<C>,
+}
+
+impl<C> Clone for Entry<C>
+where
+    C: RaftTypeConfig,
+    C::D: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            log_id: self.log_id.clone(),
+            payload: self.payload.clone(),
+        }
+    }
+}
+
+impl<C> fmt::Debug for Entry<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Entry").field("log_id", &self.log_id).field("payload", &self.payload).finish()
+    }
+}
+
+impl<C> Default for Entry<C>
+where C: RaftTypeConfig
+{
+    fn default() -> Self {
+        Self {
+            log_id: LogIdOf::<C>::default(),
+            payload: EntryPayload::Blank,
+        }
+    }
+}
+
+impl<C> PartialEq for Entry<C>
+where
+    C::D: PartialEq,
+    C: RaftTypeConfig,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.log_id == other.log_id && self.payload == other.payload
+    }
+}
+
+impl<C> AsRef<Entry<C>> for Entry<C>
+where C: RaftTypeConfig
+{
+    fn as_ref(&self) -> &Entry<C> {
+        self
+    }
+}
+
+impl<C> fmt::Display for Entry<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.log_id, self.payload)
+    }
+}
+
+impl<C> RaftPayload<C> for Entry<C>
+where C: RaftTypeConfig
+{
+    fn get_membership(&self) -> Option<Membership<C>> {
+        self.payload.get_membership()
+    }
+}
+
+impl<C> RaftEntry<C> for Entry<C>
+where C: RaftTypeConfig
+{
+    fn new(log_id: LogIdOf<C>, payload: EntryPayload<C>) -> Self {
+        Self { log_id, payload }
+    }
+
+    fn log_id_parts(&self) -> (&CommittedLeaderIdOf<C>, u64) {
+        (&self.log_id.leader_id, self.log_id.index)
+    }
+
+    fn set_log_id(&mut self, new: LogIdOf<C>) {
+        self.log_id = new;
+    }
+}

--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -25,113 +25,17 @@
 //! Applications typically use the default [`Entry`] type, or implement [`RaftEntry`] for custom
 //! behavior.
 
-use std::fmt;
-use std::fmt::Debug;
-
-use crate::Membership;
+#[cfg(doc)]
 use crate::RaftTypeConfig;
 
+#[allow(clippy::module_inception)]
+mod entry;
 pub mod payload;
+mod raft_entry;
 pub(crate) mod raft_entry_ext;
-mod traits;
+mod raft_payload;
 
+pub use entry::Entry;
 pub use payload::EntryPayload;
-pub use traits::RaftEntry;
-pub use traits::RaftPayload;
-
-use crate::type_config::alias::CommittedLeaderIdOf;
-use crate::type_config::alias::LogIdOf;
-
-/// A Raft log entry.
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct Entry<C>
-where C: RaftTypeConfig
-{
-    /// The log ID uniquely identifying this entry.
-    pub log_id: LogIdOf<C>,
-
-    /// This entry's payload.
-    pub payload: EntryPayload<C>,
-}
-
-impl<C> Clone for Entry<C>
-where
-    C: RaftTypeConfig,
-    C::D: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            log_id: self.log_id.clone(),
-            payload: self.payload.clone(),
-        }
-    }
-}
-
-impl<C> Debug for Entry<C>
-where C: RaftTypeConfig
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Entry").field("log_id", &self.log_id).field("payload", &self.payload).finish()
-    }
-}
-
-impl<C> Default for Entry<C>
-where C: RaftTypeConfig
-{
-    fn default() -> Self {
-        Self {
-            log_id: LogIdOf::<C>::default(),
-            payload: EntryPayload::Blank,
-        }
-    }
-}
-
-impl<C> PartialEq for Entry<C>
-where
-    C::D: PartialEq,
-    C: RaftTypeConfig,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.log_id == other.log_id && self.payload == other.payload
-    }
-}
-
-impl<C> AsRef<Entry<C>> for Entry<C>
-where C: RaftTypeConfig
-{
-    fn as_ref(&self) -> &Entry<C> {
-        self
-    }
-}
-
-impl<C> fmt::Display for Entry<C>
-where C: RaftTypeConfig
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.log_id, self.payload)
-    }
-}
-
-impl<C> RaftPayload<C> for Entry<C>
-where C: RaftTypeConfig
-{
-    fn get_membership(&self) -> Option<Membership<C>> {
-        self.payload.get_membership()
-    }
-}
-
-impl<C> RaftEntry<C> for Entry<C>
-where C: RaftTypeConfig
-{
-    fn new(log_id: LogIdOf<C>, payload: EntryPayload<C>) -> Self {
-        Self { log_id, payload }
-    }
-
-    fn log_id_parts(&self) -> (&CommittedLeaderIdOf<C>, u64) {
-        (&self.log_id.leader_id, self.log_id.index)
-    }
-
-    fn set_log_id(&mut self, new: LogIdOf<C>) {
-        self.log_id = new;
-    }
-}
+pub use raft_entry::RaftEntry;
+pub use raft_payload::RaftPayload;

--- a/openraft/src/entry/payload.rs
+++ b/openraft/src/entry/payload.rs
@@ -5,7 +5,7 @@ use std::fmt::Formatter;
 
 use crate::Membership;
 use crate::RaftTypeConfig;
-use crate::entry::traits::RaftPayload;
+use crate::entry::raft_payload::RaftPayload;
 
 /// Log entry payload variants.
 #[derive(PartialEq)]

--- a/openraft/src/entry/raft_entry.rs
+++ b/openraft/src/entry/raft_entry.rs
@@ -8,16 +8,9 @@ use crate::Membership;
 use crate::RaftTypeConfig;
 use crate::base::OptionalFeatures;
 use crate::base::finalized::Final;
+use crate::entry::RaftPayload;
 use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::LogIdOf;
-
-/// Defines operations on an entry payload.
-pub trait RaftPayload<C>
-where C: RaftTypeConfig
-{
-    /// Return `Some(Membership)` if the entry payload contains a membership payload.
-    fn get_membership(&self) -> Option<Membership<C>>;
-}
 
 /// Defines operations on an entry.
 pub trait RaftEntry<C>

--- a/openraft/src/entry/raft_payload.rs
+++ b/openraft/src/entry/raft_payload.rs
@@ -1,0 +1,9 @@
+use crate::Membership;
+use crate::RaftTypeConfig;
+/// Defines operations on an entry payload.
+pub trait RaftPayload<C>
+where C: RaftTypeConfig
+{
+    /// Return `Some(Membership)` if the entry payload contains a membership payload.
+    fn get_membership(&self) -> Option<Membership<C>>;
+}


### PR DESCRIPTION

## Changelog

##### chore: move `Entry` implementation to separate files

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1437)
<!-- Reviewable:end -->
