### PR TITLE
feat: Add `with_leader()` conditional write to `WriteRequest`

### DIFF
--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -21,6 +21,7 @@ use crate::raft::VoteResponse;
 use crate::raft::linearizable_read::Linearizer;
 use crate::raft::responder::core_responder::CoreResponder;
 use crate::storage::Snapshot;
+use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::alias::VoteOf;
@@ -74,6 +75,7 @@ where C: RaftTypeConfig
     ClientWriteRequest {
         app_data: C::D,
         responder: Option<CoreResponder<C>>,
+        expected_leader: Option<CommittedLeaderIdOf<C>>,
     },
 
     EnsureLinearizableRead {

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -72,7 +72,13 @@ where C: RaftTypeConfig
     /// Fire-and-forget version of `client_write`, accept a generic responder.
     #[since(version = "0.10.0")]
     async fn do_client_write_ff(&self, app_data: C::D, responder: Option<CoreResponder<C>>) -> Result<(), Fatal<C>> {
-        self.inner.send_msg(RaftMsg::ClientWriteRequest { app_data, responder }).await?;
+        self.inner
+            .send_msg(RaftMsg::ClientWriteRequest {
+                app_data,
+                responder,
+                expected_leader: None,
+            })
+            .await?;
 
         Ok(())
     }

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -75,7 +75,7 @@ impl IntoMemClientRequest<ClientRequest> for ClientRequest {
 }
 
 /// The application data response type which the `MemStore` works with.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ClientResponse(pub Option<String>);
 
 pub type MemNodeId = u64;


### PR DESCRIPTION

## Changelog

##### feat: Add `with_leader()` conditional write to `WriteRequest`
Add `WriteRequest::with_leader()` method to support conditional writes
that only execute when the current leader matches the expected leader.
This prevents duplicate operations when retrying writes after network
partitions or leadership changes.

Example: With standard LeaderId (term-only):

```rust,ignore
let term = my_raft.as_leader()?.term();
raft.write(my_data)
    .with_leader(term)
    .await?;
```

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1520)
<!-- Reviewable:end -->
