### PR TITLE
fix: prevent heartbeat-induced log reversion panic

### DIFF
--- a/openraft/src/core/heartbeat/handle.rs
+++ b/openraft/src/core/heartbeat/handle.rs
@@ -16,8 +16,23 @@ use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::JoinHandleOf;
 use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::OneshotSenderOf;
-use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::alias::WatchSenderOf;
+
+/// Handle for a single heartbeat worker task.
+pub(crate) struct WorkerHandle<C>
+where C: RaftTypeConfig
+{
+    /// Channel to send heartbeat events to the worker.
+    event_tx: WatchSenderOf<C, Option<HeartbeatEvent<C>>>,
+
+    /// Channel to signal shutdown to the worker.
+    ///
+    /// When this sender is dropped, the worker's receiver will detect it and shutdown.
+    _shutdown_tx: OneshotSenderOf<C, ()>,
+
+    /// Join handle for the worker task.
+    _join_handle: JoinHandleOf<C, ()>,
+}
 
 pub(crate) struct HeartbeatWorkersHandle<C>
 where C: RaftTypeConfig
@@ -26,37 +41,25 @@ where C: RaftTypeConfig
 
     pub(crate) config: Arc<Config>,
 
-    /// Inform the heartbeat task to broadcast a heartbeat message.
-    ///
-    /// A Leader will periodically update this value to trigger sending heartbeat messages.
-    pub(crate) tx: WatchSenderOf<C, Option<HeartbeatEvent<C>>>,
-
-    /// The receiving end of heartbeat command.
-    ///
-    /// A separate task will have a clone of this receiver to receive and execute heartbeat command.
-    pub(crate) rx: WatchReceiverOf<C, Option<HeartbeatEvent<C>>>,
-
-    pub(crate) workers: BTreeMap<C::NodeId, (OneshotSenderOf<C, ()>, JoinHandleOf<C, ()>)>,
+    pub(crate) workers: BTreeMap<C::NodeId, WorkerHandle<C>>,
 }
 
 impl<C> HeartbeatWorkersHandle<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(id: C::NodeId, config: Arc<Config>) -> Self {
-        let (tx, rx) = C::watch_channel(None);
-
         Self {
             id,
             config,
-            tx,
-            rx,
             workers: Default::default(),
         }
     }
 
-    pub(crate) fn broadcast(&self, event: HeartbeatEvent<C>) {
-        tracing::debug!("id={} send_heartbeat {}", self.id, event);
-        let _ = self.tx.send(Some(event));
+    pub(crate) fn broadcast(&self, events: impl IntoIterator<Item = (C::NodeId, HeartbeatEvent<C>)>) {
+        for (target, event) in events {
+            tracing::debug!("id={} target={} send_heartbeat {}", self.id, target, event);
+            self.workers.get(&target).unwrap().event_tx.send(Some(event)).ok();
+        }
     }
 
     pub(crate) async fn spawn_workers<NF>(
@@ -71,9 +74,11 @@ where C: RaftTypeConfig
             tracing::debug!("id={} spawn HeartbeatWorker target={}", self.id, target);
             let network = network_factory.new_client(target.clone(), &node).await;
 
+            let (tx, rx) = C::watch_channel(None);
+
             let worker = HeartbeatWorker {
                 id: self.id.clone(),
-                rx: self.rx.clone(),
+                rx,
                 network,
                 target: target.clone(),
                 node,
@@ -86,7 +91,14 @@ where C: RaftTypeConfig
             let (tx_shutdown, rx_shutdown) = C::oneshot();
 
             let worker_handle = C::spawn(worker.run(rx_shutdown).instrument(span));
-            self.workers.insert(target, (tx_shutdown, worker_handle));
+
+            let handle = WorkerHandle {
+                event_tx: tx,
+                _shutdown_tx: tx_shutdown,
+                _join_handle: worker_handle,
+            };
+
+            self.workers.insert(target, handle);
         }
     }
 

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -68,7 +68,7 @@ where C: RaftTypeConfig
 ///
 /// [`RPCError`]: crate::error::RPCError
 /// [`RaftNetwork::append_entries`]: crate::network::RaftNetwork::append_entries
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub enum AppendEntriesResponse<C: RaftTypeConfig> {

--- a/openraft/src/raft/message/install_snapshot.rs
+++ b/openraft/src/raft/message/install_snapshot.rs
@@ -50,7 +50,7 @@ pub struct InstallSnapshotResponse<C: RaftTypeConfig> {
 }
 
 /// The response to `Raft::install_full_snapshot` API.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[derive(derive_more::Display)]
 #[display("SnapshotResponse{{vote:{}}}", vote)]

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -10,3 +10,4 @@ mod t50_append_entries_backoff_rejoin;
 mod t60_feature_loosen_follower_log_revert;
 mod t61_allow_follower_log_revert;
 mod t62_follower_clear_restart_recover;
+mod t99_issue_1500_heartbeat_cause_reversion_panic;

--- a/tests/tests/replication/t50_append_entries_backoff.rs
+++ b/tests/tests/replication/t50_append_entries_backoff.rs
@@ -36,14 +36,18 @@ async fn append_entries_backoff() -> Result<()> {
 
     tracing::info!(log_index, "--- set node 2 to unreachable, and write 10 entries");
     {
-        router.set_rpc_pre_hook(RPCTypes::AppendEntries, |_router, _req, _id, target| {
-            if target == 2 {
-                let any_err = AnyError::error("unreachable");
-                Err(RPCError::Unreachable(Unreachable::new(&any_err)))
-            } else {
-                Ok(())
-            }
-        });
+        router
+            .set_rpc_pre_hook(RPCTypes::AppendEntries, |_router, _req, _id, target| {
+                let res = if target == 2 {
+                    let any_err = AnyError::error("unreachable");
+                    Err(RPCError::Unreachable(Unreachable::new(&any_err)))
+                } else {
+                    Ok(())
+                };
+                let fu = futures::future::ready(res);
+                Box::pin(fu)
+            })
+            .await;
         // The above is equivalent to the following:
         // router.set_unreachable(2, true);
 

--- a/tests/tests/replication/t99_issue_1500_heartbeat_cause_reversion_panic.rs
+++ b/tests/tests/replication/t99_issue_1500_heartbeat_cause_reversion_panic.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::RPCTypes;
+
+use crate::fixtures::RPCRequest;
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// Test heartbeat does not cause false log reversion panic when follower lags behind.
+///
+/// Issue: A lagging follower receiving a heartbeat with `prev_log_id` set to the committed
+/// log id causes a conflict response. When this delayed conflict arrives after the follower
+/// catches up, the leader incorrectly interprets it as log reversion and panics.
+///
+/// Before fix: Leader used `prev_log_id = committed` in heartbeats, which may not exist on
+/// the follower yet, causing false conflicts.
+///
+/// After fix: Leader uses `prev_log_id = matching` (last confirmed replicated log id),
+/// which is guaranteed to exist on the follower.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn t99_issue_1500_heartbeat_cause_reversion_panic() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: true,
+            allow_log_reversion: Some(false),
+            election_timeout_min: 800,
+            election_timeout_max: 801,
+            heartbeat_interval: 100,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up cluster of 3 node");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    // Set a hook to delay heartbeat response from node 2, but bypass normal replication
+    // (non-empty payload). This creates a race condition where the heartbeat conflict response
+    // may arrive after the follower has caught up via normal replication.
+    router
+        .set_rpc_post_hook(RPCTypes::AppendEntries, |_router, req, _resp, _id, target| {
+            let sleep_ms = if target == 2 {
+                tracing::debug!("Post-hook for target {}: {}", target, req);
+                match req {
+                    RPCRequest::AppendEntries(append) => {
+                        if append.entries.is_empty() {
+                            10
+                        } else {
+                            0
+                        }
+                    }
+                    _ => 0,
+                }
+            } else {
+                0
+            };
+
+            let fu = async move {
+                if sleep_ms > 0 {
+                    tracing::debug!("Post-hook for target {}: delaying response by {}ms", target, sleep_ms);
+                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                    tracing::debug!("Post-hook for target {}: delay complete", target);
+                }
+                Ok::<_, _>(())
+            };
+
+            Box::pin(fu)
+        })
+        .await;
+
+    tracing::info!(log_index, "--- write some logs");
+    {
+        log_index += router.client_request_many(0, "foo", 500).await?;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "commit all written entries").await?;
+    }
+
+    tracing::info!(log_index, "--- check if panic occurs");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.with_raft_state(|_st| ()).await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION

## Changelog

##### fix: prevent heartbeat-induced log reversion panic
Use per-follower matching log id in heartbeat `prev_log_id` instead of
committed log id to prevent false reversion detection when followers
fall behind.

Problem:

When using committed log id `c` as `prev_log_id` in heartbeat
AppendEntries, the follower may not have `c` yet and returns conflict.
If this conflict response arrives after the follower successfully
replicates `c`, the leader updates its matching cursor to `c` and
incorrectly interprets the delayed conflict as log reversion.

The root cause is the leader using a non-existent log id as
`prev_log_id`.

Solution:

Use the known matching log id (last confirmed replicated) as
`prev_log_id` in heartbeats, eliminating false conflicts.

Changes:
- Add matching field to HeartbeatEvent
- Change heartbeat workers to per-follower channels
- Include matching log id from progress in heartbeat events
- Use matching log id as `prev_log_id` in heartbeat append-entries
- Add test reproducing issue #1500

- Fix: #1500

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1501)
<!-- Reviewable:end -->
