### PR TITLE
refactor: remove `allow_notification_reorder` and `allow_io_notification_reorder` config

### DIFF
--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -43,8 +43,6 @@ where P: AsRef<Path> {
     let config = Config {
         heartbeat_interval: 250,
         election_timeout_min: 299,
-        // RocksDB flush and send IO notification in another task, which does not guarantee the order.
-        allow_io_notification_reorder: Some(true),
         ..Default::default()
     };
 

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -307,23 +307,6 @@ pub struct Config {
            default_missing_value = "true"
     )]
     pub allow_log_reversion: Option<bool>,
-
-    /// Allow IO completion notifications to arrive out of order.
-    ///
-    /// When enabled, storage implementations may report IO completions non-monotonically.
-    /// For example, flushed entries `[5..6)` may notify before `[6..8)`.
-    ///
-    /// Enable this if your storage does not guarantee strictly ordered notifications.
-    ///
-    /// Default: `false` (detects out-of-order bugs by default)
-    ///
-    /// Since: 0.10.0
-    #[clap(long,
-           action = clap::ArgAction::Set,
-           num_args = 0..=1,
-           default_missing_value = "true"
-    )]
-    pub allow_io_notification_reorder: Option<bool>,
 }
 
 /// Updatable config for a raft runtime.
@@ -379,14 +362,6 @@ impl Config {
     #[since(version = "0.10.0")]
     pub(crate) fn get_allow_log_reversion(&self) -> bool {
         self.allow_log_reversion.unwrap_or(false)
-    }
-
-    /// Returns whether IO completion notifications can arrive out of order.
-    ///
-    /// Default: `false`
-    #[since(version = "0.10.0")]
-    pub(crate) fn get_allow_io_notification_reorder(&self) -> bool {
-        self.allow_io_notification_reorder.unwrap_or(false)
     }
 
     /// Get the API channel size for bounded MPSC channel.

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -198,34 +198,6 @@ fn test_config_allow_log_reversion() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_config_allow_io_notification_reorder() -> anyhow::Result<()> {
-    let config = Config::build(&["foo", "--allow-io-notification-reorder=false"])?;
-    assert_eq!(Some(false), config.allow_io_notification_reorder);
-
-    let config = Config::build(&["foo", "--allow-io-notification-reorder=true"])?;
-    assert_eq!(Some(true), config.allow_io_notification_reorder);
-
-    let config = Config::build(&["foo", "--allow-io-notification-reorder"])?;
-    assert_eq!(Some(true), config.allow_io_notification_reorder);
-
-    let mut config = Config::build(&["foo"])?;
-    assert_eq!(None, config.allow_io_notification_reorder);
-
-    // test get_allow_io_notification_reorder method
-
-    config.allow_io_notification_reorder = None;
-    assert_eq!(false, config.get_allow_io_notification_reorder());
-
-    config.allow_io_notification_reorder = Some(true);
-    assert_eq!(true, config.get_allow_io_notification_reorder());
-
-    config.allow_io_notification_reorder = Some(false);
-    assert_eq!(false, config.get_allow_io_notification_reorder());
-
-    Ok(())
-}
-
-#[test]
 fn test_config_api_channel_size() -> anyhow::Result<()> {
     // Test default value
     let config = Config::build(&["foo"])?;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1538,7 +1538,7 @@ where
             }
 
             Notification::LocalIO { io_id } => {
-                self.engine.state.log_progress_mut().flush(io_id.clone());
+                self.engine.state.log_progress_mut().try_flush(io_id.clone());
 
                 match io_id {
                     IOId::Log(log_io_id) => {
@@ -1611,18 +1611,18 @@ where
                             func_name!()
                         );
 
-                        self.engine.state.log_progress_mut().flush(IOId::Log(log_io_id));
+                        self.engine.state.log_progress_mut().try_flush(IOId::Log(log_io_id));
 
                         if let Some(meta) = meta {
                             let st = self.engine.state.io_state_mut();
                             if let Some(last) = &meta.last_log_id {
-                                st.apply_progress.flush(last.clone());
-                                st.snapshot.flush(last.clone());
+                                st.apply_progress.try_flush(last.clone());
+                                st.snapshot.try_flush(last.clone());
                             }
                         }
                     }
                     sm::Response::Apply(res) => {
-                        self.engine.state.apply_progress_mut().flush(res.last_applied);
+                        self.engine.state.apply_progress_mut().try_flush(res.last_applied);
                     }
                 }
             }

--- a/openraft/src/docs/data/io_id.md
+++ b/openraft/src/docs/data/io_id.md
@@ -117,8 +117,7 @@ This ensures monotonic ordering across both vote and log I/O operations:
 let mut progress = IOProgress::new_synchronized(
     None,
     "storage",
-    "log",
-    false
+    "log"
 );
 
 // Accept a vote I/O

--- a/openraft/src/engine/pending_responds.rs
+++ b/openraft/src/engine/pending_responds.rs
@@ -186,9 +186,9 @@ mod tests {
         snapshot: Option<TestLogId>,
     ) -> IOState<UTConfig> {
         let vote = Vote::new(1, 1);
-        let mut io_state = IOState::new("xx", &vote, applied, snapshot, None, false);
+        let mut io_state = IOState::new("xx", &vote, applied, snapshot, None);
         if let Some(id) = log_io {
-            io_state.log_progress = Valid::new(IOProgress::new_synchronized(Some(id), "xx", "log", false));
+            io_state.log_progress = Valid::new(IOProgress::new_synchronized(Some(id), "xx", "log"));
         }
         io_state
     }

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -369,9 +369,7 @@ where C: RaftTypeConfig
         let eng_config = EngineConfig::new(id.clone(), config.as_ref());
 
         let state = {
-            let mut helper = StorageHelper::new(&mut log_store, &mut state_machine)
-                .with_allow_io_notification_reorder(config.get_allow_io_notification_reorder())
-                .with_id(id.clone());
+            let mut helper = StorageHelper::new(&mut log_store, &mut state_machine).with_id(id.clone());
             helper.get_initial_state().await?
         };
 

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -151,9 +151,9 @@ where C: RaftTypeConfig
     fn default() -> Self {
         Self {
             building_snapshot: false,
-            log_progress: new_progress(None, "xx", LOG_PROGRESS_NAME, false),
-            apply_progress: new_progress(None, "xx", APPLY_PROGRESS_NAME, false),
-            snapshot: new_progress(None, "xx", SNAPSHOT_PROGRESS_NAME, false),
+            log_progress: new_progress(None, "xx", LOG_PROGRESS_NAME),
+            apply_progress: new_progress(None, "xx", APPLY_PROGRESS_NAME),
+            snapshot: new_progress(None, "xx", SNAPSHOT_PROGRESS_NAME),
             cluster_committed: MonotonicIncrease::default(),
             purged: None,
         }
@@ -188,23 +188,18 @@ impl<C> IOState<C>
 where C: RaftTypeConfig
 {
     /// Creates a new `IOState` with initial values.
-    ///
-    /// - `allow_io_notification_reorder`: Allow I/O completion notifications to arrive out of order
     pub(crate) fn new(
         id: &str,
         vote: &VoteOf<C>,
         applied: Option<LogIdOf<C>>,
         snapshot: Option<LogIdOf<C>>,
         purged: Option<LogIdOf<C>>,
-        allow_io_notification_reorder: bool,
     ) -> Self {
-        let reorder = allow_io_notification_reorder;
-
         Self {
             building_snapshot: false,
-            log_progress: new_progress(Some(IOId::new(vote)), id, LOG_PROGRESS_NAME, reorder),
-            apply_progress: new_progress(applied, id, APPLY_PROGRESS_NAME, reorder),
-            snapshot: new_progress(snapshot, id, SNAPSHOT_PROGRESS_NAME, reorder),
+            log_progress: new_progress(Some(IOId::new(vote)), id, LOG_PROGRESS_NAME),
+            apply_progress: new_progress(applied, id, APPLY_PROGRESS_NAME),
+            snapshot: new_progress(snapshot, id, SNAPSHOT_PROGRESS_NAME),
             cluster_committed: MonotonicIncrease::default(),
             purged,
         }
@@ -290,19 +285,7 @@ where C: RaftTypeConfig
 /// Creates a new `IOProgress` wrapped in `Valid`.
 ///
 /// All three stages (accepted, submitted, flushed) are initialized to `initial_value`.
-fn new_progress<T>(
-    initial_value: Option<T>,
-    id: impl ToString,
-    name: &'static str,
-    allow_notification_reorder: bool,
-) -> Valid<IOProgress<T>>
-where
-    T: PartialOrd + fmt::Debug + fmt::Display + Clone,
-{
-    Valid::new(IOProgress::new_synchronized(
-        initial_value,
-        id,
-        name,
-        allow_notification_reorder,
-    ))
+fn new_progress<T>(initial_value: Option<T>, id: impl ToString, name: &'static str) -> Valid<IOProgress<T>>
+where T: PartialOrd + fmt::Debug + fmt::Display + Clone {
+    Valid::new(IOProgress::new_synchronized(initial_value, id, name))
 }

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -47,8 +47,6 @@ where
     id: Option<C::NodeId>,
     id_str: String,
 
-    /// Whether to allow IO completion notifications to arrive out of order.
-    allow_io_notification_reorder: bool,
     _p: PhantomData<C>,
 }
 
@@ -64,18 +62,10 @@ where
         Self {
             log_store: sto,
             state_machine: sm,
-            allow_io_notification_reorder: false,
             id: None,
             id_str: "xx".to_string(),
             _p: Default::default(),
         }
-    }
-
-    /// Configure whether to allow IO completion notifications to arrive out of order.
-    #[since(version = "0.10.0")]
-    pub fn with_allow_io_notification_reorder(mut self, allow_io_notification_reorder: bool) -> Self {
-        self.allow_io_notification_reorder = allow_io_notification_reorder;
-        self
     }
 
     /// Set the ID of this node
@@ -205,7 +195,6 @@ where
             last_applied.clone(),
             snapshot_meta.last_log_id.clone(),
             last_purged_log_id.clone(),
-            self.allow_io_notification_reorder,
         );
 
         let now = C::now();

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -472,7 +472,7 @@ where
         want.vote.update(initial.vote.last_update().unwrap(), Duration::default(), vote.clone());
         want.log_progress_mut().accept(IOId::new(&vote));
         want.log_progress_mut().submit(IOId::new(&vote));
-        want.log_progress_mut().flush(IOId::new(&vote));
+        want.log_progress_mut().try_flush(IOId::new(&vote));
 
         // Set the id to the NODE_ID used in these tests.
         want.log_progress_mut().set_id(NODE_ID.to_string());


### PR DESCRIPTION

## Changelog

##### refactor: remove `allow_notification_reorder` and `allow_io_notification_reorder` config
In the codebase, accept a new IO or submit a new IO operation never
allows to reorder, always use `accept()` and `submit()`. But for flushed
notification, it always assumes it will be re-ordered.

Because currently, save-vote IO notification is sent in RaftCore task,
and AppendEntries IO notification is sent from user task, These two task
has no coordination thus there is a chance these two notification will
be re-ordered.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1524)
<!-- Reviewable:end -->
