### PR TITLE
feat: add `send_if_greater()` default method to `WatchSender` trait

### DIFF
--- a/openraft/src/type_config/async_runtime/watch/mod.rs
+++ b/openraft/src/type_config/async_runtime/watch/mod.rs
@@ -112,6 +112,25 @@ where
             }
         })
     }
+
+    /// Sends a new value only if it is greater than the current value.
+    ///
+    /// This is a convenience method that compares the new value with the stored value
+    /// and only updates and notifies receivers if the new value is greater.
+    ///
+    /// Returns `true` if the value was updated (i.e., new value was greater),
+    /// `false` otherwise.
+    fn send_if_greater(&self, value: T) -> bool
+    where T: PartialOrd {
+        self.send_if_modified(|current| {
+            if value > *current {
+                *current = value;
+                true
+            } else {
+                false
+            }
+        })
+    }
 }
 
 /// Receives values from the associated Sender.


### PR DESCRIPTION

## Changelog

##### feat: add `send_if_greater()` default method to `WatchSender` trait
Add a convenience method that only sends when the new value is greater
than the current value. Useful for monotonically increasing values.


##### feat: add `send_if_different()` default method to `WatchSender` trait
Add a convenience method that only sends when the new value differs from
the current value. This avoids unnecessary change notifications when
updating watch channels with potentially unchanged values.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1540)
<!-- Reviewable:end -->
