### PR TITLE
refactor: move RuntimeStats from RaftState to RaftCore

### DIFF
--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -93,6 +93,7 @@ use crate::metrics::Wait;
 use crate::raft::raft_inner::RaftInner;
 pub use crate::raft::runtime_config_handle::RuntimeConfigHandle;
 use crate::raft::trigger::Trigger;
+use crate::raft_state::RuntimeStats;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::storage::Snapshot;
@@ -394,6 +395,8 @@ where C: RaftTypeConfig
             tx_data_metrics,
             tx_server_metrics,
             tx_progress,
+
+            runtime_stats: RuntimeStats::new(),
 
             span: core_span,
         };

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -87,9 +87,6 @@ where C: RaftTypeConfig
     /// If a log is in use by a replication task, the purge is postponed and is stored in this
     /// field.
     pub(crate) purge_upto: Option<LogIdOf<C>>,
-
-    /// Runtime statistics for various Raft operations.
-    pub(crate) runtime_stats: RuntimeStats,
 }
 
 impl<C> Default for RaftState<C>
@@ -105,7 +102,6 @@ where C: RaftTypeConfig
             server_state: ServerState::default(),
             io_state: Valid::new(IOState::default()),
             purge_upto: None,
-            runtime_stats: RuntimeStats::default(),
         }
     }
 }

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -196,7 +196,6 @@ where
             server_state: Default::default(),
             io_state: Valid::new(io_state),
             purge_upto: last_purged_log_id,
-            runtime_stats: Default::default(),
         })
     }
 


### PR DESCRIPTION

## Changelog

##### refactor: move RuntimeStats from RaftState to RaftCore
RuntimeStats is operational metrics collected at runtime, not part of the
consensus state. Moving it to RaftCore provides better semantic separation:

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1449)
<!-- Reviewable:end -->
