### PR TITLE
refactor: extract ReplicationState into separate module

### DIFF
--- a/openraft/src/replication/log_state.rs
+++ b/openraft/src/replication/log_state.rs
@@ -2,38 +2,15 @@
 
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::type_config::alias::LogIdOf;
 
-/// Tracks the log replication state for a follower from the leader's perspective.
-///
-/// This struct maintains the progress of log replication, including which logs have been matched,
-/// the search range for finding matching logs, and the stream identifier for error isolation.
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct LogState<C>
 where C: RaftTypeConfig
 {
-    /// Replication stream identifier.
-    ///
-    /// Used until a replication error occurs and is reported to RaftCore.
-    /// A new stream_id is generated after each error to isolate delayed messages from previous
-    /// streams.
-    pub(crate) stream_id: u64,
-
-    /// The last purged log id.
-    ///
-    /// Log entries at or below this id are absent on the leader and require snapshot replication.
-    pub(crate) purged: Option<LogId<C>>,
-
-    /// The last known committed log id on the leader.
+    /// The last known committed log id on a node.
     pub(crate) committed: Option<LogId<C>>,
 
-    /// The last matching log id on the follower.
-    pub(crate) matching: Option<LogIdOf<C>>,
-
-    /// Upper bound (exclusive) of the log index range on the follower that may match the leader.
-    pub(crate) searching_end: u64,
-
-    /// The last log id on this leader node.
-    pub(crate) last_log_id: Option<LogId<C>>,
+    /// The last log id on a node.
+    pub(crate) last: Option<LogId<C>>,
 }

--- a/openraft/src/replication/replication_state.rs
+++ b/openraft/src/replication/replication_state.rs
@@ -1,0 +1,42 @@
+use crate::LogId;
+use crate::RaftTypeConfig;
+use crate::replication::log_state::LogState;
+
+/// Tracks the log replication state for a follower from the leader's perspective.
+///
+/// This struct maintains the progress of log replication, including which logs have been matched,
+/// the search range for finding matching logs, and the stream identifier for error isolation.
+#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct ReplicationState<C>
+where C: RaftTypeConfig
+{
+    /// Replication stream identifier.
+    ///
+    /// Used until a replication error occurs and is reported to RaftCore.
+    /// A new stream_id is generated after each error to isolate delayed messages from previous
+    /// streams.
+    pub(crate) stream_id: u64,
+
+    /// The last purged log id.
+    ///
+    /// Log entries at or below this id are absent on the leader and require snapshot replication.
+    pub(crate) purged: Option<LogId<C>>,
+
+    /// Log state on the leader node.
+    ///
+    /// - `committed`: the leader's committed log id.
+    /// - `last`: unused.
+    pub(crate) local: LogState<C>,
+
+    /// Known log state on the remote follower.
+    ///
+    /// - `committed`: unused.
+    /// - `last`: the last matching log id, i.e., the follower has all logs up to this id.
+    pub(crate) remote: LogState<C>,
+
+    /// Upper bound (exclusive) of the log index range on the follower that may match the leader.
+    pub(crate) searching_end: u64,
+}
+
+impl<C> ReplicationState<C> where C: RaftTypeConfig {}


### PR DESCRIPTION

## Changelog

##### refactor: extract ReplicationState into separate module
Move `ReplicationState` from `log_state.rs` to its own module to improve
code organization. Refactor the struct to use `LogState` for both local
and remote states, replacing individual fields with structured components.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1521)
<!-- Reviewable:end -->
