### PR TITLE
feat: add stream-oriented AppendEntries API for pipelined replication

### DIFF
--- a/openraft/src/raft/message/mod.rs
+++ b/openraft/src/raft/message/mod.rs
@@ -5,6 +5,7 @@
 
 mod append_entries;
 mod install_snapshot;
+mod stream_append_error;
 mod transfer_leader;
 mod vote;
 
@@ -18,6 +19,7 @@ pub use client_write::ClientWriteResult;
 pub use install_snapshot::InstallSnapshotRequest;
 pub use install_snapshot::InstallSnapshotResponse;
 pub use install_snapshot::SnapshotResponse;
+pub use stream_append_error::StreamAppendError;
 pub use transfer_leader::TransferLeaderRequest;
 pub use vote::VoteRequest;
 pub use vote::VoteResponse;

--- a/openraft/src/raft/message/stream_append_error.rs
+++ b/openraft/src/raft/message/stream_append_error.rs
@@ -1,0 +1,36 @@
+use std::fmt;
+
+use crate::RaftTypeConfig;
+use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::VoteOf;
+
+/// Error type for stream append entries.
+///
+/// When this error is returned, the stream is terminated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub enum StreamAppendError<C: RaftTypeConfig> {
+    /// Log conflict at the given prev_log_id.
+    ///
+    /// The follower's log at this position does not match the leader's.
+    Conflict(Option<LogIdOf<C>>),
+
+    /// Seen a higher vote from another leader.
+    HigherVote(VoteOf<C>),
+}
+
+impl<C> fmt::Display for StreamAppendError<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StreamAppendError::Conflict(log_id) => {
+                write!(f, "Conflict({})", log_id.display())
+            }
+            StreamAppendError::HigherVote(vote) => {
+                write!(f, "HigherVote({})", vote)
+            }
+        }
+    }
+}

--- a/openraft/src/raft/stream_append.rs
+++ b/openraft/src/raft/stream_append.rs
@@ -1,0 +1,83 @@
+//! Stream-based AppendEntries API implementation with pipelining.
+
+use std::sync::Arc;
+
+use futures::Stream;
+use futures::StreamExt;
+
+use crate::AsyncRuntime;
+use crate::OptionalSend;
+use crate::RaftTypeConfig;
+use crate::core::raft_msg::RaftMsg;
+use crate::entry::RaftEntry;
+use crate::raft::AppendEntriesRequest;
+use crate::raft::AppendEntriesResponse;
+use crate::raft::StreamAppendError;
+use crate::raft::raft_inner::RaftInner;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::async_runtime::MpscReceiver;
+use crate::type_config::async_runtime::MpscSender;
+use crate::type_config::util::TypeConfigExt;
+
+/// Result type for stream append operations.
+pub type StreamAppendResult<C> = Result<Option<LogIdOf<C>>, StreamAppendError<C>>;
+
+const PIPELINE_BUFFER_SIZE: usize = 64;
+
+struct Pending<C: RaftTypeConfig> {
+    response_rx: OneshotReceiverOf<C, AppendEntriesResponse<C>>,
+    prev_log_id: Option<LogIdOf<C>>,
+    last_log_id: Option<LogIdOf<C>>,
+}
+
+/// Create a pipelined stream that processes AppendEntries requests.
+///
+/// Spawns a background task that reads from input, sends to RaftCore,
+/// and forwards response receivers. The returned stream awaits responses in order.
+pub(crate) fn stream_append<C, S>(
+    inner: Arc<RaftInner<C>>,
+    input: S,
+) -> impl Stream<Item = StreamAppendResult<C>> + OptionalSend + 'static
+where
+    C: RaftTypeConfig,
+    S: Stream<Item = AppendEntriesRequest<C>> + OptionalSend + 'static,
+{
+    let (tx, rx) = C::mpsc::<Pending<C>>(PIPELINE_BUFFER_SIZE);
+
+    let inner2 = inner.clone();
+    let _handle = C::AsyncRuntime::spawn(async move {
+        let inner = inner2;
+        futures::pin_mut!(input);
+
+        while let Some(req) = input.next().await {
+            let prev = req.prev_log_id.clone();
+            let last = req.entries.last().map(|e| e.log_id()).or(prev.clone());
+            let (resp_tx, resp_rx) = C::oneshot();
+
+            if inner.send_msg(RaftMsg::AppendEntries { rpc: req, tx: resp_tx }).await.is_err() {
+                break;
+            }
+            let pending = Pending {
+                response_rx: resp_rx,
+                prev_log_id: prev,
+                last_log_id: last,
+            };
+            if MpscSender::send(&tx, pending).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    futures::stream::unfold(Some((rx, inner)), |state| async move {
+        let (mut rx, inner) = state?;
+        let p: Pending<C> = MpscReceiver::recv(&mut rx).await?;
+
+        let resp = inner.recv_msg(p.response_rx).await.ok()?;
+
+        let result = resp.into_stream_result(p.prev_log_id, p.last_log_id);
+        let cont = result.is_ok();
+
+        Some((result, if cont { Some((rx, inner)) } else { None }))
+    })
+}

--- a/tests/tests/append_entries/main.rs
+++ b/tests/tests/append_entries/main.rs
@@ -9,6 +9,7 @@ mod fixtures;
 
 mod t10_conflict_with_empty_entries;
 mod t10_see_higher_vote;
+mod t10_stream_append;
 mod t11_append_conflicts;
 mod t11_append_entries_with_bigger_term;
 mod t11_append_inconsistent_log;

--- a/tests/tests/append_entries/t10_stream_append.rs
+++ b/tests/tests/append_entries/t10_stream_append.rs
@@ -1,0 +1,171 @@
+use std::pin::pin;
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::StreamExt;
+use openraft::Config;
+use openraft::Vote;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::StreamAppendError;
+use openraft::raft::VoteRequest;
+use openraft::testing::blank_ent;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// Test stream_append with successful append entries.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn stream_append_success() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.new_raft_node(0).await;
+
+    let raft = router.get_raft_handle(&0)?;
+
+    let requests = vec![
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1),
+            prev_log_id: None,
+            entries: vec![blank_ent(0, 0, 0), blank_ent(1, 1, 1)],
+            leader_commit: None,
+        },
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1),
+            prev_log_id: Some(log_id(1, 1, 1)),
+            entries: vec![blank_ent(1, 1, 2), blank_ent(1, 1, 3)],
+            leader_commit: None,
+        },
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1),
+            prev_log_id: Some(log_id(1, 1, 3)),
+            entries: vec![blank_ent(1, 1, 4)],
+            leader_commit: Some(log_id(1, 1, 4)),
+        },
+    ];
+
+    let input_stream = futures::stream::iter(requests);
+    let output_stream = pin!(raft.stream_append(input_stream));
+
+    let results: Vec<_> = output_stream.collect().await;
+    assert_eq!(results, vec![
+        Ok(Some(log_id(1, 1, 1))),
+        Ok(Some(log_id(1, 1, 3))),
+        Ok(Some(log_id(1, 1, 4))),
+    ]);
+
+    Ok(())
+}
+
+/// Test stream_append terminates on conflict.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn stream_append_conflict() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.new_raft_node(0).await;
+
+    let raft = router.get_raft_handle(&0)?;
+
+    // First request succeeds, second has conflicting prev_log_id
+    let requests = vec![
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1),
+            prev_log_id: None,
+            entries: vec![blank_ent(0, 0, 0), blank_ent(1, 1, 1)],
+            leader_commit: None,
+        },
+        // This will conflict: prev_log_id at index 5 doesn't exist
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1),
+            prev_log_id: Some(log_id(1, 1, 5)),
+            entries: vec![blank_ent(1, 1, 6)],
+            leader_commit: None,
+        },
+        // This should never be processed because stream terminates on conflict
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1),
+            prev_log_id: Some(log_id(1, 1, 6)),
+            entries: vec![blank_ent(1, 1, 7)],
+            leader_commit: None,
+        },
+    ];
+
+    let input_stream = futures::stream::iter(requests);
+    let output_stream = pin!(raft.stream_append(input_stream));
+
+    let results: Vec<_> = output_stream.collect().await;
+    assert_eq!(results, vec![
+        Ok(Some(log_id(1, 1, 1))),
+        Err(StreamAppendError::Conflict(Some(log_id(1, 1, 5)))),
+    ]);
+
+    Ok(())
+}
+
+/// Test stream_append terminates on higher vote.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn stream_append_higher_vote() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.new_raft_node(0).await;
+
+    let raft = router.get_raft_handle(&0)?;
+
+    // Establish a higher vote on the node
+    let resp = raft
+        .vote(VoteRequest {
+            vote: Vote::new(10, 2),
+            last_log_id: Some(log_id(10, 2, 100)),
+        })
+        .await?;
+    assert!(resp.is_granted_to(&Vote::new(10, 2)));
+
+    // Now try to append with a lower vote
+    let requests = vec![
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1), // Lower than (10, 2)
+            prev_log_id: None,
+            entries: vec![blank_ent(0, 0, 0)],
+            leader_commit: None,
+        },
+        // This should never be processed
+        AppendEntriesRequest::<openraft_memstore::TypeConfig> {
+            vote: Vote::new_committed(1, 1),
+            prev_log_id: Some(log_id(0, 0, 0)),
+            entries: vec![blank_ent(1, 1, 1)],
+            leader_commit: None,
+        },
+    ];
+
+    let input_stream = futures::stream::iter(requests);
+    let output_stream = pin!(raft.stream_append(input_stream));
+
+    let results: Vec<_> = output_stream.collect().await;
+    assert_eq!(results, vec![Err(StreamAppendError::HigherVote(Vote::new(10, 2))),]);
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### feat: add stream-oriented AppendEntries API for pipelined replication
Add `Raft::stream_append()` method that allows processing multiple AppendEntries
requests through a pipelined stream interface. This enables efficient batched
log replication with backpressure support via a bounded channel.

Example usage:

```rust
use std::pin::pin;
use futures::StreamExt;

let input = futures::stream::iter(vec![request1, request2, request3]);
let mut output = pin!(raft.stream_append(input));

while let Some(result) = output.next().await {
    match result {
        Ok(log_id) => println!("Flushed: {:?}", log_id),
        Err(err) => {
            println!("Error: {}", err);
            break;
        }
    }
}
```

Changes:
- Add `Raft::stream_append()` for stream-based AppendEntries processing
- Add `StreamAppendError` with `Conflict` and `HigherVote` variants
- Add `StreamAppendResult` type alias for stream item results
- Add `AppendEntriesResponse::into_stream_result()` conversion method
- Add `ProtocolApi::stream_append()` internal implementation
- Add integration tests for success, conflict, and higher vote scenarios

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1533)
<!-- Reviewable:end -->
