### PR TITLE
refactor: rename alias::ResponderOf to WriteResponderOf

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -96,8 +96,8 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscUnboundedReceiverOf;
 use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::OneshotReceiverOf;
-use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::WatchSenderOf;
+use crate::type_config::alias::WriteResponderOf;
 use crate::type_config::async_runtime::MpscUnboundedReceiver;
 use crate::vote::RaftLeaderId;
 use crate::vote::RaftVote;
@@ -508,7 +508,7 @@ where
     pub(crate) fn send_heartbeat(&mut self, emitter: impl fmt::Display) -> bool {
         tracing::debug!(now = display(C::now().display()), "send_heartbeat");
 
-        let Some((mut lh, _)) = self.engine.get_leader_handler_or_reject(None::<ResponderOf<C>>) else {
+        let Some((mut lh, _)) = self.engine.get_leader_handler_or_reject(None::<WriteResponderOf<C>>) else {
             tracing::debug!(
                 now = display(C::now().display()),
                 "{} failed to send heartbeat, not a Leader",

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -20,9 +20,9 @@ use crate::raft::VoteResponse;
 use crate::raft::linearizable_read::Linearizer;
 use crate::storage::Snapshot;
 use crate::type_config::alias::OneshotSenderOf;
-use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::alias::VoteOf;
+use crate::type_config::alias::WriteResponderOf;
 
 pub(crate) mod external_command;
 
@@ -72,7 +72,7 @@ where C: RaftTypeConfig
 
     ClientWriteRequest {
         app_data: C::D,
-        tx: ResponderOf<C>,
+        tx: WriteResponderOf<C>,
     },
 
     CheckIsLeaderRequest {

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -50,9 +50,9 @@ use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
-use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::alias::VoteOf;
+use crate::type_config::alias::WriteResponderOf;
 use crate::vote::RaftLeaderId;
 use crate::vote::RaftTerm;
 use crate::vote::RaftVote;
@@ -649,7 +649,7 @@ where C: RaftTypeConfig
     pub(crate) fn trigger_transfer_leader(&mut self, to: C::NodeId) {
         tracing::info!(to = display(&to), "{}", func_name!());
 
-        let Some((mut lh, _)) = self.get_leader_handler_or_reject(None::<ResponderOf<C>>) else {
+        let Some((mut lh, _)) = self.get_leader_handler_or_reject(None::<WriteResponderOf<C>>) else {
             tracing::info!(
                 to = display(to),
                 "{}: this node is not a Leader, ignore transfer Leader",

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -17,7 +17,7 @@ use crate::raft::raft_inner::RaftInner;
 use crate::raft::responder::ResponderBuilder;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::ResponderBuilderOf;
-use crate::type_config::alias::ResponderReceiverOf;
+use crate::type_config::alias::WriteResponderReceiverOf;
 
 /// Provides application-facing APIs for interacting with the Raft system.
 ///
@@ -55,7 +55,7 @@ where C: RaftTypeConfig
         // TODO: ClientWriteError can only be ForwardToLeader Error
     ) -> Result<Result<ClientWriteResponse<C>, ClientWriteError<C>>, Fatal<C>>
     where
-        ResponderReceiverOf<C>: Future<Output = Result<ClientWriteResult<C>, E>>,
+        WriteResponderReceiverOf<C>: Future<Output = Result<ClientWriteResult<C>, E>>,
         E: Error + OptionalSend,
     {
         let rx = self.client_write_ff(app_data).await?;
@@ -67,7 +67,7 @@ where C: RaftTypeConfig
 
     #[since(version = "0.10.0")]
     #[tracing::instrument(level = "debug", skip(self, app_data))]
-    pub(crate) async fn client_write_ff(&self, app_data: C::D) -> Result<ResponderReceiverOf<C>, Fatal<C>> {
+    pub(crate) async fn client_write_ff(&self, app_data: C::D) -> Result<WriteResponderReceiverOf<C>, Fatal<C>> {
         let (tx, rx) = ResponderBuilderOf::<C>::build(&app_data);
 
         self.inner.send_msg(RaftMsg::ClientWriteRequest { app_data, tx }).await?;

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -95,10 +95,10 @@ use crate::storage::Snapshot;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::LogIdOf;
-use crate::type_config::alias::ResponderReceiverOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
+use crate::type_config::alias::WriteResponderReceiverOf;
 use crate::vote::raft_vote::RaftVoteExt;
 
 /// Define types for a Raft type configuration.
@@ -729,7 +729,7 @@ where C: RaftTypeConfig
         app_data: C::D,
     ) -> Result<ClientWriteResponse<C>, RaftError<C, ClientWriteError<C>>>
     where
-        ResponderReceiverOf<C>: Future<Output = Result<ClientWriteResult<C>, E>>,
+        WriteResponderReceiverOf<C>: Future<Output = Result<ClientWriteResult<C>, E>>,
         E: Error + OptionalSend,
     {
         self.app_api().client_write(app_data).await.into_raft_result()
@@ -742,7 +742,7 @@ where C: RaftTypeConfig
     ///
     /// It is same as [`Self::client_write`] but does not wait for the response.
     #[since(version = "0.10.0")]
-    pub async fn client_write_ff(&self, app_data: C::D) -> Result<ResponderReceiverOf<C>, Fatal<C>> {
+    pub async fn client_write_ff(&self, app_data: C::D) -> Result<WriteResponderReceiverOf<C>, Fatal<C>> {
         self.app_api().client_write_ff(app_data).await
     }
 

--- a/openraft/src/raft/responder/core_responder.rs
+++ b/openraft/src/raft/responder/core_responder.rs
@@ -2,7 +2,7 @@ use crate::RaftTypeConfig;
 use crate::impls::OneshotResponder;
 use crate::raft::ClientWriteResult;
 use crate::raft::responder::Responder;
-use crate::type_config::alias::ResponderOf;
+use crate::type_config::alias::WriteResponderOf;
 
 /// The responder used in RaftCore.
 ///
@@ -12,7 +12,7 @@ pub(crate) enum CoreResponder<C>
 where C: RaftTypeConfig
 {
     Oneshot(OneshotResponder<C>),
-    UserDefined(ResponderOf<C>),
+    UserDefined(WriteResponderOf<C>),
 }
 
 impl<C> Responder<ClientWriteResult<C>> for CoreResponder<C>

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -172,9 +172,10 @@ pub mod alias {
     pub type SnapshotDataOf<C> = <C as RaftTypeConfig>::SnapshotData;
     pub type AsyncRuntimeOf<C> = <C as RaftTypeConfig>::AsyncRuntime;
     pub type ResponderBuilderOf<C> = <C as RaftTypeConfig>::ResponderBuilder;
-    pub type ResponderOf<C> = <ResponderBuilderOf<C> as ResponderBuilder<DOf<C>, ClientWriteResult<C>>>::Responder;
-    pub type ResponderReceiverOf<C> =
-        <ResponderBuilderOf<C> as ResponderBuilder<DOf<C>, ClientWriteResult<C>>>::Receiver;
+    pub type ResponderOf<C, V> = <ResponderBuilderOf<C> as ResponderBuilder<DOf<C>, V>>::Responder;
+    pub type ResponderReceiverOf<C, V> = <ResponderBuilderOf<C> as ResponderBuilder<DOf<C>, V>>::Receiver;
+    pub type WriteResponderOf<C> = ResponderOf<C, ClientWriteResult<C>>;
+    pub type WriteResponderReceiverOf<C> = ResponderReceiverOf<C, ClientWriteResult<C>>;
 
     type Rt<C> = AsyncRuntimeOf<C>;
 


### PR DESCRIPTION

## Changelog

##### refactor: rename alias::ResponderOf to WriteResponderOf
rename alias::ResponderOf to WriteResponderOf
rename alias::ResponderReceiverOf to WriteResponderReceiverOf

And add a type parameter to `ResponderOf`:
change `alias::ResponderOf<C>` to `alias::ResponderOf<C, V>`
and `alias::ResponderReceiverOf<C>` to `alias::ResponderReceiverOf<C, V>`.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1439)
<!-- Reviewable:end -->
