### PR TITLE
refactor: macro `expand!` support type parameter

### DIFF
--- a/macros/tests/expand/expand/type_param.expanded.rs
+++ b/macros/tests/expand/expand/type_param.expanded.rs
@@ -1,0 +1,11 @@
+#![feature(prelude_import)]
+#[macro_use]
+extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
+fn main() {
+    type Responder<T>
+        = crate::impls::OneshotResponder<Self, T>
+    where
+        T: Send;
+}

--- a/macros/tests/expand/expand/type_param.rs
+++ b/macros/tests/expand/expand/type_param.rs
@@ -1,0 +1,7 @@
+fn main() {
+    openraft_macros::expand!(
+        !KEYED,
+        (T, ATTR, V) => {ATTR type T = V;},
+        (Responder<T>, , crate::impls::OneshotResponder<Self, T> where T: Send,),
+    );
+}


### PR DESCRIPTION

## Changelog

##### refactor: macro `expand!` support type parameter
Now it allows to expand:

```rust
openraft_macros::expand!(
    !KEYED,
    (T, ATTR, V) => {ATTR type T = V;},
    (Responder<T>, , crate::impls::OneshotResponder<Self, T> where T: Send,),
);
```

to

```
type Responder<T> = crate::impls::OneshotResponder<Self, T> where T: Send;
```

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1440)
<!-- Reviewable:end -->
