### PR TITLE
refactor: use watch channel for communication between core and replication task

### DIFF
--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -22,7 +22,7 @@ use crate::raft::message::TransferLeaderRequest;
 use crate::raft_state::IOId;
 use crate::raft_state::IOState;
 use crate::replication::ReplicationSessionId;
-use crate::replication::request::Replicate;
+use crate::replication::request::Data;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::VoteOf;
@@ -94,7 +94,7 @@ where C: RaftTypeConfig
     },
 
     /// Replicate log entries to a target.
-    Replicate { target: C::NodeId, req: Replicate<C> },
+    Replicate { target: C::NodeId, req: Data<C> },
 
     /// Replicate snapshot to a target.
     ReplicateSnapshot { target: C::NodeId, inflight_id: InflightId },

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -25,7 +25,7 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
-use crate::replication::request::Replicate;
+use crate::replication::request::Data;
 use crate::testing::blank_ent;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
@@ -151,11 +151,11 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
             },
             Command::Replicate {
                 target: 2,
-                req: Replicate::logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(1)),
+                req: Data::new_logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(1)),
             },
             Command::Replicate {
                 target: 3,
-                req: Replicate::logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(2)),
+                req: Data::new_logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(2)),
             },
         ],
         eng.output.take_commands()
@@ -280,7 +280,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
             },
             Command::Replicate {
                 target: 2,
-                req: Replicate::logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(1))
+                req: Data::new_logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(1))
             },
         ],
         eng.output.take_commands()

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -23,7 +23,7 @@ use crate::proposer::Leader;
 use crate::proposer::LeaderQuorumSet;
 use crate::raft_state::LogStateReader;
 use crate::raft_state::io_state::log_io_id::LogIOId;
-use crate::replication::request::Replicate;
+use crate::replication::request::Data;
 use crate::replication::response::ReplicationResult;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
@@ -348,7 +348,7 @@ where C: RaftTypeConfig
                 log_id_range,
                 inflight_id,
             } => {
-                let req = Replicate::logs(log_id_range.clone(), *inflight_id);
+                let req = Data::new_logs(log_id_range.clone(), *inflight_id);
                 output.push_command(Command::Replicate {
                     target: target.clone(),
                     req,

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -18,7 +18,7 @@ use crate::log_id_range::LogIdRange;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
 use crate::raft_state::IOId;
-use crate::replication::request::Replicate;
+use crate::replication::request::Data;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::EntryOf;
 use crate::utime::Leased;
@@ -73,7 +73,7 @@ fn test_become_leader() -> anyhow::Result<()> {
         },
         Command::Replicate {
             target: 0,
-            req: Replicate::logs(LogIdRange::new(None, Some(log_id(2, 1, 0))), InflightId::new(1))
+            req: Data::new_logs(LogIdRange::new(None, Some(log_id(2, 1, 0))), InflightId::new(1))
         }
     ]);
 

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -22,7 +22,7 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
 use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
-use crate::replication::request::Replicate;
+use crate::replication::request::Data;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;
@@ -219,7 +219,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
                 },
                 Command::Replicate {
                     target: 2,
-                    req: Replicate::logs(LogIdRange::new(None, Some(log_id(2, 1, 1))), InflightId::new(1))
+                    req: Data::new_logs(LogIdRange::new(None, Some(log_id(2, 1, 1))), InflightId::new(1))
                 },
             ],
             eng.output.take_commands()

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -21,7 +21,7 @@ use crate::progress::Inflight;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
 use crate::raft_state::IOId;
-use crate::replication::request::Replicate;
+use crate::replication::request::Data;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;
@@ -89,7 +89,7 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
             },
             Command::Replicate {
                 target: 3,
-                req: Replicate::logs(LogIdRange::new(None, Some(log_id(2, 2, 4))), InflightId::new(1)),
+                req: Data::new_logs(LogIdRange::new(None, Some(log_id(2, 2, 4))), InflightId::new(1)),
             }
         ],
         eng.output.take_commands()
@@ -137,7 +137,7 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
             },
             Command::Replicate {
                 target: 3,
-                req: Replicate::logs(LogIdRange::new(None, Some(log_id(1, 2, 6))), InflightId::new(1))
+                req: Data::new_logs(LogIdRange::new(None, Some(log_id(1, 2, 6))), InflightId::new(1))
             }
         ],
         eng.output.take_commands()

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -450,6 +450,8 @@ where C: RaftTypeConfig
             sm_span,
         );
 
+        let (committed_tx, committed_rx) = C::watch_channel(None);
+
         let core: RaftCore<C, N, LS> = RaftCore {
             id: id.clone(),
             config: config.clone(),
@@ -475,6 +477,8 @@ where C: RaftTypeConfig
 
             tx_io_completed,
 
+            committed_tx,
+            _committed_rx: committed_rx,
             tx_metrics,
             tx_data_metrics,
             tx_server_metrics,

--- a/openraft/src/replication/event_watcher.rs
+++ b/openraft/src/replication/event_watcher.rs
@@ -1,0 +1,41 @@
+use futures::FutureExt;
+
+use crate::RaftTypeConfig;
+use crate::async_runtime::watch::RecvError;
+use crate::async_runtime::watch::WatchReceiver;
+use crate::replication::request::Data;
+use crate::replication::request::Replicate;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::WatchReceiverOf;
+
+#[derive(Clone)]
+pub(crate) struct EventWatcher<C>
+where C: RaftTypeConfig
+{
+    pub(crate) entries_rx: WatchReceiverOf<C, Data<C>>,
+    pub(crate) committed_rx: WatchReceiverOf<C, Option<LogIdOf<C>>>,
+}
+
+impl<C> EventWatcher<C>
+where C: RaftTypeConfig
+{
+    pub(crate) async fn recv(&mut self) -> Result<Replicate<C>, RecvError> {
+        let entries = self.entries_rx.changed();
+        let committed = self.committed_rx.changed();
+
+        futures::select! {
+            entries_res = entries.fuse() => {
+                entries_res?;
+
+                let data = self.entries_rx.borrow_watched().clone();
+                Ok(Replicate::Data {data})
+            }
+            committed_res = committed.fuse() => {
+                committed_res?;
+
+                let committed = self.committed_rx.borrow_watched().clone();
+                Ok(Replicate::Committed {committed})
+            }
+        }
+    }
+}

--- a/openraft/src/replication/replication_handle.rs
+++ b/openraft/src/replication/replication_handle.rs
@@ -1,10 +1,9 @@
 use crate::RaftTypeConfig;
 use crate::error::ReplicationClosed;
 use crate::replication::ReplicationSessionId;
-use crate::replication::request::Replicate;
+use crate::replication::request::Data;
 use crate::replication::snapshot_transmitter_handle::SnapshotTransmitterHandle;
 use crate::type_config::alias::JoinHandleOf;
-use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::WatchSenderOf;
 
 /// The handle to a spawned replication stream.
@@ -18,11 +17,11 @@ where C: RaftTypeConfig
     pub(crate) join_handle: JoinHandleOf<C, Result<(), ReplicationClosed>>,
 
     /// The channel used for communicating with the replication task.
-    pub(crate) tx_repl: MpscUnboundedSenderOf<C, Replicate<C>>,
+    pub(crate) entries_tx: WatchSenderOf<C, Data<C>>,
 
     /// Handle to the snapshot transmitter task, if one is running.
     pub(crate) snapshot_transmit_handle: Option<SnapshotTransmitterHandle<C>>,
 
     /// Sender for the cancellation signal; dropping this stops replication.
-    pub(crate) _cancel_tx: WatchSenderOf<C, ()>,
+    pub(crate) cancel_tx: WatchSenderOf<C, ()>,
 }


### PR DESCRIPTION

## Changelog

##### refactor: use watch channel for communication between core and replication task
Replace unbounded MPSC channel with watch channel for broadcasting
committed log id to replication tasks. This simplifies the replication
event handling by using an EventWatcher that monitors both entries and
committed updates.

Changes:
- Add `EventWatcher` to receive events from entries and committed watch channels
- Rename `Replicate` to `Data` for log entries replication data
- Add `committed_tx`/`committed_rx` watch channel pair in `RaftCore`
- Use `send_if_greater()` for committed log id updates
- Remove per-replication MPSC sender in favor of shared watch channel

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1541)
<!-- Reviewable:end -->
