### PR TITLE
refactor: remove `Default` from `RaftLeaderId` trait bounds

### DIFF
--- a/openraft/src/vote/leader_id/raft_leader_id.rs
+++ b/openraft/src/vote/leader_id/raft_leader_id.rs
@@ -30,7 +30,7 @@ use crate::vote::leader_id::raft_committed_leader_id::RaftCommittedLeaderId;
 pub trait RaftLeaderId<C>
 where
     C: RaftTypeConfig,
-    Self: OptionalFeatures + PartialOrd + Eq + Clone + Debug + Display + Default + 'static,
+    Self: OptionalFeatures + PartialOrd + Eq + Clone + Debug + Display + 'static,
     Self: PartialOrd<Self::Committed>,
 {
     /// The committed version of this leader ID.


### PR DESCRIPTION

## Changelog

##### refactor: remove `Default` from `RaftLeaderId` trait bounds
Remove the `Default` bound from `RaftLeaderId` trait since a leader ID
always requires a valid term and node id. This is part of the effort to
make `RaftLeaderId::node_id()` return a non-Option value.

Changes:
- Remove `Default` from `RaftLeaderId` trait bounds

If you implement custom `RaftLeaderId`, you no longer need to implement `Default`.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1515)
<!-- Reviewable:end -->
