### PR TITLE
change: in 0.10.0: remove `Default` from `RaftVote` trait bounds

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -103,6 +103,7 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscReceiverOf;
 use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchSenderOf;
 use crate::type_config::alias::WriteResponderOf;
 use crate::type_config::async_runtime::mpsc::MpscSender;
@@ -588,6 +589,14 @@ where
         let membership_config = st.membership_state.effective().stored_membership().clone();
         let current_leader = self.current_leader();
 
+        // Get the last flushed vote, or use initial vote (term=0, node_id=self.id)
+        // if no IO has been flushed yet (e.g., during startup).
+        let vote = st
+            .log_progress()
+            .flushed()
+            .map(|io_id| io_id.to_app_vote())
+            .unwrap_or_else(|| VoteOf::<C>::new_with_default_term(self.id.clone()));
+
         #[allow(deprecated)]
         let m = RaftMetrics {
             running_state: Ok(()),
@@ -595,7 +604,7 @@ where
 
             // --- data ---
             current_term: st.vote_ref().term(),
-            vote: st.log_progress().flushed().map(|io_id| io_id.to_app_vote()).unwrap_or_default(),
+            vote: vote.clone(),
             last_log_index: st.last_log_id().index(),
             last_applied: st.io_applied().cloned(),
             snapshot: st.io_snapshot_last_log_id().cloned(),
@@ -627,7 +636,7 @@ where
 
         let server_metrics = RaftServerMetrics {
             id: self.id.clone(),
-            vote: st.log_progress().flushed().map(|io_id| io_id.to_app_vote()).unwrap_or_default(),
+            vote: vote.clone(),
             state: st.server_state,
             current_leader,
             membership_config,

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -15,6 +15,7 @@ use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::SerdeInstantOf;
 use crate::type_config::alias::VoteOf;
+use crate::vote::raft_vote::RaftVoteExt;
 
 /// Comprehensive metrics describing the current state of a Raft node.
 ///
@@ -213,13 +214,14 @@ where C: RaftTypeConfig
 {
     /// Create initial metrics for a new Raft node with the given ID.
     pub fn new_initial(id: C::NodeId) -> Self {
+        let vote = VoteOf::<C>::new_with_default_term(id.clone());
         #[allow(deprecated)]
         Self {
             running_state: Ok(()),
             id,
 
             current_term: Default::default(),
-            vote: Default::default(),
+            vote,
             last_log_index: None,
             last_applied: None,
             snapshot: None,
@@ -332,7 +334,7 @@ where C: RaftTypeConfig
 }
 
 /// Subset of RaftMetrics, only include server-related metrics
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftServerMetrics<C: RaftTypeConfig> {
     /// The ID of this Raft node.
@@ -366,5 +368,24 @@ where C: RaftTypeConfig
 
         write!(f, "}}")?;
         Ok(())
+    }
+}
+
+impl<C> RaftServerMetrics<C>
+where C: RaftTypeConfig
+{
+    /// Create initial server metrics for a new Raft node.
+    ///
+    /// The vote is initialized with the default term (0) and the given node id,
+    /// representing the initial state before any leader election has occurred.
+    pub(crate) fn new_initial(id: C::NodeId) -> Self {
+        let vote = VoteOf::<C>::new_with_default_term(id.clone());
+        Self {
+            id,
+            vote,
+            state: Default::default(),
+            current_leader: None,
+            membership_config: Arc::new(Default::default()),
+        }
     }
 }

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -17,7 +17,9 @@ use crate::metrics::Wait;
 use crate::metrics::WaitError;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::NodeIdOf;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchSenderOf;
+use crate::vote::raft_vote::RaftVoteExt;
 
 /// Test wait for different state changes
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -245,14 +247,14 @@ pub(crate) type InitResult<C> = (RaftMetrics<C>, Wait<C>, WatchSenderOf<C, RaftM
 /// Build a initial state for testing of Wait:
 /// Returns init metrics, Wait, and the tx to send an updated metrics.
 fn init_wait_test<C>() -> InitResult<C>
-where C: RaftTypeConfig {
+where C: RaftTypeConfig<NodeId = u64> {
     #[allow(deprecated)]
     let init = RaftMetrics {
         running_state: Ok(()),
         id: NodeIdOf::<C>::default(),
         state: ServerState::Learner,
         current_term: Default::default(),
-        vote: Default::default(),
+        vote: VoteOf::<C>::new_with_default_term(0),
         last_log_index: None,
         last_applied: None,
         purged: None,

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -345,7 +345,7 @@ where C: RaftTypeConfig
         let (tx_notify, rx_notify) = C::mpsc(notification_channel_size);
         let (tx_metrics, rx_metrics) = C::watch_channel(RaftMetrics::new_initial(id.clone()));
         let (tx_data_metrics, rx_data_metrics) = C::watch_channel(RaftDataMetrics::default());
-        let (tx_server_metrics, rx_server_metrics) = C::watch_channel(RaftServerMetrics::default());
+        let (tx_server_metrics, rx_server_metrics) = C::watch_channel(RaftServerMetrics::new_initial(id.clone()));
         let (tx_progress, progress_watcher) = IoProgressWatcher::new();
         let (tx_shutdown, rx_shutdown) = C::oneshot();
 

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -92,12 +92,17 @@ where C: RaftTypeConfig
     pub(crate) purge_upto: Option<LogIdOf<C>>,
 }
 
+/// This impl is only for testing, require in the test NodeId has default value.
 impl<C> Default for RaftState<C>
-where C: RaftTypeConfig
+where
+    C: RaftTypeConfig,
+    C::NodeId: Default,
 {
     fn default() -> Self {
+        let vote = VoteOf::<C>::new_with_default_term(C::NodeId::default());
+
         Self {
-            vote: Leased::default(),
+            vote: Leased::without_last_update(vote),
             purged_next: 0,
             log_ids: LogIdList::default(),
             membership_state: MembershipState::default(),

--- a/openraft/src/vote/raft_vote.rs
+++ b/openraft/src/vote/raft_vote.rs
@@ -20,7 +20,7 @@ use crate::vote::vote_status::VoteStatus;
 pub trait RaftVote<C>
 where
     C: RaftTypeConfig,
-    Self: OptionalFeatures + Eq + Clone + Debug + Display + Default + 'static,
+    Self: OptionalFeatures + Eq + Clone + Debug + Display + 'static,
 {
     /// Create a new vote for the specified leader with optional quorum commitment.
     #[since(version = "0.10.0")]


### PR DESCRIPTION

## Changelog

##### change: in 0.10.0: remove `Default` from `RaftVote` trait bounds
Remove the `Default` bound from `RaftVote` trait since a `Vote` always requires
a `node_id` and a truly default value is semantically meaningless. This prepares
for making `LeaderId::node_id()` return a non-Option value.

Changes:
- Add `RaftServerMetrics::new_empty()` to create initial server metrics with proper vote
- Update `RaftMetrics::new_initial()` to use `Vote::new_with_default_term()`
- Update `RaftState::default()` to require `NodeId: Default` and create proper vote for testing

Upgrade tip:

If you implement custom `RaftVote`, you no longer need to implement `Default`.

For code that used `Vote::default()`, replace with:
- `VoteOf::<C>::new_with_default_term(node_id)` for creating initial votes
- `RaftServerMetrics::new_empty(id)` for creating empty server metrics

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1513)
<!-- Reviewable:end -->
