### PR TITLE
feat: Add `RaftVoteExt::to_committed_leader_id()`

### DIFF
--- a/openraft/src/vote/raft_vote.rs
+++ b/openraft/src/vote/raft_vote.rs
@@ -99,6 +99,19 @@ where
         }
     }
 
+    /// Returns the leader ID as `CommittedLeaderId` if this vote is committed.
+    ///
+    /// Returns `Some(CommittedLeaderId)` if the vote is committed and has a leader ID.
+    /// Returns `None` if the vote is not committed or has no leader ID.
+    #[allow(dead_code)]
+    fn to_committed_leader_id(&self) -> Option<CommittedLeaderIdOf<C>> {
+        if self.is_committed() {
+            self.leader_id().map(|l| l.to_committed())
+        } else {
+            None
+        }
+    }
+
     /// Checks if this vote is for the same leader as specified by the given committed leader ID.
     fn is_same_leader(&self, leader_id: &CommittedLeaderIdOf<C>) -> bool {
         self.leader_id().map(|x| x.to_committed()).unwrap_or_default() == *leader_id

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -133,6 +133,23 @@ mod tests {
             assert!(vote(2, 2) < committed(2, 2));
             Ok(())
         }
+
+        #[test]
+        fn test_to_committed_leader_id() -> anyhow::Result<()> {
+            use crate::type_config::alias::LeaderIdOf;
+            use crate::vote::RaftLeaderId;
+            use crate::vote::raft_vote::RaftVoteExt;
+
+            let vote = Vote::<UTConfig>::new(1, 2);
+            assert_eq!(None, vote.to_committed_leader_id());
+
+            let committed = Vote::<UTConfig>::new_committed(1, 2);
+            let leader_id = committed.to_committed_leader_id();
+            let expected = LeaderIdOf::<UTConfig>::new(1, 2).to_committed();
+            assert_eq!(Some(expected), leader_id);
+
+            Ok(())
+        }
     }
 
     mod feature_single_term_leader {
@@ -221,6 +238,26 @@ mod tests {
                 assert_panic(|| committed(2, 2) < committed(2, 3));
                 assert_panic(|| committed(2, 2) <= committed(2, 3));
             }
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_to_committed_leader_id() -> anyhow::Result<()> {
+            use crate::vote::RaftLeaderId;
+            use crate::vote::raft_vote::RaftVoteExt;
+
+            let vote = Vote::<TC>::new(1, 2);
+            assert_eq!(None, vote.to_committed_leader_id());
+
+            let committed = Vote::<TC>::new_committed(1, 2);
+            let leader_id = committed.to_committed_leader_id();
+            let expected = LeaderId {
+                term: 1,
+                voted_for: Some(2),
+            }
+            .to_committed();
+            assert_eq!(Some(expected), leader_id);
 
             Ok(())
         }


### PR DESCRIPTION

## Changelog

##### feat: Add `RaftVoteExt::to_committed_leader_id()`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1506)
<!-- Reviewable:end -->
