### PR TITLE
chore: rename RaftMsg::CheckIsLeaderRequest to EnsureLinearizableRead

### DIFF
--- a/examples/client-http/README.md
+++ b/examples/client-http/README.md
@@ -62,10 +62,10 @@ impl ExampleClient {
     pub async fn read(&self, req: &String) -> Result<String, RPCError>;
     
     /// Consistent read with linearizability guarantee
-    pub async fn linearizable_read(&self, req: &String) -> Result<Result<String, CheckIsLeaderError>, RPCError>;
-    
+    pub async fn linearizable_read(&self, req: &String) -> Result<Result<String, LinearizableReadError>, RPCError>;
+
     /// Auto-forwarding linearizable read
-    pub async fn linearizable_read_auto_forward(&self, req: &String) -> Result<Result<String, CheckIsLeaderError>, RPCError>;
+    pub async fn linearizable_read_auto_forward(&self, req: &String) -> Result<Result<String, LinearizableReadError>, RPCError>;
 }
 ```
 
@@ -110,7 +110,7 @@ The client sends requests to these server endpoints:
 |---------------|---------------|--------------|---------------|-------------|
 | `write` | `POST /write` | `RaftTypeConfig::D` | `Result<ClientWriteResponse, ClientWriteError>` | Write data to cluster |
 | `read` | `POST /read` | `String` | `String` | Read data (inconsistent) |
-| `linearizable_read` | `POST /linearizable_read` | `RaftTypeConfig::R` | `Result<String, CheckIsLeaderError>` | Read data (consistent) |
+| `linearizable_read` | `POST /linearizable_read` | `RaftTypeConfig::R` | `Result<String, LinearizableReadError>` | Read data (consistent) |
 | `init` | `POST /init` | `{}` | `Result<(), InitializeError>` | Initialize cluster |
 | `add_learner` | `POST /add-learner` | `(NodeId, String)` | `Result<ClientWriteResponse, ClientWriteError>` | Add learner node |
 | `change_membership` | `POST /change-membership` | `BTreeSet<NodeId>` | `Result<ClientWriteResponse, ClientWriteError>` | Change membership |

--- a/examples/client-http/src/lib.rs
+++ b/examples/client-http/src/lib.rs
@@ -3,11 +3,11 @@ use std::fmt;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use openraft::error::CheckIsLeaderError;
 use openraft::error::ClientWriteError;
 use openraft::error::ForwardToLeader;
 use openraft::error::Infallible;
 use openraft::error::InitializeError;
+use openraft::error::LinearizableReadError;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
 use openraft::error::Unreachable;
@@ -77,8 +77,11 @@ where C: RaftTypeConfig<Node = BasicNode>
 
     /// Consistent Read value by key, in an inconsistent mode.
     ///
-    /// This method MUST return consistent value or CheckIsLeaderError.
-    pub async fn linearizable_read(&self, req: &String) -> Result<Result<String, CheckIsLeaderError<C>>, RPCError<C>> {
+    /// This method MUST return consistent value or LinearizableReadError.
+    pub async fn linearizable_read(
+        &self,
+        req: &String,
+    ) -> Result<Result<String, LinearizableReadError<C>>, RPCError<C>> {
         self.send_with_forwarding("linearizable_read", Some(req), 0).await
     }
 
@@ -87,7 +90,7 @@ where C: RaftTypeConfig<Node = BasicNode>
     pub async fn linearizable_read_auto_forward(
         &self,
         req: &String,
-    ) -> Result<Result<String, CheckIsLeaderError<C>>, RPCError<C>> {
+    ) -> Result<Result<String, LinearizableReadError<C>>, RPCError<C>> {
         self.send_with_forwarding("linearizable_read", Some(req), 3).await
     }
 

--- a/examples/raft-kv-memstore-network-v2/src/api.rs
+++ b/examples/raft-kv-memstore-network-v2/src/api.rs
@@ -29,7 +29,7 @@ pub async fn read(app: &mut App, req: String) -> String {
             let state_machine = app.state_machine.state_machine.lock().await;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<CheckIsLeaderError>> = Ok(value.unwrap_or_default());
+            let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
             res
         }
         Err(e) => Err(e),

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
@@ -29,7 +29,7 @@ pub async fn read(app: &mut App, req: String) -> String {
             let state_machine = app.state_machine.state_machine.lock().await;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<CheckIsLeaderError>> = Ok(value.unwrap_or_default());
+            let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
             res
         }
         Err(e) => Err(e),

--- a/examples/raft-kv-memstore-singlethreaded/src/api.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/api.rs
@@ -30,7 +30,7 @@ pub async fn read(app: &mut App, req: String) -> String {
             let state_machine = app.state_machine.state_machine.borrow();
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<CheckIsLeaderError>> = Ok(value.unwrap_or_default());
+            let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
             res
         }
         Err(e) => Err(e),

--- a/examples/raft-kv-memstore-singlethreaded/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-singlethreaded/tests/cluster/test_cluster.rs
@@ -11,10 +11,10 @@ use openraft::BasicNode;
 use raft_kv_memstore_singlethreaded::router::Router;
 use raft_kv_memstore_singlethreaded::start_raft;
 use raft_kv_memstore_singlethreaded::store::Request;
-use raft_kv_memstore_singlethreaded::typ::CheckIsLeaderError;
 use raft_kv_memstore_singlethreaded::typ::ClientWriteError;
 use raft_kv_memstore_singlethreaded::typ::ClientWriteResponse;
 use raft_kv_memstore_singlethreaded::typ::InitializeError;
+use raft_kv_memstore_singlethreaded::typ::LinearizableReadError;
 use raft_kv_memstore_singlethreaded::typ::RaftMetrics;
 use raft_kv_memstore_singlethreaded::NodeId;
 use tokio::task;
@@ -184,7 +184,7 @@ async fn run_test(router: Router) {
 
     println!("=== read `foo` on node 1");
     let resp = router
-        .send::<String, String, CheckIsLeaderError>(NodeId::new(1), "/app/read", "foo".to_string())
+        .send::<String, String, LinearizableReadError>(NodeId::new(1), "/app/read", "foo".to_string())
         .await
         .unwrap();
     println!("read resp: {:#?}", resp);

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -4,8 +4,8 @@ use actix_web::web::Data;
 use actix_web::Responder;
 use client_http::FollowerReadError;
 use openraft::error::decompose::DecomposeResult;
-use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
+use openraft::error::LinearizableReadError;
 use openraft::raft::linearizable_read::Linearizer;
 use openraft::ReadPolicy;
 use web::Json;
@@ -51,7 +51,7 @@ pub async fn linearizable_read(app: Data<App>, req: Json<String>) -> actix_web::
             let key = req.0;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, CheckIsLeaderError<TypeConfig>> = Ok(value.unwrap_or_default());
+            let res: Result<String, LinearizableReadError<TypeConfig>> = Ok(value.unwrap_or_default());
             Ok(Json(res))
         }
         Err(e) => Ok(Json(Err(e))),
@@ -103,7 +103,7 @@ pub async fn follower_read(app: Data<App>, req: Json<String>) -> actix_web::Resu
         }
     };
 
-    let linearizer_data_result: Result<crate::network::management::LinearizerData, CheckIsLeaderError<TypeConfig>> =
+    let linearizer_data_result: Result<crate::network::management::LinearizerData, LinearizableReadError<TypeConfig>> =
         match response.json().await {
             Ok(result) => result,
             Err(e) => {

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -229,7 +229,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     let x = client.linearizable_read(&("foo".to_string())).await??;
     assert_eq!("wow", x);
 
-    println!("=== linearizable_read `foo` on node 2 MUST return CheckIsLeaderError");
+    println!("=== linearizable_read `foo` on node 2 MUST return LinearizableReadError");
     let x = client2.linearizable_read(&("foo".to_string())).await?;
     match x {
         Err(e) => {
@@ -239,7 +239,7 @@ async fn test_cluster() -> anyhow::Result<()> {
 
             assert_eq!(s, expect_err);
         }
-        Ok(_) => panic!("MUST return CheckIsLeaderError"),
+        Ok(_) => panic!("MUST return LinearizableReadError"),
     }
 
     // --- Remove node 1,2 from the cluster.

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -3,8 +3,8 @@ use actix_web::web;
 use actix_web::web::Data;
 use actix_web::Responder;
 use openraft::error::decompose::DecomposeResult;
-use openraft::error::CheckIsLeaderError;
 use openraft::error::Infallible;
+use openraft::error::LinearizableReadError;
 use openraft::ReadPolicy;
 use web::Json;
 
@@ -40,7 +40,7 @@ pub async fn linearizable_read(app: Data<App>, req: Json<String>) -> actix_web::
             let kvs = app.key_values.read().await;
             let value = kvs.get(&key);
 
-            let res: Result<String, CheckIsLeaderError<TypeConfig>> = Ok(value.cloned().unwrap_or_default());
+            let res: Result<String, LinearizableReadError<TypeConfig>> = Ok(value.cloned().unwrap_or_default());
             Ok(Json(res))
         }
         Err(e) => Ok(Json(Err(e))),

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -224,7 +224,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     let x = leader.linearizable_read(&("foo".to_string())).await??;
     assert_eq!("wow", x);
 
-    println!("=== linearizable_read `foo=wow` on node 2 MUST return CheckIsLeaderError");
+    println!("=== linearizable_read `foo=wow` on node 2 MUST return LinearizableReadError");
     let x = client2.linearizable_read(&("foo".to_string())).await?;
     println!("=== linearize_read on node 2 result: {:?}", x);
     match x {
@@ -235,7 +235,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
 
             assert_eq!(s, expect_err);
         }
-        Ok(_) => panic!("MUST return CheckIsLeaderError"),
+        Ok(_) => panic!("MUST return LinearizableReadError"),
     }
 
     println!("=== linearizable_read_auto_forward `foo=wow` on node 2 returns value");

--- a/examples/utils/declare_types.rs
+++ b/examples/utils/declare_types.rs
@@ -38,7 +38,7 @@ pub type StreamingError = openraft::error::StreamingError<TypeConfig>;
 pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
 
 pub type ClientWriteError = openraft::error::ClientWriteError<TypeConfig>;
-pub type CheckIsLeaderError = openraft::error::CheckIsLeaderError<TypeConfig>;
+pub type LinearizableReadError = openraft::error::LinearizableReadError<TypeConfig>;
 pub type ForwardToLeader = openraft::error::ForwardToLeader<TypeConfig>;
 pub type InitializeError = openraft::error::InitializeError<TypeConfig>;
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -264,7 +264,7 @@ where
     // TODO: the second condition is such a read request can only read from state machine only when the last log it sees
     //       at `T1` is committed.
     #[tracing::instrument(level = "trace", skip(self, tx))]
-    pub(super) async fn handle_check_is_leader_request(&mut self, read_policy: ReadPolicy, tx: ClientReadTx<C>) {
+    pub(super) async fn handle_ensure_linearizable_read(&mut self, read_policy: ReadPolicy, tx: ClientReadTx<C>) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
         let resp = {
@@ -1322,8 +1322,8 @@ where
             RaftMsg::InstallFullSnapshot { vote, snapshot, tx } => {
                 self.engine.handle_install_full_snapshot(vote, snapshot, tx);
             }
-            RaftMsg::CheckIsLeaderRequest { read_policy, tx } => {
-                self.handle_check_is_leader_request(read_policy, tx).await;
+            RaftMsg::EnsureLinearizableRead { read_policy, tx } => {
+                self.handle_ensure_linearizable_read(read_policy, tx).await;
             }
             RaftMsg::ClientWriteRequest { app_data, responder } => {
                 self.write_entry(C::Entry::new_normal(LogIdOf::<C>::default(), app_data), responder);

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -7,9 +7,9 @@ use crate::RaftTypeConfig;
 use crate::base::BoxOnce;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::display_ext::DisplayBTreeMapDebugValueExt;
-use crate::error::CheckIsLeaderError;
 use crate::error::Infallible;
 use crate::error::InitializeError;
+use crate::error::LinearizableReadError;
 use crate::impls::ProgressResponder;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
@@ -37,7 +37,7 @@ pub(crate) type VoteTx<C> = OneshotSenderOf<C, VoteResponse<C>>;
 pub(crate) type AppendEntriesTx<C> = OneshotSenderOf<C, AppendEntriesResponse<C>>;
 
 /// TX for Linearizable Read Response
-pub(crate) type ClientReadTx<C> = ResultSender<C, Linearizer<C>, CheckIsLeaderError<C>>;
+pub(crate) type ClientReadTx<C> = ResultSender<C, Linearizer<C>, LinearizableReadError<C>>;
 
 /// A message sent by application to the [`RaftCore`].
 ///
@@ -76,7 +76,7 @@ where C: RaftTypeConfig
         responder: Option<CoreResponder<C>>,
     },
 
-    CheckIsLeaderRequest {
+    EnsureLinearizableRead {
         read_policy: ReadPolicy,
         tx: ClientReadTx<C>,
     },
@@ -134,8 +134,8 @@ where C: RaftTypeConfig
                 write!(f, "InstallFullSnapshot: vote: {}, snapshot: {}", vote, snapshot)
             }
             RaftMsg::ClientWriteRequest { .. } => write!(f, "ClientWriteRequest"),
-            RaftMsg::CheckIsLeaderRequest { read_policy, .. } => {
-                write!(f, "CheckIsLeaderRequest with read policy: {}", read_policy)
+            RaftMsg::EnsureLinearizableRead { read_policy, .. } => {
+                write!(f, "EnsureLinearizable with read policy: {}", read_policy)
             }
             RaftMsg::Initialize { members, .. } => {
                 write!(f, "Initialize: {}", members.display())

--- a/openraft/src/error/linearizable_read_error.rs
+++ b/openraft/src/error/linearizable_read_error.rs
@@ -1,0 +1,30 @@
+use crate::RaftTypeConfig;
+use crate::TryAsRef;
+use crate::error::ForwardToLeader;
+use crate::error::QuorumNotEnough;
+
+/// An error related to an is_leader request.
+#[derive(Debug, Clone, thiserror::Error, derive_more::TryInto)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub enum LinearizableReadError<C>
+where C: RaftTypeConfig
+{
+    /// This node is not the leader; request should be forwarded to the leader.
+    #[error(transparent)]
+    ForwardToLeader(#[from] ForwardToLeader<C>),
+
+    /// Cannot finish a request, such as elect or replicate, because a quorum is not available.
+    #[error(transparent)]
+    QuorumNotEnough(#[from] QuorumNotEnough<C>),
+}
+
+impl<C> TryAsRef<ForwardToLeader<C>> for LinearizableReadError<C>
+where C: RaftTypeConfig
+{
+    fn try_as_ref(&self) -> Option<&ForwardToLeader<C>> {
+        match self {
+            Self::ForwardToLeader(f) => Some(f),
+            _ => None,
+        }
+    }
+}

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -3,9 +3,9 @@ use openraft_macros::since;
 use crate::RaftTypeConfig;
 use crate::ReadPolicy;
 use crate::core::raft_msg::RaftMsg;
-use crate::error::CheckIsLeaderError;
 use crate::error::ClientWriteError;
 use crate::error::Fatal;
+use crate::error::LinearizableReadError;
 use crate::impls::ProgressResponder;
 use crate::raft::ClientWriteResponse;
 use crate::raft::ClientWriteResult;
@@ -38,9 +38,9 @@ where C: RaftTypeConfig
     pub(crate) async fn get_read_linearizer(
         &self,
         read_policy: ReadPolicy,
-    ) -> Result<Result<Linearizer<C>, CheckIsLeaderError<C>>, Fatal<C>> {
+    ) -> Result<Result<Linearizer<C>, LinearizableReadError<C>>, Fatal<C>> {
         let (tx, rx) = C::oneshot();
-        self.inner.call_core(RaftMsg::CheckIsLeaderRequest { read_policy, tx }, rx).await
+        self.inner.call_core(RaftMsg::EnsureLinearizableRead { read_policy, tx }, rx).await
     }
 
     #[since(version = "0.10.0")]

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -34,9 +34,9 @@ use openraft::RaftTypeConfig;
 use openraft::ReadPolicy;
 use openraft::ServerState;
 use openraft::Vote;
-use openraft::error::CheckIsLeaderError;
 use openraft::error::ClientWriteError;
 use openraft::error::Fatal;
+use openraft::error::LinearizableReadError;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
 use openraft::error::RaftError;
@@ -713,7 +713,7 @@ impl TypedRaftRouter {
         &self,
         target: MemNodeId,
         read_policy: ReadPolicy,
-    ) -> Result<(Option<LogIdOf<MemConfig>>, Option<LogIdOf<MemConfig>>), CheckIsLeaderError<MemConfig>> {
+    ) -> Result<(Option<LogIdOf<MemConfig>>, Option<LogIdOf<MemConfig>>), LinearizableReadError<MemConfig>> {
         let n = self.get_raft_handle(&target).unwrap();
         n.get_read_log_id(read_policy).await.map_err(|e| e.into_api_error().unwrap())
     }


### PR DESCRIPTION

## Changelog

##### chore: rename RaftMsg::CheckIsLeaderRequest to EnsureLinearizableRead
Changes

- Rename `RaftMsg::CheckIsLeaderRequest` to `EnsureLinearizableRead`
- Rename `CheckIsLeaderError` to `LinearizableReadError`,
  `CheckIsLeaderError` is still kept for backward compatibility.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1518)
<!-- Reviewable:end -->
