### PR TITLE
change: in 0.10.0: make `RaftLeaderId::node_id()` return `&NodeId` instead of `Option`

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_leader_id.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_leader_id.rs
@@ -53,8 +53,8 @@ impl RaftLeaderId<TypeConfig> for pb::LeaderId {
         self.term
     }
 
-    fn node_id(&self) -> Option<&u64> {
-        Some(&self.node_id)
+    fn node_id(&self) -> &u64 {
+        &self.node_id
     }
 
     fn to_committed(&self) -> Self::Committed {

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -766,8 +766,7 @@ where
             return None;
         }
 
-        // Safe unwrap(): vote that is committed has to already have voted for some node.
-        let id = vote.to_leader_id().node_id().cloned().unwrap();
+        let id = vote.to_leader_id().node_id().clone();
 
         // TODO: `is_voter()` is slow, maybe cache `current_leader`,
         //       e.g., only update it when membership or vote changes

--- a/openraft/src/engine/handler/establish_handler/mod.rs
+++ b/openraft/src/engine/handler/establish_handler/mod.rs
@@ -26,7 +26,7 @@ where C: RaftTypeConfig
 
         debug_assert_eq!(
             vote.leader_node_id(),
-            Some(&self.config.id),
+            &self.config.id,
             "it can only commit its own vote"
         );
 

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -223,7 +223,7 @@ where C: RaftTypeConfig
     /// This node then becomes raft-follower or raft-learner.
     pub(crate) fn become_following(&mut self) {
         debug_assert!(
-            self.state.vote_ref().to_leader_id().node_id() != Some(&self.config.id)
+            self.state.vote_ref().to_leader_id().node_id() != &self.config.id
                 || !self.state.membership_state.effective().membership().is_voter(&self.config.id),
             "It must hold: vote is not mine, or I am not a voter(leader just left the cluster)"
         );

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -212,8 +212,7 @@ where
         // For `Leading`, the vote is always the leader's vote.
         // Thus vote.voted_for() is this node.
 
-        // Safe unwrap: voted_for() is always non-None in Openraft
-        let node_id = self.committed_vote.to_leader_node_id().unwrap();
+        let node_id = self.committed_vote.to_leader_node_id();
         let now = C::now();
 
         tracing::debug!(

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -500,7 +500,7 @@ where C: RaftTypeConfig
         let committed_vote = metrics.vote.try_to_committed()?;
         let leader_id = committed_vote.leader_id();
 
-        if leader_id.node_id() == Some(&self.inner.id) {
+        if leader_id.node_id() == &self.inner.id {
             Some(Leader {
                 raft: self.clone(),
                 leader_id: leader_id.clone(),

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -438,7 +438,7 @@ where C: RaftTypeConfig
     ///
     /// [Determine Server State]: crate::docs::data::vote#vote-and-membership-define-the-server-state
     pub(crate) fn is_leading(&self, id: &C::NodeId) -> bool {
-        self.membership_state.contains(id) && self.vote.leader_node_id() == Some(id)
+        self.membership_state.contains(id) && self.vote.leader_node_id() == id
     }
 
     /// The node is leader
@@ -477,8 +477,7 @@ where C: RaftTypeConfig
         let vote = self.vote_ref();
 
         if vote.is_committed() {
-            // Safe unwrap(): vote that is committed has to already have voted for some node.
-            let id = vote.to_leader_id().node_id().cloned().unwrap();
+            let id = vote.to_leader_id().node_id().clone();
 
             return self.new_forward_to_leader(id);
         }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -405,7 +405,7 @@ where
         let append_res = res.map_err(|_e| {
             let to = Timeout {
                 action: RPCTypes::AppendEntries,
-                id: self.session_id.vote().to_leader_node_id().unwrap(),
+                id: self.session_id.vote().to_leader_node_id(),
                 target: self.target.clone(),
                 timeout: the_timeout,
             };

--- a/openraft/src/vote/leader_id/leader_id_adv.rs
+++ b/openraft/src/vote/leader_id/leader_id_adv.rs
@@ -57,8 +57,8 @@ where C: RaftTypeConfig<LeaderId = Self>
         self.term
     }
 
-    fn node_id(&self) -> Option<&C::NodeId> {
-        Some(&self.node_id)
+    fn node_id(&self) -> &C::NodeId {
+        &self.node_id
     }
 
     fn to_committed(&self) -> Self::Committed {

--- a/openraft/src/vote/leader_id/leader_id_std.rs
+++ b/openraft/src/vote/leader_id/leader_id_std.rs
@@ -111,8 +111,8 @@ where C: RaftTypeConfig
         self.term
     }
 
-    fn node_id(&self) -> Option<&C::NodeId> {
-        self.voted_for.as_ref()
+    fn node_id(&self) -> &C::NodeId {
+        self.voted_for.as_ref().unwrap()
     }
 
     fn to_committed(&self) -> Self::Committed {
@@ -218,15 +218,9 @@ mod tests {
         #[allow(clippy::redundant_closure)]
         let lid = |term, node_id| LeaderId::<UTConfig>::new(term, node_id);
 
-        let lid_none = |term| LeaderId::<UTConfig> { term, voted_for: None };
-
         // Compare term first
         assert!(lid(2, 2) > lid(1, 2));
         assert!(lid(1, 2) < lid(2, 2));
-
-        // Equal term, Some > None
-        assert!(lid(2, 2) > lid_none(2));
-        assert!(lid_none(2) < lid(2, 2));
 
         // Equal
         assert!(lid(2, 2) == lid(2, 2));

--- a/openraft/src/vote/leader_id/raft_leader_id.rs
+++ b/openraft/src/vote/leader_id/raft_leader_id.rs
@@ -44,8 +44,8 @@ where
     /// Get the term number of this leader
     fn term(&self) -> C::Term;
 
-    /// Get the node ID of this leader if one is set
-    fn node_id(&self) -> Option<&C::NodeId>;
+    /// Get the node ID of this leader
+    fn node_id(&self) -> &C::NodeId;
 
     /// Convert this leader ID to a committed leader ID.
     ///
@@ -72,8 +72,8 @@ where
     }
 
     /// Get the node ID of this leader as an owned value.
-    fn to_node_id(&self) -> Option<C::NodeId> {
-        self.node_id().cloned()
+    fn to_node_id(&self) -> C::NodeId {
+        self.node_id().clone()
     }
 }
 

--- a/openraft/src/vote/raft_vote.rs
+++ b/openraft/src/vote/raft_vote.rs
@@ -62,13 +62,13 @@ where
         self.leader_id().term()
     }
 
-    /// Gets the node ID of the leader this vote is for, if present.
-    fn to_leader_node_id(&self) -> Option<C::NodeId> {
-        self.leader_node_id().cloned()
+    /// Gets the node ID of the leader this vote is for.
+    fn to_leader_node_id(&self) -> C::NodeId {
+        self.leader_node_id().clone()
     }
 
-    /// Gets a reference to the node ID of the leader this vote is for, if present.
-    fn leader_node_id(&self) -> Option<&C::NodeId> {
+    /// Gets a reference to the node ID of the leader this vote is for.
+    fn leader_node_id(&self) -> &C::NodeId {
         self.leader_id().node_id()
     }
 

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -180,11 +180,6 @@ mod tests {
             #[allow(clippy::redundant_closure)]
             let vote = |term, node_id| Vote::<TC>::new(term, node_id);
 
-            let none = |term| Vote::<TC> {
-                leader_id: LeaderId { term, voted_for: None },
-                committed: false,
-            };
-
             #[allow(clippy::redundant_closure)]
             let committed = |term, node_id| Vote::<TC>::new_committed(term, node_id);
 
@@ -193,12 +188,6 @@ mod tests {
             assert!(vote(2, 2) >= vote(1, 2));
             assert!(vote(1, 2) < vote(2, 2));
             assert!(vote(1, 2) <= vote(2, 2));
-
-            // Equal term, Some > None
-            assert!(vote(2, 2) > none(2));
-            assert!(vote(2, 2) >= none(2));
-            assert!(none(2) < vote(2, 2));
-            assert!(none(2) <= vote(2, 2));
 
             // Committed greater than non-committed if leader_id is incomparable
             assert!(committed(2, 2) > vote(2, 2));

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -850,7 +850,7 @@ impl TypedRaftRouter {
         if let Some(voted_for) = &expect_voted_for {
             assert_eq!(
                 vote.leader_node_id(),
-                Some(voted_for),
+                voted_for,
                 "expected node {} to have voted for {}, got {:?}",
                 id,
                 voted_for,
@@ -979,7 +979,7 @@ impl RaftNetworkV2<MemConfig> for RaftRouterNetwork {
         mut rpc: AppendEntriesRequest<MemConfig>,
         _option: RPCOption,
     ) -> Result<AppendEntriesResponse<MemConfig>, RPCError<MemConfig>> {
-        let from_id = rpc.vote.to_leader_node_id().unwrap();
+        let from_id = rpc.vote.to_leader_node_id();
 
         tracing::debug!("append_entries to id={} {}", self.target, rpc);
         self.owner.count_rpc(RPCTypes::AppendEntries);
@@ -1051,7 +1051,7 @@ impl RaftNetworkV2<MemConfig> for RaftRouterNetwork {
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,
     ) -> Result<SnapshotResponse<MemConfig>, StreamingError<MemConfig>> {
-        let from_id = vote.leader_id().to_node_id().unwrap();
+        let from_id = vote.leader_id().to_node_id();
 
         self.owner.count_rpc(RPCTypes::InstallSnapshot);
         self.owner.call_rpc_pre_hook(snapshot.clone(), from_id, self.target).await?;
@@ -1079,7 +1079,7 @@ impl RaftNetworkV2<MemConfig> for RaftRouterNetwork {
         rpc: VoteRequest<MemConfig>,
         _option: RPCOption,
     ) -> Result<VoteResponse<MemConfig>, RPCError<MemConfig>> {
-        let from_id = rpc.vote.leader_id().to_node_id().unwrap();
+        let from_id = rpc.vote.leader_id().to_node_id();
 
         self.owner.count_rpc(RPCTypes::Vote);
         self.owner.call_rpc_pre_hook(rpc.clone(), from_id, self.target).await?;
@@ -1106,7 +1106,7 @@ impl RaftNetworkV2<MemConfig> for RaftRouterNetwork {
         rpc: TransferLeaderRequest<MemConfig>,
         _option: RPCOption,
     ) -> Result<(), RPCError<MemConfig>> {
-        let from_id = rpc.from_leader().leader_id().to_node_id().unwrap();
+        let from_id = rpc.from_leader().leader_id().to_node_id();
 
         self.owner.count_rpc(RPCTypes::TransferLeader);
         self.owner.call_rpc_pre_hook(rpc.clone(), from_id, self.target).await?;
@@ -1164,13 +1164,13 @@ where
         Self::from_leader_id(leader_id, false)
     }
 
-    /// Gets the node ID of the leader this vote is for, if present.
-    fn to_leader_node_id(&self) -> Option<C::NodeId> {
-        self.leader_node_id().cloned()
+    /// Gets the node ID of the leader this vote is for.
+    fn to_leader_node_id(&self) -> C::NodeId {
+        self.leader_node_id().clone()
     }
 
-    /// Gets a reference to the node ID of the leader this vote is for, if present.
-    fn leader_node_id(&self) -> Option<&C::NodeId> {
+    /// Gets a reference to the node ID of the leader this vote is for.
+    fn leader_node_id(&self) -> &C::NodeId {
         self.leader_id().node_id()
     }
 

--- a/tests/tests/life_cycle/t50_single_follower_restart.rs
+++ b/tests/tests/life_cycle/t50_single_follower_restart.rs
@@ -48,7 +48,7 @@ async fn single_follower_restart() -> anyhow::Result<()> {
         let v = sto.read_vote().await?.unwrap_or_default();
 
         // Set a non-committed vote so that the node restarts as a follower.
-        sto.save_vote(&Vote::new(v.leader_id.term() + 1, v.leader_id.to_node_id().unwrap())).await?;
+        sto.save_vote(&Vote::new(v.leader_id.term() + 1, v.leader_id.to_node_id())).await?;
 
         tracing::info!(log_index, "--- restart node-0");
 


### PR DESCRIPTION

## Changelog

##### change: in 0.10.0: make `RaftLeaderId::node_id()` return `&NodeId` instead of `Option`
In practice, a `LeaderId` always has a node_id. Changed the trait method
signature to return a direct reference instead of `Option<&NodeId>` to
reflect this invariant. The struct fields remain unchanged for storage
compatibility.

Changes:
- Change `RaftLeaderId::node_id()` to return `&C::NodeId` instead of `Option<&C::NodeId>`
- Change `RaftLeaderIdExt::to_node_id()` to return `C::NodeId` instead of `Option<C::NodeId>`
- Change `RaftVoteExt::leader_node_id()` to return `&C::NodeId` instead of `Option<&C::NodeId>`
- Change `RaftVoteExt::to_leader_node_id()` to return `C::NodeId` instead of `Option<C::NodeId>`
- Simplify `LeaderIdCompare::std()` to no longer handle None cases

Upgrade tip:

If you implement `RaftLeaderId` trait, update the `node_id()` method signature
from `fn node_id(&self) -> Option<&C::NodeId>` to `fn node_id(&self) -> &C::NodeId`.

For call sites, replace:
- `leader_id.node_id().unwrap()` → `leader_id.node_id()`
- `leader_id.node_id().cloned().unwrap()` → `leader_id.node_id().clone()`
- `leader_id.node_id() == Some(&id)` → `leader_id.node_id() == &id`
- `vote.to_leader_node_id().unwrap()` → `vote.to_leader_node_id()`
- `vote.leader_node_id() == Some(&id)` → `vote.leader_node_id() == &id`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1516)
<!-- Reviewable:end -->
