### PR TITLE
refactor: update `Default` impl for `CommittedVote` and `NonCommittedVote`

### DIFF
--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -8,12 +8,13 @@ use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::RaftLeaderId;
 use crate::vote::RaftVote;
+use crate::vote::leader_id::raft_leader_id::RaftLeaderIdExt;
 use crate::vote::raft_vote::RaftVoteExt;
 
 /// Represents a committed Vote that has been accepted by a quorum.
 ///
 /// The inner `Vote`'s attribute `committed` is always set to `true`
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[derive(PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
@@ -21,6 +22,18 @@ pub(crate) struct CommittedVote<C>
 where C: RaftTypeConfig
 {
     leader_id: LeaderIdOf<C>,
+}
+
+impl<C> Default for CommittedVote<C>
+where
+    C: RaftTypeConfig,
+    C::NodeId: Default,
+{
+    fn default() -> Self {
+        Self {
+            leader_id: LeaderIdOf::<C>::new_with_default_term(C::NodeId::default()),
+        }
+    }
 }
 
 /// The `CommittedVote` is totally ordered.

--- a/openraft/src/vote/non_committed.rs
+++ b/openraft/src/vote/non_committed.rs
@@ -5,12 +5,13 @@ use crate::Vote;
 use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::RaftVote;
+use crate::vote::leader_id::raft_leader_id::RaftLeaderIdExt;
 use crate::vote::raft_vote::RaftVoteExt;
 
 /// Represents a non-committed Vote that has **NOT** been granted by a quorum.
 ///
 /// The inner `Vote`'s attribute `committed` is always set to `false`
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[derive(PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
@@ -18,6 +19,18 @@ pub(crate) struct NonCommittedVote<C>
 where C: RaftTypeConfig
 {
     leader_id: LeaderIdOf<C>,
+}
+
+impl<C> Default for NonCommittedVote<C>
+where
+    C: RaftTypeConfig,
+    C::NodeId: Default,
+{
+    fn default() -> Self {
+        Self {
+            leader_id: LeaderIdOf::<C>::new_with_default_term(C::NodeId::default()),
+        }
+    }
 }
 
 impl<C> NonCommittedVote<C>


### PR DESCRIPTION

## Changelog

##### refactor: update `Default` impl for `CommittedVote` and `NonCommittedVote`
Update the `Default` implementation for vote wrapper types to require
`NodeId: Default` and create proper initial leader IDs, consistent with
the removal of `Default` from `RaftVote` trait bounds.

Changes:
- Remove `Default` derive from `CommittedVote` and `NonCommittedVote`
- Add manual `Default` impl requiring `NodeId: Default`
- Initialize `leader_id` with `new_with_default_term(NodeId::default())`

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1514)
<!-- Reviewable:end -->
