### PR TITLE
chore: use simpler name for histogram metrics

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -807,7 +807,7 @@ where
         std::mem::swap(&mut responders, &mut self.client_responders);
 
         let entry_count = last.index() + 1 - first.index();
-        self.runtime_stats.apply_batch_size.record(entry_count);
+        self.runtime_stats.apply_batch.record(entry_count);
 
         let cmd = sm::Command::apply(first, last.clone(), responders);
         self.sm_handle.send(cmd).map_err(|e| StorageError::apply(last, AnyError::error(e)))?;
@@ -1754,7 +1754,7 @@ where
                 tracing::debug!("AppendEntries: {}", entries.display_n(10));
 
                 let entry_count = entries.len() as u64;
-                self.runtime_stats.storage_append_entries_batch_size.record(entry_count);
+                self.runtime_stats.append_batch.record(entry_count);
 
                 let io_id = IOId::new_log_io(vote, Some(last_log_id));
                 let notify = Notification::LocalIO { io_id: io_id.clone() };

--- a/openraft/src/raft_state/runtime_stats.rs
+++ b/openraft/src/raft_state/runtime_stats.rs
@@ -10,14 +10,14 @@ pub(crate) struct RuntimeStats {
     ///
     /// This tracks how many log entries are included in each apply command sent
     /// to the state machine, helping identify batch size patterns and I/O efficiency.
-    pub(crate) apply_batch_size: Histogram,
+    pub(crate) apply_batch: Histogram,
 
     /// Histogram tracking the distribution of log entry counts when appending to storage.
     ///
     /// This tracks how many log entries are included in each AppendEntries command
     /// submitted to the storage layer, helping identify write batch patterns and storage I/O
     /// efficiency.
-    pub(crate) storage_append_entries_batch_size: Histogram,
+    pub(crate) append_batch: Histogram,
 }
 
 impl Default for RuntimeStats {
@@ -29,8 +29,8 @@ impl Default for RuntimeStats {
 impl RuntimeStats {
     pub(crate) fn new() -> Self {
         Self {
-            apply_batch_size: Histogram::new(),
-            storage_append_entries_batch_size: Histogram::new(),
+            apply_batch: Histogram::new(),
+            append_batch: Histogram::new(),
         }
     }
 }


### PR DESCRIPTION

## Changelog

##### chore: use simpler name for histogram metrics

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1451)
<!-- Reviewable:end -->
