### PR TITLE
feat: add histogram for storage AppendEntries batch sizes

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1742,6 +1742,9 @@ where
                 let last_log_id = entries.last().unwrap().log_id();
                 tracing::debug!("AppendEntries: {}", entries.display_n(10));
 
+                let entry_count = entries.len() as u64;
+                self.engine.state.runtime_stats.storage_append_entries_batch_size.record(entry_count);
+
                 let io_id = IOId::new_log_io(vote, Some(last_log_id));
                 let notify = Notification::LocalIO { io_id: io_id.clone() };
                 let callback = IOFlushed::new(notify, self.tx_notification.downgrade());

--- a/openraft/src/raft_state/runtime_stats.rs
+++ b/openraft/src/raft_state/runtime_stats.rs
@@ -11,6 +11,13 @@ pub(crate) struct RuntimeStats {
     /// This tracks how many log entries are included in each apply command sent
     /// to the state machine, helping identify batch size patterns and I/O efficiency.
     pub(crate) apply_batch_size: Histogram,
+
+    /// Histogram tracking the distribution of log entry counts when appending to storage.
+    ///
+    /// This tracks how many log entries are included in each AppendEntries command
+    /// submitted to the storage layer, helping identify write batch patterns and storage I/O
+    /// efficiency.
+    pub(crate) storage_append_entries_batch_size: Histogram,
 }
 
 impl Default for RuntimeStats {
@@ -23,6 +30,7 @@ impl RuntimeStats {
     pub(crate) fn new() -> Self {
         Self {
             apply_batch_size: Histogram::new(),
+            storage_append_entries_batch_size: Histogram::new(),
         }
     }
 }


### PR DESCRIPTION

## Changelog

##### feat: add histogram for storage AppendEntries batch sizes
Track the distribution of log entry counts when appending to storage
using a histogram, similar to the existing apply batch size tracking.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1447)
<!-- Reviewable:end -->
