### PR TITLE
feat: support transient state machines with automatic snapshot restoration

### DIFF
--- a/openraft/src/storage/v2/raft_state_machine.rs
+++ b/openraft/src/storage/v2/raft_state_machine.rs
@@ -70,6 +70,15 @@ where C: RaftTypeConfig
     /// - An implementation with a persistent snapshot: `apply()` does not have to persist state on
     ///   disk. But every snapshot has to be persistent. And when starting up the application, the
     ///   state machine should be rebuilt from the last snapshot.
+    ///
+    /// - An implementation with a transient (in-memory) state machine: The state machine does NOT
+    ///   persist on each `apply()` call, but snapshots ARE persistent. On restart, in-memory state
+    ///   is lost and `applied_state()` returns `None` or an old value. Openraft will automatically
+    ///   restore the state machine by: (1) installing the last persistent snapshot, then (2)
+    ///   re-applying logs from the snapshot position to the committed position. To support this
+    ///   pattern, implement [`RaftLogStorage::save_committed()`] to persist the committed log id.
+    ///
+    /// [`RaftLogStorage::save_committed()`]: crate::storage::RaftLogStorage::save_committed
     async fn apply<I>(&mut self, entries: I) -> Result<Vec<C::R>, StorageError<C>>
     where
         I: IntoIterator<Item = C::Entry> + OptionalSend,

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -153,9 +153,10 @@ impl BlockConfig {
 pub struct MemLogStore {
     last_purged_log_id: RwLock<Option<LogId<TypeConfig>>>,
 
-    /// Saving committed log id is optional in Openraft.
+    /// Enable saving committed log id to support transient state machines.
     ///
-    /// This flag switches on the saving for testing purposes.
+    /// When enabled, on restart Openraft detects that committed > applied and
+    /// automatically re-applies logs to restore the in-memory state machine.
     pub enable_saving_committed: AtomicBool,
 
     committed: RwLock<Option<LogId<TypeConfig>>>,

--- a/tests/tests/life_cycle/main.rs
+++ b/tests/tests/life_cycle/main.rs
@@ -14,4 +14,5 @@ mod t50_leader_restart_clears_state;
 mod t50_single_follower_restart;
 mod t50_single_leader_restart_re_apply_logs;
 mod t90_issue_607_single_restart;
+mod t90_issue_881_transient_state_machine;
 mod t90_issue_920_non_voter_leader_restart;

--- a/tests/tests/life_cycle/t90_issue_881_transient_state_machine.rs
+++ b/tests/tests/life_cycle/t90_issue_881_transient_state_machine.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::MemLogStore;
+use crate::fixtures::MemRaft;
+use crate::fixtures::MemStateMachine;
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// Test transient (in-memory) state machine recovery with persistent snapshot.
+///
+/// A transient state machine does not persist on each apply() but has persistent snapshots.
+/// On restart, in-memory state is lost but can be recovered by:
+/// 1. Installing the last persistent snapshot to restore to snapshot position
+/// 2. Re-applying logs from snapshot position to committed position
+///
+/// This test uses a single-node cluster to ensure recovery happens through local
+/// snapshot installation and log re-application, not through replication from a leader.
+///
+/// Steps:
+/// 1. Creates a single-node cluster
+/// 2. Writes logs, creates persistent snapshot, writes more logs
+/// 3. Stops the node and clears its in-memory state (simulating restart)
+/// 4. Restarts the node with save_committed enabled
+/// 5. Verifies persistent snapshot is installed first, then remaining logs are re-applied
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn issue_881_transient_state_machine() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    // Enable save_committed to support transient state machines
+    router.enable_saving_committed = true;
+
+    tracing::info!("--- bring up single-node cluster");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- write 10 logs");
+    {
+        log_index += router.client_request_many(0, "foo", 10).await?;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "node-0 applied").await?;
+    }
+
+    let snapshot_log_index = log_index;
+
+    tracing::info!(log_index, "--- trigger snapshot");
+    {
+        let n = router.get_raft_handle(&0)?;
+        n.trigger().snapshot().await?;
+        router.wait(&0, timeout()).snapshot(log_id(1, 0, snapshot_log_index), "snapshot created").await?;
+    }
+
+    tracing::info!(log_index, "--- write 5 more logs after snapshot");
+    {
+        log_index += router.client_request_many(0, "bar", 5).await?;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "node-0 applied new logs").await?;
+    }
+
+    tracing::info!(log_index, "--- stop node-0 and clear its state machine");
+    {
+        let (node, ls, sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(0).unwrap();
+        node.shutdown().await?;
+
+        // Clear state machine to simulate transient (in-memory) data loss.
+        // The committed log id is preserved in log storage.
+        sm.clear_state_machine().await;
+
+        tracing::info!(log_index, "--- restart node-0 with cleared state machine");
+        router.new_raft_node_with_sto(0, ls, sm).await;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- node-0 should recover: install snapshot first, then re-apply remaining logs"
+    );
+    {
+        router
+            .wait(&0, timeout())
+            .applied_index(Some(log_index), "node-0 recovered by snapshot + log replay")
+            .await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2_000))
+}


### PR DESCRIPTION

## Changelog

##### feat: support transient state machines with automatic snapshot restoration
Transient state machines don't persist on each apply() but have persistent snapshots.
On startup, Openraft now automatically restores such state machines by installing
the last snapshot and re-applying logs from snapshot position to committed position.

This enables efficient in-memory state machines that can recover after restart
without implementing custom persistence logic for every apply() call.

Closes #881

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1455)
<!-- Reviewable:end -->
