### PR TITLE
refactor: extract test fixture types into separate modules

### DIFF
--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -13,8 +13,8 @@ use openraft::base::BoxFuture;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
 
-use crate::fixtures::RPCRequest;
 use crate::fixtures::RaftRouter;
+use crate::fixtures::rpc_request::RpcRequest;
 use crate::fixtures::ut_harness;
 
 /// Client read tests.
@@ -108,7 +108,7 @@ async fn get_read_log_id() -> Result<()> {
 
         let res = if target == 0 {
             match req {
-                RPCRequest::AppendEntries(a) => {
+                RpcRequest::AppendEntries(a) => {
                     // Heartbeat is not blocked.
                     if a.entries.is_empty() { Ok(()) } else { err() }
                 }
@@ -445,7 +445,7 @@ async fn ensure_linearizable_process_from_followers() -> Result<()> {
 
         let res = if target == 1 {
             match req {
-                RPCRequest::AppendEntries(a) => {
+                RpcRequest::AppendEntries(a) => {
                     // Heartbeat is not blocked.
                     if a.entries.is_empty() { Ok(()) } else { err() }
                 }

--- a/tests/tests/fixtures/post_hook.rs
+++ b/tests/tests/fixtures/post_hook.rs
@@ -1,0 +1,22 @@
+//! Post-hook types for intercepting RPC responses after they are received.
+
+use openraft::base::BoxFuture;
+use openraft::error::RPCError;
+use openraft_memstore::MemNodeId;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::TypedRaftRouter;
+use crate::fixtures::rpc_request::RpcRequest;
+use crate::fixtures::rpc_response::RpcResponse;
+
+/// Hook function called after an RPC response is received from a target node.
+///
+/// Arguments: `(router, request, response, from_id, to_id)`
+pub type PostHook = Box<
+    dyn Fn(&TypedRaftRouter, RpcRequest<TypeConfig>, RpcResponse<TypeConfig>, MemNodeId, MemNodeId) -> PostHookResult
+        + Send
+        + 'static,
+>;
+
+/// Result type for post-hook functions.
+pub type PostHookResult = BoxFuture<'static, Result<(), RPCError<TypeConfig>>>;

--- a/tests/tests/fixtures/pre_hook.rs
+++ b/tests/tests/fixtures/pre_hook.rs
@@ -1,0 +1,21 @@
+//! Pre-hook types for intercepting RPC calls before they are sent.
+
+use openraft::base::BoxFuture;
+use openraft::error::Infallible;
+use openraft::error::RPCError;
+use openraft_memstore::MemNodeId;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::TypedRaftRouter;
+use crate::fixtures::rpc_request::RpcRequest;
+
+/// Hook function called before an RPC is sent to a target node.
+///
+/// Arguments: `(router, rpc, from_id, to_id)`
+pub type PreHook =
+    Box<dyn Fn(&TypedRaftRouter, RpcRequest<TypeConfig>, MemNodeId, MemNodeId) -> PreHookResult + Send + 'static>;
+
+/// Result type for pre-hook functions.
+///
+/// Pre-hooks cannot return remote errors, only local errors.
+pub type PreHookResult = BoxFuture<'static, Result<(), RPCError<TypeConfig, Infallible>>>;

--- a/tests/tests/fixtures/rpc_error_type.rs
+++ b/tests/tests/fixtures/rpc_error_type.rs
@@ -1,0 +1,30 @@
+//! RPC error type definitions for test fixtures.
+
+use anyerror::AnyError;
+use openraft::RaftTypeConfig;
+use openraft::error::NetworkError;
+use openraft::error::RPCError;
+use openraft::error::Unreachable;
+
+use crate::fixtures::Direction;
+
+/// Type of RPC error to inject during testing.
+#[derive(Debug, Clone, Copy)]
+pub enum RpcErrorType {
+    /// Returns [`Unreachable`](`openraft::error::Unreachable`).
+    Unreachable,
+    /// Returns [`NetworkError`](`openraft::error::NetworkError`).
+    NetworkError,
+}
+
+impl RpcErrorType {
+    pub fn make_error<C>(&self, id: C::NodeId, dir: Direction) -> RPCError<C>
+    where C: RaftTypeConfig {
+        let msg = format!("error {} id={}", dir, id);
+
+        match self {
+            RpcErrorType::Unreachable => Unreachable::new(&AnyError::error(msg)).into(),
+            RpcErrorType::NetworkError => NetworkError::new(&AnyError::error(msg)).into(),
+        }
+    }
+}

--- a/tests/tests/fixtures/rpc_request.rs
+++ b/tests/tests/fixtures/rpc_request.rs
@@ -1,0 +1,54 @@
+//! RPC request type enum for all Raft RPC calls.
+
+use std::fmt;
+
+use openraft::RPCTypes;
+use openraft::RaftTypeConfig;
+use openraft::Snapshot;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::raft::TransferLeaderRequest;
+use openraft::raft::VoteRequest;
+
+/// Unified enum for all RPC request types in the test framework.
+#[derive(Debug)]
+#[derive(derive_more::From, derive_more::TryInto)]
+pub enum RpcRequest<C: RaftTypeConfig>
+where C::SnapshotData: fmt::Debug
+{
+    AppendEntries(AppendEntriesRequest<C>),
+    InstallSnapshot(InstallSnapshotRequest<C>),
+    InstallFullSnapshot(Snapshot<C>),
+    Vote(VoteRequest<C>),
+    TransferLeader(TransferLeaderRequest<C>),
+}
+
+impl<C: RaftTypeConfig> RpcRequest<C>
+where C::SnapshotData: fmt::Debug
+{
+    pub fn get_type(&self) -> RPCTypes {
+        match self {
+            RpcRequest::AppendEntries(_) => RPCTypes::AppendEntries,
+            RpcRequest::InstallSnapshot(_) => RPCTypes::InstallSnapshot,
+            RpcRequest::InstallFullSnapshot(_) => RPCTypes::InstallSnapshot,
+            RpcRequest::Vote(_) => RPCTypes::Vote,
+            RpcRequest::TransferLeader(_) => RPCTypes::TransferLeader,
+        }
+    }
+}
+
+impl<C> fmt::Display for RpcRequest<C>
+where
+    C: RaftTypeConfig,
+    C::SnapshotData: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RpcRequest::AppendEntries(req) => write!(f, "AppendEntries({})", req),
+            RpcRequest::InstallSnapshot(req) => write!(f, "InstallSnapshot({})", req),
+            RpcRequest::InstallFullSnapshot(req) => write!(f, "InstallFullSnapshot({})", req.meta),
+            RpcRequest::Vote(req) => write!(f, "Vote({})", req),
+            RpcRequest::TransferLeader(req) => write!(f, "TransferLeader({})", req),
+        }
+    }
+}

--- a/tests/tests/fixtures/rpc_response.rs
+++ b/tests/tests/fixtures/rpc_response.rs
@@ -1,0 +1,57 @@
+//! RPC response type enum for all Raft RPC calls.
+
+use std::fmt;
+
+use openraft::RPCTypes;
+use openraft::RaftTypeConfig;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::InstallSnapshotResponse;
+use openraft::raft::SnapshotResponse;
+use openraft::raft::VoteResponse;
+
+/// Unified enum for all RPC response types in the test framework.
+#[derive(Debug)]
+#[derive(derive_more::From, derive_more::TryInto)]
+pub enum RpcResponse<C>
+where
+    C: RaftTypeConfig,
+    C::SnapshotData: fmt::Debug,
+{
+    AppendEntries(AppendEntriesResponse<C>),
+    InstallSnapshot(InstallSnapshotResponse<C>),
+    InstallFullSnapshot(SnapshotResponse<C>),
+    Vote(VoteResponse<C>),
+    TransferLeader(()),
+}
+
+impl<C> RpcResponse<C>
+where
+    C: RaftTypeConfig,
+    C::SnapshotData: fmt::Debug,
+{
+    pub fn get_type(&self) -> RPCTypes {
+        match self {
+            RpcResponse::AppendEntries(_) => RPCTypes::AppendEntries,
+            RpcResponse::InstallSnapshot(_) => RPCTypes::InstallSnapshot,
+            RpcResponse::InstallFullSnapshot(_) => RPCTypes::InstallSnapshot,
+            RpcResponse::Vote(_) => RPCTypes::Vote,
+            RpcResponse::TransferLeader(_) => RPCTypes::TransferLeader,
+        }
+    }
+}
+
+impl<C> fmt::Display for RpcResponse<C>
+where
+    C: RaftTypeConfig,
+    C::SnapshotData: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RpcResponse::AppendEntries(resp) => write!(f, "AppendEntries({})", resp),
+            RpcResponse::InstallSnapshot(req) => write!(f, "InstallSnapshot({})", req),
+            RpcResponse::InstallFullSnapshot(resp) => write!(f, "InstallFullSnapshot({})", resp),
+            RpcResponse::Vote(resp) => write!(f, "Vote({})", resp),
+            RpcResponse::TransferLeader(_resp) => write!(f, "TransferLeader(())"),
+        }
+    }
+}

--- a/tests/tests/replication/t99_issue_1500_heartbeat_cause_reversion_panic.rs
+++ b/tests/tests/replication/t99_issue_1500_heartbeat_cause_reversion_panic.rs
@@ -5,8 +5,8 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::RPCTypes;
 
-use crate::fixtures::RPCRequest;
 use crate::fixtures::RaftRouter;
+use crate::fixtures::rpc_request::RpcRequest;
 use crate::fixtures::ut_harness;
 
 /// Test heartbeat does not cause false log reversion panic when follower lags behind.
@@ -48,7 +48,7 @@ async fn t99_issue_1500_heartbeat_cause_reversion_panic() -> anyhow::Result<()> 
             let sleep_ms = if target == 2 {
                 tracing::debug!("Post-hook for target {}: {}", target, req);
                 match req {
-                    RPCRequest::AppendEntries(append) => {
+                    RpcRequest::AppendEntries(append) => {
                         if append.entries.is_empty() {
                             10
                         } else {


### PR DESCRIPTION

## Changelog

##### refactor: extract test fixture types into separate modules
Split the large test fixtures module into focused submodules for better
organization and maintainability. Each RPC-related type now lives in its
own file with clear naming.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1502)
<!-- Reviewable:end -->
