### PR TITLE
change: in 0.10.0: Rename `local_leader_id()` to `as_leader()` returning `Leader` struct

### DIFF
--- a/openraft/src/raft/leader.rs
+++ b/openraft/src/raft/leader.rs
@@ -1,0 +1,57 @@
+use openraft_macros::since;
+
+use crate::Raft;
+use crate::RaftTypeConfig;
+use crate::impls::leader_id_std;
+use crate::type_config::alias::CommittedLeaderIdOf;
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::LeaderIdOf;
+use crate::vote::RaftLeaderId;
+
+/// Information about a node when it is a leader.
+///
+/// This struct contains metadata about the current leader state, including
+/// its identity and health indicators.
+#[since(version = "0.10.0")]
+#[derive(Clone, Debug)]
+pub struct Leader<C>
+where C: RaftTypeConfig
+{
+    pub(crate) raft: Raft<C>,
+
+    /// The leader ID, including term and node ID.
+    pub(crate) leader_id: LeaderIdOf<C>,
+
+    /// The timestamp when the leader was last acknowledged by a quorum.
+    ///
+    /// `None` if the leader has not yet been acknowledged by a quorum.
+    /// Being acknowledged means receiving a reply of AppendEntries with committed vote.
+    pub(crate) last_quorum_acked: Option<InstantOf<C>>,
+}
+
+impl<C> Leader<C>
+where C: RaftTypeConfig
+{
+    pub fn raft(&self) -> &Raft<C> {
+        &self.raft
+    }
+
+    pub fn leader_id(&self) -> &LeaderIdOf<C> {
+        &self.leader_id
+    }
+
+    pub fn to_committed_leader_id(&self) -> CommittedLeaderIdOf<C> {
+        self.leader_id.to_committed()
+    }
+
+    /// Only when the [`CommittedLeaderIdOf`] is a single term this method is allowed.
+    /// Otherwise, the user may mistakenly get the term as the entire [`CommittedLeaderIdOf`]
+    pub fn term(&self) -> C::Term
+    where C: RaftTypeConfig<LeaderId = leader_id_std::LeaderId<C>> {
+        self.leader_id.term()
+    }
+
+    pub fn last_quorum_acked(&self) -> Option<InstantOf<C>> {
+        self.last_quorum_acked
+    }
+}


### PR DESCRIPTION

## Changelog

##### change: in 0.10.0: Rename `local_leader_id()` to `as_leader()` returning `Leader` struct
The `as_leader()` method now returns a `Leader` struct containing leader
metadata instead of just the leader ID. This provides richer information
about the leader state, including health indicators.

- Add `Leader` struct with `leader_id`, `last_quorum_acked`
- Add `Leader::leader_id()`, `Leader::term()`, `Leader::to_committed_leader_id()` accessors
- Add `Leader::last_quorum_acked()` to check leader health
- Add `Leader::raft()` to access the `Raft` handle

Upgrade tip:

Replace `local_leader_id()` calls with `as_leader()` and use accessor methods:

For basic leader ID access:
- `raft.local_leader_id()` → `raft.as_leader().map(|l| l.leader_id().clone())`
- `if let Some(id) = raft.local_leader_id()` → `if let Some(leader) = raft.as_leader()`

To access additional leader information:
- `leader.leader_id()` returns `&LeaderIdOf<C>`
- `leader.last_quorum_acked()` returns `Option<InstantOf<C>>`
- `leader.term()` returns `C::Term` (for std LeaderId only)
- `leader.raft()` returns `&Raft<C>`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1510)
<!-- Reviewable:end -->
