### PR TITLE
change: make responder optional in client_write_ff

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1298,7 +1298,7 @@ where
                 self.handle_check_is_leader_request(read_policy, tx).await;
             }
             RaftMsg::ClientWriteRequest { app_data, responder } => {
-                self.write_entry(C::Entry::new_normal(LogIdOf::<C>::default(), app_data), Some(responder));
+                self.write_entry(C::Entry::new_normal(LogIdOf::<C>::default(), app_data), responder);
             }
             RaftMsg::Initialize { members, tx } => {
                 tracing::info!(

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -73,7 +73,7 @@ where C: RaftTypeConfig
 
     ClientWriteRequest {
         app_data: C::D,
-        responder: CoreResponder<C>,
+        responder: Option<CoreResponder<C>>,
     },
 
     CheckIsLeaderRequest {

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -747,7 +747,11 @@ where C: RaftTypeConfig
     /// It is same as [`Self::client_write`] but does not wait for the response.
     #[since(version = "0.10.0", date = "2025-10-27", change = "add responder arg")]
     #[since(version = "0.10.0")]
-    pub async fn client_write_ff(&self, app_data: C::D, responder: WriteResponderOf<C>) -> Result<(), Fatal<C>> {
+    pub async fn client_write_ff(
+        &self,
+        app_data: C::D,
+        responder: Option<WriteResponderOf<C>>,
+    ) -> Result<(), Fatal<C>> {
         self.app_api().client_write_ff(app_data, responder).await
     }
 

--- a/tests/tests/client_api/t10_client_writes.rs
+++ b/tests/tests/client_api/t10_client_writes.rs
@@ -88,14 +88,17 @@ async fn client_write_ff() -> Result<()> {
     let n0 = router.get_raft_handle(&0)?;
 
     let (responder, rx) = OneshotResponder::new_pair();
-    n0.client_write_ff(ClientRequest::make_request("foo", 2), responder).await?;
+    n0.client_write_ff(ClientRequest::make_request("foo", 2), Some(responder)).await?;
     let got: ClientWriteResponse<TypeConfig> = rx.await??;
     assert_eq!(None, got.response().0.as_deref());
 
+    // Deliberately set the responder to None and do not wait for the result.
+    n0.client_write_ff(ClientRequest::make_request("foo", 3), None).await?;
+
     let (responder, rx) = OneshotResponder::new_pair();
-    n0.client_write_ff(ClientRequest::make_request("foo", 3), responder).await?;
+    n0.client_write_ff(ClientRequest::make_request("foo", 4), Some(responder)).await?;
     let got: ClientWriteResponse<TypeConfig> = rx.await??;
-    assert_eq!(Some("request-2"), got.response().0.as_deref());
+    assert_eq!(Some("request-3"), got.response().0.as_deref());
 
     Ok(())
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

Fix: #1458

Upgrade tip:

```rust
// before (0.9.x):
let (responder, rx) = OneshotResponder::new_pair();
n0.client_write_ff(ClientRequest::make_request("foo", 2), responder).await?;

// after (0.10.0):
let (responder, rx) = OneshotResponder::new_pair();
n0.client_write_ff(ClientRequest::make_request("foo", 2), Some(responder)).await?;
```


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1463)
<!-- Reviewable:end -->
