### PR TITLE
change: storage traits return `io::Error`

### DIFF
--- a/examples/mem-log/src/log_store.rs
+++ b/examples/mem-log/src/log_store.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::io;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
@@ -12,7 +13,6 @@ use openraft::entry::RaftEntry;
 use openraft::storage::IOFlushed;
 use openraft::LogState;
 use openraft::RaftTypeConfig;
-use openraft::StorageError;
 use tokio::sync::Mutex;
 
 /// RaftLogStore implementation with a in-memory storage
@@ -51,7 +51,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug>(
         &mut self,
         range: RB,
-    ) -> Result<Vec<C::Entry>, StorageError<C>>
+    ) -> Result<Vec<C::Entry>, io::Error>
     where
         C::Entry: Clone,
     {
@@ -59,7 +59,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         Ok(response)
     }
 
-    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>> {
+    async fn get_log_state(&mut self) -> Result<LogState<C>, io::Error> {
         let last = self.log.iter().next_back().map(|(_, ent)| ent.log_id());
 
         let last_purged = self.last_purged_log_id.clone();
@@ -75,25 +75,25 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         })
     }
 
-    async fn save_committed(&mut self, committed: Option<LogIdOf<C>>) -> Result<(), StorageError<C>> {
+    async fn save_committed(&mut self, committed: Option<LogIdOf<C>>) -> Result<(), io::Error> {
         self.committed = committed;
         Ok(())
     }
 
-    async fn read_committed(&mut self) -> Result<Option<LogIdOf<C>>, StorageError<C>> {
+    async fn read_committed(&mut self) -> Result<Option<LogIdOf<C>>, io::Error> {
         Ok(self.committed.clone())
     }
 
-    async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), StorageError<C>> {
+    async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), io::Error> {
         self.vote = Some(vote.clone());
         Ok(())
     }
 
-    async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, StorageError<C>> {
+    async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, io::Error> {
         Ok(self.vote.clone())
     }
 
-    async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), StorageError<C>>
+    async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), io::Error>
     where I: IntoIterator<Item = C::Entry> {
         // Simple implementation that calls the flush-before-return `append_to_log`.
         for entry in entries {
@@ -104,7 +104,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         Ok(())
     }
 
-    async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>> {
+    async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), io::Error> {
         let keys = self.log.range(log_id.index()..).map(|(k, _v)| *k).collect::<Vec<_>>();
         for key in keys {
             self.log.remove(&key);
@@ -113,7 +113,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         Ok(())
     }
 
-    async fn purge(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>> {
+    async fn purge(&mut self, log_id: LogIdOf<C>) -> Result<(), io::Error> {
         {
             let ld = &mut self.last_purged_log_id;
             assert!(ld.as_ref() <= Some(&log_id));
@@ -133,6 +133,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
 
 mod impl_log_store {
     use std::fmt::Debug;
+    use std::io;
     use std::ops::RangeBounds;
 
     use openraft::alias::LogIdOf;
@@ -142,7 +143,6 @@ mod impl_log_store {
     use openraft::LogState;
     use openraft::RaftLogReader;
     use openraft::RaftTypeConfig;
-    use openraft::StorageError;
 
     use crate::log_store::LogStore;
 
@@ -152,12 +152,12 @@ mod impl_log_store {
         async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug>(
             &mut self,
             range: RB,
-        ) -> Result<Vec<C::Entry>, StorageError<C>> {
+        ) -> Result<Vec<C::Entry>, io::Error> {
             let mut inner = self.inner.lock().await;
             inner.try_get_log_entries(range).await
         }
 
-        async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, StorageError<C>> {
+        async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, io::Error> {
             let mut inner = self.inner.lock().await;
             inner.read_vote().await
         }
@@ -168,38 +168,38 @@ mod impl_log_store {
     {
         type LogReader = Self;
 
-        async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>> {
+        async fn get_log_state(&mut self) -> Result<LogState<C>, io::Error> {
             let mut inner = self.inner.lock().await;
             inner.get_log_state().await
         }
 
-        async fn save_committed(&mut self, committed: Option<LogIdOf<C>>) -> Result<(), StorageError<C>> {
+        async fn save_committed(&mut self, committed: Option<LogIdOf<C>>) -> Result<(), io::Error> {
             let mut inner = self.inner.lock().await;
             inner.save_committed(committed).await
         }
 
-        async fn read_committed(&mut self) -> Result<Option<LogIdOf<C>>, StorageError<C>> {
+        async fn read_committed(&mut self) -> Result<Option<LogIdOf<C>>, io::Error> {
             let mut inner = self.inner.lock().await;
             inner.read_committed().await
         }
 
-        async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), StorageError<C>> {
+        async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), io::Error> {
             let mut inner = self.inner.lock().await;
             inner.save_vote(vote).await
         }
 
-        async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), StorageError<C>>
+        async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), io::Error>
         where I: IntoIterator<Item = C::Entry> {
             let mut inner = self.inner.lock().await;
             inner.append(entries, callback).await
         }
 
-        async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>> {
+        async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), io::Error> {
             let mut inner = self.inner.lock().await;
             inner.truncate(log_id).await
         }
 
-        async fn purge(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>> {
+        async fn purge(&mut self, log_id: LogIdOf<C>) -> Result<(), io::Error> {
             let mut inner = self.inner.lock().await;
             inner.purge(log_id).await
         }

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Debug;
+use std::io;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -81,7 +82,7 @@ pub struct StateMachineStore {
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn build_snapshot(&mut self) -> Result<Snapshot, StorageError> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot, io::Error> {
         let data;
         let last_applied_log;
         let last_membership;
@@ -130,13 +131,13 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     type SnapshotBuilder = Self;
 
-    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), StorageError> {
+    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), io::Error> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<(), StorageError>
+    async fn apply<I>(&mut self, entries: I) -> Result<(), io::Error>
     where
         I: IntoIterator<Item = EntryResponder<TypeConfig>>,
         I::IntoIter: Send,
@@ -172,12 +173,12 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotData, StorageError> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotData, io::Error> {
         Ok(Default::default())
     }
 
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
-    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: SnapshotData) -> Result<(), StorageError> {
+    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: SnapshotData) -> Result<(), io::Error> {
         tracing::info!("install snapshot");
 
         let new_snapshot = StoredSnapshot {
@@ -199,7 +200,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot>, StorageError> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot>, io::Error> {
         match &*self.current_snapshot.lock().unwrap() {
             Some(snapshot) => {
                 let data = snapshot.data.clone();

--- a/examples/raft-kv-memstore/tests/cluster/main.rs
+++ b/examples/raft-kv-memstore/tests/cluster/main.rs
@@ -1,1 +1,2 @@
+mod test_cluster;
 mod test_follower_read;

--- a/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs
@@ -10,7 +10,7 @@ use raft_kv_memstore::TypeConfig;
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_follower_read() -> Result<(), Box<dyn std::error::Error>> {
     fn get_addr(node_id: u64) -> String {
-        format!("127.0.0.1:2100{}", node_id)
+        format!("127.0.0.1:2800{}", node_id)
     }
 
     // Start 3 raft nodes

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -58,6 +58,7 @@ use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::error::QuorumNotEnough;
 use crate::error::RPCError;
+use crate::error::StorageIOResult;
 use crate::error::Timeout;
 use crate::impls::OneshotResponder;
 use crate::log_id::option_raft_log_id_ext::OptionRaftLogIdExt;
@@ -1776,11 +1777,11 @@ where
                 self.engine.state.log_progress_mut().submit(io_id);
 
                 // Submit IO request, do not wait for the response.
-                self.log_store.append(entries, callback).await?;
+                self.log_store.append(entries, callback).await.sto_write_logs()?;
             }
             Command::SaveVote { vote } => {
                 self.engine.state.log_progress_mut().submit(IOId::new(&vote));
-                self.log_store.save_vote(&vote).await?;
+                self.log_store.save_vote(&vote).await.sto_write_vote()?;
 
                 let _ = self
                     .tx_notification
@@ -1804,11 +1805,11 @@ where
                 }
             }
             Command::PurgeLog { upto } => {
-                self.log_store.purge(upto.clone()).await?;
+                self.log_store.purge(upto.clone()).await.sto_write_logs()?;
                 self.engine.state.io_state_mut().update_purged(Some(upto));
             }
             Command::TruncateLog { since } => {
-                self.log_store.truncate(since.clone()).await?;
+                self.log_store.truncate(since.clone()).await.sto_write_logs()?;
 
                 // Inform clients waiting for logs to be applied.
                 let removed = self.client_responders.split_off(&since.index());
@@ -1847,7 +1848,7 @@ where
             } => {
                 self.engine.state.apply_progress_mut().submit(upto.clone());
 
-                self.log_store.save_committed(Some(upto.clone())).await?;
+                self.log_store.save_committed(Some(upto.clone())).await.sto_write()?;
 
                 let first = self.engine.state.get_log_id(already_committed.next_index()).unwrap();
                 self.apply_to_state_machine(first, upto).await?;

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -90,7 +90,8 @@ where C: RaftTypeConfig
                 continue;
             }
 
-            let mid = sto.get_log_id((first.index() + last.index()) / 2).await?;
+            let mid_index = (first.index() + last.index()) / 2;
+            let mid = sto.get_log_id(mid_index).await?;
 
             if first.committed_leader_id() == mid.committed_leader_id() {
                 // Case AAC

--- a/openraft/src/error/mod.rs
+++ b/openraft/src/error/mod.rs
@@ -9,6 +9,8 @@ mod membership_error;
 mod node_not_found;
 mod operation;
 mod replication_closed;
+pub(crate) mod storage_error;
+mod storage_io_result;
 mod streaming_error;
 
 use std::collections::BTreeSet;
@@ -26,6 +28,7 @@ pub use self::membership_error::MembershipError;
 pub use self::node_not_found::NodeNotFound;
 pub use self::operation::Operation;
 pub use self::replication_closed::ReplicationClosed;
+pub(crate) use self::storage_io_result::StorageIOResult;
 pub use self::streaming_error::StreamingError;
 use crate::Membership;
 use crate::RaftTypeConfig;

--- a/openraft/src/error/storage_io_result.rs
+++ b/openraft/src/error/storage_io_result.rs
@@ -1,0 +1,118 @@
+use crate::RaftTypeConfig;
+use crate::StorageError;
+use crate::storage::SnapshotSignature;
+use crate::type_config::alias::LogIdOf;
+
+/// Simplified error conversion from io::Error to StorageError
+///
+/// Provides methods that mirror StorageError creation methods for easier error handling.
+pub(crate) trait StorageIOResult<C, T>
+where C: RaftTypeConfig
+{
+    /// Convert io::Error to StorageError for writing a single log entry
+    #[allow(dead_code)]
+    fn sto_write_log_entry(self, log_id: LogIdOf<C>) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for reading a single log entry
+    #[allow(dead_code)]
+    fn sto_read_log_entry(self, log_id: LogIdOf<C>) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for reading a log entry at an index
+    #[allow(dead_code)]
+    fn sto_read_log_at_index(self, log_index: u64) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for writing multiple log entries
+    fn sto_write_logs(self) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for reading multiple log entries
+    fn sto_read_logs(self) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for writing vote state
+    fn sto_write_vote(self) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for reading vote state
+    fn sto_read_vote(self) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for applying a log entry
+    fn sto_apply(self, log_id: LogIdOf<C>) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for writing to state machine
+    #[allow(dead_code)]
+    fn sto_write_sm(self) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for reading from state machine
+    fn sto_read_sm(self) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for writing a snapshot
+    fn sto_write_snapshot(self, signature: Option<SnapshotSignature<C>>) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for reading a snapshot
+    fn sto_read_snapshot(self, signature: Option<SnapshotSignature<C>>) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for general read operations
+    #[allow(dead_code)]
+    fn sto_read(self) -> Result<T, StorageError<C>>;
+
+    /// Convert io::Error to StorageError for general write operations
+    fn sto_write(self) -> Result<T, StorageError<C>>;
+}
+
+impl<C, T> StorageIOResult<C, T> for Result<T, std::io::Error>
+where C: RaftTypeConfig
+{
+    fn sto_write_log_entry(self, log_id: LogIdOf<C>) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::write_log_entry(log_id, &e))
+    }
+
+    fn sto_read_log_entry(self, log_id: LogIdOf<C>) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::read_log_entry(log_id, &e))
+    }
+
+    fn sto_read_log_at_index(self, log_index: u64) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::read_log_at_index(log_index, &e))
+    }
+
+    fn sto_write_logs(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::write_logs(&e))
+    }
+
+    fn sto_read_logs(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::read_logs(&e))
+    }
+
+    fn sto_write_vote(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::write_vote(&e))
+    }
+
+    fn sto_read_vote(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::read_vote(&e))
+    }
+
+    fn sto_apply(self, log_id: LogIdOf<C>) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::apply(log_id, &e))
+    }
+
+    fn sto_write_sm(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::write_state_machine(&e))
+    }
+
+    fn sto_read_sm(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::read_state_machine(&e))
+    }
+
+    fn sto_write_snapshot(self, signature: Option<SnapshotSignature<C>>) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::write_snapshot(signature, &e))
+    }
+
+    fn sto_read_snapshot(self, signature: Option<SnapshotSignature<C>>) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::read_snapshot(signature, &e))
+    }
+
+    fn sto_read(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::read(&e))
+    }
+
+    fn sto_write(self) -> Result<T, StorageError<C>> {
+        self.map_err(|e| StorageError::write(&e))
+    }
+}

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -44,7 +44,6 @@ mod quorum;
 mod raft_types;
 mod replication;
 mod runtime;
-mod storage_error;
 mod summary;
 mod try_as_ref;
 
@@ -79,6 +78,12 @@ use std::fmt;
 
 pub use anyerror;
 pub use anyerror::AnyError;
+pub use error::storage_error::ErrorSubject;
+pub use error::storage_error::ErrorVerb;
+pub use error::storage_error::StorageError;
+#[allow(deprecated)]
+pub use error::storage_error::StorageIOError;
+pub use error::storage_error::ToStorageResult;
 pub use openraft_macros::add_async_trait;
 pub use type_config::AsyncRuntime;
 pub use type_config::async_runtime;
@@ -125,12 +130,6 @@ pub use crate::raft_state::MembershipState;
 pub use crate::raft_state::RaftState;
 pub use crate::raft_types::SnapshotId;
 pub use crate::raft_types::SnapshotSegmentId;
-pub use crate::storage_error::ErrorSubject;
-pub use crate::storage_error::ErrorVerb;
-pub use crate::storage_error::StorageError;
-#[allow(deprecated)]
-pub use crate::storage_error::StorageIOError;
-pub use crate::storage_error::ToStorageResult;
 pub use crate::summary::MessageSummary;
 pub use crate::try_as_ref::TryAsRef;
 pub use crate::type_config::RaftTypeConfig;

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -30,6 +30,7 @@ mod tokio_rt {
     use crate::error::RPCError;
     use crate::error::RaftError;
     use crate::error::ReplicationClosed;
+    use crate::error::StorageIOResult;
     use crate::error::StreamingError;
     use crate::network::RPCOption;
     use crate::raft::InstallSnapshotRequest;
@@ -210,9 +211,7 @@ mod tokio_rt {
                 let streaming = streaming.take().unwrap();
                 let mut data = streaming.into_snapshot_data();
 
-                data.shutdown()
-                    .await
-                    .map_err(|e| StorageError::write_snapshot(Some(snapshot_meta.signature()), &e))?;
+                data.shutdown().await.sto_write_snapshot(Some(snapshot_meta.signature()))?;
 
                 tracing::info!("finished streaming snapshot: {:?}", snapshot_meta);
                 return Ok(Some(Snapshot::new(snapshot_meta, data)));

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -36,6 +36,7 @@ use crate::error::PayloadTooLarge;
 use crate::error::RPCError;
 use crate::error::ReplicationClosed;
 use crate::error::ReplicationError;
+use crate::error::StorageIOResult;
 use crate::error::Timeout;
 use crate::log_id::LogIdOptionExt;
 use crate::log_id_range::LogIdRange;
@@ -401,7 +402,7 @@ where
                 (vec![], r)
             } else {
                 // limited_get_log_entries will return logs smaller than the range [start, end).
-                let logs = self.log_reader.limited_get_log_entries(start, end).await?;
+                let logs = self.log_reader.limited_get_log_entries(start, end).await.sto_read_logs()?;
 
                 let first = logs.first().map(|ent| ent.ref_log_id()).unwrap();
                 let last = logs.last().map(|ent| ent.log_id()).unwrap();

--- a/openraft/src/storage/log_reader_ext.rs
+++ b/openraft/src/storage/log_reader_ext.rs
@@ -5,6 +5,7 @@ use crate::RaftLogReader;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::entry::RaftEntry;
+use crate::error::StorageIOResult;
 use crate::type_config::alias::LogIdOf;
 
 /// Extension trait for [`RaftLogReader`] providing convenience methods for log access.
@@ -16,13 +17,13 @@ where C: RaftTypeConfig
     ///
     /// It does not return an error if the log entry at `log_index` is not found.
     async fn try_get_log_entry(&mut self, log_index: u64) -> Result<Option<C::Entry>, StorageError<C>> {
-        let mut res = self.try_get_log_entries(log_index..(log_index + 1)).await?;
+        let mut res = self.try_get_log_entries(log_index..(log_index + 1)).await.sto_read_logs()?;
         Ok(res.pop())
     }
 
     /// Get the log id of the entry at `index`.
     async fn get_log_id(&mut self, log_index: u64) -> Result<LogIdOf<C>, StorageError<C>> {
-        let entries = self.try_get_log_entries(log_index..=log_index).await?;
+        let entries = self.try_get_log_entries(log_index..=log_index).await.sto_read_logs()?;
 
         if entries.is_empty() {
             return Err(StorageError::read_log_at_index(

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -5,6 +5,7 @@ use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::core::notification::Notification;
 use crate::entry::RaftEntry;
+use crate::error::StorageIOResult;
 use crate::raft_state::io_state::io_id::IOId;
 use crate::storage::IOFlushed;
 use crate::storage::RaftLogStorage;
@@ -39,7 +40,7 @@ where C: RaftTypeConfig
         let notify = Notification::LocalIO { io_id };
 
         let callback = IOFlushed::<C>::new(notify, tx.downgrade());
-        self.append(entries, callback).await?;
+        self.append(entries, callback).await.sto_write_logs()?;
 
         let got = rx.recv().await.unwrap();
         if let Notification::StorageError { error } = got {

--- a/openraft/src/storage/v2/raft_snapshot_builder.rs
+++ b/openraft/src/storage/v2/raft_snapshot_builder.rs
@@ -1,9 +1,10 @@
+use std::io;
+
 use openraft_macros::add_async_trait;
 
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftTypeConfig;
-use crate::StorageError;
 use crate::storage::Snapshot;
 /// A trait defining the interface for a Raft state machine snapshot subsystem.
 ///
@@ -28,7 +29,7 @@ where C: RaftTypeConfig
     /// - Performing log compaction, e.g., merge log entries that operate on the same key, like an
     ///   LSM-tree does,
     /// - or by fetching a snapshot from the state machine.
-    async fn build_snapshot(&mut self) -> Result<Snapshot<C>, StorageError<C>>;
+    async fn build_snapshot(&mut self) -> Result<Snapshot<C>, io::Error>;
 
     // NOTES:
     // This interface is geared toward small file-based snapshots. However, not all snapshots can

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -6,7 +7,6 @@ use openraft::Config;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
-use openraft::StorageError;
 use openraft::StoredMembership;
 use openraft::alias::LogIdOf;
 use openraft::error::Fatal;
@@ -87,7 +87,7 @@ async fn with_state_machine_wrong_sm_type() -> Result<()> {
     tracing::info!("--- use wrong type SM");
     {
         type TC = TypeConfig;
-        type Err = StorageError<TC>;
+        type Err = io::Error;
         struct FooSM;
         impl RaftSnapshotBuilder<TC> for FooSM {
             async fn build_snapshot(&mut self) -> Result<Snapshot<TC>, Err> {


### PR DESCRIPTION

## Changelog

##### change: storage traits return `io::Error`
Issue #1457: Simplify storage trait error API.

Benefits: Simpler trait implementation - Storage code doesn't need to
know about `StorageError<C>` or generic type parameters in error handling.

## Changes

Storage trait methods now return `io::Error` instead of `StorageError<C>`:
- `RaftLogStorage`: `append()`, `truncate()`, `purge()`, `save_vote()`, `save_committed()`
- `RaftLogReader`: `try_get_log_entries()`, `limited_get_log_entries()`, `read_vote()`, `get_key_log_ids()`
- `RaftStateMachine`: `applied_state()`, `apply()`, `get_current_snapshot()`, `begin_receiving_snapshot()`, `install_snapshot()`
- `RaftSnapshotBuilder`: `build_snapshot()`

Added internal `StorageIOResult` trait for error conversion:
- Provides 14 methods like `.sto_read_logs()`, `.sto_write_snapshot()`, etc.
- Converts `io::Error` to `StorageError<C>` with proper context at Openraft boundaries

- Fix: #1457

Upgrade tip:

Storage implementors should update trait methods to return `io::Error`:

```rust
// Before
async fn read_vote(&mut self) -> Result<Option<Vote>, StorageError<C>> {
    self.vote.read().map_err(|e| StorageError::read_vote(&e))
}

// After
async fn read_vote(&mut self) -> Result<Option<Vote>, io::Error> {
    self.vote.read()
}
```

Return `io::Error` directly - Openraft adds context automatically.
The method body may leave unchanged: `io::Error` can be converted to
`StorageError` with a simple `?`.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1478)
<!-- Reviewable:end -->
