### PR TITLE
feat: Add `watch_snapshot_progress()`

### DIFF
--- a/openraft/src/core/io_flush_tracking/mod.rs
+++ b/openraft/src/core/io_flush_tracking/mod.rs
@@ -21,5 +21,6 @@ pub(crate) use sender::IoProgressSender;
 pub use watch_progress::AppliedProgress;
 pub use watch_progress::CommitProgress;
 pub use watch_progress::LogProgress;
+pub use watch_progress::SnapshotProgress;
 pub use watch_progress::VoteProgress;
 pub(crate) use watcher::IoProgressWatcher;

--- a/openraft/src/core/io_flush_tracking/watch_progress.rs
+++ b/openraft/src/core/io_flush_tracking/watch_progress.rs
@@ -27,6 +27,12 @@ pub type VoteProgress<C> = WatchProgress<C, Option<Vote<C>>>;
 /// Returns `Some(LogId)` containing the latest committed log id.
 pub type CommitProgress<C> = WatchProgress<C, Option<LogIdOf<C>>>;
 
+/// Handle for tracking snapshot persistence progress.
+///
+/// Returns `None` if no snapshot has been persisted yet.
+/// Returns `Some(LogId)` containing the last persisted snapshot log id.
+pub type SnapshotProgress<C> = WatchProgress<C, Option<LogIdOf<C>>>;
+
 /// Handle for tracking applied log progress.
 ///
 /// Returns `None` if no log has been applied yet.

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -549,9 +549,11 @@ where
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn flush_metrics(&mut self) {
-        self.tx_progress.send_log_progress(self.engine.state.log_progress().flushed().cloned());
-        self.tx_progress.send_commit_progress(self.engine.state.apply_progress().accepted().cloned());
-        self.tx_progress.send_apply_progress(self.engine.state.io_applied().cloned());
+        let io_state = self.engine.state.io_state();
+        self.tx_progress.send_log_progress(io_state.log_progress.flushed().cloned());
+        self.tx_progress.send_commit_progress(io_state.apply_progress.accepted().cloned());
+        self.tx_progress.send_apply_progress(io_state.apply_progress.flushed().cloned());
+        self.tx_progress.send_snapshot_progress(io_state.snapshot.flushed().cloned());
 
         let (replication, heartbeat) = if let Some(leader) = self.engine.leader.as_ref() {
             let replication_prog = &leader.progress;

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -70,6 +70,7 @@ use crate::core::io_flush_tracking::CommitProgress;
 pub use crate::core::io_flush_tracking::FlushPoint;
 use crate::core::io_flush_tracking::IoProgressWatcher;
 use crate::core::io_flush_tracking::LogProgress;
+use crate::core::io_flush_tracking::SnapshotProgress;
 use crate::core::io_flush_tracking::VoteProgress;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::raft_msg::external_command::ExternalCommand;
@@ -1080,6 +1081,26 @@ where C: RaftTypeConfig
     #[must_use = "progress handle should be stored to track commit progress"]
     pub fn watch_commit_progress(&self) -> CommitProgress<C> {
         self.inner.progress_watcher.commit_progress()
+    }
+
+    /// Get a handle to watch snapshot persistence progress.
+    ///
+    /// Tracks when snapshots are persisted to storage.
+    /// Updated whenever a snapshot is built or installed and persisted.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let mut snapshot_progress = raft.watch_snapshot_progress();
+    ///
+    /// // Wait until snapshot covering log index 100 is persisted
+    /// let target = Some(LogId::new(LeaderId::new(2, node_id), 100));
+    /// snapshot_progress.wait_until_ge(&target).await?;
+    /// ```
+    #[since(version = "0.10.0")]
+    #[must_use = "progress handle should be stored to track snapshot progress"]
+    pub fn watch_snapshot_progress(&self) -> SnapshotProgress<C> {
+        self.inner.progress_watcher.snapshot_progress()
     }
 
     /// Get a handle to watch applied log progress.

--- a/tests/tests/metrics/main.rs
+++ b/tests/tests/metrics/main.rs
@@ -17,3 +17,4 @@ mod t40_metrics_wait;
 mod t50_apply_progress_api;
 mod t50_commit_progress_api;
 mod t50_log_progress_api;
+mod t50_snapshot_progress_api;

--- a/tests/tests/metrics/t50_snapshot_progress_api.rs
+++ b/tests/tests/metrics/t50_snapshot_progress_api.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// Test snapshot progress API: get() and wait_until_ge()
+///
+/// What does this test do?
+///
+/// - Creates a single-node cluster
+/// - Gets `watch_snapshot_progress()` handle
+/// - Verifies initial state with `get()`
+/// - Triggers snapshot to advance the snapshot log id
+/// - Uses `wait_until_ge()` with a concrete target value
+/// - Verifies `get()` returns the same value as `wait_until_ge()`
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn snapshot_progress_api() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- get snapshot progress watcher");
+    let n0 = router.get_raft_handle(&0)?;
+    let progress = n0.watch_snapshot_progress();
+
+    tracing::info!(log_index, "--- verify initial snapshot progress with get()");
+    let got = progress.get();
+    assert_eq!(got, None);
+
+    tracing::info!(log_index, "--- write some logs");
+    log_index += router.client_request_many(0, "foo", 5).await?;
+
+    tracing::info!(log_index, "--- spawn task to wait for future snapshot progress");
+    let target = Some(log_id(1, 0, log_index));
+
+    let n0_clone = router.get_raft_handle(&0)?;
+    let handle = tokio::spawn(async move {
+        let mut progress = n0_clone.watch_snapshot_progress();
+        progress.wait_until_ge(&target).await
+    });
+
+    tracing::info!(log_index, "--- trigger snapshot to update snapshot progress");
+    n0.trigger().snapshot().await?;
+
+    tracing::info!(log_index, "--- verify wait_until_ge returns after snapshot is built");
+    let got_wait = handle.await??;
+    let got_get = progress.get();
+
+    let want = Some(log_id(1, 0, log_index));
+    assert_eq!(got_wait, want);
+    assert_eq!(got_get, want);
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### feat: Add `watch_snapshot_progress()`
Add `watch_snapshot_progress()` API to track
when snapshots are persisted to storage.

The returned handle exposes a `WatchProgress` handle with:
- `get()`: Get current progress state immediately
- `wait_until_ge()`: Wait asynchronously until progress reaches threshold

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1481)
<!-- Reviewable:end -->
