### PR TITLE
docs: add follower read example in raft-kv-memstore

### DIFF
--- a/examples/raft-kv-memstore/README.md
+++ b/examples/raft-kv-memstore/README.md
@@ -15,11 +15,12 @@ Includes:
   - raft-internal network APIs for replication and voting.
   - Admin APIs to add nodes, change-membership etc.
   - Application APIs to write a value by key or read a value by key.
+  - Linearizable read implementations including follower reads.
 
 - Client and `RaftNetwork`([rpc](./src/network/raft_network_impl)) are built upon [reqwest](https://docs.rs/reqwest).
 
   [ExampleClient](./src/client.rs) is a minimal raft client in rust to talk to a raft cluster.
-  - It includes application API `write()` and `read()`, and administrative API `init()`, `add_learner()`, `change_membership()`, `metrics()`.
+  - It includes application API `write()`, `read()`, `linearizable_read()`, `follower_read()`, and administrative API `init()`, `add_learner()`, `change_membership()`, `metrics()`.
   - This client tracks the last known leader id, a write operation(such as `write()` or `change_membership()`) will be redirected to the leader on client side.
 
 ## Run it
@@ -101,6 +102,13 @@ POST - 127.0.0.1:21002/read  "foo"
 ```
 
 You should be able to read that on the another instance even if you did not sync any data!
+
+For linearizable reads, use the `/linearizable_read` endpoint on the leader, or `/follower_read` on any node to distribute read load:
+
+```
+POST - 127.0.0.1:21001/linearizable_read  "foo"
+POST - 127.0.0.1:21002/follower_read  "foo"
+```
 
 
 ## How it's structured.

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -94,10 +94,12 @@ pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std:
             .service(management::add_learner)
             .service(management::change_membership)
             .service(management::metrics)
+            .service(management::get_linearizer)
             // application API
             .service(api::write)
             .service(api::read)
             .service(api::linearizable_read)
+            .service(api::follower_read)
     });
 
     let x = server.bind(http_addr)?;

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -2,9 +2,11 @@ use actix_web::post;
 use actix_web::web;
 use actix_web::web::Data;
 use actix_web::Responder;
+use client_http::FollowerReadError;
 use openraft::error::decompose::DecomposeResult;
 use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
+use openraft::raft::linearizable_read::Linearizer;
 use openraft::ReadPolicy;
 use web::Json;
 
@@ -54,4 +56,90 @@ pub async fn linearizable_read(app: Data<App>, req: Json<String>) -> actix_web::
         }
         Err(e) => Ok(Json(Err(e))),
     }
+}
+
+/// Perform a linearizable read on a follower by obtaining a linearizer from the leader
+///
+/// This demonstrates how to distribute read load across followers while maintaining
+/// linearizability guarantees:
+/// 1. Get current leader from local metrics
+/// 2. Fetch linearizer from leader via HTTP
+/// 3. Wait for local state machine to catch up to the linearizer's read_log_id
+/// 4. Read from local state machine
+#[post("/follower_read")]
+pub async fn follower_read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl Responder> {
+    // 1. Get current leader
+    let leader_id = match app.raft.current_leader().await {
+        Some(id) => id,
+        None => {
+            return Ok(Json(Err(FollowerReadError {
+                message: "No leader available".to_string(),
+            })));
+        }
+    };
+
+    // 2. Get leader's address from membership config
+    let metrics = app.raft.metrics().borrow().clone();
+    let leader_node = match metrics.membership_config.membership().get_node(&leader_id) {
+        Some(node) => node,
+        None => {
+            return Ok(Json(Err(FollowerReadError {
+                message: format!("Leader node {} not found in membership", leader_id),
+            })));
+        }
+    };
+    let leader_addr = &leader_node.addr;
+
+    // 3. Get linearizer from leader via HTTP
+    let client = reqwest::Client::new();
+    let url = format!("http://{}/get_linearizer", leader_addr);
+
+    let response = match client.post(&url).send().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            return Ok(Json(Err(FollowerReadError {
+                message: format!("Failed to contact leader: {}", e),
+            })));
+        }
+    };
+
+    let linearizer_data_result: Result<crate::network::management::LinearizerData, CheckIsLeaderError<TypeConfig>> =
+        match response.json().await {
+            Ok(result) => result,
+            Err(e) => {
+                return Ok(Json(Err(FollowerReadError {
+                    message: format!("Failed to parse linearizer data: {}", e),
+                })));
+            }
+        };
+
+    let linearizer_data = match linearizer_data_result {
+        Ok(data) => data,
+        Err(e) => {
+            return Ok(Json(Err(FollowerReadError {
+                message: format!("Leader returned error: {:?}", e),
+            })));
+        }
+    };
+
+    // Reconstruct linearizer from the data
+    let linearizer = Linearizer::new(
+        linearizer_data.node_id,
+        linearizer_data.read_log_id,
+        linearizer_data.applied,
+    );
+
+    // 4. Wait for local state machine to catch up
+    if let Err(e) = linearizer.await_ready(&app.raft).await {
+        return Ok(Json(Err(FollowerReadError {
+            message: format!("Failed to wait for state machine: {:?}", e),
+        })));
+    }
+
+    // 5. Read from local state machine
+    let state_machine = app.state_machine_store.state_machine.read().await;
+    let key = req.0;
+    let value = state_machine.data.get(&key).cloned();
+
+    Ok(Json(Ok(value.unwrap_or_default())))
 }

--- a/examples/raft-kv-memstore/tests/cluster/main.rs
+++ b/examples/raft-kv-memstore/tests/cluster/main.rs
@@ -1,3 +1,1 @@
-#![allow(clippy::uninlined_format_args)]
-
-mod test_cluster;
+mod test_follower_read;

--- a/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use client_http::ExampleClient;
+use maplit::btreeset;
+use raft_kv_memstore::start_example_raft_node;
+use raft_kv_memstore::store::Request;
+use raft_kv_memstore::TypeConfig;
+
+/// Test follower read functionality
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_follower_read() -> Result<(), Box<dyn std::error::Error>> {
+    fn get_addr(node_id: u64) -> String {
+        format!("127.0.0.1:2100{}", node_id)
+    }
+
+    // Start 3 raft nodes
+    let _h1 = tokio::spawn(start_example_raft_node(1, get_addr(1)));
+    let _h2 = tokio::spawn(start_example_raft_node(2, get_addr(2)));
+    let _h3 = tokio::spawn(start_example_raft_node(3, get_addr(3)));
+
+    // Wait for servers to start
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let leader = ExampleClient::<TypeConfig>::new(1, get_addr(1));
+
+    // Initialize cluster
+    println!("=== init single node cluster");
+    leader.init().await??;
+
+    // Wait for leader election
+    println!("=== wait for leader election");
+    loop {
+        let metrics = leader.metrics().await?;
+        if metrics.current_leader == Some(1) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Add learners
+    println!("=== add learners");
+    leader.add_learner((2, get_addr(2))).await??;
+    leader.add_learner((3, get_addr(3))).await??;
+
+    // Change membership
+    println!("=== change membership");
+    leader.change_membership(&btreeset! {1,2,3}).await??;
+
+    // Write some data
+    println!("=== write test_key=test_value");
+    leader
+        .write(&Request::Set {
+            key: "test_key".to_string(),
+            value: "test_value".to_string(),
+        })
+        .await??;
+
+    // Wait for replication
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Test follower read on node 2
+    println!("=== follower_read on node 2");
+    let client2 = ExampleClient::<TypeConfig>::new(2, get_addr(2));
+    let result = client2.follower_read(&"test_key".to_string()).await?;
+    let value = result.expect("follower_read should succeed");
+    println!("=== follower_read returned: {}", value);
+    assert_eq!("test_value", value, "follower read should return the correct value");
+
+    // Test follower read on node 3
+    println!("=== follower_read on node 3");
+    let client3 = ExampleClient::<TypeConfig>::new(3, get_addr(3));
+    let result = client3.follower_read(&"test_key".to_string()).await?;
+    let value = result.expect("follower_read should succeed");
+    println!("=== follower_read returned: {}", value);
+    assert_eq!("test_value", value, "follower read should return the correct value");
+
+    // Test with non-existent key
+    println!("=== follower_read on node 2 with non-existent key");
+    let result = client2.follower_read(&"non_existent".to_string()).await?;
+    let value = result.expect("follower_read should succeed");
+    println!("=== follower_read returned: {}", value);
+    assert_eq!("", value, "non-existent key should return empty string");
+
+    println!("=== test passed!");
+    Ok(())
+}

--- a/openraft/src/docs/protocol/read.md
+++ b/openraft/src/docs/protocol/read.md
@@ -84,6 +84,11 @@ let linearized_state = linearizer.try_await_ready(&my_raft, None).await?.unwrap(
 let val = my_raft.with_state_machine(|sm| { sm.read("foo") }).await?;
 ```
 
+See a complete implementation in the [raft-kv-memstore example](https://github.com/databendlabs/openraft/tree/main/examples/raft-kv-memstore):
+- [`/get_linearizer` endpoint](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/network/management.rs) - Leader provides linearizer data
+- [`/follower_read` endpoint](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/network/api.rs) - Follower read implementation
+- [Test coverage](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs)
+
 
 ## Ensuring Linearizability with `read_log_id`
 


### PR DESCRIPTION

## Changelog

##### docs: add follower read example in raft-kv-memstore
Demonstrates how to distribute read load across followers while
maintaining linearizability by fetching linearizer data from the leader
via application-level RPC.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1454)
<!-- Reviewable:end -->
