### PR TITLE
docs: add FAQ entry on detecting valid leadership

### DIFF
--- a/openraft/src/docs/faq/faq-toc.md
+++ b/openraft/src/docs/faq/faq-toc.md
@@ -3,6 +3,7 @@
 - [Observation and Management](#observation-and-management)
   * [How do leader elections get triggered?](#how-do-leader-elections-get-triggered)
   * [How to get notified when the server state changes?](#how-to-get-notified-when-the-server-state-changes)
+  * [How to detect if a leader is valid?](#how-to-detect-if-a-leader-is-valid)
 - [Data structure](#data-structure)
   * [Why is log id a tuple of `(term, node_id, log_index)`?](#why-is-log-id-a-tuple-of-term-node_id-log_index)
 - [Replication](#replication)

--- a/openraft/src/docs/faq/faq.md
+++ b/openraft/src/docs/faq/faq.md
@@ -117,6 +117,66 @@ loop {
 ```
 
 
+### How to detect if a leader is valid?
+
+**Problem**: In distributed systems, you can perceive multiple leaders at the
+same time. However, only one of them is the **legal leader** at any specific
+point in time - only one can actually commit logs successfully.
+
+This commonly happens when:
+- A leader node restarts and immediately resumes as Leader (by design)
+- Network partitions occur
+- There are message delays or concurrent elections
+
+**Solution**: Use the [`RaftMetrics::last_quorum_acked`][] field to verify leadership validity.
+
+The `last_quorum_acked` field shows the most recently acknowledged timestamp by a quorum:
+
+```rust,ignore
+/// For a leader, it is the most recently acknowledged timestamp by a quorum.
+///
+/// It is `None` if this node is not leader, or the leader is not yet acknowledged by a quorum.
+/// Being acknowledged means receiving a reply of
+/// `AppendEntries`(`AppendEntriesRequest.vote.committed == true`).
+pub last_quorum_acked: Option<SerdeInstantOf<C>>,
+```
+
+**A valid leader must have `last_quorum_acked` as `Some` with a recent timestamp:**
+
+- **`None`**: Invalid leader (not acknowledged by quorum)
+- **`Some(old_timestamp)`**: Invalid leader (lost connection with cluster)
+- **`Some(recent_timestamp)`**: Valid leader
+
+**Example**:
+
+```rust,ignore
+let mut rx = self.raft.metrics();
+loop {
+    let m = rx.borrow();
+
+    // Only act if:
+    // 1. State shows Leader, AND
+    // 2. last_quorum_acked is Some with a recent timestamp
+    if m.state == ServerState::Leader {
+        if let Some(last_acked) = m.last_quorum_acked {
+            // Check if acknowledged recently (e.g., within 2× election timeout)
+            let election_timeout = Duration::from_millis(500); // your configured timeout
+            if last_acked.elapsed() < election_timeout * 2 {
+                do_critical_leader_operation();
+            }
+        }
+        // If last_quorum_acked is None, this is NOT a valid leader
+    }
+
+    rx.changed().await?;
+}
+```
+
+If you want to be extra careful, wait for metrics to flush by adding a small
+delay and checking again. However, **`None` itself means the leader is not
+valid**.
+
+
 ## Data structure
 
 
@@ -568,6 +628,7 @@ OpenRaft intentionally supports this behavior because:
 [`RaftMetrics::current_leader`]: `crate::metrics::RaftMetrics::current_leader`
 [`RaftMetrics::heartbeat`]: `crate::metrics::RaftMetrics::heartbeat`
 [`RaftMetrics::last_log_index`]: `crate::metrics::RaftMetrics::last_log_index`
+[`RaftMetrics::last_quorum_acked`]: `crate::metrics::RaftMetrics::last_quorum_acked`
 [`RaftMetrics::replication`]: `crate::metrics::RaftMetrics::replication`
 [`Raft::metrics`]: `crate::Raft::metrics`
 [`Raft::shutdown`]: `crate::Raft::shutdown`


### PR DESCRIPTION

## Changelog

##### docs: add FAQ entry on detecting valid leadership
Add FAQ explaining how to verify if a leader is valid using
`RaftMetrics::last_quorum_acked` field. Covers distributed systems
reality of perceiving multiple leaders and provides code example.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1470)
<!-- Reviewable:end -->
