### PR TITLE
refactor: remove unnecessary testing wrapper methods

### DIFF
--- a/tests/tests/append_entries/t11_append_conflicts.rs
+++ b/tests/tests/append_entries/t11_append_conflicts.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use maplit::btreeset;
 use openraft::Config;
 use openraft::Entry;
 use openraft::RaftLogReader;
@@ -36,7 +35,7 @@ async fn append_conflicts() -> Result<()> {
 
     tracing::info!("--- wait for init node to ready");
 
-    router.wait_for_log(&btreeset![0], None, timeout(), "empty").await?;
+    router.wait(&0, timeout()).applied_index(None, "empty").await?;
     router.wait(&0, timeout()).state(ServerState::Learner, "empty").await?;
 
     let (r0, mut sto0, _sm0) = router.remove_node(0).unwrap();

--- a/tests/tests/append_entries/t11_append_updates_membership.rs
+++ b/tests/tests/append_entries/t11_append_updates_membership.rs
@@ -36,7 +36,7 @@ async fn append_updates_membership() -> Result<()> {
 
     tracing::info!("--- wait for init node to ready");
 
-    router.wait_for_log(&btreeset![0], None, None, "empty").await?;
+    router.wait(&0, None).applied_index(None, "empty").await?;
     router.wait(&0, None).state(ServerState::Learner, "empty").await?;
 
     let (r0, _sto0, _sm0) = router.remove_node(0).unwrap();

--- a/tests/tests/append_entries/t30_replication_1_voter_to_isolated_learner.rs
+++ b/tests/tests/append_entries/t30_replication_1_voter_to_isolated_learner.rs
@@ -36,14 +36,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
         router.client_request_many(0, "0", (10 - log_index) as usize).await?;
         log_index = 10;
 
-        router
-            .wait_for_log(
-                &btreeset![0],
-                Some(log_index),
-                timeout(),
-                "send log to trigger snapshot",
-            )
-            .await?;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "send log to trigger snapshot").await?;
     }
 
     tracing::info!(log_index, "--- restore replication to node 1");
@@ -53,14 +46,7 @@ async fn replication_1_voter_to_isolated_learner() -> Result<()> {
         router.client_request_many(0, "0", (10 - log_index) as usize).await?;
         log_index = 10;
 
-        router
-            .wait_for_log(
-                &btreeset![0],
-                Some(log_index),
-                timeout(),
-                "send log to trigger snapshot",
-            )
-            .await?;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "send log to trigger snapshot").await?;
     }
     Ok(())
 }

--- a/tests/tests/client_api/t10_client_writes.rs
+++ b/tests/tests/client_api/t10_client_writes.rs
@@ -50,7 +50,9 @@ async fn client_writes() -> Result<()> {
     while clients.next().await.is_some() {}
 
     log_index += 100 * 6;
-    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "sync logs").await?;
+    for id in [0, 1, 2] {
+        router.wait(&id, None).applied_index(Some(log_index), "sync logs").await?;
+    }
 
     router
         .assert_storage_state(

--- a/tests/tests/client_api/t50_lagging_network_write.rs
+++ b/tests/tests/client_api/t50_lagging_network_write.rs
@@ -37,7 +37,9 @@ async fn lagging_network_write() -> Result<()> {
 
     router.client_request_many(0, "client", 1).await?;
     log_index += 1;
-    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), timeout(), "write one log").await?;
+    for id in [0, 1, 2] {
+        router.wait(&id, timeout()).applied_index(Some(log_index), "write one log").await?;
+    }
 
     let node = router.get_raft_handle(&0)?;
     node.change_membership([0, 1, 2], false).await?;
@@ -46,11 +48,15 @@ async fn lagging_network_write() -> Result<()> {
     for node in [1, 2] {
         router.wait(&node, None).state(ServerState::Follower, "changed").await?;
     }
-    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), timeout(), "3 candidates").await?;
+    for id in [0, 1, 2] {
+        router.wait(&id, timeout()).applied_index(Some(log_index), "3 candidates").await?;
+    }
 
     router.client_request_many(0, "client", 1).await?;
     log_index += 1;
-    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), timeout(), "write 2nd log").await?;
+    for id in [0, 1, 2] {
+        router.wait(&id, timeout()).applied_index(Some(log_index), "write 2nd log").await?;
+    }
 
     Ok(())
 }

--- a/tests/tests/life_cycle/t10_initialization.rs
+++ b/tests/tests/life_cycle/t10_initialization.rs
@@ -58,8 +58,8 @@ async fn initialization() -> anyhow::Result<()> {
     let mut log_index = 0;
 
     // Assert all nodes are in learner state & have no entries.
-    router.wait_for_log(&btreeset![0, 1, 2], None, timeout(), "empty").await?;
     for node in [0, 1, 2] {
+        router.wait(&node, timeout()).applied_index(None, "empty").await?;
         router.wait(&node, timeout()).state(ServerState::Learner, "empty").await?;
     }
 

--- a/tests/tests/membership/t10_learner_restart.rs
+++ b/tests/tests/membership/t10_learner_restart.rs
@@ -40,7 +40,9 @@ async fn learner_restart() -> Result<()> {
     router.client_request(0, "foo", 1).await?;
     log_index += 1;
 
-    router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "write one log").await?;
+    for id in [0, 1] {
+        router.wait(&id, None).applied_index(Some(log_index), "write one log").await?;
+    }
 
     let (node0, _sto0, _sm0) = router.remove_node(0).unwrap();
     node0.shutdown().await?;

--- a/tests/tests/membership/t10_single_node.rs
+++ b/tests/tests/membership/t10_single_node.rs
@@ -37,7 +37,7 @@ async fn single_node() -> Result<()> {
 
     // Write some data to the single node cluster.
     log_index += router.client_request_many(0, "0", 1000).await?;
-    router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "client_request_many").await?;
+    router.wait(&0, timeout()).applied_index(Some(log_index), "client_request_many").await?;
     router.assert_storage_state(1, log_index, Some(0), log_id(1, 0, log_index), None).await?;
 
     // Read some data from the single node cluster.

--- a/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
+++ b/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
@@ -118,20 +118,18 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
 
     wait_log(&router, &candidates, log_index).await?;
     router
-        .wait_for_metrics(
-            &3u64,
+        .wait(&3u64, timeout())
+        .metrics(
             |x| x.state == ServerState::Learner,
-            timeout(),
             &format!("n{}.state -> {:?}", 3, ServerState::Learner),
         )
         .await?;
 
     // THe learner should receive the last written log
     router
-        .wait_for_metrics(
-            &3u64,
+        .wait(&3u64, timeout())
+        .metrics(
             |x| x.last_log_index == Some(log_index),
-            timeout(),
             &format!("n{}.last_log_index -> {}", 3, log_index),
         )
         .await?;
@@ -142,18 +140,16 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
 async fn wait_log(router: &RaftRouter, node_ids: &BTreeSet<u64>, want_log: u64) -> anyhow::Result<()> {
     for i in node_ids.iter() {
         router
-            .wait_for_metrics(
-                i,
+            .wait(i, timeout())
+            .metrics(
                 |x| x.last_log_index == Some(want_log),
-                timeout(),
                 &format!("n{}.last_log_index -> {}", i, want_log),
             )
             .await?;
         router
-            .wait_for_metrics(
-                i,
+            .wait(i, timeout())
+            .metrics(
                 |x| x.last_applied.index() == Some(want_log),
-                timeout(),
                 &format!("n{}.last_applied -> {}", i, want_log),
             )
             .await?;

--- a/tests/tests/membership/t30_elect_with_new_config.rs
+++ b/tests/tests/membership/t30_elect_with_new_config.rs
@@ -49,9 +49,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     node_1.trigger().elect().await?;
     log_index += 1; // leader initial blank log
 
-    router
-        .wait_for_metrics(&1, |x| x.current_leader == Some(1), timeout(), "wait for new leader")
-        .await?;
+    router.wait(&1, timeout()).metrics(|x| x.current_leader == Some(1), "wait for new leader").await?;
 
     for node_id in [1, 2, 3, 4] {
         router

--- a/tests/tests/membership/t31_add_remove_follower.rs
+++ b/tests/tests/membership/t31_add_remove_follower.rs
@@ -38,7 +38,9 @@ async fn add_remove_voter() -> Result<()> {
         router.client_request_many(0, "client", 100).await?;
         log_index += 100;
 
-        router.wait_for_log(&c01234, Some(log_index), timeout(), "write 100 logs").await?;
+        for id in c01234.iter() {
+            router.wait(id, timeout()).applied_index(Some(log_index), "write 100 logs").await?;
+        }
     }
 
     tracing::info!(log_index, "--- remove n{}", 4);
@@ -47,7 +49,9 @@ async fn add_remove_voter() -> Result<()> {
         node.change_membership(c0123.clone(), false).await?;
         log_index += 2; // two member-change logs
 
-        router.wait_for_log(&c0123, Some(log_index), timeout(), "removed node-4 from membership").await?;
+        for id in c0123.iter() {
+            router.wait(id, timeout()).applied_index(Some(log_index), "removed node-4 from membership").await?;
+        }
     }
 
     tracing::info!(log_index, "--- write another 100 logs");
@@ -56,7 +60,9 @@ async fn add_remove_voter() -> Result<()> {
         log_index += 100;
     }
 
-    router.wait_for_log(&c0123, Some(log_index), timeout(), "4 nodes recv logs 100~200").await?;
+    for id in c0123.iter() {
+        router.wait(id, timeout()).applied_index(Some(log_index), "4 nodes recv logs 100~200").await?;
+    }
 
     tracing::info!(log_index, "--- log will not be sync to removed node");
     {

--- a/tests/tests/membership/t31_remove_leader.rs
+++ b/tests/tests/membership/t31_remove_leader.rs
@@ -39,7 +39,9 @@ async fn remove_leader() -> Result<()> {
     // Submit a config change which adds two new nodes and removes the current leader.
     let orig_leader = router.leader().expect("expected the cluster to have a leader");
     assert_eq!(0, orig_leader, "expected original leader to be node 0");
-    router.wait_for_log(&btreeset![0, 1], Some(log_index), timeout(), "add learner").await?;
+    for id in [0, 1] {
+        router.wait(&id, timeout()).applied_index(Some(log_index), "add learner").await?;
+    }
 
     let node = router.get_raft_handle(&orig_leader)?;
     node.change_membership([1, 2, 3], false).await?;

--- a/tests/tests/membership/t31_removed_follower.rs
+++ b/tests/tests/membership/t31_removed_follower.rs
@@ -33,7 +33,9 @@ async fn stop_replication_to_removed_follower() -> Result<()> {
     router.add_learner(0, 3).await?;
     router.add_learner(0, 4).await?;
     log_index += 2;
-    router.wait_for_log(&btreeset![0, 1, 2], Some(log_index), None, "cluster of 2 learners").await?;
+    for id in [0, 1, 2] {
+        router.wait(&id, None).applied_index(Some(log_index), "cluster of 2 learners").await?;
+    }
 
     tracing::info!(log_index, "--- changing config to 0,3,4");
     {

--- a/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -56,7 +56,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     tracing::info!(log_index, "--- wait for log to sync");
     log_index += 1;
     for node_id in 0..2 {
-        router.wait_for_log(&btreeset![node_id], Some(log_index), None, "write one log").await?;
+        router.wait(&node_id, None).applied_index(Some(log_index), "write one log").await?;
         let (_sto, sm) = router.get_storage_handle(&node_id)?;
         assert!(sm.get_state_machine().await.client_status.contains_key("foo"));
     }

--- a/tests/tests/metrics/t40_metrics_wait.rs
+++ b/tests/tests/metrics/t40_metrics_wait.rs
@@ -40,7 +40,7 @@ async fn metrics_wait() -> Result<()> {
     }
 
     router.wait(&0, None).current_leader(0, "become leader").await?;
-    router.wait_for_log(&cluster, Some(1), None, "initial log").await?;
+    router.wait(&0, None).applied_index(Some(1), "initial log").await?;
 
     tracing::info!("--- wait and timeout");
 

--- a/tests/tests/snapshot_building/t10_build_snapshot.rs
+++ b/tests/tests/snapshot_building/t10_build_snapshot.rs
@@ -58,7 +58,7 @@ async fn build_snapshot() -> Result<()> {
 
     tracing::info!(log_index, "--- log_index: {}", log_index);
 
-    router.wait_for_log(&btreeset![0], Some(log_index), timeout(), "write").await?;
+    router.wait(&0, timeout()).applied_index(Some(log_index), "write").await?;
     router.wait(&0, None).snapshot(log_id(1, 0, log_index), "snapshot").await?;
 
     router
@@ -91,7 +91,9 @@ async fn build_snapshot() -> Result<()> {
 
     tracing::info!(log_index, "--- log_index: {}", log_index);
 
-    router.wait_for_log(&btreeset![0, 1], Some(log_index), timeout(), "add follower").await?;
+    for id in [0, 1] {
+        router.wait(&id, timeout()).applied_index(Some(log_index), "add follower").await?;
+    }
 
     tracing::info!(
         log_index,

--- a/tests/tests/snapshot_streaming/t32_snapshot_uses_prev_snap_membership.rs
+++ b/tests/tests/snapshot_streaming/t32_snapshot_uses_prev_snap_membership.rs
@@ -54,14 +54,9 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold - 1;
 
-        router
-            .wait_for_log(
-                &btreeset![0, 1],
-                Some(log_index),
-                timeout(),
-                "send log to trigger snapshot",
-            )
-            .await?;
+        for id in [0, 1] {
+            router.wait(&id, timeout()).applied_index(Some(log_index), "send log to trigger snapshot").await?;
+        }
         router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "1st snapshot").await?;
 
         {
@@ -87,7 +82,9 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
         router.client_request_many(0, "0", (snapshot_threshold * 2 - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold * 2 - 1;
 
-        router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "send log to trigger snapshot").await?;
+        for id in [0, 1] {
+            router.wait(&id, None).applied_index(Some(log_index), "send log to trigger snapshot").await?;
+        }
         router.wait(&0, None).snapshot(log_id(1, 0, log_index), "2nd snapshot").await?;
     }
 

--- a/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
+++ b/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
@@ -39,7 +39,7 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
         router.client_request_many(0, "0", (snapshot_threshold - 1 - log_index) as usize).await?;
         log_index = snapshot_threshold - 1;
 
-        router.wait_for_log(&btreeset![0], Some(log_index), None, "send log to trigger snapshot").await?;
+        router.wait(&0, None).applied_index(Some(log_index), "send log to trigger snapshot").await?;
 
         router.wait(&0, None).snapshot(log_id(1, 0, log_index), "snapshot").await?;
         router
@@ -68,7 +68,9 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
         router.add_learner(0, 1).await.expect("failed to add new node as learner");
         log_index += 1;
 
-        router.wait_for_log(&btreeset![0, 1], Some(log_index), None, "add learner").await?;
+        for id in [0, 1] {
+            router.wait(&id, None).applied_index(Some(log_index), "add learner").await?;
+        }
         router.wait(&1, None).snapshot(log_id(1, 0, snapshot_threshold - 1), "").await?;
         let expected_snap = Some(((snapshot_threshold - 1).into(), 1));
         router

--- a/tests/tests/state_machine/t10_total_order_apply.rs
+++ b/tests/tests/state_machine/t10_total_order_apply.rs
@@ -70,10 +70,9 @@ async fn total_order_apply() -> Result<()> {
 
     let want = n as u64;
     router
-        .wait_for_metrics(
-            &1u64,
+        .wait(&1u64, timeout())
+        .metrics(
             |x| x.last_applied.index() >= Some(want),
-            timeout(),
             &format!("n{}.last_applied -> {}", 1, want),
         )
         .await?;

--- a/tests/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/tests/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -60,7 +60,7 @@ async fn state_machine_apply_membership() -> Result<()> {
         router.add_learner(0, 4).await?;
     }
     log_index += 4;
-    router.wait_for_log(&btreeset![0], Some(log_index), None, "add learner").await?;
+    router.wait(&0, None).applied_index(Some(log_index), "add learner").await?;
 
     tracing::info!(log_index, "--- changing cluster config");
     let node = router.get_raft_handle(&0)?;


### PR DESCRIPTION

## Changelog

##### refactor: remove unnecessary testing wrapper methods
- remove wait_for_log() wrapper method
- remove wait_for_members() wrapper method
- remove wait_for_metrics() wrapper method

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1468)
<!-- Reviewable:end -->
