### PR TITLE
fix: test_watch_wait_until

### DIFF
--- a/openraft/src/testing/runtime/mod.rs
+++ b/openraft/src/testing/runtime/mod.rs
@@ -410,7 +410,7 @@ impl<Rt: AsyncRuntime> Suite<Rt> {
     }
 
     pub async fn test_watch_wait_until() {
-        let init_value = 0;
+        let init_value = 5;
         let (tx, mut rx) = Rt::Watch::channel(init_value);
 
         // Spawn a task that waits for an even value


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

This PR fixes `test_watch_wait_until` by changing its initial value to an odd number.

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1477)
<!-- Reviewable:end -->
