### PR TITLE
Use VecDeque for `RaftCore.client_responders`

### DIFF
--- a/openraft/src/core/client_responder_queue.rs
+++ b/openraft/src/core/client_responder_queue.rs
@@ -1,0 +1,239 @@
+//! Queue of client responders indexed by log index, optimized for sequential
+//! insertion and range extraction.
+
+use std::collections::VecDeque;
+
+/// Queue of client responders indexed by log index.
+///
+/// Responders must be pushed in monotonically increasing order.
+/// In debug builds, non-monotonic pushes panic.
+///
+/// # Performance
+///
+/// - `push()`: O(1) amortized
+/// - `extend()`: O(k) where k = items added
+/// - `drain_upto()`: O(k) where k = drained count
+/// - `drain_from()`: O(log n + k) where n = total responders, k = drained count
+/// - `first_index()`, `len()`, `is_empty()`: O(1)
+pub(crate) struct ClientResponderQueue<T> {
+    /// Responders stored as (log_index, responder) pairs in sorted order
+    responders: VecDeque<(u64, T)>,
+}
+
+impl<T> ClientResponderQueue<T> {
+    /// Creates a new empty responder queue.
+    pub(crate) fn new() -> Self {
+        Self {
+            responders: VecDeque::new(),
+        }
+    }
+
+    /// Creates a new empty responder queue with the specified capacity.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            responders: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    /// Pushes a responder to the end of the queue.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `index <= last_index`.
+    pub(crate) fn push(&mut self, index: u64, responder: T) {
+        #[cfg(debug_assertions)]
+        if let Some((last_index, _)) = self.responders.back() {
+            debug_assert!(
+                index > *last_index,
+                "Responder indices must be monotonically increasing: tried to push {} after {}",
+                index,
+                last_index
+            );
+        }
+
+        self.responders.push_back((index, responder));
+    }
+
+    /// Extends the queue with multiple responders.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if indices are not monotonically increasing.
+    #[allow(dead_code)]
+    pub(crate) fn extend(&mut self, iter: impl IntoIterator<Item = (u64, T)>) {
+        for (index, responder) in iter {
+            self.push(index, responder);
+        }
+    }
+
+    /// Drains responders from the beginning up to and including `last_index`.
+    ///
+    /// Returns matching responders and removes them from the queue.
+    /// Not all indices in the range may have responders.
+    pub(crate) fn drain_upto(&mut self, last_index: u64) -> Vec<(u64, T)> {
+        let end_pos = self.responders.partition_point(|(index, _)| *index <= last_index);
+        self.responders.drain(0..end_pos).collect()
+    }
+
+    /// Drains all responders from the specified index onwards.
+    ///
+    /// Returns an iterator over responders with `log_index >= from_index` and removes them.
+    /// Used when truncating logs to notify affected responders.
+    pub(crate) fn drain_from(&mut self, from_index: u64) -> impl Iterator<Item = (u64, T)> + '_ {
+        let start_pos =
+            self.responders.binary_search_by_key(&from_index, |(index, _)| *index).unwrap_or_else(|pos| pos);
+
+        self.responders.drain(start_pos..)
+    }
+
+    /// Returns the first (smallest) log index in the queue, if any.
+    #[allow(dead_code)]
+    pub(crate) fn first_index(&self) -> Option<u64> {
+        self.responders.front().map(|(index, _)| *index)
+    }
+
+    /// Returns the number of responders in the queue.
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.responders.len()
+    }
+
+    /// Returns true if the queue is empty.
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.responders.is_empty()
+    }
+}
+
+impl<T> Default for ClientResponderQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestQueue = ClientResponderQueue<u64>;
+
+    #[test]
+    fn test_new() {
+        let queue = TestQueue::new();
+        assert!(queue.is_empty());
+        assert_eq!(queue.first_index(), None);
+    }
+
+    #[test]
+    fn test_push() {
+        let mut queue = TestQueue::new();
+        queue.push(10, 100);
+        queue.push(20, 200);
+        queue.push(30, 300);
+
+        assert_eq!(queue.len(), 3);
+        assert_eq!(queue.first_index(), Some(10));
+        assert_eq!(queue.drain_upto(30), vec![(10, 100), (20, 200), (30, 300)]);
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut queue = TestQueue::new();
+        queue.extend(vec![(10, 100), (20, 200), (30, 300)]);
+        assert_eq!(queue.drain_upto(30), vec![(10, 100), (20, 200), (30, 300)]);
+
+        queue.push(40, 400);
+        queue.extend(vec![(50, 500), (60, 600)]);
+        assert_eq!(queue.drain_upto(60), vec![(40, 400), (50, 500), (60, 600)]);
+    }
+
+    #[test]
+    fn test_drain_upto() {
+        let mut queue = TestQueue::new();
+        queue.push(10, 100);
+        queue.push(20, 200);
+        queue.push(30, 300);
+        queue.push(40, 400);
+
+        // Partial drain
+        assert_eq!(queue.drain_upto(25), vec![(10, 100), (20, 200)]);
+        assert_eq!(queue.first_index(), Some(30));
+
+        // Drain with gaps
+        queue.push(60, 600);
+        assert_eq!(queue.drain_upto(50), vec![(30, 300), (40, 400)]);
+        assert_eq!(queue.first_index(), Some(60));
+
+        // Drain all
+        assert_eq!(queue.drain_upto(100), vec![(60, 600)]);
+        assert!(queue.is_empty());
+
+        // Drain empty
+        assert_eq!(queue.drain_upto(100), vec![]);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Responder indices must be monotonically increasing")]
+    fn test_push_panics_non_monotonic() {
+        let mut queue = TestQueue::new();
+        queue.push(20, 200);
+        queue.push(10, 100);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Responder indices must be monotonically increasing")]
+    fn test_push_panics_duplicate() {
+        let mut queue = TestQueue::new();
+        queue.push(20, 200);
+        queue.push(20, 200);
+    }
+
+    #[test]
+    fn test_large_scale() {
+        let mut queue = TestQueue::new();
+        for i in 0..1000 {
+            queue.push(i * 10, i * 10);
+        }
+
+        assert_eq!(queue.drain_upto(4990).len(), 500);
+        assert_eq!(queue.drain_upto(9990).len(), 500);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn test_drain_from() {
+        let mut queue = TestQueue::new();
+        queue.push(10, 100);
+        queue.push(20, 200);
+        queue.push(30, 300);
+        queue.push(40, 400);
+
+        // Drain from middle
+        let drained: Vec<_> = queue.drain_from(25).collect();
+        assert_eq!(drained, vec![(30, 300), (40, 400)]);
+        assert_eq!(queue.first_index(), Some(10));
+
+        // Drain from exact match
+        let drained: Vec<_> = queue.drain_from(10).collect();
+        assert_eq!(drained, vec![(10, 100), (20, 200)]);
+        assert!(queue.is_empty());
+
+        // Drain from empty
+        let drained: Vec<_> = queue.drain_from(50).collect();
+        assert_eq!(drained, vec![]);
+
+        // Early break
+        queue.extend(vec![(10, 100), (20, 200), (30, 300)]);
+        let mut result = Vec::new();
+        for (log_index, value) in queue.drain_from(20) {
+            result.push((log_index, value));
+            if log_index == 20 {
+                break;
+            }
+        }
+        assert_eq!(result, vec![(20, 200)]);
+        assert_eq!(queue.first_index(), Some(10));
+    }
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -24,6 +24,7 @@
 //! details.
 
 pub(crate) mod balancer;
+mod client_responder_queue;
 pub(crate) mod core_state;
 pub(crate) mod heartbeat;
 pub(crate) mod io_flush_tracking;
@@ -35,6 +36,7 @@ mod server_state;
 pub(crate) mod sm;
 mod tick;
 
+pub(crate) use client_responder_queue::ClientResponderQueue;
 pub(crate) use raft_core::ApplyResult;
 pub use raft_core::RaftCore;
 pub(crate) use replication_state::replication_lag;

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
@@ -47,7 +46,9 @@ where C: RaftTypeConfig
         /// The last log id to apply, inclusive.
         last: LogIdOf<C>,
 
-        client_resp_channels: BTreeMap<u64, CoreResponder<C>>,
+        /// Client responders as a vector of (log_index, responder) pairs.
+        /// The vector is sorted by log_index in ascending order.
+        client_resp_channels: Vec<(u64, CoreResponder<C>)>,
     },
 
     /// Apply a custom function to the state machine.
@@ -87,7 +88,7 @@ where C: RaftTypeConfig
     pub(crate) fn apply(
         first: LogIdOf<C>,
         last: LogIdOf<C>,
-        client_resp_channels: BTreeMap<u64, CoreResponder<C>>,
+        client_resp_channels: Vec<(u64, CoreResponder<C>)>,
     ) -> Self {
         Command::Apply {
             first,

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -20,7 +20,6 @@ mod runtime_config_handle;
 pub mod trigger;
 
 use std::any::Any;
-use std::collections::BTreeMap;
 
 pub(crate) use api::app::AppApi;
 pub(crate) use api::management::ManagementApi;
@@ -62,6 +61,7 @@ use crate::base::BoxMaybeAsyncOnceMut;
 use crate::base::BoxOnce;
 use crate::config::Config;
 use crate::config::RuntimeConfig;
+use crate::core::ClientResponderQueue;
 use crate::core::RaftCore;
 use crate::core::Tick;
 use crate::core::heartbeat::handle::HeartbeatWorkersHandle;
@@ -382,7 +382,8 @@ where C: RaftTypeConfig
 
             engine,
 
-            client_responders: BTreeMap::new(),
+            // initially, allocate for 8 kilo outstanding requests.
+            client_responders: ClientResponderQueue::with_capacity(1024 * 8),
 
             replications: Default::default(),
 


### PR DESCRIPTION
This commit addresses issue #1336 by replacing the BTreeMap-based client responder storage with an optimized queue structure that leverages VecDeque with binary search for efficient range extraction.

## Changes

### New Module: ClientResponderQueue

### Performance Improvements
**Before:**
- Insert: O(log n) - BTreeMap tree insertion
- Extract range: O(m) - split_off where m = entries after split point
- SM worker: O(k log k) - k individual BTreeMap remove() calls

**After:**
- Insert: O(1) amortized - VecDeque push_back
- Extract range: O(log n + k) - binary search + drain
- SM worker: O(k) - linear iteration over Vec

### Core Changes
- **RaftCore**: Uses `ClientResponderQueue` instead of `BTreeMap`
- **sm::Command**: Changed `client_resp_channels` from `BTreeMap` to `Vec`
- **SM Worker**: Removed BTreeMap operations, now uses iterator over Vec
- **apply_to_state_machine()**: Simplified extraction with `extract_range()`
- **TruncateLog**: Uses `extract_from()` instead of `split_off()`

### Benefits
- Faster insertion (O(1) vs O(log n))
- Faster extraction (O(log n + k) vs O(m))
- Better cache locality (contiguous memory)
- Less memory overhead (no tree nodes)
- Cleaner SM worker implementation


- Fixes #1336




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1499)
<!-- Reviewable:end -->
