### PR TITLE
feat: Add `watch_commit_progress()`

### DIFF
--- a/openraft/src/core/io_flush_tracking/mod.rs
+++ b/openraft/src/core/io_flush_tracking/mod.rs
@@ -19,6 +19,7 @@ mod watcher;
 pub use flush_point::FlushPoint;
 pub(crate) use sender::IoProgressSender;
 pub use watch_progress::AppliedProgress;
+pub use watch_progress::CommitProgress;
 pub use watch_progress::LogProgress;
 pub use watch_progress::VoteProgress;
 pub(crate) use watcher::IoProgressWatcher;

--- a/openraft/src/core/io_flush_tracking/watch_progress.rs
+++ b/openraft/src/core/io_flush_tracking/watch_progress.rs
@@ -21,6 +21,12 @@ pub type LogProgress<C> = WatchProgress<C, Option<FlushPoint<C>>>;
 /// Returns `Some(Vote)` containing the last flushed vote.
 pub type VoteProgress<C> = WatchProgress<C, Option<Vote<C>>>;
 
+/// Handle for tracking commit log progress.
+///
+/// Returns `None` if no log has been committed yet.
+/// Returns `Some(LogId)` containing the latest committed log id.
+pub type CommitProgress<C> = WatchProgress<C, Option<LogIdOf<C>>>;
+
 /// Handle for tracking applied log progress.
 ///
 /// Returns `None` if no log has been applied yet.

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -550,6 +550,7 @@ where
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn flush_metrics(&mut self) {
         self.tx_progress.send_log_progress(self.engine.state.log_progress().flushed().cloned());
+        self.tx_progress.send_commit_progress(self.engine.state.apply_progress().accepted().cloned());
         self.tx_progress.send_apply_progress(self.engine.state.io_applied().cloned());
 
         let (replication, heartbeat) = if let Some(leader) = self.engine.leader.as_ref() {

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -66,6 +66,7 @@ use crate::core::RaftCore;
 use crate::core::Tick;
 use crate::core::heartbeat::handle::HeartbeatWorkersHandle;
 use crate::core::io_flush_tracking::AppliedProgress;
+use crate::core::io_flush_tracking::CommitProgress;
 pub use crate::core::io_flush_tracking::FlushPoint;
 use crate::core::io_flush_tracking::IoProgressWatcher;
 use crate::core::io_flush_tracking::LogProgress;
@@ -1059,6 +1060,26 @@ where C: RaftTypeConfig
     #[must_use = "progress handle should be stored to track vote progress"]
     pub fn watch_vote_progress(&self) -> VoteProgress<C> {
         self.inner.progress_watcher.vote_progress()
+    }
+
+    /// Get a handle to watch commit log progress.
+    ///
+    /// Tracks when committed logs advance(persisted on a quorum and the last-log is proposed by the
+    /// leader). Updated whenever the committed cursor moves forward.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let mut commit_progress = raft.watch_commit_progress();
+    ///
+    /// // Wait until log index 42 is committed
+    /// let target = Some(LogId::new(LeaderId::new(2, node_id), 42));
+    /// commit_progress.wait_until_ge(&target).await?;
+    /// ```
+    #[since(version = "0.10.0")]
+    #[must_use = "progress handle should be stored to track commit progress"]
+    pub fn watch_commit_progress(&self) -> CommitProgress<C> {
+        self.inner.progress_watcher.commit_progress()
     }
 
     /// Get a handle to watch applied log progress.

--- a/tests/tests/metrics/main.rs
+++ b/tests/tests/metrics/main.rs
@@ -15,4 +15,5 @@ mod t20_metrics_state_machine_consistency;
 mod t30_leader_metrics;
 mod t40_metrics_wait;
 mod t50_apply_progress_api;
+mod t50_commit_progress_api;
 mod t50_log_progress_api;

--- a/tests/tests/metrics/t50_commit_progress_api.rs
+++ b/tests/tests/metrics/t50_commit_progress_api.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// Test commit progress API: get() and wait_until_ge()
+///
+/// What does this test do?
+///
+/// - Creates a single-node cluster
+/// - Gets `watch_commit_progress()` handle
+/// - Verifies initial state with `get()`
+/// - Writes client requests to advance the committed log id
+/// - Uses `wait_until_ge()` with a concrete target value
+/// - Verifies `get()` returns the same value as `wait_until_ge()`
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn commit_progress_api() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- get commit progress watcher");
+    let n0 = router.get_raft_handle(&0)?;
+    let progress = n0.watch_commit_progress();
+
+    tracing::info!(log_index, "--- verify initial commit progress with get()");
+    let got = progress.get();
+    let want = Some(log_id(1, 0, log_index));
+    assert_eq!(got, want);
+
+    tracing::info!(log_index, "--- spawn task to wait for future commit progress");
+    let target_index = log_index + 5;
+    let target = Some(log_id(1, 0, target_index));
+
+    let n0_clone = router.get_raft_handle(&0)?;
+    let handle = tokio::spawn(async move {
+        let mut progress = n0_clone.watch_commit_progress();
+        progress.wait_until_ge(&target).await
+    });
+
+    tracing::info!(log_index, "--- send client requests to trigger wait_until_ge return");
+    log_index += router.client_request_many(0, "foo", 5).await?;
+
+    tracing::info!(log_index, "--- verify wait_until_ge returns after logs are committed");
+    let got_wait = handle.await??;
+    let got_get = progress.get();
+
+    let want = Some(log_id(1, 0, log_index));
+    assert_eq!(got_wait, want);
+    assert_eq!(got_get, want);
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### feat: Add `watch_commit_progress()`
Add `watch_commit_progress()` APIs to track
when log entries are confirmed to be committed.

The returned handle expose a `WatchProgress` handle with:
- `get()`: Get current progress state immediately
- `wait_until_ge()`: Wait asynchronously until progress reaches threshold

Additionally, add `wait_until()` method to `WatchReceiver` trait that
accepts a closure for custom conditions, complementing `wait_until_ge()`.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1480)
<!-- Reviewable:end -->
