### PR TITLE
refactor: decouple log replication from commit index update

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1292,16 +1292,12 @@ where
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub(super) fn handle_append_entries_request(&mut self, req: AppendEntriesRequest<C>, tx: AppendEntriesTx<C>) {
-        // TODO: test this function when `is_ok` is removed, it should be able to get the right conclusion
-        // it self.
         tracing::debug!(req = display(&req), func = func_name!());
 
-        let is_ok = self.engine.handle_append_entries(&req.vote, req.prev_log_id, req.entries, tx);
+        self.engine.handle_append_entries(&req.vote, req.prev_log_id, req.entries, tx);
 
-        if is_ok {
-            let committed = LogIOId::new(req.vote.to_committed(), req.leader_commit);
-            self.engine.state.update_committed(committed);
-        }
+        let committed = LogIOId::new(req.vote.to_committed(), req.leader_commit);
+        self.engine.state.update_committed(committed);
     }
 
     // TODO: Make this method non-async. It does not need to run any async command in it.

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -405,7 +405,7 @@ where C: RaftTypeConfig
         prev_log_id: Option<LogIdOf<C>>,
         entries: Vec<C::Entry>,
         tx: AppendEntriesTx<C>,
-    ) -> bool {
+    ) {
         tracing::debug!(
             vote = display(vote),
             prev_log_id = display(prev_log_id.display()),
@@ -433,8 +433,6 @@ where C: RaftTypeConfig
             when: condition,
             resp: Respond::new(resp, tx),
         });
-
-        is_ok
     }
 
     pub(crate) fn append_entries(


### PR DESCRIPTION

## Changelog

##### refactor: decouple log replication from commit index update
This commit decouples the application of log entries from the commit
index update in `handle_append_entries_request()`.

In standard Raft, AppendEntries bundles log entries and committed index
together, requiring them to be processed atomically. If separated
improperly, a follower might mistakenly believe uncommitted local log
entries are committed.

In previous commits, we associated the committed log ID with a leader
ID, making it safe to process log replication and commit index updates
independently. This refactoring prepares for a future change where the
leader will use two separate streams to replicate log entries and
committed index to followers.

Changes:
- Change `handle_append_entries()` to return `()` instead of `bool`
- Call `update_committed()` unconditionally in `handle_append_entries_request()`
- Remove outdated TODO comment

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1532)
<!-- Reviewable:end -->
