### PR TITLE
refactor: remove wait_for_state() and wait_for_snapshot() wrappers

### DIFF
--- a/tests/tests/append_entries/t11_append_conflicts.rs
+++ b/tests/tests/append_entries/t11_append_conflicts.rs
@@ -37,7 +37,7 @@ async fn append_conflicts() -> Result<()> {
     tracing::info!("--- wait for init node to ready");
 
     router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
-    router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
+    router.wait(&0, timeout()).state(ServerState::Learner, "empty").await?;
 
     let (r0, mut sto0, _sm0) = router.remove_node(0).unwrap();
     check_logs(&mut sto0, vec![]).await?;

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -88,21 +88,13 @@ async fn append_inconsistent_log() -> Result<()> {
     tracing::info!(log_index, "--- wait for node states");
     {
         router
-            .wait_for_state(
-                &btreeset! {0},
-                ServerState::Follower,
-                Some(Duration::from_millis(2000)),
-                "node 0 become follower",
-            )
+            .wait(&0, Some(Duration::from_millis(2000)))
+            .state(ServerState::Follower, "node 0 become follower")
             .await?;
 
         router
-            .wait_for_state(
-                &btreeset! {2},
-                ServerState::Leader,
-                Some(Duration::from_millis(5000)),
-                "node 2 become leader",
-            )
+            .wait(&2, Some(Duration::from_millis(5000)))
+            .state(ServerState::Leader, "node 2 become leader")
             .await?;
     }
 

--- a/tests/tests/append_entries/t11_append_updates_membership.rs
+++ b/tests/tests/append_entries/t11_append_updates_membership.rs
@@ -37,7 +37,7 @@ async fn append_updates_membership() -> Result<()> {
     tracing::info!("--- wait for init node to ready");
 
     router.wait_for_log(&btreeset![0], None, None, "empty").await?;
-    router.wait_for_state(&btreeset![0], ServerState::Learner, None, "empty").await?;
+    router.wait(&0, None).state(ServerState::Learner, "empty").await?;
 
     let (r0, _sto0, _sm0) = router.remove_node(0).unwrap();
 

--- a/tests/tests/client_api/t50_lagging_network_write.rs
+++ b/tests/tests/client_api/t50_lagging_network_write.rs
@@ -42,8 +42,10 @@ async fn lagging_network_write() -> Result<()> {
     let node = router.get_raft_handle(&0)?;
     node.change_membership([0, 1, 2], false).await?;
     log_index += 2;
-    router.wait_for_state(&btreeset![0], ServerState::Leader, None, "changed").await?;
-    router.wait_for_state(&btreeset![1, 2], ServerState::Follower, None, "changed").await?;
+    router.wait(&0, None).state(ServerState::Leader, "changed").await?;
+    for node in [1, 2] {
+        router.wait(&node, None).state(ServerState::Follower, "changed").await?;
+    }
     router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), timeout(), "3 candidates").await?;
 
     router.client_request_many(0, "client", 1).await?;

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -440,7 +440,7 @@ impl TypedRaftRouter {
             self.add_learner(leader_id, *id).await?;
             log_index += 1;
 
-            self.wait_for_state(&btreeset![*id], ServerState::Learner, timeout(), "empty node").await?;
+            self.wait(id, timeout()).state(ServerState::Learner, "empty node").await?;
         }
 
         self.wait_for_log(
@@ -716,36 +716,6 @@ impl TypedRaftRouter {
                 msg,
             )
             .await?;
-        }
-        Ok(())
-    }
-
-    /// Wait for specified nodes until their state becomes `state`.
-    #[tracing::instrument(level = "info", skip(self))]
-    pub async fn wait_for_state(
-        &self,
-        node_ids: &BTreeSet<MemNodeId>,
-        want_state: ServerState,
-        timeout: Option<Duration>,
-        msg: &str,
-    ) -> anyhow::Result<()> {
-        for i in node_ids.iter() {
-            self.wait(i, timeout).state(want_state, msg).await?;
-        }
-        Ok(())
-    }
-
-    /// Wait for specified nodes until their snapshot becomes `want`.
-    #[tracing::instrument(level = "info", skip(self))]
-    pub async fn wait_for_snapshot(
-        &self,
-        node_ids: &BTreeSet<MemNodeId>,
-        want: LogIdOf<TypeConfig>,
-        timeout: Option<Duration>,
-        msg: &str,
-    ) -> anyhow::Result<()> {
-        for i in node_ids.iter() {
-            self.wait(i, timeout).snapshot(want, msg).await?;
         }
         Ok(())
     }

--- a/tests/tests/life_cycle/t10_initialization.rs
+++ b/tests/tests/life_cycle/t10_initialization.rs
@@ -59,7 +59,9 @@ async fn initialization() -> anyhow::Result<()> {
 
     // Assert all nodes are in learner state & have no entries.
     router.wait_for_log(&btreeset![0, 1, 2], None, timeout(), "empty").await?;
-    router.wait_for_state(&btreeset![0, 1, 2], ServerState::Learner, timeout(), "empty").await?;
+    for node in [0, 1, 2] {
+        router.wait(&node, timeout()).state(ServerState::Learner, "empty").await?;
+    }
 
     // Sending an external requests will also find all nodes in Learner state.
     //

--- a/tests/tests/snapshot_building/t10_build_snapshot.rs
+++ b/tests/tests/snapshot_building/t10_build_snapshot.rs
@@ -59,7 +59,7 @@ async fn build_snapshot() -> Result<()> {
     tracing::info!(log_index, "--- log_index: {}", log_index);
 
     router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "write").await?;
-    router.wait_for_snapshot(&btreeset![0], log_id(1, 0, log_index), None, "snapshot").await?;
+    router.wait(&0, None).snapshot(log_id(1, 0, log_index), "snapshot").await?;
 
     router
         .assert_storage_state(

--- a/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
@@ -61,7 +61,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             )
             .await?;
 
-        router.wait_for_snapshot(&btreeset![0], log_id(1, 0, log_index), timeout(), "snapshot").await?;
+        router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "snapshot").await?;
         router
             .assert_storage_state(
                 1,
@@ -119,7 +119,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             tracing::info!(log_index, "--- DONE add learner");
 
             router.wait_for_log(&btreeset![0, 1], Some(log_index), timeout(), "add learner").await?;
-            router.wait_for_snapshot(&btreeset![1], log_id(1, 0, snapshot_index), timeout(), "").await?;
+            router.wait(&1, timeout()).snapshot(log_id(1, 0, snapshot_index), "").await?;
 
             let expected_snap = Some((snapshot_index.into(), 1));
 

--- a/tests/tests/snapshot_streaming/t32_snapshot_uses_prev_snap_membership.rs
+++ b/tests/tests/snapshot_streaming/t32_snapshot_uses_prev_snap_membership.rs
@@ -62,7 +62,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
                 "send log to trigger snapshot",
             )
             .await?;
-        router.wait_for_snapshot(&btreeset![0], log_id(1, 0, log_index), timeout(), "1st snapshot").await?;
+        router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "1st snapshot").await?;
 
         {
             let logs = sto0.try_get_log_entries(..).await?;
@@ -88,7 +88,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         log_index = snapshot_threshold * 2 - 1;
 
         router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "send log to trigger snapshot").await?;
-        router.wait_for_snapshot(&btreeset![0], log_id(1, 0, log_index), None, "2nd snapshot").await?;
+        router.wait(&0, None).snapshot(log_id(1, 0, log_index), "2nd snapshot").await?;
     }
 
     tracing::info!(log_index, "--- check membership");

--- a/tests/tests/snapshot_streaming/t50_snapshot_line_rate_to_snapshot.rs
+++ b/tests/tests/snapshot_streaming/t50_snapshot_line_rate_to_snapshot.rs
@@ -69,9 +69,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
                 "send log to trigger snapshot",
             )
             .await?;
-        router
-            .wait_for_snapshot(&btreeset![0], log_id(1, 0, log_index), timeout(), "snapshot on node 0")
-            .await?;
+        router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "snapshot on node 0").await?;
     }
 
     tracing::info!(log_index, "--- restore node 1 and replication");
@@ -79,9 +77,7 @@ async fn snapshot_line_rate_to_snapshot() -> Result<()> {
         router.set_network_error(1, false);
 
         router.wait_for_log(&btreeset![1], Some(log_index), timeout(), "replicate by snapshot").await?;
-        router
-            .wait_for_snapshot(&btreeset![1], log_id(1, 0, log_index), timeout(), "snapshot on node 1")
-            .await?;
+        router.wait(&1, timeout()).snapshot(log_id(1, 0, log_index), "snapshot on node 1").await?;
     }
 
     Ok(())

--- a/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
+++ b/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
@@ -41,7 +41,7 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
 
         router.wait_for_log(&btreeset![0], Some(log_index), None, "send log to trigger snapshot").await?;
 
-        router.wait_for_snapshot(&btreeset![0], log_id(1, 0, log_index), None, "snapshot").await?;
+        router.wait(&0, None).snapshot(log_id(1, 0, log_index), "snapshot").await?;
         router
             .assert_storage_state(
                 1,
@@ -69,7 +69,7 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
         log_index += 1;
 
         router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "add learner").await?;
-        router.wait_for_snapshot(&btreeset![1], log_id(1, 0, snapshot_threshold - 1), None, "").await?;
+        router.wait(&1, None).snapshot(log_id(1, 0, snapshot_threshold - 1), "").await?;
         let expected_snap = Some(((snapshot_threshold - 1).into(), 1));
         router
             .assert_storage_state(

--- a/tests/tests/snapshot_streaming/t60_snapshot_chunk_size.rs
+++ b/tests/tests/snapshot_streaming/t60_snapshot_chunk_size.rs
@@ -42,7 +42,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.new_raft_node(0).await;
 
         router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
-        router.wait_for_state(&btreeset![0], ServerState::Learner, timeout(), "empty").await?;
+        router.wait(&0, timeout()).state(ServerState::Learner, "empty").await?;
 
         router.initialize(0).await?;
         log_index += 1;
@@ -65,7 +65,7 @@ async fn snapshot_chunk_size() -> Result<()> {
                 "send log to trigger snapshot",
             )
             .await?;
-        router.wait_for_snapshot(&btreeset![0], log_id(1, 0, log_index), timeout(), "snapshot").await?;
+        router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "snapshot").await?;
         router.assert_storage_state(1, log_index, Some(0), log_id(1, 0, log_index), want_snap).await?;
 
         let n0 = router.get_raft_handle(&0)?;


### PR DESCRIPTION

## Changelog

##### refactor: remove wait_for_state() and wait_for_snapshot() wrappers
Removed the `wait_for_state()` and `wait_for_snapshot()` helper methods from
the test fixtures and replaced all usages with direct calls to `wait().state()`
and `wait().snapshot()`. This simplifies the test API by reducing unnecessary
wrapper methods.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1466)
<!-- Reviewable:end -->
