### PR TITLE
feat: initial support multi-raft

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -374,6 +374,7 @@ jobs:
           - 'raft-kv-memstore-opendal-snapshot-data'
           - 'raft-kv-memstore-singlethreaded'
           - 'raft-kv-rocksdb'
+          - 'multi-raft-kv'
 
     steps:
       - uses: actions/checkout@v4
@@ -401,13 +402,17 @@ jobs:
 
       - name: Test demo script of examples/${{ matrix.example }}
         # The script is not meant for testing. Just to ensure it works but do not
-        # rely on it.
+        # rely on it. Skip if test-cluster.sh doesn't exist.
         if: ${{ matrix.toolchain == 'stable' }}
 
         shell: bash
         run: |
           cd examples/${{ matrix.example }}
-          ./test-cluster.sh
+          if [ -f test-cluster.sh ]; then
+            ./test-cluster.sh
+          else
+            echo "No test-cluster.sh found, skipping"
+          fi
 
       - name: Format
         # clippy/format produces different result with stable and nightly. Only with nightly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ exclude = [
     "examples/raft-kv-memstore-opendal-snapshot-data",
     "examples/raft-kv-rocksdb",
 
+    "examples/multi-raft-kv",
+
     "rt-monoio",
-    "rt-compio"
+    "rt-compio",
+    "multiraft"
 ]

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ test:
 	cargo test --features serde
 	# only crate `tests` has single-term-leader feature
 	cargo test --features single-term-leader -p tests
+	# multiraft crate tests
+	cargo test --manifest-path multiraft/Cargo.toml
 	$(MAKE) test-examples
 
 check-parallel:
@@ -40,6 +42,7 @@ test-examples:
 	cargo test --manifest-path examples/raft-kv-memstore-singlethreaded/Cargo.toml
 	cargo test --manifest-path examples/raft-kv-rocksdb/Cargo.toml
 	cargo test --manifest-path examples/rocksstore/Cargo.toml
+	cargo test --manifest-path examples/multi-raft-kv/Cargo.toml
 
 bench:
 	cargo bench --features bench
@@ -75,19 +78,27 @@ guide:
 
 lint:
 	cargo fmt
+	cargo fmt --manifest-path multiraft/Cargo.toml
+	cargo fmt --manifest-path rt-compio/Cargo.toml
+	cargo fmt --manifest-path rt-monoio/Cargo.toml
 	cargo fmt --manifest-path examples/mem-log/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-singlethreaded/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-rocksdb/Cargo.toml
+	cargo fmt --manifest-path examples/multi-raft-kv/Cargo.toml
 	cargo clippy --no-deps --all-targets -- -D warnings
-	cargo clippy --no-deps --manifest-path examples/mem-log/Cargo.toml                               --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path multiraft/Cargo.toml                                       --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path rt-compio/Cargo.toml                                       --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path rt-monoio/Cargo.toml                                       --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path examples/mem-log/Cargo.toml                                --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml            --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-singlethreaded/Cargo.toml        --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore/Cargo.toml                       --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-rocksdb/Cargo.toml                        --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path examples/multi-raft-kv/Cargo.toml                          --all-targets -- -D warnings
 	# Bug: clippy --all-targets reports false warning about unused dep in
 	# `[dev-dependencies]`:
 	# https://github.com/rust-lang/rust/issues/72686#issuecomment-635539688

--- a/examples/mem-log/Cargo.toml
+++ b/examples/mem-log/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../../openraft", features = ["type-alias"] }
+openraft = { path = "../../openraft", default-features = false, features = ["type-alias", "tokio-rt"] }
 
 tokio = { version = "1.0", default-features = false, features = ["sync"] }
 

--- a/examples/multi-raft-kv/Cargo.toml
+++ b/examples/multi-raft-kv/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "multi-raft-kv"
+version = "0.1.0"
+readme = "README.md"
+
+edition = "2021"
+authors = [
+    "AriesDevil <ariesdevil77@gmail.com>",
+]
+categories = ["algorithms", "asynchronous", "data-structures"]
+description = "An example Multi-Raft distributed key-value store with 3 groups built upon `openraft`."
+homepage = "https://github.com/databendlabs/openraft"
+keywords = ["raft", "consensus", "multi-raft"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/databendlabs/openraft"
+
+[dependencies]
+mem-log         = { path = "../mem-log", features = [] }
+openraft        = { path = "../../openraft", default-features = false, features = ["serde", "type-alias"] }
+openraft-multi = { path = "../../multiraft" }
+
+futures            = { version = "0.3" }
+serde              = { version = "1", features = ["derive"] }
+serde_json         = { version = "1" }
+tokio              = { version = "1", default-features = false, features = ["sync"] }
+tracing            = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+
+[features]
+
+[package.metadata.docs.rs]
+all-features = true
+

--- a/examples/multi-raft-kv/README.md
+++ b/examples/multi-raft-kv/README.md
@@ -1,0 +1,85 @@
+# Multi-Raft KV Store Example
+
+This example demonstrates how to use OpenRaft's Multi-Raft support to run multiple independent Raft consensus groups within a single process.
+
+## Overview
+
+The example creates a distributed key-value store with **3 Raft groups**:
+- **users** - Stores user data
+- **orders** - Stores order data  
+- **products** - Stores product data
+
+Each group runs its own independent Raft consensus, but they share the same network infrastructure.
+
+## Architecture
+
+```
++-----------------------------------------------------------------------+
+|                           Node 1                                       |
+|  +-------------------+  +-------------------+  +-------------------+   |
+|  |  Group "users"    |  |  Group "orders"   |  |  Group "products" |   |
+|  |  (Raft Instance)  |  |  (Raft Instance)  |  |  (Raft Instance)  |   |
+|  +-------------------+  +-------------------+  +-------------------+   |
+|           |                      |                      |              |
+|           +----------------------+----------------------+              |
+|                                  |                                     |
+|                         +--------+--------+                            |
+|                         |     Router      |                            |
+|                         | (shared network)|                            |
+|                         +-----------------+                            |
++------------------------------------------------------------------------+
+                                  |
+                         Network Connection
+                                  |
++------------------------------------------------------------------------+
+|                               Node 2                                   |
+|  +-------------------+  +-------------------+  +-------------------+   |
+|  |  Group "users"    |  |  Group "orders"   |  |  Group "products" |   |
+|  |  (Raft Instance)  |  |  (Raft Instance)  |  |  (Raft Instance)  |   |
+|  +-------------------+  +-------------------+  +-------------------+   |
++------------------------------------------------------------------------+
+```
+
+## Key Concepts
+
+### GroupId
+A string identifier that uniquely identifies each Raft group (e.g., "users", "orders", "products").
+
+### Shared Network
+Multiple Raft groups share the same network infrastructure (`Router`), reducing connection overhead. Messages are routed to the correct group using the `group_id`.
+
+### Independent Consensus
+Each group runs its own Raft consensus independently:
+- Separate log storage
+- Separate state machine
+- Separate leader election
+- Separate membership
+
+## Running the Test
+
+```bash
+# Run the integration test
+cargo test -p multi-raft-kv test_multi_raft_cluster -- --nocapture
+
+# With debug logging
+RUST_LOG=debug cargo test -p multi-raft-kv test_multi_raft_cluster -- --nocapture
+```
+
+## Code Structure
+
+```
+multi-raft-kv/
+├── Cargo.toml
+├── README.md
+├── src/
+│   ├── lib.rs          # Type definitions and group constants
+│   ├── app.rs          # Application handler for each group
+│   ├── api.rs          # API handlers (read, write, raft operations)
+│   ├── network.rs      # Network implementation with group routing
+│   ├── router.rs       # Message router for (node_id, group_id)
+│   └── store.rs        # State machine storage
+└── tests/
+    └── cluster/
+        ├── main.rs
+        └── test_cluster.rs   # Integration tests
+```

--- a/examples/multi-raft-kv/src/api.rs
+++ b/examples/multi-raft-kv/src/api.rs
@@ -1,0 +1,111 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use openraft::raft::TransferLeaderRequest;
+use openraft::BasicNode;
+use openraft::ReadPolicy;
+
+use crate::app::GroupApp;
+use crate::decode;
+use crate::encode;
+use crate::typ::*;
+use crate::NodeId;
+
+/// Write a key-value pair to the group's state machine
+pub async fn write(app: &mut GroupApp, req: String) -> String {
+    let res = app.raft.client_write(decode(&req)).await;
+    encode(res)
+}
+
+/// Read a value from the group's state machine using linearizable read
+pub async fn read(app: &mut GroupApp, req: String) -> String {
+    let key: String = decode(&req);
+
+    let ret = app.raft.get_read_linearizer(ReadPolicy::ReadIndex).await;
+
+    let res = match ret {
+        Ok(linearizer) => {
+            linearizer.await_ready(&app.raft).await.unwrap();
+
+            let state_machine = app.state_machine.state_machine.lock().await;
+            let value = state_machine.data.get(&key).cloned();
+
+            let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
+            res
+        }
+        Err(e) => Err(e),
+    };
+    encode(res)
+}
+
+// ============================================================================
+// Raft Protocol API
+// ============================================================================
+
+/// Handle vote request
+pub async fn vote(app: &mut GroupApp, req: String) -> String {
+    let res = app.raft.vote(decode(&req)).await;
+    encode(res)
+}
+
+/// Handle append entries request
+pub async fn append(app: &mut GroupApp, req: String) -> String {
+    let res = app.raft.append_entries(decode(&req)).await;
+    encode(res)
+}
+
+/// Receive a snapshot and install it
+pub async fn snapshot(app: &mut GroupApp, req: String) -> String {
+    let (vote, snapshot_meta, snapshot_data): (Vote, SnapshotMeta, SnapshotData) = decode(&req);
+    let snapshot = Snapshot {
+        meta: snapshot_meta,
+        snapshot: snapshot_data,
+    };
+    let res = app.raft.install_full_snapshot(vote, snapshot).await.map_err(RaftError::<Infallible>::Fatal);
+    encode(res)
+}
+
+/// Handle transfer leader request
+pub async fn transfer_leader(app: &mut GroupApp, req: String) -> String {
+    let transfer_req: TransferLeaderRequest<crate::TypeConfig> = decode(&req);
+    let res = app.raft.handle_transfer_leader(transfer_req).await;
+    encode(res)
+}
+
+// ============================================================================
+// Management API
+// ============================================================================
+
+/// Add a node as **Learner** to this group.
+///
+/// This should be done before adding a node as a member into the cluster
+/// (by calling `change-membership`)
+pub async fn add_learner(app: &mut GroupApp, req: String) -> String {
+    let node_id: NodeId = decode(&req);
+    let node = BasicNode { addr: "".to_string() };
+    let res = app.raft.add_learner(node_id, node, true).await;
+    encode(res)
+}
+
+/// Changes specified learners to members, or remove members from this group.
+pub async fn change_membership(app: &mut GroupApp, req: String) -> String {
+    let node_ids: BTreeSet<NodeId> = decode(&req);
+    let res = app.raft.change_membership(node_ids, false).await;
+    encode(res)
+}
+
+/// Initialize a single-node cluster for this group.
+pub async fn init(app: &mut GroupApp) -> String {
+    let mut nodes = BTreeMap::new();
+    nodes.insert(app.node_id, BasicNode { addr: "".to_string() });
+    let res = app.raft.initialize(nodes).await;
+    encode(res)
+}
+
+/// Get the latest metrics of this Raft group
+pub async fn metrics(app: &mut GroupApp) -> String {
+    let metrics = app.raft.metrics().borrow().clone();
+
+    let res: Result<RaftMetrics, Infallible> = Ok(metrics);
+    encode(res)
+}

--- a/examples/multi-raft-kv/src/app.rs
+++ b/examples/multi-raft-kv/src/app.rs
@@ -1,0 +1,120 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::api;
+use crate::encode;
+use crate::router::NodeMessage;
+use crate::router::NodeRx;
+use crate::router::NodeTx;
+use crate::router::Router;
+use crate::typ;
+use crate::GroupId;
+use crate::NodeId;
+use crate::StateMachineStore;
+
+/// A Node manages multiple Raft groups on the same physical node.
+///
+/// All groups share ONE connection to this node.
+/// The Node dispatches incoming messages to the correct group based on group_id.
+pub struct Node {
+    pub node_id: NodeId,
+    pub groups: BTreeMap<GroupId, GroupApp>,
+    pub rx: NodeRx,
+    pub router: Router,
+}
+
+impl Node {
+    pub fn new(node_id: NodeId, router: Router) -> (Self, NodeTx) {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        // Register this node's shared connection
+        router.register_node(node_id, tx.clone());
+
+        let node = Self {
+            node_id,
+            groups: BTreeMap::new(),
+            rx,
+            router,
+        };
+
+        (node, tx)
+    }
+
+    /// Add a Raft group to this node.
+    pub fn add_group(&mut self, group_id: GroupId, raft: typ::Raft, state_machine: Arc<StateMachineStore>) {
+        let app = GroupApp {
+            node_id: self.node_id,
+            group_id: group_id.clone(),
+            raft,
+            state_machine,
+        };
+        self.groups.insert(group_id, app);
+    }
+
+    /// Get a Raft instance by group_id.
+    pub fn get_raft(&self, group_id: &GroupId) -> Option<&typ::Raft> {
+        self.groups.get(group_id).map(|g| &g.raft)
+    }
+
+    /// Run the node message dispatcher.
+    /// Routes incoming messages to the correct group based on group_id.
+    pub async fn run(mut self) -> Option<()> {
+        loop {
+            let msg = self.rx.recv().await?;
+
+            let NodeMessage {
+                group_id,
+                path,
+                payload,
+                response_tx,
+            } = msg;
+
+            // Find the target group
+            let group = match self.groups.get_mut(&group_id) {
+                Some(g) => g,
+                None => {
+                    let _ = response_tx.send(encode::<Result<(), typ::RaftError>>(Err(typ::RaftError::Fatal(
+                        openraft::error::Fatal::Stopped,
+                    ))));
+                    continue;
+                }
+            };
+
+            // Dispatch to the group
+            let res = match path.as_str() {
+                // Application API
+                "/app/write" => api::write(group, payload).await,
+                "/app/read" => api::read(group, payload).await,
+
+                // Raft API
+                "/raft/append" => api::append(group, payload).await,
+                "/raft/snapshot" => api::snapshot(group, payload).await,
+                "/raft/vote" => api::vote(group, payload).await,
+                "/raft/transfer_leader" => api::transfer_leader(group, payload).await,
+
+                // Management API
+                "/mng/add-learner" => api::add_learner(group, payload).await,
+                "/mng/change-membership" => api::change_membership(group, payload).await,
+                "/mng/init" => api::init(group).await,
+                "/mng/metrics" => api::metrics(group).await,
+
+                _ => {
+                    tracing::warn!("unknown path: {}", path);
+                    encode::<Result<(), typ::RaftError>>(Err(typ::RaftError::Fatal(openraft::error::Fatal::Stopped)))
+                }
+            };
+
+            let _ = response_tx.send(res);
+        }
+    }
+}
+
+/// A single Raft group's application context.
+pub struct GroupApp {
+    pub node_id: NodeId,
+    pub group_id: GroupId,
+    pub raft: typ::Raft,
+    pub state_machine: Arc<StateMachineStore>,
+}

--- a/examples/multi-raft-kv/src/lib.rs
+++ b/examples/multi-raft-kv/src/lib.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use openraft::Config;
+
+use crate::app::Node;
+use crate::router::Router;
+use crate::store::Request;
+use crate::store::Response;
+use crate::store::StateMachineData;
+
+pub mod router;
+
+pub mod api;
+pub mod app;
+pub mod network;
+pub mod store;
+
+/// Node ID type - identifies a node in the cluster
+pub type NodeId = u64;
+
+/// Group ID type - identifies a Raft group
+pub type GroupId = String;
+
+openraft::declare_raft_types!(
+    /// Declare the type configuration for Multi-Raft K/V store.
+    pub TypeConfig:
+        D = Request,
+        R = Response,
+        // In this example, snapshot is just a copy of the state machine.
+        SnapshotData = StateMachineData,
+);
+
+pub type LogStore = store::LogStore;
+pub type StateMachineStore = store::StateMachineStore;
+
+/// Define all Raft-related type aliases
+#[path = "../../utils/declare_types.rs"]
+pub mod typ;
+
+pub mod groups {
+    pub const USERS: &str = "users";
+    pub const ORDERS: &str = "orders";
+    pub const PRODUCTS: &str = "products";
+
+    pub fn all() -> Vec<String> {
+        vec![USERS.to_string(), ORDERS.to_string(), PRODUCTS.to_string()]
+    }
+}
+
+pub fn encode<T: serde::Serialize>(t: T) -> String {
+    serde_json::to_string(&t).unwrap()
+}
+
+pub fn decode<T: serde::de::DeserializeOwned>(s: &str) -> T {
+    serde_json::from_str(s).unwrap()
+}
+
+/// Create a Node with multiple Raft groups.
+///
+/// - One Node has ONE connection (shared by all groups)
+/// - Each group has its own Raft instance
+pub async fn create_node(node_id: NodeId, group_ids: &[GroupId], router: Router) -> Node {
+    let (mut node, _tx) = Node::new(node_id, router.clone());
+
+    for group_id in group_ids {
+        let config = Config {
+            heartbeat_interval: 500,
+            election_timeout_min: 1500,
+            election_timeout_max: 3000,
+            max_in_snapshot_log_to_keep: 0,
+            ..Default::default()
+        };
+
+        let config = Arc::new(config.validate().unwrap());
+        let log_store = LogStore::default();
+        let state_machine_store = Arc::new(StateMachineStore::default());
+
+        let network = network::NetworkFactory::new(router.clone(), group_id.clone());
+
+        let raft = openraft::Raft::new(node_id, config, network, log_store, state_machine_store.clone()).await.unwrap();
+
+        node.add_group(group_id.clone(), raft, state_machine_store);
+    }
+
+    node
+}

--- a/examples/multi-raft-kv/src/network.rs
+++ b/examples/multi-raft-kv/src/network.rs
@@ -1,0 +1,92 @@
+use std::future::Future;
+
+use openraft::error::RPCError;
+use openraft::error::ReplicationClosed;
+use openraft::error::StreamingError;
+use openraft::network::Backoff;
+use openraft::network::RPCOption;
+use openraft::network::RaftNetworkFactory;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::SnapshotResponse;
+use openraft::raft::TransferLeaderRequest;
+use openraft::raft::VoteRequest;
+use openraft::raft::VoteResponse;
+use openraft::storage::Snapshot;
+use openraft::OptionalSend;
+use openraft_multi::GroupNetworkAdapter;
+use openraft_multi::GroupNetworkFactory;
+use openraft_multi::GroupRouter;
+
+use crate::router::Router;
+use crate::typ;
+use crate::GroupId;
+use crate::NodeId;
+use crate::TypeConfig;
+
+impl GroupRouter<TypeConfig, GroupId> for Router {
+    async fn append_entries(
+        &self,
+        target: NodeId,
+        group_id: GroupId,
+        rpc: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig>> {
+        self.send(target, &group_id, "/raft/append", rpc).await.map_err(RPCError::Unreachable)
+    }
+
+    async fn vote(
+        &self,
+        target: NodeId,
+        group_id: GroupId,
+        rpc: VoteRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig>> {
+        self.send(target, &group_id, "/raft/vote", rpc).await.map_err(RPCError::Unreachable)
+    }
+
+    async fn full_snapshot(
+        &self,
+        target: NodeId,
+        group_id: GroupId,
+        vote: typ::Vote,
+        snapshot: Snapshot<TypeConfig>,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<TypeConfig>, StreamingError<TypeConfig>> {
+        self.send(
+            target,
+            &group_id,
+            "/raft/snapshot",
+            (vote, snapshot.meta, snapshot.snapshot),
+        )
+        .await
+        .map_err(StreamingError::Unreachable)
+    }
+
+    async fn transfer_leader(
+        &self,
+        target: NodeId,
+        group_id: GroupId,
+        req: TransferLeaderRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<(), RPCError<TypeConfig>> {
+        self.send(target, &group_id, "/raft/transfer_leader", req).await.map_err(RPCError::Unreachable)
+    }
+
+    fn backoff(&self) -> Backoff {
+        Backoff::new(std::iter::repeat(std::time::Duration::from_millis(500)))
+    }
+}
+
+/// Network factory that creates `GroupNetworkAdapter` instances.
+pub type NetworkFactory = GroupNetworkFactory<Router, GroupId>;
+
+impl RaftNetworkFactory<TypeConfig> for NetworkFactory {
+    /// The network type is `GroupNetworkAdapter` binding (Router, target, group_id).
+    type Network = GroupNetworkAdapter<TypeConfig, GroupId, Router>;
+
+    async fn new_client(&mut self, target: NodeId, _node: &openraft::BasicNode) -> Self::Network {
+        GroupNetworkAdapter::new(self.factory.clone(), target, self.group_id.clone())
+    }
+}

--- a/examples/multi-raft-kv/src/router.rs
+++ b/examples/multi-raft-kv/src/router.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use openraft::error::Unreachable;
+use tokio::sync::oneshot;
+
+use crate::decode;
+use crate::encode;
+use crate::typ::RaftError;
+use crate::GroupId;
+use crate::NodeId;
+
+pub type NodeTx = tokio::sync::mpsc::UnboundedSender<NodeMessage>;
+pub type NodeRx = tokio::sync::mpsc::UnboundedReceiver<NodeMessage>;
+
+#[derive(Debug)]
+pub struct RouterError(pub String);
+
+impl fmt::Display for RouterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for RouterError {}
+
+/// Message sent through a node connection, containing group_id for routing.
+pub struct NodeMessage {
+    pub group_id: GroupId,
+    pub path: String,
+    pub payload: String,
+    pub response_tx: oneshot::Sender<String>,
+}
+
+/// Multi-Raft Router with per-node connection sharing.
+#[derive(Debug, Clone, Default)]
+pub struct Router {
+    /// Map from node_id to node connection.
+    /// All groups on the same node share this connection.
+    pub nodes: Arc<Mutex<BTreeMap<NodeId, NodeTx>>>,
+}
+
+impl Router {
+    pub fn new() -> Self {
+        Self {
+            nodes: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    /// Register a node connection. All groups on this node will use this connection.
+    pub fn register_node(&self, node_id: NodeId, tx: NodeTx) {
+        let mut nodes = self.nodes.lock().unwrap();
+        nodes.insert(node_id, tx);
+    }
+
+    /// Unregister a node connection.
+    pub fn unregister_node(&self, node_id: NodeId) -> Option<NodeTx> {
+        let mut nodes = self.nodes.lock().unwrap();
+        nodes.remove(&node_id)
+    }
+
+    /// Send a request to a specific (node, group).
+    pub async fn send<Req, Resp>(
+        &self,
+        to_node: NodeId,
+        to_group: &GroupId,
+        path: &str,
+        req: Req,
+    ) -> Result<Resp, Unreachable>
+    where
+        Req: serde::Serialize,
+        Result<Resp, RaftError>: serde::de::DeserializeOwned,
+    {
+        let (resp_tx, resp_rx) = oneshot::channel();
+
+        let encoded_req = encode(&req);
+        tracing::debug!(
+            "send to: node={}, group={}, path={}, req={}",
+            to_node,
+            to_group,
+            path,
+            encoded_req
+        );
+
+        // Send through the shared node connection
+        {
+            let nodes = self.nodes.lock().unwrap();
+            let tx = nodes
+                .get(&to_node)
+                .ok_or_else(|| Unreachable::new(&RouterError(format!("node {} not connected", to_node))))?;
+
+            let msg = NodeMessage {
+                group_id: to_group.clone(),
+                path: path.to_string(),
+                payload: encoded_req,
+                response_tx: resp_tx,
+            };
+
+            tx.send(msg).map_err(|e| Unreachable::new(&RouterError(e.to_string())))?;
+        }
+
+        let resp_str = resp_rx.await.map_err(|e| Unreachable::new(&RouterError(e.to_string())))?;
+        tracing::debug!(
+            "resp from: node={}, group={}, path={}, resp={}",
+            to_node,
+            to_group,
+            path,
+            resp_str
+        );
+
+        let res = decode::<Result<Resp, RaftError>>(&resp_str);
+        res.map_err(|e| Unreachable::new(&RouterError(e.to_string())))
+    }
+
+    pub fn has_node(&self, node_id: NodeId) -> bool {
+        let nodes = self.nodes.lock().unwrap();
+        nodes.contains_key(&node_id)
+    }
+}

--- a/examples/multi-raft-kv/src/store.rs
+++ b/examples/multi-raft-kv/src/store.rs
@@ -1,0 +1,213 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fmt::Debug;
+use std::io;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use futures::Stream;
+use futures::TryStreamExt;
+use openraft::storage::EntryResponder;
+use openraft::storage::RaftStateMachine;
+use openraft::EntryPayload;
+use openraft::OptionalSend;
+use openraft::RaftSnapshotBuilder;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::typ::*;
+use crate::TypeConfig;
+
+pub type LogStore = mem_log::LogStore<TypeConfig>;
+
+/// Application request type
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Request {
+    Set { key: String, value: String },
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Request::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
+}
+
+impl Request {
+    pub fn set(key: impl ToString, value: impl ToString) -> Self {
+        Self::Set {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Response {
+    pub value: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct StoredSnapshot {
+    pub meta: SnapshotMeta,
+
+    /// The data of the state machine at the time of this snapshot.
+    pub data: SnapshotData,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct StateMachineData {
+    pub last_applied: Option<LogId>,
+
+    pub last_membership: StoredMembership,
+
+    /// Application data - the key-value store
+    pub data: BTreeMap<String, String>,
+}
+
+/// Each group may have its own independent state machine instance.
+#[derive(Debug, Default)]
+pub struct StateMachineStore {
+    pub state_machine: tokio::sync::Mutex<StateMachineData>,
+
+    snapshot_idx: Mutex<u64>,
+
+    /// The last received snapshot.
+    current_snapshot: Mutex<Option<StoredSnapshot>>,
+}
+
+impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn build_snapshot(&mut self) -> Result<Snapshot, io::Error> {
+        let data;
+        let last_applied_log;
+        let last_membership;
+
+        {
+            // Serialize the data of the state machine.
+            let state_machine = self.state_machine.lock().await.clone();
+
+            last_applied_log = state_machine.last_applied;
+            last_membership = state_machine.last_membership.clone();
+            data = state_machine;
+        }
+
+        let snapshot_idx = {
+            let mut l = self.snapshot_idx.lock().unwrap();
+            *l += 1;
+            *l
+        };
+
+        let snapshot_id = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
+        } else {
+            format!("--{}", snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id: last_applied_log,
+            last_membership,
+            snapshot_id,
+        };
+
+        let snapshot = StoredSnapshot {
+            meta: meta.clone(),
+            data: data.clone(),
+        };
+
+        {
+            let mut current_snapshot = self.current_snapshot.lock().unwrap();
+            *current_snapshot = Some(snapshot);
+        }
+
+        Ok(Snapshot { meta, snapshot: data })
+    }
+}
+
+impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), io::Error> {
+        let state_machine = self.state_machine.lock().await;
+        Ok((state_machine.last_applied, state_machine.last_membership.clone()))
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, entries))]
+    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    where Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Unpin + OptionalSend {
+        let mut sm = self.state_machine.lock().await;
+
+        while let Some((entry, responder)) = entries.try_next().await? {
+            tracing::debug!(%entry.log_id, "replicate to sm");
+
+            sm.last_applied = Some(entry.log_id);
+
+            let response = match entry.payload {
+                EntryPayload::Blank => Response { value: None },
+                EntryPayload::Normal(ref req) => match req {
+                    Request::Set { key, value, .. } => {
+                        sm.data.insert(key.clone(), value.clone());
+                        Response {
+                            value: Some(value.clone()),
+                        }
+                    }
+                },
+                EntryPayload::Membership(ref mem) => {
+                    sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
+                    Response { value: None }
+                }
+            };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotData, io::Error> {
+        Ok(Default::default())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, snapshot))]
+    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: SnapshotData) -> Result<(), io::Error> {
+        tracing::info!("install snapshot");
+
+        let new_snapshot = StoredSnapshot {
+            meta: meta.clone(),
+            data: snapshot,
+        };
+
+        // Update the state machine.
+        {
+            let updated_state_machine: StateMachineData = new_snapshot.data.clone();
+            let mut state_machine = self.state_machine.lock().await;
+            *state_machine = updated_state_machine;
+        }
+
+        // Update current snapshot.
+        let mut current_snapshot = self.current_snapshot.lock().unwrap();
+        *current_snapshot = Some(new_snapshot);
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot>, io::Error> {
+        match &*self.current_snapshot.lock().unwrap() {
+            Some(snapshot) => {
+                let data = snapshot.data.clone();
+                Ok(Some(Snapshot {
+                    meta: snapshot.meta.clone(),
+                    snapshot: data,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+}

--- a/examples/multi-raft-kv/tests/cluster/main.rs
+++ b/examples/multi-raft-kv/tests/cluster/main.rs
@@ -1,0 +1,1 @@
+mod test_cluster;

--- a/examples/multi-raft-kv/tests/cluster/test_cluster.rs
+++ b/examples/multi-raft-kv/tests/cluster/test_cluster.rs
@@ -1,0 +1,250 @@
+//! Integration test for Multi-Raft KV store with 3 groups.
+//!
+//! This test demonstrates the TRUE Multi-Raft pattern:
+//! - Each Node has ONE shared connection (not per-group connections)
+//! - Multiple Raft groups share this connection
+//! - Messages are routed to the correct group based on group_id
+
+use std::backtrace::Backtrace;
+use std::collections::BTreeMap;
+use std::panic::PanicHookInfo;
+use std::time::Duration;
+
+use multi_raft_kv::create_node;
+use multi_raft_kv::groups;
+use multi_raft_kv::router::Router;
+use multi_raft_kv::store::Request;
+use multi_raft_kv::typ;
+use multi_raft_kv::GroupId;
+use openraft::BasicNode;
+use tokio::task;
+use tokio::task::LocalSet;
+use tracing_subscriber::EnvFilter;
+
+pub fn log_panic(panic: &PanicHookInfo) {
+    let backtrace = format!("{:?}", Backtrace::force_capture());
+
+    eprintln!("{}", panic);
+
+    if let Some(location) = panic.location() {
+        tracing::error!(
+            message = %panic,
+            backtrace = %backtrace,
+            panic.file = location.file(),
+            panic.line = location.line(),
+            panic.column = location.column(),
+        );
+        eprintln!("{}:{}:{}", location.file(), location.line(), location.column());
+    } else {
+        tracing::error!(message = %panic, backtrace = %backtrace);
+    }
+
+    eprintln!("{}", backtrace);
+}
+
+/// Test Multi-Raft cluster with 3 groups and 2 nodes.
+#[tokio::test]
+async fn test_multi_raft_cluster() {
+    std::panic::set_hook(Box::new(|panic| {
+        log_panic(panic);
+    }));
+
+    tracing_subscriber::fmt()
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true)
+        .with_ansi(false)
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    // Shared router - this is where connection sharing happens
+    let router = Router::new();
+    let group_ids = groups::all();
+
+    let local = LocalSet::new();
+
+    // Create nodes - each node has ONE connection, multiple groups
+    let node1 = create_node(1, &group_ids, router.clone()).await;
+    let node2 = create_node(2, &group_ids, router.clone()).await;
+
+    // Get Raft handles before moving nodes into tasks
+    let node1_rafts: Vec<_> = group_ids.iter().map(|g| node1.get_raft(g).unwrap().clone()).collect();
+    let node2_rafts: Vec<_> = group_ids.iter().map(|g| node2.get_raft(g).unwrap().clone()).collect();
+
+    local
+        .run_until(async move {
+            // Spawn node message handlers (one per node, not per group!)
+            task::spawn_local(node1.run());
+            task::spawn_local(node2.run());
+
+            run_test(&node1_rafts, &node2_rafts, &group_ids).await;
+        })
+        .await;
+}
+
+async fn run_test(node1_rafts: &[typ::Raft], node2_rafts: &[typ::Raft], group_ids: &[GroupId]) {
+    // Wait for servers to start up
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    println!("\n╔════════════════════════════════════════════════════════════════════╗");
+    println!("║   Multi-Raft Test: 3 groups, 2 nodes, CONNECTION SHARING          ║");
+    println!("╚════════════════════════════════════════════════════════════════════╝\n");
+
+    // =========================================================================
+    // Initialize each group with node 1 as leader
+    // =========================================================================
+    println!("=== Initializing 3 Raft groups (all on Node 1) ===\n");
+
+    for (i, raft) in node1_rafts.iter().enumerate() {
+        let mut nodes = BTreeMap::new();
+        nodes.insert(1u64, BasicNode { addr: "".to_string() });
+        raft.initialize(nodes).await.unwrap();
+        println!("  ✓ Group '{}' initialized on Node 1", group_ids[i]);
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // =========================================================================
+    // Add Node 2 as learner for each group
+    // =========================================================================
+    println!("\n=== Adding Node 2 as learner to all groups ===\n");
+
+    for (i, raft) in node1_rafts.iter().enumerate() {
+        let node = BasicNode { addr: "".to_string() };
+        raft.add_learner(2, node, true).await.unwrap();
+        println!("  ✓ Group '{}': Node 2 added as learner", group_ids[i]);
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // =========================================================================
+    // Write data to each group
+    // =========================================================================
+    println!("\n=== Writing data to each group ===\n");
+
+    // users group
+    node1_rafts[0].client_write(Request::set("user:1", "Alice")).await.unwrap();
+    node1_rafts[0].client_write(Request::set("user:2", "Bob")).await.unwrap();
+    println!("  ✓ Group 'users': wrote user:1=Alice, user:2=Bob");
+
+    // orders group
+    node1_rafts[1].client_write(Request::set("order:1001", "pending")).await.unwrap();
+    node1_rafts[1].client_write(Request::set("order:1002", "shipped")).await.unwrap();
+    println!("  ✓ Group 'orders': wrote order:1001=pending, order:1002=shipped");
+
+    // products group
+    node1_rafts[2].client_write(Request::set("product:A", "Widget")).await.unwrap();
+    node1_rafts[2].client_write(Request::set("product:B", "Gadget")).await.unwrap();
+    println!("  ✓ Group 'products': wrote product:A=Widget, product:B=Gadget");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // =========================================================================
+    // Verify replication
+    // =========================================================================
+    println!("\n=== Verifying replication to Node 2 ===\n");
+
+    for (i, raft) in node2_rafts.iter().enumerate() {
+        let metrics = raft.metrics().borrow().clone();
+        println!(
+            "  Group '{}' on Node 2: last_applied={:?}",
+            group_ids[i], metrics.last_applied
+        );
+        assert!(
+            metrics.last_applied.is_some(),
+            "Group {} should have applied logs",
+            group_ids[i]
+        );
+    }
+}
+
+// ============================================================================
+// Test: Leader Distribution using transfer_leader
+// ============================================================================
+
+/// Test that demonstrates using transfer_leader to distribute leaders.
+#[tokio::test]
+async fn test_leader_distribution() {
+    let router = Router::new();
+    let group_ids = groups::all();
+
+    let local = LocalSet::new();
+
+    // Create 3 nodes
+    let node1 = create_node(1, &group_ids, router.clone()).await;
+    let node2 = create_node(2, &group_ids, router.clone()).await;
+    let node3 = create_node(3, &group_ids, router.clone()).await;
+
+    let node1_rafts: Vec<_> = group_ids.iter().map(|g| node1.get_raft(g).unwrap().clone()).collect();
+    let node2_rafts: Vec<_> = group_ids.iter().map(|g| node2.get_raft(g).unwrap().clone()).collect();
+    let node3_rafts: Vec<_> = group_ids.iter().map(|g| node3.get_raft(g).unwrap().clone()).collect();
+
+    local
+        .run_until(async move {
+            task::spawn_local(node1.run());
+            task::spawn_local(node2.run());
+            task::spawn_local(node3.run());
+
+            run_leader_distribution_test(&node1_rafts, &node2_rafts, &node3_rafts, &group_ids).await;
+        })
+        .await;
+}
+
+async fn run_leader_distribution_test(
+    node1_rafts: &[typ::Raft],
+    node2_rafts: &[typ::Raft],
+    node3_rafts: &[typ::Raft],
+    group_ids: &[GroupId],
+) {
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    println!("\n╔════════════════════════════════════════════════════════════════════╗");
+    println!("║   Leader Distribution Test using transfer_leader                  ║");
+    println!("╚════════════════════════════════════════════════════════════════════╝\n");
+
+    // Initialize all groups on Node 1 with all 3 nodes as voters
+    println!("=== Initializing all groups with 3 voters ===\n");
+
+    let all_nodes = {
+        let mut nodes = BTreeMap::new();
+        nodes.insert(1u64, BasicNode { addr: "".to_string() });
+        nodes.insert(2u64, BasicNode { addr: "".to_string() });
+        nodes.insert(3u64, BasicNode { addr: "".to_string() });
+        nodes
+    };
+
+    for (i, raft) in node1_rafts.iter().enumerate() {
+        raft.initialize(all_nodes.clone()).await.unwrap();
+        println!("  ✓ Group '{}' initialized (voters: 1, 2, 3)", group_ids[i]);
+    }
+
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // Transfer leaders to distribute load
+    println!("\n=== Using transfer_leader to distribute leaders ===\n");
+
+    // orders -> Node 2
+    println!("  → Transferring 'orders' leader to Node 2...");
+    node1_rafts[1].trigger().transfer_leader(2).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // products -> Node 3
+    println!("  → Transferring 'products' leader to Node 3...");
+    node1_rafts[2].trigger().transfer_leader(3).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // Verify distribution
+    println!("\n=== Verifying leader distribution ===\n");
+
+    let users_leader = node1_rafts[0].metrics().borrow().current_leader;
+    let orders_leader = node2_rafts[1].metrics().borrow().current_leader;
+    let products_leader = node3_rafts[2].metrics().borrow().current_leader;
+
+    println!("  Group 'users':    leader = {:?}", users_leader);
+    println!("  Group 'orders':   leader = {:?}", orders_leader);
+    println!("  Group 'products': leader = {:?}", products_leader);
+
+    assert_eq!(users_leader, Some(1), "users leader should be Node 1");
+    assert_eq!(orders_leader, Some(2), "orders leader should be Node 2");
+    assert_eq!(products_leader, Some(3), "products leader should be Node 3");
+}

--- a/multiraft/Cargo.toml
+++ b/multiraft/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "openraft-multi"
+description = "Multi-Raft adapters for connection sharing across Raft groups"
+documentation = "https://docs.rs/openraft-multiraft"
+readme = "README.md"
+version = "0.10.0"
+edition = "2021"
+authors = ["Databend Authors <opensource@datafuselabs.com>"]
+categories = ["network", "asynchronous", "data-structures"]
+homepage = "https://github.com/databendlabs/openraft"
+keywords = ["consensus", "raft", "multi-raft"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/databendlabs/openraft"
+
+[dependencies]
+openraft  = { path = "../openraft", version = "0.10.0", default-features = false }
+anyerror  = { version = "0.1" }
+

--- a/multiraft/README.md
+++ b/multiraft/README.md
@@ -1,0 +1,40 @@
+# openraft-multi
+
+Multi-Raft adapters for connection sharing across Raft groups.
+
+## Components
+
+- **`GroupRouter`** - Trait for sending RPCs with (target, group) routing
+- **`GroupNetworkAdapter`** - Wraps `GroupRouter`, implements `RaftNetworkV2`
+- **`GroupNetworkFactory`** - Simple factory + group_id wrapper
+
+## Usage
+
+1. Implement `GroupRouter` on your shared router/connection pool
+2. Use `GroupNetworkAdapter` to get automatic `RaftNetworkV2` implementation
+
+```rust
+use openraft_multiraft::{GroupRouter, GroupNetworkAdapter, GroupNetworkFactory};
+
+// Your Router implements GroupRouter
+impl GroupRouter<TypeConfig, GroupId> for Router {
+    // ...
+}
+
+// Create factory for a specific group
+let factory = GroupNetworkFactory::new(router, group_id);
+
+// Factory creates adapters that implement RaftNetworkV2
+impl RaftNetworkFactory<TypeConfig> for NetworkFactory {
+    type Network = GroupNetworkAdapter<TypeConfig, GroupId, Router>;
+    
+    async fn new_client(&mut self, target: NodeId, _node: &Node) -> Self::Network {
+        GroupNetworkAdapter::new(self.factory.clone(), target, self.group_id.clone())
+    }
+}
+```
+
+## Examples
+
+- [multi-raft-kv](../examples/multi-raft-kv/) - Basic Multi-Raft with 3 groups
+

--- a/multiraft/src/lib.rs
+++ b/multiraft/src/lib.rs
@@ -1,0 +1,5 @@
+mod network;
+
+pub use network::GroupNetworkAdapter;
+pub use network::GroupNetworkFactory;
+pub use network::GroupRouter;

--- a/multiraft/src/network.rs
+++ b/multiraft/src/network.rs
@@ -1,0 +1,205 @@
+//! Network adapters for Multi-Raft connection sharing.
+//!
+//! - [`GroupRouter`] - Trait for sending RPCs with target + group routing
+//! - [`GroupNetworkAdapter`] - Wraps `GroupRouter` with (target, group_id), implements
+//!   `RaftNetworkV2`
+//! - [`GroupNetworkFactory`] - Simple wrapper for factory + group_id
+//!
+//! See `examples/multi-raft-kv` for usage.
+
+use std::future::Future;
+use std::time::Duration;
+
+use openraft::error::RPCError;
+use openraft::error::ReplicationClosed;
+use openraft::error::StreamingError;
+use openraft::error::Unreachable;
+use openraft::network::v2::RaftNetworkV2;
+use openraft::network::Backoff;
+use openraft::network::RPCOption;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::SnapshotResponse;
+use openraft::raft::TransferLeaderRequest;
+use openraft::raft::VoteRequest;
+use openraft::raft::VoteResponse;
+use openraft::storage::Snapshot;
+use openraft::type_config::alias::VoteOf;
+use openraft::OptionalSend;
+use openraft::OptionalSync;
+use openraft::RaftTypeConfig;
+
+/// Trait for sending Raft RPCs with target and group routing.
+///
+/// Implement this on your shared router/connection pool to enable connection
+/// sharing across all Raft groups. The adapter will bind (target, group_id).
+pub trait GroupRouter<C, G>: Clone + OptionalSend + OptionalSync + 'static
+where C: RaftTypeConfig
+{
+    /// Send AppendEntries to target node for a specific group.
+    fn append_entries(
+        &self,
+        target: C::NodeId,
+        group_id: G,
+        rpc: AppendEntriesRequest<C>,
+        option: RPCOption,
+    ) -> impl Future<Output = Result<AppendEntriesResponse<C>, RPCError<C>>> + OptionalSend;
+
+    /// Send Vote to target node for a specific group.
+    fn vote(
+        &self,
+        target: C::NodeId,
+        group_id: G,
+        rpc: VoteRequest<C>,
+        option: RPCOption,
+    ) -> impl Future<Output = Result<VoteResponse<C>, RPCError<C>>> + OptionalSend;
+
+    /// Send snapshot to target node for a specific group.
+    fn full_snapshot(
+        &self,
+        target: C::NodeId,
+        group_id: G,
+        vote: VoteOf<C>,
+        snapshot: Snapshot<C>,
+        cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        option: RPCOption,
+    ) -> impl Future<Output = Result<SnapshotResponse<C>, StreamingError<C>>> + OptionalSend;
+
+    /// Send TransferLeader to target node for a specific group.
+    /// Default: returns "not implemented" error.
+    fn transfer_leader(
+        &self,
+        _target: C::NodeId,
+        _group_id: G,
+        _req: TransferLeaderRequest<C>,
+        _option: RPCOption,
+    ) -> impl Future<Output = Result<(), RPCError<C>>> + OptionalSend {
+        async {
+            Err(RPCError::Unreachable(Unreachable::new(&anyerror::AnyError::error(
+                "transfer_leader not implemented",
+            ))))
+        }
+    }
+
+    /// Backoff strategy for retries. Default: 500ms constant.
+    fn backoff(&self) -> Backoff {
+        Backoff::new(std::iter::repeat(Duration::from_millis(500)))
+    }
+}
+
+/// Adapter that binds (target, group_id) to a shared router.
+///
+/// This wraps a [`GroupRouter`] implementation (e.g., your Router) and
+/// automatically implements `RaftNetworkV2` for a specific (target, group).
+pub struct GroupNetworkAdapter<C, G, N>
+where
+    C: RaftTypeConfig,
+    N: GroupRouter<C, G>,
+{
+    router: N,
+    target: C::NodeId,
+    group_id: G,
+}
+
+impl<C, G, N> Clone for GroupNetworkAdapter<C, G, N>
+where
+    C: RaftTypeConfig,
+    G: Clone,
+    N: GroupRouter<C, G>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            router: self.router.clone(),
+            target: self.target.clone(),
+            group_id: self.group_id.clone(),
+        }
+    }
+}
+
+impl<C, G, N> GroupNetworkAdapter<C, G, N>
+where
+    C: RaftTypeConfig,
+    N: GroupRouter<C, G>,
+{
+    /// Create adapter binding router to specific (target, group).
+    pub fn new(router: N, target: C::NodeId, group_id: G) -> Self {
+        Self {
+            router,
+            target,
+            group_id,
+        }
+    }
+
+    /// Returns the target node ID.
+    pub fn target(&self) -> &C::NodeId {
+        &self.target
+    }
+
+    /// Returns the group ID.
+    pub fn group_id(&self) -> &G {
+        &self.group_id
+    }
+}
+
+// Implement RaftNetworkV2 for GroupNetworkAdapter.
+impl<C, G, N> RaftNetworkV2<C> for GroupNetworkAdapter<C, G, N>
+where
+    C: RaftTypeConfig,
+    G: Clone + OptionalSend + OptionalSync + 'static,
+    N: GroupRouter<C, G>,
+{
+    async fn append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<C>,
+        option: RPCOption,
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C>> {
+        self.router.append_entries(self.target.clone(), self.group_id.clone(), rpc, option).await
+    }
+
+    async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
+        self.router.vote(self.target.clone(), self.group_id.clone(), rpc, option).await
+    }
+
+    async fn full_snapshot(
+        &mut self,
+        vote: VoteOf<C>,
+        snapshot: Snapshot<C>,
+        cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        option: RPCOption,
+    ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
+        self.router
+            .full_snapshot(
+                self.target.clone(),
+                self.group_id.clone(),
+                vote,
+                snapshot,
+                cancel,
+                option,
+            )
+            .await
+    }
+
+    async fn transfer_leader(&mut self, req: TransferLeaderRequest<C>, option: RPCOption) -> Result<(), RPCError<C>> {
+        self.router.transfer_leader(self.target.clone(), self.group_id.clone(), req, option).await
+    }
+
+    fn backoff(&self) -> Backoff {
+        self.router.backoff()
+    }
+}
+
+/// Simple wrapper for network factory + group_id.
+#[derive(Clone)]
+pub struct GroupNetworkFactory<F, G> {
+    /// The underlying factory (e.g., Router).
+    pub factory: F,
+    /// The group ID.
+    pub group_id: G,
+}
+
+impl<F, G> GroupNetworkFactory<F, G> {
+    /// Create a new factory wrapper.
+    pub fn new(factory: F, group_id: G) -> Self {
+        Self { factory, group_id }
+    }
+}

--- a/openraft/src/error/mod.rs
+++ b/openraft/src/error/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod higher_vote;
 pub mod into_ok;
 pub(crate) mod into_raft_result;
 mod invalid_sm;
+mod leader_changed;
 mod linearizable_read_error;
 mod membership_error;
 mod node_not_found;
@@ -15,8 +16,6 @@ pub(crate) mod replication_error;
 pub(crate) mod storage_error;
 mod storage_io_result;
 mod streaming_error;
-
-mod leader_changed;
 
 use std::collections::BTreeSet;
 use std::error::Error;

--- a/rt-monoio/src/lib.rs
+++ b/rt-monoio/src/lib.rs
@@ -205,8 +205,6 @@ mod oneshot_mod {
 ///
 /// Tokio MPSC channel are runtime independent.
 mod mpsc_mod {
-    //! MPSC channel wrapper types and their trait impl.
-
     use std::future::Future;
 
     use futures::TryFutureExt;


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

# Add Multi-Raft Support via `openraft-multi` Crate

## Summary

This PR introduces Multi-Raft support for OpenRaft through a new standalone crate `openraft-multi`. 

It provides network adapters for efficient connection sharing across multiple Raft groups within a single process.

**This is a separate crate that does not affect the core `openraft` crate.**

## Key Features

- **Connection Sharing** - Multiple Raft groups share the same network connections, reducing resource overhead
- **Simple Adapter Pattern** - Just implement `GroupedRpc` on your router, get `RaftNetworkV2` for free
- **Type Safety** - Full generic support for custom `GroupId` types
- **Runtime Agnostic** - Works with any async runtime (tokio, compio, monoio, etc.)

## New Components

| Component | Description |
|-----------|-------------|
| `GroupedRpc` trait | Defines RPC methods with `(target, group_id)` routing |
| `GroupNetworkAdapter` | Wraps `GroupedRpc` impl, auto-implements `RaftNetworkV2` |
| `GroupNetworkFactory` | Simple wrapper holding `(factory, group_id)` |



# Fix: #1485 



**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1534)
<!-- Reviewable:end -->
