### PR TITLE
change: add `subscribe()` method to `WatchSender` trait

### DIFF
--- a/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
+++ b/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime.rs
@@ -232,6 +232,10 @@ where T: OptionalSend + OptionalSync
     fn borrow_watched(&self) -> <TokioWatch as watch::Watch>::Ref<'_, T> {
         self.borrow()
     }
+
+    fn subscribe(&self) -> <TokioWatch as watch::Watch>::Receiver<T> {
+        self.subscribe()
+    }
 }
 
 impl<T> watch::WatchReceiver<TokioWatch, T> for tokio_watch::Receiver<T>

--- a/openraft/src/type_config/async_runtime/watch/mod.rs
+++ b/openraft/src/type_config/async_runtime/watch/mod.rs
@@ -88,6 +88,11 @@ where
     /// long-lived borrows could cause the producer half to block.
     /// See: [`Watch::Ref`]
     fn borrow_watched(&self) -> W::Ref<'_, T>;
+
+    /// Creates a new Receiver connected to this Sender.
+    ///
+    /// All messages sent after this call will be visible to the new Receiver.
+    fn subscribe(&self) -> W::Receiver<T>;
 }
 
 /// Receives values from the associated Sender.

--- a/rt-compio/src/watch.rs
+++ b/rt-compio/src/watch.rs
@@ -55,6 +55,11 @@ where T: OptionalSend + OptionalSync
         let inner = self.0.borrow();
         SeeRef(inner)
     }
+
+    #[inline]
+    fn subscribe(&self) -> <See as watch::Watch>::Receiver<T> {
+        SeeReceiver(self.0.subscribe())
+    }
 }
 
 impl<T> Clone for SeeReceiver<T> {

--- a/rt-monoio/src/lib.rs
+++ b/rt-monoio/src/lib.rs
@@ -439,6 +439,11 @@ mod watch_mod {
             let inner = self.0.borrow();
             TokioWatchRef(inner)
         }
+
+        #[inline]
+        fn subscribe(&self) -> <TokioWatch as watch::Watch>::Receiver<T> {
+            TokioWatchReceiver(self.0.subscribe())
+        }
     }
 
     impl<T> Clone for TokioWatchReceiver<T> {


### PR DESCRIPTION

## Changelog

##### change: add `subscribe()` method to `WatchSender` trait
Add the ability to create new receivers from a watch channel sender,
mirroring tokio's `watch::Sender::subscribe()` API.

Changes:
- Add `subscribe()` method to `WatchSender` trait
- Implement for tokio, monoio, and compio runtimes
- Add `test_watch_subscribe()` to runtime test suite

Upgrade tip:

If you implement `WatchSender` trait, add the new `subscribe()` method:

```rust
fn subscribe(&self) -> W::Receiver<T> {
    // Return a new receiver connected to this sender
}
```

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1539)
<!-- Reviewable:end -->
