### PR TITLE
refactor: add Clone bound to WatchSender trait

### DIFF
--- a/openraft/src/type_config/async_runtime/watch/mod.rs
+++ b/openraft/src/type_config/async_runtime/watch/mod.rs
@@ -55,7 +55,7 @@ pub trait Watch: Sized + OptionalSend {
 }
 
 /// Sends values to the associated Receiver.
-pub trait WatchSender<W, T>: OptionalSend
+pub trait WatchSender<W, T>: OptionalSend + Clone
 where
     W: Watch,
     T: OptionalSend + OptionalSync,

--- a/rt-compio/src/watch.rs
+++ b/rt-compio/src/watch.rs
@@ -28,6 +28,12 @@ impl watch::Watch for See {
     }
 }
 
+impl<T> Clone for SeeSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<T> watch::WatchSender<See, T> for SeeSender<T>
 where T: OptionalSend + OptionalSync
 {

--- a/rt-monoio/src/lib.rs
+++ b/rt-monoio/src/lib.rs
@@ -416,6 +416,12 @@ mod watch_mod {
         }
     }
 
+    impl<T> Clone for TokioWatchSender<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
     impl<T> watch::WatchSender<TokioWatch, T> for TokioWatchSender<T>
     where T: OptionalSend + OptionalSync
     {


### PR DESCRIPTION

## Changelog

##### refactor: add Clone bound to WatchSender trait

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1522)
<!-- Reviewable:end -->
