### PR TITLE
change: avoid Vec allocation in RaftStateMachine::apply()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ check_all: lint fmt doc unused_dep typos
 
 basic_check:
 	cargo fmt
+	cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged
 	cargo test --lib
 	cargo test --test '*'
 	cargo clippy --no-deps --all-targets -- -D warnings

--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use openraft::alias::LogIdOf;
 use openraft::alias::SnapshotDataOf;
 use openraft::entry::RaftEntry;
+use openraft::storage::EntryResponder;
 use openraft::storage::IOFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogReader;
@@ -265,26 +266,28 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         Ok((sm.last_applied_log, sm.last_membership.clone()))
     }
 
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<ClientResponse>, StorageError<TypeConfig>>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError<TypeConfig>>
+    where
+        I: IntoIterator<Item = EntryResponder<TypeConfig>> + Send,
+        I::IntoIter: Send,
+    {
         let mut sm = self.sm.write().await;
 
-        let it = entries.into_iter();
-        let mut res = Vec::with_capacity(it.size_hint().1.unwrap_or(0));
-
-        for entry in it {
+        for (entry, responder) in entries {
             sm.last_applied_log = Some(entry.log_id);
 
             match entry.payload {
-                EntryPayload::Blank => res.push(ClientResponse {}),
-                EntryPayload::Normal(_) => res.push(ClientResponse {}),
+                EntryPayload::Blank | EntryPayload::Normal(_) => {}
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    res.push(ClientResponse {})
                 }
             };
+
+            if let Some(responder) = responder {
+                responder.send(ClientResponse {});
+            }
         }
-        Ok(res)
+        Ok(())
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/examples/raft-kv-memstore-grpc/src/store/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/store/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use openraft::entry::RaftEntry;
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::RaftSnapshotBuilder;
 
@@ -110,13 +111,14 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError>
-    where I: IntoIterator<Item = Entry> {
-        let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
-
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError>
+    where
+        I: IntoIterator<Item = EntryResponder<TypeConfig>>,
+        I::IntoIter: Send,
+    {
         let mut sm = self.state_machine.lock().unwrap();
 
-        for entry in entries {
+        for (entry, responder) in entries {
             let log_id = entry.log_id();
 
             tracing::debug!("replicate to sm: {}", log_id);
@@ -134,9 +136,11 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
                 None
             };
 
-            res.push(Response { value });
+            if let Some(responder) = responder {
+                responder.send(Response { value });
+            }
         }
-        Ok(res)
+        Ok(())
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::EntryPayload;
 use openraft::RaftSnapshotBuilder;
@@ -135,34 +136,39 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError>
-    where I: IntoIterator<Item = Entry> {
-        let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
-
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError>
+    where
+        I: IntoIterator<Item = EntryResponder<TypeConfig>>,
+        I::IntoIter: Send,
+    {
         let mut sm = self.state_machine.lock().unwrap();
 
-        for entry in entries {
+        for (entry, responder) in entries {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
             sm.last_applied = Some(entry.log_id);
 
-            match entry.payload {
-                EntryPayload::Blank => res.push(Response { value: None }),
+            let response = match entry.payload {
+                EntryPayload::Blank => Response { value: None },
                 EntryPayload::Normal(ref req) => match req {
                     Request::Set { key, value, .. } => {
                         sm.data.insert(key.clone(), value.clone());
-                        res.push(Response {
+                        Response {
                             value: Some(value.clone()),
-                        })
+                        }
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    res.push(Response { value: None })
+                    Response { value: None }
                 }
             };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
         }
-        Ok(res)
+        Ok(())
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use opendal::Operator;
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::RaftSnapshotBuilder;
 use serde::Deserialize;
@@ -158,34 +159,39 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError>
-    where I: IntoIterator<Item = Entry> {
-        let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
-
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError>
+    where
+        I: IntoIterator<Item = EntryResponder<TypeConfig>>,
+        I::IntoIter: Send,
+    {
         let mut sm = self.state_machine.lock().unwrap();
 
-        for entry in entries {
+        for (entry, responder) in entries {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
             sm.last_applied = Some(entry.log_id);
 
-            match entry.payload {
-                EntryPayload::Blank => res.push(Response { value: None }),
+            let response = match entry.payload {
+                EntryPayload::Blank => Response { value: None },
                 EntryPayload::Normal(ref req) => match req {
                     Request::Set { key, value, .. } => {
                         sm.data.insert(key.clone(), value.clone());
-                        res.push(Response {
+                        Response {
                             value: Some(value.clone()),
-                        })
+                        }
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    res.push(Response { value: None })
+                    Response { value: None }
                 }
             };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
         }
-        Ok(res)
+        Ok(())
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -7,6 +7,7 @@ use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::rc::Rc;
 
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::RaftLogReader;
@@ -192,34 +193,36 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError>
-    where I: IntoIterator<Item = Entry> {
-        let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
-
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError>
+    where I: IntoIterator<Item = EntryResponder<TypeConfig>> {
         let mut sm = self.state_machine.borrow_mut();
 
-        for entry in entries {
+        for (entry, responder) in entries {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
             sm.last_applied = Some(entry.log_id);
 
-            match entry.payload {
-                EntryPayload::Blank => res.push(Response { value: None }),
+            let response = match entry.payload {
+                EntryPayload::Blank => Response { value: None },
                 EntryPayload::Normal(ref req) => match req {
                     Request::Set { key, value, .. } => {
                         sm.data.insert(key.clone(), value.clone());
-                        res.push(Response {
+                        Response {
                             value: Some(value.clone()),
-                        })
+                        }
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    res.push(Response { value: None })
+                    Response { value: None }
                 }
             };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
         }
-        Ok(res)
+        Ok(())
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -7,9 +7,9 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use openraft::alias::SnapshotDataOf;
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
-use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::RaftSnapshotBuilder;
@@ -168,34 +168,39 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<TypeConfig>>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
-        let mut res = Vec::new(); //No `with_capacity`; do not know `len` of iterator
-
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError<TypeConfig>>
+    where
+        I: IntoIterator<Item = EntryResponder<TypeConfig>> + Send,
+        I::IntoIter: Send,
+    {
         let mut sm = self.state_machine.write().await;
 
-        for entry in entries {
+        for (entry, responder) in entries {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
             sm.last_applied_log = Some(entry.log_id);
 
-            match entry.payload {
-                EntryPayload::Blank => res.push(Response { value: None }),
+            let response = match entry.payload {
+                EntryPayload::Blank => Response { value: None },
                 EntryPayload::Normal(ref req) => match req {
                     Request::Set { key, value } => {
                         sm.data.insert(key.clone(), value.clone());
-                        res.push(Response {
+                        Response {
                             value: Some(value.clone()),
-                        })
+                        }
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    res.push(Response { value: None })
+                    Response { value: None }
                 }
             };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
         }
-        Ok(res)
+        Ok(())
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -5,6 +5,7 @@ use std::io::Cursor;
 use std::path::Path;
 use std::sync::Arc;
 
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::AnyError;
 use openraft::EntryPayload;
@@ -206,37 +207,34 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
         Ok((self.data.last_applied_log_id, self.data.last_membership.clone()))
     }
 
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError>
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError>
     where
-        I: IntoIterator<Item = Entry> + OptionalSend,
+        I: IntoIterator<Item = EntryResponder<TypeConfig>> + OptionalSend,
         I::IntoIter: OptionalSend,
     {
-        let entries = entries.into_iter();
-        let mut replies = Vec::with_capacity(entries.size_hint().0);
+        for (entry, responder) in entries {
+            self.data.last_applied_log_id = Some(entry.log_id);
 
-        for ent in entries {
-            self.data.last_applied_log_id = Some(ent.log_id);
-
-            let mut resp_value = None;
-
-            match ent.payload {
-                EntryPayload::Blank => {}
+            let response = match entry.payload {
+                EntryPayload::Blank => Response { value: None },
                 EntryPayload::Normal(req) => match req {
                     Request::Set { key, value } => {
-                        resp_value = Some(value.clone());
-
                         let mut st = self.data.kvs.write().await;
-                        st.insert(key, value);
+                        st.insert(key, value.clone());
+                        Response { value: Some(value) }
                     }
                 },
                 EntryPayload::Membership(mem) => {
-                    self.data.last_membership = StoredMembership::new(Some(ent.log_id), mem);
+                    self.data.last_membership = StoredMembership::new(Some(entry.log_id), mem);
+                    Response { value: None }
                 }
-            }
+            };
 
-            replies.push(Response { value: resp_value });
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
         }
-        Ok(replies)
+        Ok(())
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {

--- a/examples/rocksstore/src/lib.rs
+++ b/examples/rocksstore/src/lib.rs
@@ -22,10 +22,10 @@ use std::sync::Arc;
 use log_store::RocksLogStore;
 use openraft::alias::SnapshotDataOf;
 use openraft::entry::RaftEntry;
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::AnyError;
-use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::RaftSnapshotBuilder;
@@ -219,38 +219,43 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         self.get_meta()
     }
 
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<RocksResponse>, StorageError<TypeConfig>>
-    where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
-        let entries_iter = entries.into_iter();
-        let mut res = Vec::with_capacity(entries_iter.size_hint().0);
-
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError<TypeConfig>>
+    where
+        I: IntoIterator<Item = EntryResponder<TypeConfig>> + Send,
+        I::IntoIter: Send,
+    {
         let cf_data = self.cf_sm_data();
         let cf_meta = self.cf_sm_meta();
 
         let mut batch = rocksdb::WriteBatch::default();
         let mut last_applied_log = None;
         let mut last_membership = None;
+        let mut responses = Vec::new();
 
-        for entry in entries_iter {
+        for (entry, responder) in entries {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
             last_applied_log = Some(entry.log_id());
 
-            match entry.payload {
-                EntryPayload::Blank => res.push(RocksResponse { value: None }),
+            let response = match entry.payload {
+                EntryPayload::Blank => RocksResponse { value: None },
                 EntryPayload::Normal(ref req) => match req {
                     RocksRequest::Set { key, value } => {
                         batch.put_cf(cf_data, key.as_bytes(), value.as_bytes());
-                        res.push(RocksResponse {
+                        RocksResponse {
                             value: Some(value.clone()),
-                        })
+                        }
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     last_membership = Some(StoredMembership::new(Some(entry.log_id), mem.clone()));
-                    res.push(RocksResponse { value: None })
+                    RocksResponse { value: None }
                 }
             };
+
+            if let Some(responder) = responder {
+                responses.push((responder, response));
+            }
         }
 
         // Add metadata writes to the batch for atomic commit
@@ -262,10 +267,15 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
             batch.put_cf(cf_meta, "last_membership", serialize(membership)?);
         }
 
-        // Atomic write of all data + metadata
+        // Atomic write of all data + metadata - fail fast before sending any responses
         self.db.write(batch).map_err(|e| StorageError::write(&e))?;
 
-        Ok(res)
+        // Only send responses after successful write
+        for (responder, response) in responses {
+            responder.send(response);
+        }
+
+        Ok(())
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {

--- a/examples/utils/declare_types.rs
+++ b/examples/utils/declare_types.rs
@@ -13,6 +13,9 @@ pub type EntryPayload = openraft::EntryPayload<TypeConfig>;
 pub type Membership = openraft::membership::Membership<TypeConfig>;
 pub type StoredMembership = openraft::StoredMembership<TypeConfig>;
 
+pub type ApplyResponder = openraft::storage::ApplyResponder<TypeConfig>;
+pub type EntryResponder = openraft::storage::EntryResponder<TypeConfig>;
+
 pub type Node = <TypeConfig as openraft::RaftTypeConfig>::Node;
 
 pub type LogState = openraft::storage::LogState<TypeConfig>;

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -18,14 +18,12 @@ use crate::core::sm::handle::Handle;
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySliceExt;
 use crate::entry::RaftEntry;
-use crate::entry::RaftPayload;
-use crate::raft::ClientWriteResponse;
-use crate::raft::responder::Responder;
 use crate::raft::responder::core_responder::CoreResponder;
 #[cfg(doc)]
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::storage::Snapshot;
+use crate::storage::v2::entry_responder::EntryResponderBuilder;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::JoinHandleOf;
 use crate::type_config::alias::LogIdOf;
@@ -181,10 +179,6 @@ where
         last: LogIdOf<C>,
         client_resp_channels: &mut BTreeMap<u64, CoreResponder<C>>,
     ) -> Result<ApplyResult<C>, StorageError<C>> {
-        // TODO: prepare response before apply,
-        //       so that an Entry does not need to be Clone,
-        //       and no references will be used by apply
-
         let since = first.index();
         let end = last.index() + 1;
 
@@ -201,46 +195,19 @@ where
 
         let last_applied = last;
 
-        // Fake complain: avoid using `collect()` when not needed
-        #[allow(clippy::needless_collect)]
-        let applying_entries = entries.iter().map(|e| (e.log_id(), e.get_membership())).collect::<Vec<_>>();
+        // Prepare entries with responders upfront.
+        // Entries are consumed and responders attached before calling apply() to avoid
+        // the need for cloning entries or using references during application.
+        let apply_items = entries.into_iter().map(|entry| {
+            let log_index = entry.index();
+            let responder = client_resp_channels.remove(&log_index);
 
-        let n_entries = end - since;
+            let item = EntryResponderBuilder { entry, responder };
+            tracing::debug!("prepared {}", item);
+            item.into_parts()
+        });
 
-        let apply_results = self.state_machine.apply(entries).await?;
-
-        let n_replies = apply_results.len() as u64;
-
-        debug_assert_eq!(
-            n_entries, n_replies,
-            "n_entries: {} should equal n_replies: {}",
-            n_entries, n_replies
-        );
-
-        let mut results = apply_results.into_iter();
-        let mut applying_entries = applying_entries.into_iter();
-        for log_index in since..end {
-            let (log_id, membership) = applying_entries.next().unwrap();
-            let resp = results.next().unwrap();
-            let tx = client_resp_channels.remove(&log_index);
-            tracing::debug!(
-                log_id = debug(&log_id),
-                membership = debug(&membership),
-                "send_response"
-            );
-
-            if let Some(tx) = tx {
-                let membership = membership;
-
-                let res = Ok(ClientWriteResponse {
-                    log_id,
-                    data: resp,
-                    membership,
-                });
-
-                tx.send(res);
-            }
-        }
+        self.state_machine.apply(apply_items).await?;
 
         let resp = ApplyResult {
             since,

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -293,7 +293,8 @@ where
                 start,
                 chunk_end
             );
-            self.state_machine.apply(entries).await?;
+            let apply_items = entries.into_iter().map(|entry| (entry, None));
+            self.state_machine.apply(apply_items).await?;
 
             start = chunk_end;
         }

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -32,7 +32,7 @@ mod log_state;
 mod snapshot;
 mod snapshot_meta;
 mod snapshot_signature;
-mod v2;
+pub(crate) mod v2;
 
 pub use self::callback::IOFlushed;
 pub use self::callback::LogApplied;
@@ -44,6 +44,8 @@ pub use self::log_state::LogState;
 pub use self::snapshot::Snapshot;
 pub use self::snapshot_meta::SnapshotMeta;
 pub use self::snapshot_signature::SnapshotSignature;
+pub use self::v2::ApplyResponder;
+pub use self::v2::EntryResponder;
 pub use self::v2::RaftLogReader;
 pub use self::v2::RaftLogStorage;
 pub use self::v2::RaftLogStorageExt;

--- a/openraft/src/storage/v2/apply_responder.rs
+++ b/openraft/src/storage/v2/apply_responder.rs
@@ -1,0 +1,60 @@
+use crate::RaftTypeConfig;
+use crate::storage::v2::apply_responder_inner::ApplyResponderInner;
+
+/// Responder for sending client write responses after applying an entry.
+///
+/// This wrapper enables zero-allocation response handling by allowing state machines
+/// to send responses immediately after applying each entry, rather than buffering
+/// them in a Vec.
+///
+/// # Construction
+///
+/// This type cannot be constructed by user code. Instances are provided by
+/// Openraft when entries are passed to [`RaftStateMachine::apply`](super::RaftStateMachine::apply).
+/// State machine implementations should call [`send()`](Self::send) to
+/// return the response after applying each entry.
+///
+/// # Example
+///
+/// ```ignore
+/// use openraft::storage::EntryResponder;
+/// use openraft::StorageError;
+/// use openraft::EntryPayload;
+///
+/// async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError<C>>
+/// where
+///     I: IntoIterator<Item = EntryResponder<C>>,
+///     I::IntoIter: Send,
+/// {
+///     for (entry, responder) in entries {
+///         // Compute response based on entry type
+///         let response = match entry.payload {
+///             EntryPayload::Blank => Response::default(),
+///             EntryPayload::Normal(ref data) => {
+///                 self.apply_normal_entry(data)?;
+///                 self.compute_response(data)?
+///             }
+///             EntryPayload::Membership(ref mem) => {
+///                 self.apply_membership_change(mem)?;
+///                 Response::default()
+///             }
+///         };
+///
+///         // Send response only when there's a client waiting (leader entries)
+///         if let Some(responder) = responder {
+///             responder.send(response);
+///         }
+///     }
+///     Ok(())
+/// }
+/// ```
+pub struct ApplyResponder<C: RaftTypeConfig> {
+    pub(crate) inner: ApplyResponderInner<C>,
+}
+
+impl<C: RaftTypeConfig> ApplyResponder<C> {
+    /// Send the response after applying an entry.
+    pub fn send(self, response: C::R) {
+        self.inner.send(response)
+    }
+}

--- a/openraft/src/storage/v2/apply_responder_inner.rs
+++ b/openraft/src/storage/v2/apply_responder_inner.rs
@@ -1,0 +1,51 @@
+use crate::Membership;
+use crate::RaftTypeConfig;
+use crate::raft::responder::core_responder::CoreResponder;
+use crate::type_config::alias::LogIdOf;
+
+/// Internal implementation of [`ApplyResponder`](super::ApplyResponder).
+pub(crate) enum ApplyResponderInner<C: RaftTypeConfig> {
+    /// Normal entry response without membership change.
+    Normal {
+        log_id: LogIdOf<C>,
+        responder: CoreResponder<C>,
+    },
+
+    /// Entry response with membership change.
+    Membership {
+        log_id: LogIdOf<C>,
+        membership: Membership<C>,
+        responder: CoreResponder<C>,
+    },
+}
+
+impl<C: RaftTypeConfig> ApplyResponderInner<C> {
+    /// Send the response after applying an entry.
+    pub(crate) fn send(self, response: C::R) {
+        use crate::raft::ClientWriteResponse;
+        use crate::raft::responder::Responder as ResponderTrait;
+
+        match self {
+            ApplyResponderInner::Normal { log_id, responder } => {
+                let res = Ok(ClientWriteResponse {
+                    log_id,
+                    data: response,
+                    membership: None,
+                });
+                responder.send(res);
+            }
+            ApplyResponderInner::Membership {
+                log_id,
+                membership,
+                responder,
+            } => {
+                let res = Ok(ClientWriteResponse {
+                    log_id,
+                    data: response,
+                    membership: Some(membership),
+                });
+                responder.send(res);
+            }
+        }
+    }
+}

--- a/openraft/src/storage/v2/entry_responder.rs
+++ b/openraft/src/storage/v2/entry_responder.rs
@@ -1,0 +1,65 @@
+use crate::RaftTypeConfig;
+use crate::entry::RaftEntry;
+use crate::entry::RaftPayload;
+use crate::raft::responder::core_responder::CoreResponder;
+use crate::storage::v2::apply_responder::ApplyResponder;
+use crate::storage::v2::apply_responder_inner::ApplyResponderInner;
+use crate::type_config::alias::EntryOf;
+
+pub type EntryResponder<C> = (EntryOf<C>, Option<ApplyResponder<C>>);
+
+/// Internal builder for constructing [`EntryResponder`] tuples.
+///
+/// This struct optimizes memory usage by storing the entry and responder separately,
+/// avoiding duplication of log_id and membership data (which are already in the entry).
+/// The [`ApplyResponder`] is constructed lazily when [`into_parts()`](Self::into_parts)
+/// is called.
+///
+/// This is an internal implementation detail. User code works with the public
+/// [`EntryResponder`] type alias directly.
+pub(crate) struct EntryResponderBuilder<C: RaftTypeConfig> {
+    pub(crate) entry: C::Entry,
+    pub(crate) responder: Option<CoreResponder<C>>,
+}
+
+impl<C: RaftTypeConfig> EntryResponderBuilder<C> {
+    /// Consume this item and return the entry and optional responder.
+    ///
+    /// Returns `None` for the responder when this entry has no client waiting for a response
+    /// (e.g., entries being applied on followers).
+    ///
+    /// This method extracts the log_id and membership from the entry to construct
+    /// the appropriate [`ApplyResponder`] wrapper when a responder is present.
+    pub(crate) fn into_parts(self) -> (C::Entry, Option<ApplyResponder<C>>) {
+        let responder = match self.responder {
+            None => return (self.entry, None),
+            Some(r) => r,
+        };
+
+        let log_id = self.entry.log_id();
+        let membership = self.entry.get_membership();
+
+        let inner = match membership {
+            Some(membership) => ApplyResponderInner::Membership {
+                log_id,
+                membership,
+                responder,
+            },
+            None => ApplyResponderInner::Normal { log_id, responder },
+        };
+
+        (self.entry, Some(ApplyResponder { inner }))
+    }
+}
+
+impl<C: RaftTypeConfig> std::fmt::Display for EntryResponderBuilder<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "EntryResponderBuilder(log_id={}, has_responder={}, has_membership={})",
+            self.entry.log_id(),
+            self.responder.is_some(),
+            self.entry.get_membership().is_some()
+        )
+    }
+}

--- a/openraft/src/storage/v2/mod.rs
+++ b/openraft/src/storage/v2/mod.rs
@@ -3,12 +3,17 @@
 //! [`RaftLogStorage`] is responsible for storing logs,
 //! and [`RaftStateMachine`] is responsible for storing state machine and snapshot.
 
+mod apply_responder;
+mod apply_responder_inner;
+pub(crate) mod entry_responder;
 mod raft_log_reader;
 mod raft_log_storage;
 mod raft_log_storage_ext;
 mod raft_snapshot_builder;
 mod raft_state_machine;
 
+pub use self::apply_responder::ApplyResponder;
+pub use self::entry_responder::EntryResponder;
 pub use self::raft_log_reader::RaftLogReader;
 pub use self::raft_log_storage::RaftLogStorage;
 pub use self::raft_log_storage_ext::RaftLogStorageExt;

--- a/openraft/src/storage/v2/raft_state_machine.rs
+++ b/openraft/src/storage/v2/raft_state_machine.rs
@@ -7,6 +7,7 @@ use crate::RaftSnapshotBuilder;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::StoredMembership;
+use crate::storage::EntryResponder;
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
 use crate::type_config::alias::LogIdOf;
@@ -58,6 +59,8 @@ where C: RaftTypeConfig
     /// - Store the log id as last-applied log id.
     /// - Deal with the business logic log.
     /// - Store membership config if `RaftEntry::get_membership()` returns `Some`.
+    /// - Call [`ApplyResponder::send`](crate::storage::ApplyResponder::send) with the response
+    ///   immediately after applying the entry.
     ///
     /// Note that for a membership log, the implementation needs to do nothing about it, except
     /// storing it.
@@ -79,9 +82,9 @@ where C: RaftTypeConfig
     ///   pattern, implement [`RaftLogStorage::save_committed()`] to persist the committed log id.
     ///
     /// [`RaftLogStorage::save_committed()`]: crate::storage::RaftLogStorage::save_committed
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<C::R>, StorageError<C>>
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError<C>>
     where
-        I: IntoIterator<Item = C::Entry> + OptionalSend,
+        I: IntoIterator<Item = EntryResponder<C>> + OptionalSend,
         I::IntoIter: OptionalSend;
 
     /// Try to create a snapshot builder for the state machine.

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -1252,8 +1252,7 @@ where
         {
             let entry = blank_ent_0::<C>(0, 0);
 
-            let replies = apply(&mut sm, [entry]).await?;
-            assert_eq!(replies.len(), 1, "expected 1 response");
+            apply(&mut sm, [entry]).await?;
             let (last_applied, _) = sm.applied_state().await?;
 
             assert_eq!(last_applied, Some(log_id_0(0, 0)),);
@@ -1263,8 +1262,7 @@ where
         {
             let entry = membership_ent_0::<C>(1, 1, btreeset! {1,2});
 
-            let replies = apply(&mut sm, [entry]).await?;
-            assert_eq!(replies.len(), 1, "expected 1 response");
+            apply(&mut sm, [entry]).await?;
             let (last_applied, mem) = sm.applied_state().await?;
 
             assert_eq!(last_applied, Some(log_id_0(1, 1)),);
@@ -1299,8 +1297,7 @@ where
 
         let entries = [blank_ent_0::<C>(0, 0), membership_ent_0::<C>(1, 1, btreeset! {1,2})];
 
-        let replies = apply(&mut sm, entries).await?;
-        assert_eq!(replies.len(), 2);
+        apply(&mut sm, entries).await?;
 
         let (last_applied, mem) = sm.applied_state().await?;
         assert_eq!(last_applied, Some(log_id_0(1, 1)),);
@@ -1326,7 +1323,7 @@ where
 
         // Add a few entries so we have state to snapshot
         let snapshot_entries = vec![membership_ent_0::<C>(1, 2, btreeset! {1, 2, 3}), blank_ent_0::<C>(3, 3)];
-        sm_l.apply(snapshot_entries).await?;
+        apply(&mut sm_l, snapshot_entries).await?;
         let snapshot_last_log_id = Some(log_id_0(3, 3));
         let snapshot_last_membership = StoredMembership::new(
             Some(log_id_0(1, 2)),
@@ -1429,15 +1426,16 @@ where
 }
 
 /// A wrapper for calling nonblocking `RaftStateMachine::apply()`
-async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<Vec<C::R>, StorageError<C>>
+async fn apply<C, SM, I>(sm: &mut SM, entries: I) -> Result<(), StorageError<C>>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
     I: IntoIterator<Item = C::Entry> + OptionalSend,
     I::IntoIter: OptionalSend,
 {
-    let resp = sm.apply(entries).await?;
-    Ok(resp)
+    let apply_items = entries.into_iter().map(|entry| (entry, None));
+    sm.apply(apply_items).await?;
+    Ok(())
 }
 
 /// A wrapper for calling nonblocking `RaftLogStorage::append()`

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -25,6 +25,7 @@ use openraft::StoredMembership;
 use openraft::Vote;
 use openraft::alias::SnapshotDataOf;
 use openraft::entry::RaftEntry;
+use openraft::storage::EntryResponder;
 use openraft::storage::IOFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogReader;
@@ -475,33 +476,35 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<ClientResponse>, StorageError<TypeConfig>>
+    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError<TypeConfig>>
     where
-        I: IntoIterator<Item = Entry<TypeConfig>> + OptionalSend,
+        I: IntoIterator<Item = EntryResponder<TypeConfig>> + OptionalSend,
         I::IntoIter: OptionalSend,
     {
-        let mut res = Vec::new();
-
         let mut sm = self.sm.write().await;
 
-        for entry in entries {
+        for (entry, responder) in entries {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
             sm.last_applied_log = Some(entry.log_id);
 
-            match entry.payload {
-                EntryPayload::Blank => res.push(ClientResponse(None)),
+            let response = match entry.payload {
+                EntryPayload::Blank => ClientResponse(None),
                 EntryPayload::Normal(ref data) => {
                     let previous = sm.client_status.insert(data.client.clone(), data.status.clone());
-                    res.push(ClientResponse(previous));
+                    ClientResponse(previous)
                 }
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    res.push(ClientResponse(None))
+                    ClientResponse(None)
                 }
             };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
         }
-        Ok(res)
+        Ok(())
     }
 
     async fn try_create_snapshot_builder(&mut self, force: bool) -> Option<Self::SnapshotBuilder> {

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
-use openraft::Entry;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
@@ -11,10 +10,10 @@ use openraft::StorageError;
 use openraft::StoredMembership;
 use openraft::alias::LogIdOf;
 use openraft::error::Fatal;
+use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::storage::SnapshotMeta;
-use openraft_memstore::ClientResponse;
 use openraft_memstore::TypeConfig;
 
 use crate::fixtures::MemStateMachine;
@@ -102,9 +101,9 @@ async fn with_state_machine_wrong_sm_type() -> Result<()> {
                 todo!()
             }
 
-            async fn apply<I>(&mut self, _entries: I) -> Result<Vec<ClientResponse>, Err>
+            async fn apply<I>(&mut self, _entries: I) -> Result<(), Err>
             where
-                I: IntoIterator<Item = Entry<TC>> + OptionalSend,
+                I: IntoIterator<Item = EntryResponder<TC>> + OptionalSend,
                 I::IntoIter: OptionalSend,
             {
                 todo!()


### PR DESCRIPTION

## Changelog

##### change: avoid Vec allocation in RaftStateMachine::apply()
Replace the Vec-returning API with a callback-based approach that
enables zero-allocation response handling. This allows state machines
to send responses immediately after applying each entry, rather than
buffering them in a Vec.

Previously, `RaftStateMachine::apply()` required returning a Vec of
responses, which meant:
1. Allocating memory for the Vec
2. Collecting all responses before returning
3. Extra clones and memory overhead

The new API uses `ApplyItem` and `ApplyResponder` to:
1. Pair each entry with its responder
2. Allow immediate response sending via `responder.send()`
3. Eliminate Vec allocation overhead

Changes:

- Add `ApplyItem<C>` struct that pairs an entry with optional responder
- Add `ApplyResponder<C>` public wrapper for sending responses
- Change `RaftStateMachine::apply()` signature:
  - Input: `IntoIterator<Item = ApplyItem<C>>` (was `C::Entry`)
  - Return: `Result<(), StorageError<C>>` (was `Result<Vec<C::R>, ...>`)

- Fix: #1459

Upgrade tip:

Update your `RaftStateMachine::apply()` implementation:

```rust
// Before (0.9.x):
async fn apply<I>(&mut self, entries: I) -> Result<Vec<Response>, StorageError<C>>
where I: IntoIterator<Item = C::Entry> {
    let mut responses = Vec::new();
    for entry in entries {
        let response = /* process entry */;
        responses.push(response);
    }
    Ok(responses)
}

// After (0.10.0):
use openraft::storage::ApplyItem;

async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError<C>>
where I: IntoIterator<Item = ApplyItem<C>> {
    for item in entries {
        let (entry, responder) = item.into_parts();
        let response = /* process entry */;
        responder.send(response);
    }
    Ok(())
}
```

Key changes:

- Change parameter from `C::Entry` to `ApplyItem<C>`
- Call `item.into_parts()` to get `(entry, responder)`
- Replace `responses.push(response)` with `responder.send(response)`
- Change return type to `Result<(), ...>` and remove Vec

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1461)
<!-- Reviewable:end -->
