### PR TITLE
feat: add `write()` builder API for Raft client writes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ basic_check:
 	cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged
 	cargo test --lib
 	cargo test --test '*'
+	cargo test --features singlethreaded --lib
 	cargo clippy --no-deps --all-targets -- -D warnings
 	RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --all --no-deps
 	# test result in different output on CI are ignored and only run locally

--- a/openraft/src/raft/message/mod.rs
+++ b/openraft/src/raft/message/mod.rs
@@ -9,6 +9,7 @@ mod transfer_leader;
 mod vote;
 
 mod client_write;
+mod write_request;
 
 pub use append_entries::AppendEntriesRequest;
 pub use append_entries::AppendEntriesResponse;
@@ -20,3 +21,4 @@ pub use install_snapshot::SnapshotResponse;
 pub use transfer_leader::TransferLeaderRequest;
 pub use vote::VoteRequest;
 pub use vote::VoteResponse;
+pub use write_request::WriteRequest;

--- a/openraft/src/raft/message/write_request.rs
+++ b/openraft/src/raft/message/write_request.rs
@@ -1,0 +1,87 @@
+use std::future::IntoFuture;
+
+use openraft_macros::since;
+
+use crate::RaftTypeConfig;
+use crate::base::BoxFuture;
+use crate::core::raft_msg::RaftMsg;
+use crate::error::Fatal;
+use crate::raft::raft_inner::RaftInner;
+use crate::raft::responder::core_responder::CoreResponder;
+use crate::type_config::alias::WriteResponderOf;
+
+/// Builder for submitting write requests to Raft.
+///
+/// Returned by [`Raft::write()`]. The request is fire-and-forget by default.
+/// Use [`.responder()`] to attach a responder for receiving the result.
+///
+/// # Performance
+///
+/// Currently, allocates (`Pin<Box<dyn Future>>`) when awaited due to stable Rust limitations.
+/// This will be optimized to zero-allocation when `impl_trait_in_assoc_type` stabilizes,
+/// allowing `type IntoFuture = impl Future` in trait implementations.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Fire-and-forget
+/// raft.write(my_data).await?;
+///
+/// // With responder to receive result
+/// let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+/// raft.write(my_data).responder(responder).await?;
+/// let result = complete_rx.await??;
+/// ```
+///
+/// [`Raft::write()`]: crate::Raft::write
+/// [`.responder()`]: WriteRequest::responder
+#[since(version = "0.10.0")]
+pub struct WriteRequest<'a, C>
+where C: RaftTypeConfig
+{
+    pub(in crate::raft) inner: &'a RaftInner<C>,
+    pub(in crate::raft) app_data: C::D,
+    pub(in crate::raft) responder: Option<CoreResponder<C>>,
+}
+
+impl<'a, C> WriteRequest<'a, C>
+where C: RaftTypeConfig
+{
+    /// Attach a responder to receive the write result.
+    ///
+    /// The responder is notified when the write completes or fails.
+    /// Await the responder's receiver to get the result.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use openraft::impls::ProgressResponder;
+    ///
+    /// let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    /// raft.write(my_data).responder(responder).await?;
+    /// let result = complete_rx.await??;
+    /// ```
+    #[since(version = "0.10.0")]
+    pub fn responder(mut self, responder: WriteResponderOf<C>) -> Self {
+        self.responder = Some(CoreResponder::UserDefined(responder));
+        self
+    }
+}
+
+impl<'a, C> IntoFuture for WriteRequest<'a, C>
+where C: RaftTypeConfig
+{
+    type Output = Result<(), Fatal<C>>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            self.inner
+                .send_msg(RaftMsg::ClientWriteRequest {
+                    app_data: self.app_data,
+                    responder: self.responder,
+                })
+                .await
+        })
+    }
+}


### PR DESCRIPTION

## Changelog

##### feat: add `write()` builder API for Raft client writes
Introduce a new builder-pattern API for submitting write requests to Raft.
The `write()` method returns a `WriteRequest` builder that can be configured
before execution, providing a cleaner alternative to `client_write_ff()`.

Changes:
- Add `Raft::write()` method returning `WriteRequest` builder
- Add `WriteRequest::responder()` for attaching result receivers

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1505)
<!-- Reviewable:end -->
