### PR TITLE
feat: add I/O flush progress tracking API

### DIFF
--- a/openraft/src/core/io_flush_tracking/flush_point.rs
+++ b/openraft/src/core/io_flush_tracking/flush_point.rs
@@ -1,0 +1,53 @@
+use std::fmt;
+
+use crate::LogId;
+use crate::RaftTypeConfig;
+use crate::Vote;
+use crate::display_ext::display_option::DisplayOptionExt;
+
+/// State of the most recently flushed log I/O operation.
+///
+/// This represents the durable state of the log storage after a flush completes. It includes:
+/// - The vote(leader) under which the I/O was submitted
+/// - The last log entry that was written (if any logs were appended)
+///
+/// # Ordering
+///
+/// Ordered lexicographically as `(vote, last_log_id)`:
+/// - Higher term always > lower term
+/// - Same term: higher node_id > lower node_id (for non-committed votes)
+/// - Same vote: longer log (higher index) > shorter log
+///
+/// This enables `wait_until_ge()` to wait for specific progress milestones.
+///
+/// # Special Cases
+///
+/// - `!vote.is_committed() && last_log_id.is_none()`: A candidate's vote is accepted but it has not
+///   yet become leader (no AppendEntries received).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+pub struct FlushPoint<C>
+where C: RaftTypeConfig
+{
+    /// The vote(leader) under which this I/O operation was submitted.
+    pub vote: Vote<C>,
+
+    /// The last log entry that was flushed, or `None` if only a vote was saved without appending
+    /// logs.
+    pub last_log_id: Option<LogId<C>>,
+}
+
+impl<C> fmt::Display for FlushPoint<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FlushPoint({}, {})", self.vote, self.last_log_id.display(),)
+    }
+}
+
+impl<C> FlushPoint<C>
+where C: RaftTypeConfig
+{
+    pub fn new(vote: Vote<C>, last_log_id: Option<LogId<C>>) -> Self {
+        Self { vote, last_log_id }
+    }
+}

--- a/openraft/src/core/io_flush_tracking/mod.rs
+++ b/openraft/src/core/io_flush_tracking/mod.rs
@@ -1,0 +1,23 @@
+//! I/O flush progress tracking.
+//!
+//! This module provides watch-based notification channels for tracking when Raft I/O operations
+//! (vote saves and log appends) are flushed to storage. It enables applications to:
+//!
+//! - Wait for specific log entries to be durably written
+//! - Track vote changes across leader elections
+//! - Ensure data persistence before responding to clients
+//!
+//! The tracking is based on monotonically increasing [`crate::raft_state::IOId`] values that
+//! identify each I/O operation. When storage completes an operation, it notifies RaftCore, which
+//! updates the progress channels.
+
+mod flush_point;
+mod sender;
+mod watch_progress;
+mod watcher;
+
+pub use flush_point::FlushPoint;
+pub(crate) use sender::IoProgressSender;
+pub use watch_progress::LogProgress;
+pub use watch_progress::VoteProgress;
+pub(crate) use watcher::IoProgressWatcher;

--- a/openraft/src/core/io_flush_tracking/sender.rs
+++ b/openraft/src/core/io_flush_tracking/sender.rs
@@ -1,0 +1,80 @@
+use crate::RaftTypeConfig;
+use crate::Vote;
+use crate::async_runtime::watch::WatchSender;
+use crate::core::io_flush_tracking::FlushPoint;
+use crate::display_ext::display_option::DisplayOptionExt;
+use crate::raft_state::IOId;
+use crate::type_config::alias::WatchSenderOf;
+
+/// Sender for publishing I/O flush progress notifications.
+///
+/// Used internally by RaftCore to notify watchers when I/O operations complete.
+/// The sender maintains two independent channels (log and vote) to allow efficient
+/// filtering of notifications.
+pub(crate) struct IoProgressSender<C>
+where C: RaftTypeConfig
+{
+    /// Sender for log I/O progress (includes all I/O operations).
+    pub(crate) log_tx: WatchSenderOf<C, Option<FlushPoint<C>>>,
+
+    /// Sender for vote I/O progress (vote-specific updates).
+    ///
+    /// Note: Uses `Vote<C>` (the internal concrete type) instead of `VoteOf<C>` (the trait)
+    /// because `PartialOrd` is required for progress tracking but user-provided `VoteOf<C>`
+    /// implementations may not provide it.
+    pub(crate) vote_tx: WatchSenderOf<C, Option<Vote<C>>>,
+}
+
+impl<C> IoProgressSender<C>
+where C: RaftTypeConfig
+{
+    /// Publish an I/O flush completion notification to watchers.
+    ///
+    /// Updates progress channels conditionally:
+    /// - **vote_tx**: Updated only when the vote changes (new term or leader)
+    /// - **log_tx**: Updated when either vote or log_id changes (any I/O progress)
+    ///
+    /// This separation allows applications to efficiently wait for leadership changes
+    /// without being notified of every log append.
+    ///
+    /// # Arguments
+    ///
+    /// * `io_id` - The I/O operation that just completed. `None` means no progress to report.
+    pub(crate) fn send_log_progress(&self, io_id: Option<IOId<C>>) {
+        self.do_send_log_progress(io_id);
+    }
+
+    /// Internal implementation of `send_log_progress` that returns an option, just for easy return.
+    fn do_send_log_progress(&self, io_id: Option<IOId<C>>) -> Option<()> {
+        tracing::debug!("send_log_progress: try to update to :{}", io_id.display());
+
+        let (vote, log_id) = io_id?.to_vote_and_log_id();
+
+        {
+            let vote = vote.clone();
+
+            self.vote_tx.send_if_modified(move |prev| {
+                if prev.as_ref() != Some(&vote) {
+                    tracing::debug!("send_log_progress: udpate vote to :{}", vote);
+                    *prev = Some(vote);
+                    true
+                } else {
+                    false
+                }
+            });
+        }
+
+        self.log_tx.send_if_modified(move |prev| {
+            let x = Some(FlushPoint::new(vote, log_id));
+            if prev.as_ref() != x.as_ref() {
+                tracing::debug!("send_log_progress: udpate log to :{}", x.display());
+                *prev = x;
+                true
+            } else {
+                false
+            }
+        });
+
+        Some(())
+    }
+}

--- a/openraft/src/core/io_flush_tracking/watch_progress.rs
+++ b/openraft/src/core/io_flush_tracking/watch_progress.rs
@@ -1,0 +1,84 @@
+use crate::OptionalSend;
+use crate::OptionalSync;
+use crate::RaftTypeConfig;
+use crate::Vote;
+use crate::async_runtime::watch::RecvError;
+use crate::async_runtime::watch::WatchReceiver;
+use crate::core::io_flush_tracking::FlushPoint;
+use crate::type_config::alias::WatchReceiverOf;
+
+/// Handle for tracking log I/O flush progress.
+///
+/// Returns `None` if no I/O has completed yet (e.g., on a newly started node before any writes).
+/// Returns `Some(FlushPoint)` containing the vote and last log ID after the first flush
+/// completes.
+pub type LogProgress<C> = WatchProgress<C, Option<FlushPoint<C>>>;
+
+/// Handle for tracking vote I/O flush progress.
+///
+/// Returns `None` if no vote has been flushed yet.
+/// Returns `Some(Vote)` containing the last flushed vote.
+pub type VoteProgress<C> = WatchProgress<C, Option<Vote<C>>>;
+
+/// Watch handle for tracking I/O flush progress.
+///
+/// Provides two operations:
+/// - [`get()`](Self::get): Get current progress state immediately
+/// - [`wait_until_ge()`](Self::wait_until_ge): Wait asynchronously until progress reaches a
+///   threshold
+///
+/// # Concurrency
+///
+/// - Multiple handles can watch concurrently (each clones the receiver)
+/// - `get()` provides a snapshot at call time (may be stale immediately)
+/// - `wait_until_ge()` is sequentially consistent: if it returns, all future `get()` calls will see
+///   a value >= the returned value
+///
+/// This is a thin wrapper around a watch channel receiver that enforces the progress
+/// tracking semantics (values must be comparable via `PartialOrd`).
+#[derive(Clone)]
+pub struct WatchProgress<C, T>
+where
+    C: RaftTypeConfig,
+    T: OptionalSend + OptionalSync + PartialOrd + Clone,
+{
+    inner: WatchReceiverOf<C, T>,
+}
+
+impl<C, T> WatchProgress<C, T>
+where
+    C: RaftTypeConfig,
+    T: OptionalSend + OptionalSync + PartialOrd + Clone,
+{
+    pub(crate) fn new(inner: WatchReceiverOf<C, T>) -> Self {
+        Self { inner }
+    }
+
+    /// Wait until the flushed I/O progress becomes greater than or equal to the target value.
+    ///
+    /// Returns the current progress state once the condition is satisfied. If the progress
+    /// is already >= `target`, returns immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns `RecvError` if the sender is dropped (node is shutting down).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let target = Some(FlushPoint::new(Vote::new(2, node_id), Some(log_id(2, node_id, 100))));
+    /// let state = log_progress.wait_until_ge(&target).await?;
+    /// // state is guaranteed to be >= target
+    /// ```
+    pub async fn wait_until_ge(&mut self, target: &T) -> Result<T, RecvError> {
+        self.inner.wait_until_ge(target).await
+    }
+
+    /// Get the current flushed I/O progress state immediately without waiting.
+    ///
+    /// This returns a snapshot of the most recent flushed I/O operation. The value may become
+    /// stale immediately after reading as new I/O operations complete concurrently.
+    pub fn get(&self) -> T {
+        self.inner.borrow_watched().clone()
+    }
+}

--- a/openraft/src/core/io_flush_tracking/watcher.rs
+++ b/openraft/src/core/io_flush_tracking/watcher.rs
@@ -1,0 +1,67 @@
+use super::FlushPoint;
+use crate::RaftTypeConfig;
+use crate::Vote;
+use crate::core::io_flush_tracking::LogProgress;
+use crate::core::io_flush_tracking::VoteProgress;
+use crate::core::io_flush_tracking::sender::IoProgressSender;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::WatchReceiverOf;
+
+/// I/O flush progress watch handles.
+///
+/// This struct maintains the receiving ends of watch channels that track I/O flush progress.
+/// It provides two independent progress streams:
+///
+/// - **Log progress**: Tracks all I/O operations (both vote saves and log appends). Updated
+///   whenever any data is flushed to storage.
+///
+/// - **Vote progress**: Tracks only vote changes. Updated when the vote value changes (new term or
+///   leader), not on every log append.
+///
+/// The separation allows applications to efficiently wait for different kinds of progress:
+/// - Use log progress to wait for specific log entries to be durable
+/// - Use vote progress to wait for leadership changes to be persisted
+pub(crate) struct IoProgressWatcher<C>
+where C: RaftTypeConfig
+{
+    /// Receiver for log I/O progress (vote + log appends).
+    log: WatchReceiverOf<C, Option<FlushPoint<C>>>,
+
+    /// Receiver for vote I/O progress (vote saves only, or implied by log appends).
+    vote: WatchReceiverOf<C, Option<Vote<C>>>,
+}
+
+impl<C> IoProgressWatcher<C>
+where C: RaftTypeConfig
+{
+    /// Create a new progress watcher/sender pair.
+    ///
+    /// Returns `(IoProgressSender, IoProgressWatcher)` where:
+    /// - The sender is used by RaftCore to publish flush notifications
+    /// - The watcher is used to create watch handles for applications
+    pub(crate) fn new() -> (IoProgressSender<C>, Self) {
+        let (log_tx, log) = C::watch_channel(None);
+        let (vote_tx, vote) = C::watch_channel(None);
+
+        let sender = IoProgressSender { log_tx, vote_tx };
+        let watcher = Self { log, vote };
+
+        (sender, watcher)
+    }
+
+    /// Create a watch handle for log I/O flush progress.
+    ///
+    /// Each call creates a new independent handle. Multiple handles can watch the same progress
+    /// concurrently.
+    pub(crate) fn log_progress(&self) -> LogProgress<C> {
+        LogProgress::new(self.log.clone())
+    }
+
+    /// Create a watch handle for vote I/O flush progress.
+    ///
+    /// Each call creates a new independent handle. Multiple handles can watch the same progress
+    /// concurrently.
+    pub(crate) fn vote_progress(&self) -> VoteProgress<C> {
+        VoteProgress::new(self.vote.clone())
+    }
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -26,6 +26,7 @@
 pub(crate) mod balancer;
 pub(crate) mod core_state;
 pub(crate) mod heartbeat;
+pub(crate) mod io_flush_tracking;
 pub(crate) mod notification;
 mod raft_core;
 pub(crate) mod raft_msg;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -31,6 +31,7 @@ use crate::core::balancer::Balancer;
 use crate::core::core_state::CoreState;
 use crate::core::heartbeat::event::HeartbeatEvent;
 use crate::core::heartbeat::handle::HeartbeatWorkersHandle;
+use crate::core::io_flush_tracking::IoProgressSender;
 use crate::core::notification::Notification;
 use crate::core::raft_msg::AppendEntriesTx;
 use crate::core::raft_msg::ClientReadTx;
@@ -186,6 +187,7 @@ where
     pub(crate) tx_metrics: WatchSenderOf<C, RaftMetrics<C>>,
     pub(crate) tx_data_metrics: WatchSenderOf<C, RaftDataMetrics<C>>,
     pub(crate) tx_server_metrics: WatchSenderOf<C, RaftServerMetrics<C>>,
+    pub(crate) tx_progress: IoProgressSender<C>,
 
     pub(crate) span: Span,
 }
@@ -202,7 +204,7 @@ where
         let res = self.do_main(rx_shutdown).instrument(span).await;
 
         // Flush buffered metrics
-        self.report_metrics(None, None);
+        self.flush_metrics();
 
         // Safe unwrap: res is Result<Infallible, _>
         let err = res.unwrap_err();
@@ -232,11 +234,11 @@ where
         tracing::debug!("raft node is initializing");
 
         self.engine.startup();
-        // It may not finish running all of the commands, if there is a command waiting for a callback.
+        // It may not finish running all the commands, if there is a command waiting for a callback.
         self.run_engine_commands().await?;
 
         // Initialize metrics.
-        self.report_metrics(None, None);
+        self.flush_metrics();
 
         self.runtime_loop(rx_shutdown).await
     }
@@ -534,6 +536,8 @@ where
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn flush_metrics(&mut self) {
+        self.tx_progress.send_log_progress(self.engine.state.log_progress().flushed().cloned());
+
         let (replication, heartbeat) = if let Some(leader) = self.engine.leader.as_ref() {
             let replication_prog = &leader.progress;
             let replication =
@@ -547,6 +551,7 @@ where
         } else {
             (None, None)
         };
+
         self.report_metrics(replication, heartbeat);
     }
 
@@ -572,7 +577,7 @@ where
 
             // --- data ---
             current_term: st.vote_ref().term(),
-            vote: st.log_progress().flushed().map(|io_id| io_id.to_vote()).unwrap_or_default(),
+            vote: st.log_progress().flushed().map(|io_id| io_id.to_app_vote()).unwrap_or_default(),
             last_log_index: st.last_log_id().index(),
             last_applied: st.io_applied().cloned(),
             snapshot: st.io_snapshot_last_log_id().cloned(),
@@ -604,7 +609,7 @@ where
 
         let server_metrics = RaftServerMetrics {
             id: self.id.clone(),
-            vote: st.log_progress().flushed().map(|io_id| io_id.to_vote()).unwrap_or_default(),
+            vote: st.log_progress().flushed().map(|io_id| io_id.to_app_vote()).unwrap_or_default(),
             state: st.server_state,
             current_leader,
             membership_config,
@@ -1247,7 +1252,7 @@ where
     pub(super) fn handle_append_entries_request(&mut self, req: AppendEntriesRequest<C>, tx: AppendEntriesTx<C>) {
         tracing::debug!(req = display(&req), func = func_name!());
 
-        let is_ok = self.engine.handle_append_entries(&req.vote, req.prev_log_id, req.entries, Some(tx));
+        let is_ok = self.engine.handle_append_entries(&req.vote, req.prev_log_id, req.entries, tx);
 
         if is_ok {
             self.engine.handle_commit_entries(req.leader_commit);

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -13,6 +13,7 @@ use crate::async_runtime::watch::WatchReceiver;
 use crate::async_runtime::watch::WatchSender;
 use crate::config::RuntimeConfig;
 use crate::core::TickHandle;
+use crate::core::io_flush_tracking::IoProgressWatcher;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::display_ext::DisplayOptionExt;
@@ -43,6 +44,7 @@ where C: RaftTypeConfig
     pub(in crate::raft) rx_metrics: WatchReceiverOf<C, RaftMetrics<C>>,
     pub(in crate::raft) rx_data_metrics: WatchReceiverOf<C, RaftDataMetrics<C>>,
     pub(in crate::raft) rx_server_metrics: WatchReceiverOf<C, RaftServerMetrics<C>>,
+    pub(in crate::raft) progress_watcher: IoProgressWatcher<C>,
 
     pub(in crate::raft) tx_shutdown: std::sync::Mutex<Option<OneshotSenderOf<C, ()>>>,
     pub(in crate::raft) core_state: std::sync::Mutex<CoreState<C>>,

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -244,8 +244,8 @@ where C: RaftTypeConfig
         );
 
         if cfg!(debug_assertions) {
-            let new_vote = accepted.to_vote();
-            let current_vote = curr_accepted.clone().map(|io_id| io_id.to_vote());
+            let new_vote = accepted.to_app_vote();
+            let current_vote = curr_accepted.clone().map(|io_id| io_id.to_app_vote());
             assert!(
                 Some(new_vote.as_ref_vote()) >= current_vote.as_ref().map(|x| x.as_ref_vote()),
                 "new accepted.committed_vote {} must be >= current accepted.committed_vote: {}",

--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use crate::RaftTypeConfig;
+use crate::Vote;
 use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::VoteOf;
@@ -50,6 +51,10 @@ where C: RaftTypeConfig
 
     pub(crate) fn into_vote(self) -> VoteOf<C> {
         VoteOf::<C>::from_leader_id(self.leader_id, true)
+    }
+
+    pub(crate) fn into_internal_vote(self) -> Vote<C> {
+        Vote::<C>::from_leader_id(self.leader_id, true)
     }
 }
 

--- a/openraft/src/vote/non_committed.rs
+++ b/openraft/src/vote/non_committed.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crate::RaftTypeConfig;
+use crate::Vote;
 use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::RaftVote;
@@ -28,6 +29,10 @@ where C: RaftTypeConfig
 
     pub(crate) fn into_vote(self) -> VoteOf<C> {
         VoteOf::<C>::from_leader_id(self.leader_id, false)
+    }
+
+    pub(crate) fn into_internal_vote(self) -> Vote<C> {
+        Vote::<C>::from_leader_id(self.leader_id, false)
     }
 }
 

--- a/openraft/src/vote/ref_vote.rs
+++ b/openraft/src/vote/ref_vote.rs
@@ -2,7 +2,9 @@ use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::RaftTypeConfig;
+use crate::Vote;
 use crate::display_ext::DisplayOptionExt;
+use crate::vote::RaftVote;
 
 /// Similar to [`Vote`] but with a reference to the `LeaderId`, and provide ordering and display
 /// implementation.
@@ -25,6 +27,13 @@ where C: RaftTypeConfig
 
     pub(crate) fn is_committed(&self) -> bool {
         self.committed
+    }
+
+    /// Convert to an owned [`Vote`].
+    #[allow(dead_code)]
+    pub(crate) fn to_owned(&self) -> Option<Vote<C>> {
+        let leader_id = self.leader_id?;
+        Some(Vote::from_leader_id(leader_id.clone(), self.committed))
     }
 }
 

--- a/tests/tests/metrics/main.rs
+++ b/tests/tests/metrics/main.rs
@@ -14,3 +14,4 @@ mod t10_server_metrics_and_data_metrics;
 mod t20_metrics_state_machine_consistency;
 mod t30_leader_metrics;
 mod t40_metrics_wait;
+mod t50_progress_api;

--- a/tests/tests/metrics/t50_progress_api.rs
+++ b/tests/tests/metrics/t50_progress_api.rs
@@ -1,0 +1,234 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::Vote;
+use openraft::raft::FlushPoint;
+use tokio::time::sleep;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// Test log progress API: get() and wait_until_ge()
+///
+/// What does this test do?
+///
+/// - Creates a single-node cluster
+/// - Gets watch_log_progress() handle
+/// - Verifies initial state with get()
+/// - Writes client requests to generate logs
+/// - Uses wait_until_ge() with concrete target value
+/// - Verifies get() returns same value as wait_until_ge()
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn log_progress_api() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- get log progress watcher");
+    let n0 = router.get_raft_handle(&0)?;
+    let log_progress = n0.watch_log_progress();
+
+    tracing::info!(log_index, "--- verify initial log progress with get()");
+    let got = log_progress.get();
+    let want = Some(FlushPoint::new(
+        Vote::new_committed(1, 0),
+        Some(log_id(1, 0, log_index)),
+    ));
+    assert_eq!(got, want);
+
+    tracing::info!(log_index, "--- spawn task to wait for future log progress");
+    let target_index = log_index + 5;
+    let target = Some(FlushPoint::new(
+        Vote::new_committed(1, 0),
+        Some(log_id(1, 0, target_index)),
+    ));
+
+    let n0_clone = router.get_raft_handle(&0)?;
+    let handle = tokio::spawn(async move {
+        let mut progress = n0_clone.watch_log_progress();
+        progress.wait_until_ge(&target).await
+    });
+
+    tracing::info!(log_index, "--- send client requests to trigger wait_until_ge return");
+    log_index += router.client_request_many(0, "foo", 5).await?;
+
+    tracing::info!(log_index, "--- verify wait_until_ge returns after writes are flushed");
+    let got_wait = handle.await??;
+    let got_get = log_progress.get();
+
+    let want = Some(FlushPoint::new(
+        Vote::new_committed(1, 0),
+        Some(log_id(1, 0, log_index)),
+    ));
+    assert_eq!(got_wait, want);
+    assert_eq!(got_get, want);
+
+    Ok(())
+}
+
+/// Test log progress API with leader change
+///
+/// What does this test do?
+///
+/// - Initializes a 3-node cluster with node 0 as leader
+/// - Gets watch_log_progress() handle on node 1
+/// - Spawns task to wait for log progress with term 2 (new leader)
+/// - Shuts down node 0 to force re-election
+/// - Triggers election on node 1 to become new leader
+/// - Writes client requests on new leader
+/// - Verifies wait_until_ge() returns with new leader's vote and log
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn log_progress_with_leader_change() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing 3-node cluster");
+    let mut log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- get log progress watcher on node 1");
+    let n1 = router.get_raft_handle(&1)?;
+    let log_progress = n1.watch_log_progress();
+
+    tracing::info!(log_index, "--- verify initial log progress with get()");
+    let got = log_progress.get();
+    let want = Some(FlushPoint::new(
+        Vote::new_committed(1, 0),
+        Some(log_id(1, 0, log_index)),
+    ));
+    assert_eq!(got, want);
+
+    tracing::info!(log_index, "--- spawn task to wait for log progress with term 2");
+    let target_index = log_index + 4;
+    let target = Some(FlushPoint::new(
+        Vote::new_committed(2, 1),
+        Some(log_id(2, 1, target_index)),
+    ));
+
+    let n0 = router.get_raft_handle(&0)?;
+    n0.shutdown().await?;
+
+    // ensure node 0 is down and leader lease expire
+    sleep(Duration::from_millis(500)).await;
+
+    let n1_clone = router.get_raft_handle(&1)?;
+    let handle = tokio::spawn(async move {
+        let mut progress = n1_clone.watch_log_progress();
+        progress.wait_until_ge(&target).await
+    });
+
+    tracing::info!(log_index, "--- shutdown node 0");
+    router.remove_node(0);
+
+    tracing::info!(log_index, "--- trigger election on node 1");
+    let n1 = router.get_raft_handle(&1)?;
+    n1.trigger().elect().await?;
+
+    tracing::info!(log_index, "--- send client requests to new leader");
+    router
+        .wait(&1, Some(Duration::from_millis(2000)))
+        .state(ServerState::Leader, "wait for node 1 to become leader")
+        .await?;
+    log_index += 1;
+    log_index += router.client_request_many(1, "foo", 3).await?;
+
+    tracing::info!(log_index, "--- verify wait_until_ge returns with new leader's progress");
+    let got_wait = handle.await??;
+    let got_get = log_progress.get();
+
+    let want = Some(FlushPoint::new(
+        Vote::new_committed(2, 1),
+        Some(log_id(2, 1, log_index)),
+    ));
+    assert_eq!(got_wait, want);
+    assert_eq!(got_get, want);
+
+    Ok(())
+}
+
+/// Test vote progress API: get() and wait_until_ge() with leader change
+///
+/// What does this test do?
+///
+/// - Initializes a 3-node cluster with node 0 as leader
+/// - Gets watch_vote() handle on node 1
+/// - Spawns task to wait for future vote (term 2)
+/// - Triggers election on node 1 to seize leadership
+/// - Verifies wait_until_ge() returns when new leader is elected
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn vote_progress_api() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing 3-node cluster");
+    let _log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    tracing::info!("--- get vote progress watcher on node 1");
+    let n1 = router.get_raft_handle(&1)?;
+    let vote_progress = n1.watch_vote_progress();
+
+    tracing::info!("--- verify initial vote progress with get()");
+    let got = vote_progress.get();
+    let want = Some(Vote::new_committed(1, 0));
+    assert_eq!(got, want);
+
+    tracing::info!("--- shutdown node 0");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.shutdown().await?;
+
+        // ensure node 0 is down and leader lease expire
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    tracing::info!("--- spawn task to wait for term 2");
+    let n1 = router.get_raft_handle(&1)?;
+    let handle = tokio::spawn(async move {
+        let mut progress = n1.watch_vote_progress();
+
+        let target = Some(Vote::new(2, 1));
+        progress.wait_until_ge(&target).await
+    });
+
+    tracing::info!("--- trigger election on node 1 to seize leadership");
+    let n1 = router.get_raft_handle(&1)?;
+    n1.trigger().elect().await?;
+
+    tracing::info!("--- verify wait_until_ge returns with term 2 vote");
+    let got_wait = handle.await??;
+    let got_get = vote_progress.get();
+
+    let want = Some(Vote::new(2, 1));
+    assert_eq!(got_wait, want);
+    assert_eq!(got_get, want);
+
+    Ok(())
+}


### PR DESCRIPTION
## Changelog

##### feat: add I/O flush progress tracking API
Add `watch_log_progress()` and `watch_vote_progress()` APIs to enable
applications to track when Raft I/O operations are durably written to
storage. This allows applications to ensure data persistence before
responding to clients or making durability guarantees.

The implementation provides two independent progress streams:

- Log progress: Tracks all I/O operations (vote saves and log appends).
  Updated on every I/O completion. Returns `FlushPoint` containing the
  vote and last log ID.

- Vote progress: Tracks only vote changes (new term or leader). Updated
  when the vote value changes, not on every log append. Returns the
  flushed `Vote`.

Both APIs expose a `WatchProgress` handle with two operations:
`get()` for immediate snapshots and `wait_until_ge()` for async waiting
until progress reaches a threshold.

The progress tracking is based on monotonically increasing `IOId`
values. When storage completes an operation, RaftCore updates the
progress channels via watch channels, allowing multiple concurrent
watchers without blocking.

Example usage:

```rust
// Wait for a specific log entry to be flushed
let mut log_progress = raft.watch_log_progress();
let target = Some(FlushPoint::new(
    Vote::new_committed(2, node_id),
    Some(LogId::new(LeaderId::new(2, node_id), 100))
));
log_progress.wait_until_ge(&target).await?;
// Now log entry 100 is guaranteed durable

// Track leadership changes
let mut vote_progress = raft.watch_vote_progress();
let current = vote_progress.get();  // Get current vote immediately
let target = Some(Vote::new_committed(3, 0));
vote_progress.wait_until_ge(&target).await?;
// Now term 3 is guaranteed persisted
```

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1444)
<!-- Reviewable:end -->
