### PR TITLE
refactor: remove tokio from rt-compio

### DIFF
--- a/rt-compio/Cargo.toml
+++ b/rt-compio/Cargo.toml
@@ -15,10 +15,11 @@ repository = "https://github.com/databendlabs/openraft"
 [dependencies]
 openraft = { path = "../openraft", version = "0.10.0", default-features = false, features = ["singlethreaded"] }
 compio = { version = ">=0.14.0", features = ["runtime", "time"] }
-tokio = { version = "1.22", features = ["sync"], default-features = false }
 rand = "0.9"
 futures = "0.3"
 pin-project-lite = "0.2.16"
+see = "0.1.1"
+flume = { version = "0.11.1", default-features = false, features = ["async"] }
 
 [dev-dependencies]
 compio = { version = ">=0.14.0", features = ["macros"] }

--- a/rt-compio/src/lib.rs
+++ b/rt-compio/src/lib.rs
@@ -17,6 +17,11 @@ use openraft::OptionalSend;
 pub use rand;
 use rand::rngs::ThreadRng;
 
+use crate::mpsc::FlumeMpsc;
+use crate::mpsc_unbounded::FlumeMpscUnbounded;
+use crate::oneshot::FuturesOneshot;
+use crate::watch::See;
+
 mod mpsc;
 mod mpsc_unbounded;
 mod mutex;
@@ -109,11 +114,11 @@ impl AsyncRuntime for CompioRuntime {
     type TimeoutError = Elapsed;
     type Timeout<R, T: Future<Output = R> + OptionalSend> = CompioTimeout<T>;
     type ThreadLocalRng = ThreadRng;
-    type Mpsc = mpsc::CompioMpsc;
-    type MpscUnbounded = mpsc_unbounded::TokioMpscUnbounded;
-    type Watch = watch::TokioWatch;
-    type Oneshot = oneshot::FuturesOneshot;
-    type Mutex<T: OptionalSend + 'static> = mutex::TokioMutex<T>;
+    type Mpsc = FlumeMpsc;
+    type MpscUnbounded = FlumeMpscUnbounded;
+    type Watch = See;
+    type Oneshot = FuturesOneshot;
+    type Mutex<T: OptionalSend + 'static> = mutex::FlumeMutex<T>;
 
     fn spawn<T>(fut: T) -> Self::JoinHandle<T::Output>
     where

--- a/rt-compio/src/mutex.rs
+++ b/rt-compio/src/mutex.rs
@@ -3,16 +3,16 @@ use std::future::Future;
 use openraft::type_config::async_runtime::mutex;
 use openraft::OptionalSend;
 
-pub struct TokioMutex<T>(tokio::sync::Mutex<T>);
+pub struct FlumeMutex<T>(futures::lock::Mutex<T>);
 
-impl<T> mutex::Mutex<T> for TokioMutex<T>
+impl<T> mutex::Mutex<T> for FlumeMutex<T>
 where T: OptionalSend + 'static
 {
-    type Guard<'a> = tokio::sync::MutexGuard<'a, T>;
+    type Guard<'a> = futures::lock::MutexGuard<'a, T>;
 
     #[inline]
     fn new(value: T) -> Self {
-        TokioMutex(tokio::sync::Mutex::new(value))
+        FlumeMutex(futures::lock::Mutex::new(value))
     }
 
     #[inline]

--- a/rt-compio/src/watch.rs
+++ b/rt-compio/src/watch.rs
@@ -5,34 +5,37 @@ use openraft::async_runtime::watch::SendError;
 use openraft::type_config::async_runtime::watch;
 use openraft::OptionalSend;
 use openraft::OptionalSync;
-use tokio::sync::watch as tokio_watch;
+use see::error::SendError as SeeSendError;
+use see::unsync as see_unsync;
 
-pub struct TokioWatch;
-pub struct TokioWatchSender<T>(tokio_watch::Sender<T>);
-pub struct TokioWatchReceiver<T>(tokio_watch::Receiver<T>);
-pub struct TokioWatchRef<'a, T>(tokio_watch::Ref<'a, T>);
+pub struct See;
+pub struct SeeSender<T>(see_unsync::Sender<T>);
+pub struct SeeReceiver<T>(see_unsync::Receiver<T>);
+pub struct SeeRef<'a, T>(see_unsync::Guard<'a, T>);
 
-impl watch::Watch for TokioWatch {
-    type Sender<T: OptionalSend + OptionalSync> = TokioWatchSender<T>;
-    type Receiver<T: OptionalSend + OptionalSync> = TokioWatchReceiver<T>;
-    type Ref<'a, T: OptionalSend + 'a> = TokioWatchRef<'a, T>;
+impl watch::Watch for See {
+    type Sender<T: OptionalSend + OptionalSync> = SeeSender<T>;
+    type Receiver<T: OptionalSend + OptionalSync> = SeeReceiver<T>;
+    type Ref<'a, T: OptionalSend + 'a> = SeeRef<'a, T>;
 
     #[inline]
     fn channel<T: OptionalSend + OptionalSync>(init: T) -> (Self::Sender<T>, Self::Receiver<T>) {
-        let (tx, rx) = tokio_watch::channel(init);
-        let tx_wrapper = TokioWatchSender(tx);
-        let rx_wrapper = TokioWatchReceiver(rx);
+        let (tx, rx) = see_unsync::channel(init);
+        let tx_wrapper = SeeSender(tx);
+        let rx_wrapper = SeeReceiver(rx);
 
         (tx_wrapper, rx_wrapper)
     }
 }
 
-impl<T> watch::WatchSender<TokioWatch, T> for TokioWatchSender<T>
+impl<T> watch::WatchSender<See, T> for SeeSender<T>
 where T: OptionalSend + OptionalSync
 {
     #[inline]
     fn send(&self, value: T) -> Result<(), SendError<T>> {
-        self.0.send(value).map_err(|e| watch::SendError(e.0))
+        self.0.send(value).map_err(|e| match e {
+            SeeSendError::ChannelClosed(value) => watch::SendError(value),
+        })
     }
 
     #[inline]
@@ -42,20 +45,20 @@ where T: OptionalSend + OptionalSync
     }
 
     #[inline]
-    fn borrow_watched(&self) -> <TokioWatch as watch::Watch>::Ref<'_, T> {
+    fn borrow_watched(&self) -> <See as watch::Watch>::Ref<'_, T> {
         let inner = self.0.borrow();
-        TokioWatchRef(inner)
+        SeeRef(inner)
     }
 }
 
-impl<T> Clone for TokioWatchReceiver<T> {
+impl<T> Clone for SeeReceiver<T> {
     #[inline]
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<T> watch::WatchReceiver<TokioWatch, T> for TokioWatchReceiver<T>
+impl<T> watch::WatchReceiver<See, T> for SeeReceiver<T>
 where T: OptionalSend + OptionalSync
 {
     #[inline]
@@ -64,12 +67,12 @@ where T: OptionalSend + OptionalSync
     }
 
     #[inline]
-    fn borrow_watched(&self) -> <TokioWatch as watch::Watch>::Ref<'_, T> {
-        TokioWatchRef(self.0.borrow())
+    fn borrow_watched(&self) -> <See as watch::Watch>::Ref<'_, T> {
+        SeeRef(self.0.borrow())
     }
 }
 
-impl<T> Deref for TokioWatchRef<'_, T> {
+impl<T> Deref for SeeRef<'_, T> {
     type Target = T;
 
     #[inline]


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

The PR replace tokio in rt-compio with:
- [flume](https://github.com/zesterer/flume) for both bounded and unbounded mpsc. This is what we used internally at compio, so no additional dependencies.
- [see](https://github.com/compio-rs/see) for `tokio::sync::watch`.
- `futures::lock::Mutex` for async mutex

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1469)
<!-- Reviewable:end -->
