### PR TITLE
change: Require to impl `PartialOrd<CommittedLeaderId> for LeaderId`

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_leader_id.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_leader_id.rs
@@ -24,6 +24,18 @@ impl PartialOrd for pb::LeaderId {
     }
 }
 
+impl PartialEq<u64> for pb::LeaderId {
+    fn eq(&self, _other: &u64) -> bool {
+        false
+    }
+}
+
+impl PartialOrd<u64> for pb::LeaderId {
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        self.term.partial_cmp(other)
+    }
+}
+
 impl fmt::Display for pb::LeaderId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "T{}-N{}", self.term, self.node_id)

--- a/openraft/src/vote/leader_id/leader_id_cmp.rs
+++ b/openraft/src/vote/leader_id/leader_id_cmp.rs
@@ -55,6 +55,18 @@ mod tests {
     #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
     struct LeaderId(u64, Option<u64>);
 
+    impl PartialEq<u64> for LeaderId {
+        fn eq(&self, _other: &u64) -> bool {
+            false
+        }
+    }
+
+    impl PartialOrd<u64> for LeaderId {
+        fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+            self.0.partial_cmp(other)
+        }
+    }
+
     impl RaftLeaderId<UTConfig> for LeaderId {
         type Committed = u64;
 

--- a/openraft/src/vote/leader_id/leader_id_std.rs
+++ b/openraft/src/vote/leader_id/leader_id_std.rs
@@ -45,6 +45,54 @@ where C: RaftTypeConfig
     }
 }
 
+impl<C> PartialEq<CommittedLeaderId<C>> for LeaderId<C>
+where C: RaftTypeConfig
+{
+    fn eq(&self, _other: &CommittedLeaderId<C>) -> bool {
+        // Committed and non-committed are never equal
+        false
+    }
+}
+
+impl<C> PartialOrd<CommittedLeaderId<C>> for LeaderId<C>
+where C: RaftTypeConfig
+{
+    fn partial_cmp(&self, other: &CommittedLeaderId<C>) -> Option<Ordering> {
+        if self.term == other.term {
+            // For the same term, committed Leader overrides non-committed
+            Some(Ordering::Less)
+        } else {
+            self.term.partial_cmp(&other.term)
+        }
+    }
+}
+
+/// Reciprocal comparison: `CommittedLeaderId` compared with `LeaderId`.
+///
+/// Not required by [`RaftLeaderId`] trait bound, but provides symmetric comparison semantics.
+impl<C> PartialEq<LeaderId<C>> for CommittedLeaderId<C>
+where C: RaftTypeConfig
+{
+    fn eq(&self, _other: &LeaderId<C>) -> bool {
+        false
+    }
+}
+
+/// Reciprocal comparison: `CommittedLeaderId` compared with `LeaderId`.
+///
+/// Not required by [`RaftLeaderId`] trait bound, but provides symmetric comparison semantics.
+impl<C> PartialOrd<LeaderId<C>> for CommittedLeaderId<C>
+where C: RaftTypeConfig
+{
+    fn partial_cmp(&self, other: &LeaderId<C>) -> Option<Ordering> {
+        if self.term == other.term {
+            Some(Ordering::Greater)
+        } else {
+            self.term.partial_cmp(&other.term)
+        }
+    }
+}
+
 impl<C> RaftLeaderId<C> for LeaderId<C>
 where C: RaftTypeConfig
 {
@@ -151,6 +199,54 @@ mod tests {
         assert!(!(lid(2, 2) > lid(2, 3)));
         assert!(!(lid(2, 2) < lid(2, 3)));
         assert!(!(lid(2, 2) == lid(2, 3)));
+
+        Ok(())
+    }
+
+    #[test]
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
+    fn test_leader_id_vs_committed_partial_order() -> anyhow::Result<()> {
+        use super::CommittedLeaderId;
+
+        let lid = |term, node_id| LeaderId::<UTConfig>::new(term, node_id);
+        let clid = |term| CommittedLeaderId::<UTConfig>::new(term, 0);
+
+        // PartialEq: LeaderId and CommittedLeaderId are never equal
+        assert!(lid(2, 2) != clid(2));
+
+        // Same term: CommittedLeaderId > LeaderId
+        assert!(lid(2, 2) < clid(2));
+        assert!(!(lid(2, 2) > clid(2)));
+
+        // Different terms: compare by term
+        assert!(lid(1, 2) < clid(2));
+        assert!(lid(3, 2) > clid(2));
+
+        Ok(())
+    }
+
+    #[test]
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
+    fn test_committed_vs_leader_id_partial_order() -> anyhow::Result<()> {
+        use super::CommittedLeaderId;
+
+        let lid = |term, node_id| LeaderId::<UTConfig>::new(term, node_id);
+        let clid = |term| CommittedLeaderId::<UTConfig>::new(term, 0);
+
+        // PartialEq: CommittedLeaderId and LeaderId are never equal (symmetric)
+        assert!(clid(2) != lid(2, 2));
+        assert!(clid(2) != lid(2, 5));
+
+        // Same term: CommittedLeaderId > LeaderId (symmetric)
+        assert!(clid(2) > lid(2, 2));
+        assert!(!(clid(2) < lid(2, 2)));
+        assert!(!(clid(2) == lid(2, 2)));
+
+        // Different terms: compare by term (symmetric)
+        assert!(clid(2) > lid(1, 2));
+        assert!(clid(2) < lid(3, 2));
+        assert!(!(clid(2) > lid(3, 2)));
+        assert!(!(clid(2) == lid(1, 2)));
 
         Ok(())
     }

--- a/openraft/src/vote/leader_id/raft_leader_id.rs
+++ b/openraft/src/vote/leader_id/raft_leader_id.rs
@@ -21,11 +21,17 @@ use crate::vote::leader_id::raft_committed_leader_id::RaftCommittedLeaderId;
 /// with the same term but different node IDs (e.g., `(1,2)` and `(1,3)`) have no defined ordering -
 /// neither can overwrite the other.
 ///
+/// Note: We require `impl PartialOrd<Self::Committed> for Self` but not
+/// `impl PartialOrd<Self> for Self::Committed`. This is because in standard Raft,
+/// `CommittedLeaderId` is typically just a `u64` term number, and we cannot implement
+/// external traits for primitive types.
+///
 /// [`Vote`]: crate::vote::Vote
 pub trait RaftLeaderId<C>
 where
     C: RaftTypeConfig,
     Self: OptionalFeatures + PartialOrd + Eq + Clone + Debug + Display + Default + 'static,
+    Self: PartialOrd<Self::Committed>,
 {
     /// The committed version of this leader ID.
     ///


### PR DESCRIPTION

## Changelog

##### change: Require to impl `PartialOrd<CommittedLeaderId> for LeaderId`
Enable comparison between non-committed and committed leader IDs, where
committed leaders take precedence over non-committed ones in the same
term.

This ordering is required when determine the order of two IO operation.
In OpenRaft, log IO is identified by `(CommittedLeaderId, LogId)`, while
save-vote IO is identified by `LeaderId`(in a `Vote`)

Upgrade tip:

Implement `PartialOrd<CommittedLeaderId>` for your `LeaderId`
implementation.
If you are using OpenRaft provided `LeaderId`, nothing to do.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1482)
<!-- Reviewable:end -->
