### PR TITLE
change: migrate API and notification channels to bounded channels

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -246,7 +246,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
             let mut log = self.log.write().await;
             log.extend(entries.into_iter().map(|entry| (entry.index(), entry)));
         }
-        callback.io_completed(Ok(()));
+        callback.io_completed(Ok(())).await;
         Ok(())
     }
 

--- a/examples/mem-log/src/log_store.rs
+++ b/examples/mem-log/src/log_store.rs
@@ -99,7 +99,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         for entry in entries {
             self.log.insert(entry.index(), entry);
         }
-        callback.io_completed(Ok(()));
+        callback.io_completed(Ok(())).await;
 
         Ok(())
     }

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -314,11 +314,13 @@ impl RaftLogStorage<TypeConfig> for Rc<LogStore> {
     async fn append<I>(&mut self, entries: I, callback: IOFlushed) -> Result<(), StorageError>
     where I: IntoIterator<Item = Entry> {
         // Simple implementation that calls the flush-before-return `append_to_log`.
-        let mut log = self.log.borrow_mut();
-        for entry in entries {
-            log.insert(entry.log_id.index(), entry);
+        {
+            let mut log = self.log.borrow_mut();
+            for entry in entries {
+                log.insert(entry.log_id.index(), entry);
+            }
         }
-        callback.io_completed(Ok(()));
+        callback.io_completed(Ok(())).await;
 
         Ok(())
     }

--- a/examples/rocksstore/src/log_store.rs
+++ b/examples/rocksstore/src/log_store.rs
@@ -14,6 +14,7 @@ use openraft::alias::VoteOf;
 use openraft::entry::RaftEntry;
 use openraft::storage::IOFlushed;
 use openraft::storage::RaftLogStorage;
+use openraft::type_config::TypeConfigExt;
 use openraft::LogState;
 use openraft::OptionalSend;
 use openraft::RaftLogReader;
@@ -185,7 +186,7 @@ where C: RaftTypeConfig<AsyncRuntime = TokioRuntime>
         let db = self.db.clone();
         let handle = spawn_blocking(move || {
             let res = db.flush_wal(true).map_err(std::io::Error::other);
-            callback.io_completed(res);
+            C::spawn(callback.io_completed(res));
         });
         drop(handle);
 

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -213,6 +213,20 @@ pub struct Config {
     #[clap(long, default_value = "1")]
     pub purge_batch_size: u64,
 
+    /// The size of the bounded API channel for sending messages to RaftCore.
+    ///
+    /// This controls backpressure for client requests. When the channel is full,
+    /// new API calls will block until space becomes available.
+    #[clap(long, default_value = "65536")]
+    pub api_channel_size: Option<u64>,
+
+    /// The size of the bounded notification channel for internal events.
+    ///
+    /// This channel carries internal notifications like IO completion, replication progress,
+    /// and tick events. When full, internal components will block until space is available.
+    #[clap(long, default_value = "65536")]
+    pub notification_channel_size: Option<u64>,
+
     /// Enable or disable tick.
     ///
     /// If ticking is disabled, timeout-based events are all disabled:
@@ -373,6 +387,20 @@ impl Config {
     #[since(version = "0.10.0")]
     pub(crate) fn get_allow_io_notification_reorder(&self) -> bool {
         self.allow_io_notification_reorder.unwrap_or(false)
+    }
+
+    /// Get the API channel size for bounded MPSC channel.
+    ///
+    /// Defaults to 65536 if not specified.
+    pub(crate) fn api_channel_size(&self) -> usize {
+        self.api_channel_size.unwrap_or(65536) as usize
+    }
+
+    /// Get the notification channel size for bounded MPSC channel.
+    ///
+    /// Defaults to 65536 if not specified.
+    pub(crate) fn notification_channel_size(&self) -> usize {
+        self.notification_channel_size.unwrap_or(65536) as usize
     }
 
     /// Build a `Config` instance from a series of command line arguments.

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -17,6 +17,8 @@ fn test_config_defaults() {
 
     assert_eq!(3 * 1024 * 1024, cfg.snapshot_max_chunk_size);
     assert_eq!(SnapshotPolicy::LogsSinceLast(5000), cfg.snapshot_policy);
+    assert_eq!(Some(65536), cfg.api_channel_size);
+    assert_eq!(Some(65536), cfg.notification_channel_size);
 }
 
 #[test]
@@ -62,6 +64,8 @@ fn test_build() -> anyhow::Result<()> {
         "--snapshot-max-chunk-size=204",
         "--max-in-snapshot-log-to-keep=205",
         "--purge-batch-size=207",
+        "--api-channel-size=208",
+        "--notification-channel-size=209",
     ])?;
 
     assert_eq!("bar", config.cluster_name);
@@ -80,6 +84,8 @@ fn test_build() -> anyhow::Result<()> {
     assert_eq!(204, config.snapshot_max_chunk_size);
     assert_eq!(205, config.max_in_snapshot_log_to_keep);
     assert_eq!(207, config.purge_batch_size);
+    assert_eq!(Some(208), config.api_channel_size);
+    assert_eq!(Some(209), config.notification_channel_size);
 
     // Test config methods
     #[allow(deprecated)]
@@ -215,6 +221,54 @@ fn test_config_allow_io_notification_reorder() -> anyhow::Result<()> {
 
     config.allow_io_notification_reorder = Some(false);
     assert_eq!(false, config.get_allow_io_notification_reorder());
+
+    Ok(())
+}
+
+#[test]
+fn test_config_api_channel_size() -> anyhow::Result<()> {
+    // Test default value
+    let config = Config::build(&["foo"])?;
+    assert_eq!(Some(65536), config.api_channel_size);
+    assert_eq!(65536, config.api_channel_size());
+
+    // Test custom value
+    let config = Config::build(&["foo", "--api-channel-size=10000"])?;
+    assert_eq!(Some(10000), config.api_channel_size);
+    assert_eq!(10000, config.api_channel_size());
+
+    // Test api_channel_size() method with None
+    let mut config = Config::build(&["foo"])?;
+    config.api_channel_size = None;
+    assert_eq!(65536, config.api_channel_size());
+
+    // Test api_channel_size() method with Some
+    config.api_channel_size = Some(50000);
+    assert_eq!(50000, config.api_channel_size());
+
+    Ok(())
+}
+
+#[test]
+fn test_config_notification_channel_size() -> anyhow::Result<()> {
+    // Test default value
+    let config = Config::build(&["foo"])?;
+    assert_eq!(Some(65536), config.notification_channel_size);
+    assert_eq!(65536, config.notification_channel_size());
+
+    // Test custom value
+    let config = Config::build(&["foo", "--notification-channel-size=2048"])?;
+    assert_eq!(Some(2048), config.notification_channel_size);
+    assert_eq!(2048, config.notification_channel_size());
+
+    // Test notification_channel_size() method with None
+    let mut config = Config::build(&["foo"])?;
+    config.notification_channel_size = None;
+    assert_eq!(65536, config.notification_channel_size());
+
+    // Test notification_channel_size() method with Some
+    config.notification_channel_size = Some(512);
+    assert_eq!(512, config.notification_channel_size());
 
     Ok(())
 }

--- a/openraft/src/core/heartbeat/handle.rs
+++ b/openraft/src/core/heartbeat/handle.rs
@@ -14,7 +14,7 @@ use crate::core::heartbeat::worker::HeartbeatWorker;
 use crate::core::notification::Notification;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::JoinHandleOf;
-use crate::type_config::alias::MpscUnboundedSenderOf;
+use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::alias::WatchSenderOf;
@@ -62,7 +62,7 @@ where C: RaftTypeConfig
     pub(crate) async fn spawn_workers<NF>(
         &mut self,
         network_factory: &mut NF,
-        tx_notification: &MpscUnboundedSenderOf<C, Notification<C>>,
+        tx_notification: &MpscSenderOf<C, Notification<C>>,
         targets: impl IntoIterator<Item = (C::NodeId, C::Node)>,
     ) where
         NF: RaftNetworkFactory<C>,

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -8,7 +8,6 @@ use crate::RaftSnapshotBuilder;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::async_runtime::MpscUnboundedReceiver;
-use crate::async_runtime::MpscUnboundedSender;
 use crate::async_runtime::OneshotSender;
 use crate::core::ApplyResult;
 use crate::core::notification::Notification;
@@ -30,9 +29,10 @@ use crate::storage::Snapshot;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::JoinHandleOf;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::MpscUnboundedReceiverOf;
-use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::OneshotSenderOf;
+use crate::type_config::async_runtime::mpsc::MpscSender;
 
 pub(crate) struct Worker<C, SM, LR>
 where
@@ -50,7 +50,7 @@ where
     cmd_rx: MpscUnboundedReceiverOf<C, Command<C>>,
 
     /// Send back the result of the command to RaftCore.
-    resp_tx: MpscUnboundedSenderOf<C, Notification<C>>,
+    resp_tx: MpscSenderOf<C, Notification<C>>,
 }
 
 impl<C, SM, LR> Worker<C, SM, LR>
@@ -63,7 +63,7 @@ where
     pub(crate) fn spawn(
         state_machine: SM,
         log_reader: LR,
-        resp_tx: MpscUnboundedSenderOf<C, Notification<C>>,
+        resp_tx: MpscSenderOf<C, Notification<C>>,
         span: tracing::Span,
     ) -> Handle<C> {
         let (cmd_tx, cmd_rx) = C::mpsc_unbounded();
@@ -87,9 +87,12 @@ where
             if let Err(err) = res {
                 tracing::error!("{} while execute state machine command", err,);
 
-                let _ = self.resp_tx.send(Notification::StateMachine {
-                    command_result: CommandResult { result: Err(err) },
-                });
+                let _ = self
+                    .resp_tx
+                    .send(Notification::StateMachine {
+                        command_result: CommandResult { result: Err(err) },
+                    })
+                    .await;
             }
         };
         C::spawn(fu.instrument(span))
@@ -134,7 +137,7 @@ where
                     tracing::info!("Done install complete snapshot, meta: {}", meta);
 
                     let res = CommandResult::new(Ok(Response::InstallSnapshot((io_id, Some(meta)))));
-                    let _ = self.resp_tx.send(Notification::sm(res));
+                    self.resp_tx.send(Notification::sm(res)).await.ok();
                 }
                 Command::BeginReceivingSnapshot { tx } => {
                     tracing::info!("{}: BeginReceivingSnapshot", func_name!());
@@ -151,7 +154,7 @@ where
                 } => {
                     let resp = self.apply(first, last, &mut client_resp_channels).await?;
                     let res = CommandResult::new(Ok(Response::Apply(resp)));
-                    let _ = self.resp_tx.send(Notification::sm(res));
+                    self.resp_tx.send(Notification::sm(res)).await.ok();
                 }
                 Command::Func { func, input_sm_type } => {
                     tracing::debug!("{}: run user defined Func", func_name!());
@@ -261,7 +264,7 @@ where
     ///   as applying a log entry,
     /// - or it must be able to acquire a lock that prevents any write operations.
     #[tracing::instrument(level = "info", skip_all)]
-    async fn build_snapshot(&mut self, resp_tx: MpscUnboundedSenderOf<C, Notification<C>>) {
+    async fn build_snapshot(&mut self, resp_tx: MpscSenderOf<C, Notification<C>>) {
         // TODO: need to be abortable?
         // use futures::future::abortable;
         // let (fu, abort_handle) = abortable(async move { builder.build_snapshot().await });
@@ -271,7 +274,7 @@ where
         let Some(mut builder) = builder else {
             tracing::info!("{}: snapshot building is refused by state machine", func_name!());
             let res = CommandResult::new(Ok(Response::BuildSnapshotDone(None)));
-            resp_tx.send(Notification::sm(res)).ok();
+            resp_tx.send(Notification::sm(res)).await.ok();
             return;
         };
 
@@ -279,7 +282,7 @@ where
             let res = builder.build_snapshot().await;
             let res = res.map(|snap| Response::BuildSnapshotDone(Some(snap.meta)));
             let cmd_res = CommandResult::new(res);
-            let _ = resp_tx.send(Notification::sm(cmd_res));
+            resp_tx.send(Notification::sm(cmd_res)).await.ok();
         });
         tracing::info!("{} returning; spawned building snapshot task", func_name!());
     }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -54,6 +54,7 @@ use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::JoinHandleOf;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::MpscUnboundedReceiverOf;
 use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::MpscUnboundedWeakSenderOf;
@@ -61,6 +62,7 @@ use crate::type_config::alias::MutexOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::VoteOf;
+use crate::type_config::async_runtime::mpsc::MpscSender;
 use crate::type_config::async_runtime::mutex::Mutex;
 use crate::vote::raft_vote::RaftVoteExt;
 
@@ -94,7 +96,7 @@ where
 
     /// A channel for sending events to the RaftCore.
     #[allow(clippy::type_complexity)]
-    tx_raft_core: MpscUnboundedSenderOf<C, Notification<C>>,
+    tx_raft_core: MpscSenderOf<C, Notification<C>>,
 
     /// A channel for receiving events from the RaftCore and snapshot transmitting task.
     rx_event: MpscUnboundedReceiverOf<C, Replicate<C>>,
@@ -168,7 +170,7 @@ where
         snapshot_network: N::Network,
         log_reader: LS::LogReader,
         snapshot_reader: SnapshotReader<C>,
-        tx_raft_core: MpscUnboundedSenderOf<C, Notification<C>>,
+        tx_raft_core: MpscSenderOf<C, Notification<C>>,
         span: tracing::Span,
     ) -> ReplicationHandle<C> {
         tracing::debug!(
@@ -240,7 +242,7 @@ where
                     self.send_log_entries(log, true).await
                 }
                 Data::Snapshot(snap) => self.stream_snapshot(snap).await,
-                Data::SnapshotCallback(resp) => self.handle_snapshot_callback(resp),
+                Data::SnapshotCallback(resp) => self.handle_snapshot_callback(resp).await,
             };
 
             tracing::debug!(res = debug(&res), "replication action done");
@@ -263,17 +265,20 @@ where
                             return Err(closed);
                         }
                         ReplicationError::HigherVote(h) => {
-                            let _ = self.tx_raft_core.send(Notification::HigherVote {
-                                target: self.target,
-                                higher: h.higher,
-                                leader_vote: self.session_id.committed_vote(),
-                            });
+                            self.tx_raft_core
+                                .send(Notification::HigherVote {
+                                    target: self.target,
+                                    higher: h.higher,
+                                    leader_vote: self.session_id.committed_vote(),
+                                })
+                                .await
+                                .ok();
                             return Ok(());
                         }
                         ReplicationError::StorageError(error) => {
                             tracing::error!(error=%error, "error replication to target={}", self.target);
 
-                            let _ = self.tx_raft_core.send(Notification::StorageError { error });
+                            self.tx_raft_core.send(Notification::StorageError { error }).await.ok();
                             return Ok(());
                         }
                         ReplicationError::RPCError(err) => {
@@ -306,7 +311,7 @@ where
                             } else {
                                 // If there is no id, it is a heartbeat and do not need to notify RaftCore
                                 if need_notify {
-                                    self.send_progress_error(err);
+                                    self.send_progress_error(err).await;
                                 } else {
                                     tracing::warn!("heartbeat RPC failed, do not send any response to RaftCore");
                                 };
@@ -460,11 +465,11 @@ where
 
         match append_resp {
             AppendEntriesResponse::Success => {
-                self.notify_heartbeat_progress(leader_time);
+                self.notify_heartbeat_progress(leader_time).await;
 
                 let matching = &sending_range.last;
                 if has_payload {
-                    self.notify_progress(ReplicationResult(Ok(matching.clone())), has_payload);
+                    self.notify_progress(ReplicationResult(Ok(matching.clone())), has_payload).await;
                     Ok(self.next_action_to_send(matching.clone(), log_ids))
                 } else {
                     Ok(None)
@@ -473,10 +478,10 @@ where
             AppendEntriesResponse::PartialSuccess(matching) => {
                 Self::debug_assert_partial_success(&sending_range, &matching);
 
-                self.notify_heartbeat_progress(leader_time);
+                self.notify_heartbeat_progress(leader_time).await;
 
                 if has_payload {
-                    self.notify_progress(ReplicationResult(Ok(matching.clone())), has_payload);
+                    self.notify_progress(ReplicationResult(Ok(matching.clone())), has_payload).await;
                     Ok(self.next_action_to_send(matching.clone(), log_ids))
                 } else {
                     Ok(None)
@@ -503,11 +508,11 @@ where
                 let conflict = conflict.unwrap();
 
                 // Conflict is also a successful replication RPC, because the leadership is acknowledged.
-                self.notify_heartbeat_progress(leader_time);
+                self.notify_heartbeat_progress(leader_time).await;
 
                 // Conflict should always be sent to RaftCore, ignoring `has_payload`
                 // because a heartbeat could also cause a conflict if the follower's state reverts.
-                self.notify_progress(ReplicationResult(Err(conflict)), has_payload);
+                self.notify_progress(ReplicationResult(Err(conflict)), has_payload).await;
 
                 Ok(None)
             }
@@ -516,34 +521,40 @@ where
 
     /// Send the error result to RaftCore.
     /// RaftCore will then submit another replication command.
-    fn send_progress_error(&mut self, err: RPCError<C>) {
-        let _ = self.tx_raft_core.send(Notification::ReplicationProgress {
-            // If `result` is Err, `has_payload` is not used.
-            has_payload: true,
-            progress: Progress {
-                target: self.target.clone(),
-                result: Err(err.to_string()),
-                session_id: self.session_id.clone(),
-            },
-        });
+    async fn send_progress_error(&mut self, err: RPCError<C>) {
+        self.tx_raft_core
+            .send(Notification::ReplicationProgress {
+                // If `result` is Err, `has_payload` is not used.
+                has_payload: true,
+                progress: Progress {
+                    target: self.target.clone(),
+                    result: Err(err.to_string()),
+                    session_id: self.session_id.clone(),
+                },
+            })
+            .await
+            .ok();
     }
 
     /// A successful replication implies a successful heartbeat.
     /// This method notifies [`RaftCore`] with a heartbeat progress.
     ///
     /// [`RaftCore`]: crate::core::RaftCore
-    fn notify_heartbeat_progress(&mut self, sending_time: InstantOf<C>) {
-        let _ = self.tx_raft_core.send({
-            Notification::HeartbeatProgress {
-                session_id: self.session_id.clone(),
-                target: self.target.clone(),
-                sending_time,
-            }
-        });
+    async fn notify_heartbeat_progress(&mut self, sending_time: InstantOf<C>) {
+        self.tx_raft_core
+            .send({
+                Notification::HeartbeatProgress {
+                    session_id: self.session_id.clone(),
+                    target: self.target.clone(),
+                    sending_time,
+                }
+            })
+            .await
+            .ok();
     }
 
     /// Notify RaftCore with the success replication result (log matching or conflict).
-    fn notify_progress(&mut self, replication_result: ReplicationResult<C>, has_payload: bool) {
+    async fn notify_progress(&mut self, replication_result: ReplicationResult<C>, has_payload: bool) {
         tracing::debug!(
             target = display(self.target.clone()),
             curr_matching = display(self.matching.display()),
@@ -561,16 +572,19 @@ where
             }
         }
 
-        let _ = self.tx_raft_core.send({
-            Notification::ReplicationProgress {
-                has_payload,
-                progress: Progress {
-                    session_id: self.session_id.clone(),
-                    target: self.target.clone(),
-                    result: Ok(replication_result.clone()),
-                },
-            }
-        });
+        self.tx_raft_core
+            .send({
+                Notification::ReplicationProgress {
+                    has_payload,
+                    progress: Progress {
+                        session_id: self.session_id.clone(),
+                        target: self.target.clone(),
+                        result: Ok(replication_result.clone()),
+                    },
+                }
+            })
+            .await
+            .ok();
     }
 
     /// Drain all events in the channel in backoff mode, i.e., there was an un-retry-able error and
@@ -785,7 +799,7 @@ where
         }
     }
 
-    fn handle_snapshot_callback(
+    async fn handle_snapshot_callback(
         &mut self,
         callback: SnapshotCallback<C>,
     ) -> Result<Option<Data<C>>, ReplicationError<C>> {
@@ -814,8 +828,8 @@ where
             }));
         }
 
-        self.notify_heartbeat_progress(start_time);
-        self.notify_progress(ReplicationResult(Ok(snapshot_meta.last_log_id)), true);
+        self.notify_heartbeat_progress(start_time).await;
+        self.notify_progress(ReplicationResult(Ok(snapshot_meta.last_log_id)), true).await;
 
         Ok(None)
     }

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -3,8 +3,6 @@ use openraft_macros::add_async_trait;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::async_runtime::MpscUnboundedReceiver;
-use crate::async_runtime::MpscUnboundedSender;
 use crate::core::notification::Notification;
 use crate::entry::RaftEntry;
 use crate::raft_state::io_state::io_id::IOId;
@@ -12,6 +10,8 @@ use crate::storage::IOFlushed;
 use crate::storage::RaftLogStorage;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::VoteOf;
+use crate::type_config::async_runtime::mpsc::MpscReceiver;
+use crate::type_config::async_runtime::mpsc::MpscSender;
 use crate::vote::raft_vote::RaftVoteExt;
 
 /// Extension trait for RaftLogStorage to provide utility methods.
@@ -33,7 +33,7 @@ where C: RaftTypeConfig
 
         let last_log_id = entries.last().unwrap().log_id();
 
-        let (tx, mut rx) = C::mpsc_unbounded();
+        let (tx, mut rx) = C::mpsc(1024);
 
         let io_id = IOId::<C>::new_log_io(VoteOf::<C>::default().into_committed(), Some(last_log_id));
         let notify = Notification::LocalIO { io_id };

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -14,8 +14,6 @@ use crate::RaftSnapshotBuilder;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::StoredMembership;
-use crate::async_runtime::MpscUnboundedReceiver;
-use crate::async_runtime::MpscUnboundedSender;
 use crate::core::notification::Notification;
 use crate::entry::RaftEntry;
 use crate::membership::EffectiveMembership;
@@ -32,6 +30,8 @@ use crate::testing::log::StoreBuilder;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
+use crate::type_config::async_runtime::mpsc::MpscReceiver;
+use crate::type_config::async_runtime::mpsc::MpscSender;
 use crate::vote::RaftLeaderIdExt;
 use crate::vote::raft_vote::RaftVoteExt;
 
@@ -1452,7 +1452,7 @@ where
 
     let last_log_id = entries.last().unwrap().log_id();
 
-    let (tx, mut rx) = C::mpsc_unbounded();
+    let (tx, mut rx) = C::mpsc(1024);
 
     // Dummy log io id for blocking append
     let io_id = IOId::<C>::new_log_io(VoteOf::<C>::default().into_committed(), Some(last_log_id));

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -416,7 +416,7 @@ impl RaftLogStorage<TypeConfig> for Arc<MemLogStore> {
             log.insert(entry.index(), s);
         }
 
-        callback.io_completed(Ok(()));
+        callback.io_completed(Ok(())).await;
         Ok(())
     }
 

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -85,9 +85,11 @@ async fn append_sees_higher_vote() -> Result<()> {
             .state(ServerState::Follower, "node-0 becomes follower due to a higher vote")
             .await?;
 
-        router.external_request(0, |st| {
-            assert_eq!(&Vote::new(10, 1), st.vote_ref(), "higher vote is stored");
-        });
+        router
+            .external_request(0, |st| {
+                assert_eq!(&Vote::new(10, 1), st.vote_ref(), "higher vote is stored");
+            })
+            .await?;
     }
 
     Ok(())

--- a/tests/tests/append_entries/t60_enable_heartbeat.rs
+++ b/tests/tests/append_entries/t60_enable_heartbeat.rs
@@ -44,9 +44,11 @@ async fn enable_heartbeat() -> Result<()> {
                 .await?;
 
             // leader lease is extended.
-            router.external_request(node_id, move |state| {
-                assert!(state.vote_last_modified() > Some(now));
-            });
+            router
+                .external_request(node_id, move |state| {
+                    assert!(state.vote_last_modified() > Some(now));
+                })
+                .await?;
         }
     }
 

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -39,22 +39,26 @@ async fn heartbeat_reject_vote() -> Result<()> {
     {
         let m = vote_modified_time.clone();
 
-        router.external_request(1, move |state| {
-            let mut l = m.lock().unwrap();
-            *l = state.vote_last_modified();
-            assert!(state.vote_last_modified() > Some(now));
-        });
+        router
+            .external_request(1, move |state| {
+                let mut l = m.lock().unwrap();
+                *l = state.vote_last_modified();
+                assert!(state.vote_last_modified() > Some(now));
+            })
+            .await?;
 
         let now = TokioInstant::now();
         sleep(Duration::from_millis(700)).await;
 
         let m = vote_modified_time.clone();
 
-        router.external_request(1, move |state| {
-            let l = m.lock().unwrap();
-            assert!(state.vote_last_modified() > Some(now));
-            assert!(state.vote_last_modified() > *l);
-        });
+        router
+            .external_request(1, move |state| {
+                let l = m.lock().unwrap();
+                assert!(state.vote_last_modified() > Some(now));
+                assert!(state.vote_last_modified() > *l);
+            })
+            .await?;
     }
 
     let node0 = router.get_raft_handle(&0)?;

--- a/tests/tests/life_cycle/t10_initialization.rs
+++ b/tests/tests/life_cycle/t10_initialization.rs
@@ -75,9 +75,11 @@ async fn initialization() -> anyhow::Result<()> {
     // before other requests in the Raft core API queue, which definitely are executed
     // (since they are awaited).
     for node in [0, 1, 2] {
-        router.external_request(node, |s| {
-            assert_eq!(s.server_state, ServerState::Learner);
-        });
+        router
+            .external_request(node, |s| {
+                assert_eq!(s.server_state, ServerState::Learner);
+            })
+            .await?;
     }
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
@@ -101,25 +103,27 @@ async fn initialization() -> anyhow::Result<()> {
 
     tracing::info!(log_index, "--- check membership state");
     for node_id in [0, 1, 2] {
-        router.external_request(node_id, move |s| {
-            let want = EffectiveMembership::new(
-                Some(log_id(0, 0, 0)),
-                Membership::new_with_defaults(vec![btreeset! {0,1,2}], []),
-            );
-            let want = Arc::new(want);
-            assert_eq!(
-                s.membership_state.effective(),
-                &want,
-                "node-{}: effective membership",
-                node_id
-            );
-            assert_eq!(
-                s.membership_state.committed(),
-                &want,
-                "node-{}: committed membership",
-                node_id
-            );
-        });
+        router
+            .external_request(node_id, move |s| {
+                let want = EffectiveMembership::new(
+                    Some(log_id(0, 0, 0)),
+                    Membership::new_with_defaults(vec![btreeset! {0,1,2}], []),
+                );
+                let want = Arc::new(want);
+                assert_eq!(
+                    s.membership_state.effective(),
+                    &want,
+                    "node-{}: effective membership",
+                    node_id
+                );
+                assert_eq!(
+                    s.membership_state.committed(),
+                    &want,
+                    "node-{}: committed membership",
+                    node_id
+                );
+            })
+            .await?;
     }
 
     for i in [0, 1, 2] {
@@ -189,9 +193,11 @@ async fn initialize_err_target_not_include_target() -> anyhow::Result<()> {
     router.new_raft_node(1).await;
 
     for node in [0, 1] {
-        router.external_request(node, |s| {
-            assert_eq!(s.server_state, ServerState::Learner);
-        });
+        router
+            .external_request(node, |s| {
+                assert_eq!(s.server_state, ServerState::Learner);
+            })
+            .await?;
     }
 
     for node_id in 0..2 {
@@ -224,9 +230,11 @@ async fn initialize_err_not_allowed() -> anyhow::Result<()> {
     router.new_raft_node(0).await;
 
     for node in [0] {
-        router.external_request(node, |s| {
-            assert_eq!(s.server_state, ServerState::Learner);
-        });
+        router
+            .external_request(node, |s| {
+                assert_eq!(s.server_state, ServerState::Learner);
+            })
+            .await?;
     }
 
     tracing::info!("--- Initialize node 0");

--- a/tests/tests/life_cycle/t11_shutdown.rs
+++ b/tests/tests/life_cycle/t11_shutdown.rs
@@ -57,9 +57,11 @@ async fn return_error_after_panic() -> Result<()> {
 
     tracing::info!(log_index, "--- panic the RaftCore");
     {
-        router.external_request(0, |_s| {
-            panic!("foo");
-        });
+        router
+            .external_request(0, |_s| {
+                panic!("foo");
+            })
+            .await?;
     }
 
     tracing::info!(

--- a/tests/tests/membership/t20_change_membership.rs
+++ b/tests/tests/membership/t20_change_membership.rs
@@ -40,11 +40,13 @@ async fn update_membership_state() -> anyhow::Result<()> {
                 .wait(&node_id, timeout())
                 .applied_index(Some(log_index), "change-membership log applied")
                 .await?;
-            router.external_request(node_id, move |st| {
-                tracing::debug!("--- got state: {:?}", st);
-                assert_eq!(st.membership_state.committed().log_id().index(), Some(log_index));
-                assert_eq!(st.membership_state.effective().log_id().index(), Some(log_index));
-            });
+            router
+                .external_request(node_id, move |st| {
+                    tracing::debug!("--- got state: {:?}", st);
+                    assert_eq!(st.membership_state.committed().log_id().index(), Some(log_index));
+                    assert_eq!(st.membership_state.effective().log_id().index(), Some(log_index));
+                })
+                .await?;
         }
     }
 


### PR DESCRIPTION

## Changelog

##### change: migrate API and notification channels to bounded channels
Migrated both API and notification channels from unbounded to bounded with
configurable sizes to provide backpressure control and prevent unbounded
memory growth.

Changes:
- Added api_channel_size config (default: 65536)
- Added notification_channel_size config (default: 65536)
- Changed RaftCore to use bounded MPSC channels for both API and notifications
- Made external_request() and external_state_machine_request() async and return a Result

Upgrade tip:

`external_request()` becomes `async` and returns Result<(), Fatal<C>>. Change:
`raft.external_request(|state| { ... });`
to:
`raft.external_request(|state| { ... }).await?;`

So is for `external_state_machine_request()`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1464)
<!-- Reviewable:end -->
