### PR TITLE
change: Migrate `RaftStateMachine::apply()` from Iterator to Stream

### DIFF
--- a/cluster_benchmark/Cargo.toml
+++ b/cluster_benchmark/Cargo.toml
@@ -22,6 +22,7 @@ repository = "https://github.com/databendlabs/openraft"
 openraft = { path = "../openraft", version = "0.10.0", features = ["serde", "type-alias"] }
 
 anyhow     = { version = "1.0.63" }
+futures    = { version = "0.3" }
 maplit     = { version = "1.0.2" }
 serde      = { version = "1.0.114", features = ["derive", "rc"] }
 serde_json = { version = "1.0.57" }

--- a/examples/raft-kv-memstore-grpc/src/grpc/app_service.rs
+++ b/examples/raft-kv-memstore-grpc/src/grpc/app_service.rs
@@ -82,11 +82,7 @@ impl AppService for AppServiceImpl {
         let req = request.into_inner();
         debug!("Processing get request for key: {}", req.key);
 
-        let sm = self
-            .state_machine_store
-            .state_machine
-            .lock()
-            .map_err(|e| Status::internal(format!("error getting lock on sm: {}", e)))?;
+        let sm = self.state_machine_store.state_machine.lock().await;
         let value = sm
             .data
             .get(&req.key)

--- a/examples/raft-kv-memstore-network-v2/Cargo.toml
+++ b/examples/raft-kv-memstore-network-v2/Cargo.toml
@@ -19,6 +19,7 @@ repository = "https://github.com/databendlabs/openraft"
 mem-log  = { path = "../mem-log", features = [] }
 openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 
+futures            = { version = "0.3" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }
 tokio              = { version = "1.0", default-features = false, features = ["sync"] }

--- a/examples/raft-kv-memstore-network-v2/src/api.rs
+++ b/examples/raft-kv-memstore-network-v2/src/api.rs
@@ -26,7 +26,7 @@ pub async fn read(app: &mut App, req: String) -> String {
         Ok(linearizer) => {
             linearizer.await_ready(&app.raft).await.unwrap();
 
-            let state_machine = app.state_machine.state_machine.lock().unwrap();
+            let state_machine = app.state_machine.state_machine.lock().await;
             let value = state_machine.data.get(&key).cloned();
 
             let res: Result<String, RaftError<CheckIsLeaderError>> = Ok(value.unwrap_or_default());

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -5,9 +5,12 @@ use std::io;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use futures::Stream;
+use futures::TryStreamExt;
 use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::EntryPayload;
+use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
 use serde::Deserialize;
 use serde::Serialize;
@@ -72,7 +75,7 @@ pub struct StateMachineData {
 #[derive(Debug, Default)]
 pub struct StateMachineStore {
     /// The Raft state machine.
-    pub state_machine: Mutex<StateMachineData>,
+    pub state_machine: tokio::sync::Mutex<StateMachineData>,
 
     snapshot_idx: Mutex<u64>,
 
@@ -89,7 +92,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         {
             // Serialize the data of the state machine.
-            let state_machine = self.state_machine.lock().unwrap().clone();
+            let state_machine = self.state_machine.lock().await.clone();
 
             last_applied_log = state_machine.last_applied;
             last_membership = state_machine.last_membership.clone();
@@ -132,19 +135,16 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     type SnapshotBuilder = Self;
 
     async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), io::Error> {
-        let state_machine = self.state_machine.lock().unwrap();
+        let state_machine = self.state_machine.lock().await;
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
-    async fn apply<I>(&mut self, entries: I) -> Result<(), io::Error>
-    where
-        I: IntoIterator<Item = EntryResponder<TypeConfig>>,
-        I::IntoIter: Send,
-    {
-        let mut sm = self.state_machine.lock().unwrap();
+    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    where Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Unpin + OptionalSend {
+        let mut sm = self.state_machine.lock().await;
 
-        for (entry, responder) in entries {
+        while let Some((entry, responder)) = entries.try_next().await? {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
             sm.last_applied = Some(entry.log_id);
@@ -189,7 +189,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         // Update the state machine.
         {
             let updated_state_machine: StateMachineData = new_snapshot.data.clone();
-            let mut state_machine = self.state_machine.lock().unwrap();
+            let mut state_machine = self.state_machine.lock().await;
             *state_machine = updated_state_machine;
         }
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
@@ -21,6 +21,7 @@ mem-log  = { path = "../mem-log", features = [] }
 openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 
 bytes              = { version = "1.0" }
+futures            = { version = "0.3" }
 opendal            = { version = "0.48.0" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
@@ -26,7 +26,7 @@ pub async fn read(app: &mut App, req: String) -> String {
         Ok(linearizer) => {
             linearizer.await_ready(&app.raft).await.unwrap();
 
-            let state_machine = app.state_machine.state_machine.lock().unwrap();
+            let state_machine = app.state_machine.state_machine.lock().await;
             let value = state_machine.data.get(&key).cloned();
 
             let res: Result<String, RaftError<CheckIsLeaderError>> = Ok(value.unwrap_or_default());

--- a/examples/raft-kv-memstore-singlethreaded/Cargo.toml
+++ b/examples/raft-kv-memstore-singlethreaded/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 [dependencies]
 openraft = { path = "../../openraft", features = ["serde", "singlethreaded", "type-alias"] }
 
+futures            = { version = "0.3" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }
 tokio              = { version = "1.0", default-features = false, features = ["sync"] }

--- a/examples/raft-kv-memstore/Cargo.toml
+++ b/examples/raft-kv-memstore/Cargo.toml
@@ -27,6 +27,7 @@ openraft        = { path = "../../openraft", features = ["serde", "type-alias"] 
 
 actix-web          = { version = "4.0.0-rc.2" }
 clap               = { version = "4.1.11", features = ["derive", "env"] }
+futures            = { version = "0.3" }
 reqwest            = { version = "0.12.5", features = ["json"] }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -27,9 +27,8 @@ openraft            = { path = "../../openraft", features = ["serde", "type-alia
 openraft-rocksstore = { path = "../rocksstore" }
 
 actix-web          = { version = "4.0.0-rc.2" }
-byteorder          = { version = "1.4.3" }
 clap               = { version = "4.1.11", features = ["derive", "env"] }
-reqwest            = { version = "0.12.5", features = ["json"] }
+futures            = { version = "0.3" }
 rocksdb            = { version = "0.22.0" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }

--- a/examples/rocksstore/Cargo.toml
+++ b/examples/rocksstore/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://github.com/databendlabs/openraft"
 openraft = { path = "../../openraft", version = "0.10.0", features = ["serde", "type-alias"] }
 
 byteorder  = { version = "1.4.3" }
+futures    = { version = "0.3" }
 rand       = { version = "0.9" }
 rocksdb    = { version = "0.22.0" }
 serde      = { version = "1.0.114", features = ["derive"] }

--- a/openraft/src/base/mod.rs
+++ b/openraft/src/base/mod.rs
@@ -36,6 +36,7 @@ pub use threaded::BoxAsyncOnceMut;
 pub use threaded::BoxFuture;
 pub use threaded::BoxMaybeAsyncOnceMut;
 pub use threaded::BoxOnce;
+pub use threaded::BoxStream;
 pub use threaded::OptionalSend;
 pub use threaded::OptionalSync;
 
@@ -44,6 +45,8 @@ mod threaded {
     use std::any::Any;
     use std::future::Future;
     use std::pin::Pin;
+
+    use futures::Stream;
 
     /// A trait that is empty if the `singlethreaded` feature flag is enabled,
     /// otherwise it extends `Send`.
@@ -57,6 +60,8 @@ mod threaded {
 
     /// Type alias for a boxed pinned future that is `Send`.
     pub type BoxFuture<'a, T = ()> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+    /// Type alias for a boxed pinned stream that is `Send`.
+    pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
     /// Type alias for a boxed async function that mutates its argument and is `Send`.
     pub type BoxAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> BoxFuture<T> + Send + 'a>;
     /// Type alias for a boxed function that optionally returns an async future.
@@ -73,6 +78,8 @@ mod threaded {
     use std::future::Future;
     use std::pin::Pin;
 
+    use futures::Stream;
+
     /// A trait that is empty if the `singlethreaded` feature flag is enabled,
     /// otherwise it extends `Send`.
     pub trait OptionalSend {}
@@ -84,6 +91,7 @@ mod threaded {
     impl<T: ?Sized> OptionalSync for T {}
 
     pub type BoxFuture<'a, T = ()> = Pin<Box<dyn Future<Output = T> + 'a>>;
+    pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
     pub type BoxAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> BoxFuture<T> + 'a>;
     pub type BoxMaybeAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> Option<BoxFuture<T>> + 'a>;
     pub type BoxOnce<'a, A, T = ()> = Box<dyn FnOnce(&A) -> T + 'a>;

--- a/openraft/src/error/leader_changed.rs
+++ b/openraft/src/error/leader_changed.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+use std::fmt::Formatter;
+
+use crate::RaftTypeConfig;
+use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::VoteOf;
+
+/// Error indicating that the established leader has changed.
+///
+/// This error occurs when expecting a specific established leader but finding
+/// that the cluster has moved to a different leader or candidate (indicated by a newer vote).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub struct LeaderChanged<C>
+where C: RaftTypeConfig
+{
+    /// The expected established leader ID.
+    pub expected_leader: LeaderIdOf<C>,
+
+    /// The current vote, indicating a new established leader or a candidate.
+    pub current_vote: Option<VoteOf<C>>,
+}
+
+impl<C> fmt::Display for LeaderChanged<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LeaderChanged: from {} to vote {}",
+            self.expected_leader,
+            self.current_vote.display()
+        )
+    }
+}
+
+impl<C> LeaderChanged<C>
+where C: RaftTypeConfig
+{
+    /// Create a new LeaderChanged error.
+    pub fn new(expected_leader: LeaderIdOf<C>, current_vote: Option<VoteOf<C>>) -> Self {
+        Self {
+            expected_leader,
+            current_vote,
+        }
+    }
+}

--- a/openraft/src/error/mod.rs
+++ b/openraft/src/error/mod.rs
@@ -13,6 +13,8 @@ pub(crate) mod storage_error;
 mod storage_io_result;
 mod streaming_error;
 
+mod leader_changed;
+
 use std::collections::BTreeSet;
 use std::error::Error;
 use std::fmt;
@@ -24,6 +26,7 @@ use openraft_macros::since;
 
 pub use self::allow_next_revert_error::AllowNextRevertError;
 pub use self::invalid_sm::InvalidStateMachineType;
+pub use self::leader_changed::LeaderChanged;
 pub use self::membership_error::MembershipError;
 pub use self::node_not_found::NodeNotFound;
 pub use self::operation::Operation;

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -298,8 +298,9 @@ where
                 chunk_end
             );
             let last_applied = entries.last().map(|e| e.log_id()).unwrap();
-            let apply_items = entries.into_iter().map(|entry| (entry, None));
-            self.state_machine.apply(apply_items).await.sto_apply(last_applied)?;
+            let apply_items = entries.into_iter().map(|entry| Ok((entry, None)));
+            let apply_stream = futures::stream::iter(apply_items);
+            self.state_machine.apply(apply_stream).await.sto_apply(last_applied)?;
 
             start = chunk_end;
         }

--- a/openraft/src/storage/mod.rs
+++ b/openraft/src/storage/mod.rs
@@ -46,6 +46,8 @@ pub use self::snapshot_meta::SnapshotMeta;
 pub use self::snapshot_signature::SnapshotSignature;
 pub use self::v2::ApplyResponder;
 pub use self::v2::EntryResponder;
+pub use self::v2::LeaderBoundedStreamError;
+pub use self::v2::LeaderBoundedStreamResult;
 pub use self::v2::RaftLogReader;
 pub use self::v2::RaftLogStorage;
 pub use self::v2::RaftLogStorageExt;

--- a/openraft/src/storage/v2/mod.rs
+++ b/openraft/src/storage/v2/mod.rs
@@ -14,6 +14,8 @@ mod raft_state_machine;
 
 pub use self::apply_responder::ApplyResponder;
 pub use self::entry_responder::EntryResponder;
+pub use self::raft_log_reader::LeaderBoundedStreamError;
+pub use self::raft_log_reader::LeaderBoundedStreamResult;
 pub use self::raft_log_reader::RaftLogReader;
 pub use self::raft_log_storage::RaftLogStorage;
 pub use self::raft_log_storage_ext::RaftLogStorageExt;

--- a/openraft/src/storage/v2/raft_state_machine.rs
+++ b/openraft/src/storage/v2/raft_state_machine.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use futures::Stream;
 use openraft_macros::add_async_trait;
 use openraft_macros::since;
 
@@ -83,10 +84,9 @@ where C: RaftTypeConfig
     ///   pattern, implement [`RaftLogStorage::save_committed()`] to persist the committed log id.
     ///
     /// [`RaftLogStorage::save_committed()`]: crate::storage::RaftLogStorage::save_committed
-    async fn apply<I>(&mut self, entries: I) -> Result<(), io::Error>
-    where
-        I: IntoIterator<Item = EntryResponder<C>> + OptionalSend,
-        I::IntoIter: OptionalSend;
+    #[since(version = "0.10.0", change = "Entry-Responder-Result stream")]
+    async fn apply<Strm>(&mut self, entries: Strm) -> Result<(), io::Error>
+    where Strm: Stream<Item = Result<EntryResponder<C>, io::Error>> + Unpin + OptionalSend;
 
     /// Try to create a snapshot builder for the state machine.
     ///

--- a/openraft/src/vote/raft_vote.rs
+++ b/openraft/src/vote/raft_vote.rs
@@ -39,6 +39,11 @@ where
         Self::from_leader_id(leader_id, false)
     }
 
+    fn from_term_node_id_committed(term: C::Term, node_id: C::NodeId, committed: bool) -> Self {
+        let leader_id = C::LeaderId::new(term, node_id);
+        Self::from_leader_id(leader_id, committed)
+    }
+
     fn term(&self) -> C::Term {
         self.leader_id().map_or_else(C::Term::default, RaftLeaderId::term)
     }

--- a/stores/memstore/Cargo.toml
+++ b/stores/memstore/Cargo.toml
@@ -17,6 +17,7 @@ repository    = { workspace = true }
 openraft = { path = "../../openraft", version = "0.10.0", features = ["serde", "type-alias"] }
 
 derive_more = { workspace = true }
+futures     = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 tokio       = { workspace = true }

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::sync::Arc;
 
 use anyhow::Result;
+use futures::Stream;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::OptionalSend;
@@ -101,11 +102,8 @@ async fn with_state_machine_wrong_sm_type() -> Result<()> {
                 todo!()
             }
 
-            async fn apply<I>(&mut self, _entries: I) -> Result<(), Err>
-            where
-                I: IntoIterator<Item = EntryResponder<TC>> + OptionalSend,
-                I::IntoIter: OptionalSend,
-            {
+            async fn apply<Strm>(&mut self, _entries: Strm) -> Result<(), Err>
+            where Strm: Stream<Item = Result<EntryResponder<TC>, Err>> + Unpin + OptionalSend {
                 todo!()
             }
 


### PR DESCRIPTION
## Changelog

##### change: Migrate `RaftStateMachine::apply()` from Iterator to Stream
Update the `apply()` method signature to use `Stream` instead of `IntoIterator`
for better error handling and async streaming support:

- Change `IntoIterator<Item = EntryResponder<C>>` to
  `Stream<Item = Result<EntryResponder<C>, io::Error>>`
- All implementations now use `try_next().await?` for cleaner error handling
- Update all 10+ implementations across examples and benchmarks

Add leader-bounded streaming to `RaftLogReader`:
- New `leader_bounded_stream()` method that reads entries conditional on
  vote state, ensuring leader hasn't changed during iteration
- New `entries_stream()` method for unconditional streaming
- Add `LeaderChanged` and `LeaderBoundedStreamError` error types
- Add comprehensive test coverage for vote consistency checks

Benefits:
- Simpler error propagation with `try_next().await?` pattern
- Better support for async iteration and backpressure
- Safer log reading with leader change detection

- Fix: #1472

Upgrade tip:

For `RaftStateMachine::apply()` implementations:

```rust
// Before:
async fn apply<I>(&mut self, entries: I) -> Result<(), io::Error>
where
    I: IntoIterator<Item = EntryResponder<TypeConfig>> + Send,
    I::IntoIter: Send,
{
    for (entry, responder) in entries {
        // process entry
    }
    Ok(())
}

// After:
async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
where Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Upin + OptionalSend
{
    use futures::TryStreamExt;

    while let Some((entry, responder)) = entries.try_next().await? {
        // process entry
    }
    Ok(())
}
```

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1488)
<!-- Reviewable:end -->
