### PR TITLE
feat: add `on_leader_change()` API to monitor leader changes

### DIFF
--- a/openraft/src/docs/faq/05-monitoring/05-leader-change-services.md
+++ b/openraft/src/docs/faq/05-monitoring/05-leader-change-services.md
@@ -1,0 +1,52 @@
+### How to start/stop services when a node becomes leader?
+
+**Problem**: You want to run certain services (e.g., cron jobs, cache warming,
+background tasks) only on the leader node, and stop them when the node loses
+leadership.
+
+**Solution**: Use [`Raft::on_leader_change()`][] to register a callback that
+is invoked whenever the leader changes. The callback receives the old and new
+leader state, allowing you to start or stop services accordingly.
+
+```rust,ignore
+let my_node_id = 1;
+let service_handle = Arc::new(Mutex::new(None));
+let service_handle_clone = service_handle.clone();
+
+let mut watch_handle = raft.on_leader_change(move |_old, (leader_id, committed)| {
+    let is_leader = leader_id.node_id == my_node_id && committed;
+
+    let mut handle = service_handle_clone.lock().unwrap();
+    if is_leader {
+        // This node just became the committed leader
+        // Start leader-only services
+        if handle.is_none() {
+            *handle = Some(start_cron_service());
+        }
+    } else {
+        // This node is no longer the leader
+        // Stop leader-only services to avoid duplicate work
+        if let Some(h) = handle.take() {
+            h.shutdown();
+        }
+    }
+});
+
+// Later, when shutting down:
+watch_handle.close().await;
+```
+
+**Important considerations**:
+
+- **Check `committed` flag**: When `committed == false`, the node has voted for
+  itself but hasn't yet received votes from a quorum - it's essentially still a
+  **candidate**. Wait for `committed == true` before starting critical services
+  to ensure the leadership is stable and acknowledged by the cluster.
+
+- **Idempotent operations**: The callback may be invoked multiple times with
+  the same leader. Ensure your start/stop logic is idempotent.
+
+- **Non-blocking callback**: The callback runs in the watch task. Keep it
+  lightweight - spawn separate tasks for heavy initialization.
+
+[`Raft::on_leader_change()`]: `crate::Raft::on_leader_change`

--- a/openraft/src/docs/faq/faq-toc.md
+++ b/openraft/src/docs/faq/faq-toc.md
@@ -17,6 +17,7 @@
   * [How to detect if a leader is valid?](#how-to-detect-if-a-leader-is-valid)
   * [How to detect which nodes are currently down or unreachable?](#how-to-detect-which-nodes-are-currently-down-or-unreachable)
   * [How to minimize error logging when a follower is offline](#how-to-minimize-error-logging-when-a-follower-is-offline)
+  * [How to start/stop services when a node becomes leader?](#how-to-startstop-services-when-a-node-becomes-leader)
 - [Operations & Maintenance](#operations--maintenance)
   * [What actions are required when a node restarts?](#what-actions-are-required-when-a-node-restarts)
   * [How to remove node-2 safely from a cluster `{1, 2, 3}`?](#how-to-remove-node-2-safely-from-a-cluster-1-2-3)

--- a/openraft/src/docs/faq/faq.md
+++ b/openraft/src/docs/faq/faq.md
@@ -369,6 +369,60 @@ Excessive error logging, like `ERROR openraft::replication: 248: RPCError err=Ne
 [`NetworkError`]: `crate::error::NetworkError`
 
 
+### How to start/stop services when a node becomes leader?
+
+**Problem**: You want to run certain services (e.g., cron jobs, cache warming,
+background tasks) only on the leader node, and stop them when the node loses
+leadership.
+
+**Solution**: Use [`Raft::on_leader_change()`][] to register a callback that
+is invoked whenever the leader changes. The callback receives the old and new
+leader state, allowing you to start or stop services accordingly.
+
+```rust,ignore
+let my_node_id = 1;
+let service_handle = Arc::new(Mutex::new(None));
+let service_handle_clone = service_handle.clone();
+
+let mut watch_handle = raft.on_leader_change(move |_old, (leader_id, committed)| {
+    let is_leader = leader_id.node_id == my_node_id && committed;
+
+    let mut handle = service_handle_clone.lock().unwrap();
+    if is_leader {
+        // This node just became the committed leader
+        // Start leader-only services
+        if handle.is_none() {
+            *handle = Some(start_cron_service());
+        }
+    } else {
+        // This node is no longer the leader
+        // Stop leader-only services to avoid duplicate work
+        if let Some(h) = handle.take() {
+            h.shutdown();
+        }
+    }
+});
+
+// Later, when shutting down:
+watch_handle.close().await;
+```
+
+**Important considerations**:
+
+- **Check `committed` flag**: When `committed == false`, the node has voted for
+  itself but hasn't yet received votes from a quorum - it's essentially still a
+  **candidate**. Wait for `committed == true` before starting critical services
+  to ensure the leadership is stable and acknowledged by the cluster.
+
+- **Idempotent operations**: The callback may be invoked multiple times with
+  the same leader. Ensure your start/stop logic is idempotent.
+
+- **Non-blocking callback**: The callback runs in the watch task. Keep it
+  lightweight - spawn separate tasks for heavy initialization.
+
+[`Raft::on_leader_change()`]: `crate::Raft::on_leader_change`
+
+
 ## Operations & Maintenance
 
 ### What actions are required when a node restarts?

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -124,6 +124,7 @@ pub use crate::node::BasicNode;
 pub use crate::node::EmptyNode;
 pub use crate::node::Node;
 pub use crate::node::NodeId;
+pub use crate::raft::LeaderChangeHandle;
 pub use crate::raft::Raft;
 pub use crate::raft::ReadPolicy;
 pub use crate::raft_state::MembershipState;

--- a/openraft/src/raft/leader_watch.rs
+++ b/openraft/src/raft/leader_watch.rs
@@ -1,0 +1,30 @@
+//! Leader change watch handle.
+
+use crate::RaftTypeConfig;
+use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::OneshotSenderOf;
+
+/// Handle to control a leader watch task.
+///
+/// Use [`close()`](`Self::close`) to stop watching and wait for the task to complete.
+pub struct LeaderChangeHandle<C>
+where C: RaftTypeConfig
+{
+    pub(crate) cancel_tx: Option<OneshotSenderOf<C, ()>>,
+    pub(crate) join_handle: Option<JoinHandleOf<C, ()>>,
+}
+
+impl<C> LeaderChangeHandle<C>
+where C: RaftTypeConfig
+{
+    /// Stop watching and wait for the task to complete.
+    pub async fn close(&mut self) {
+        // Drop the sender to signal shutdown
+        drop(self.cancel_tx.take());
+
+        // Wait for task to finish
+        if let Some(handle) = self.join_handle.take() {
+            let _ = handle.await;
+        }
+    }
+}

--- a/tests/tests/metrics/main.rs
+++ b/tests/tests/metrics/main.rs
@@ -18,3 +18,4 @@ mod t50_apply_progress_api;
 mod t50_commit_progress_api;
 mod t50_log_progress_api;
 mod t50_snapshot_progress_api;
+mod t50_watch_leader_api;

--- a/tests/tests/metrics/t50_watch_leader_api.rs
+++ b/tests/tests/metrics/t50_watch_leader_api.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::vote::RaftLeaderId;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// Test on_leader_change API with leader switch
+///
+/// What does this test do?
+///
+/// - Creates a 3-node cluster with node 0 as initial leader
+/// - Watches leader change events on node 1
+/// - Shuts down node 0 to force leader change
+/// - Triggers election on node 2 to become new leader
+/// - Verifies leader change callbacks are invoked correctly
+/// - Closes the watch handle and verifies no more callbacks are invoked
+#[allow(clippy::type_complexity)]
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn on_leader_change_api() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_elect: false,
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing 3-node cluster");
+    let _log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    tracing::info!("--- create on_leader_change on node 1");
+    let n1 = router.get_raft_handle(&1)?;
+
+    // Collect (old, new) tuples: ((term, node_id, committed), (term, node_id, committed))
+    let changes: Arc<Mutex<Vec<(Option<(u64, u64, bool)>, (u64, u64, bool))>>> = Arc::new(Mutex::new(Vec::new()));
+    let changes_clone = changes.clone();
+
+    let mut handle = n1.on_leader_change(move |old, new| {
+        let old_val = old.map(|(leader_id, committed)| (leader_id.term(), *leader_id.node_id(), committed));
+        let new_val = (new.0.term(), *new.0.node_id(), new.1);
+        changes_clone.lock().unwrap().push((old_val, new_val));
+    });
+
+    // Give some time for the initial callback to be invoked
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    tracing::info!("--- verify initial leader change event");
+    {
+        let got = changes.lock().unwrap().clone();
+        // Expected: one callback with old=None, new=(term=1, node_id=0, committed=true)
+        let want = vec![(None, (1, 0, true))];
+        assert_eq!(got, want);
+    }
+
+    tracing::info!("--- shutdown node 0 (current leader)");
+    router.remove_node(0);
+
+    // Wait for leader lease to expire so other nodes accept new vote
+    tokio::time::sleep(Duration::from_millis(700)).await;
+
+    tracing::info!("--- trigger election on node 2");
+    let n2 = router.get_raft_handle(&2)?;
+    n2.trigger().elect().await?;
+
+    tracing::info!("--- wait for node 2 to become leader");
+    n2.wait(Some(Duration::from_millis(2000)))
+        .state(ServerState::Leader, "wait for node 2 to become leader")
+        .await?;
+
+    tracing::info!("--- wait for node 1 to see the new leader");
+    n1.wait(Some(Duration::from_millis(2000)))
+        .current_leader(2, "wait for node 1 to see node 2 as leader")
+        .await?;
+
+    // Give some time for the callback to be invoked
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    tracing::info!("--- verify leader change events after election");
+    {
+        let got = changes.lock().unwrap().clone();
+        // Expected:
+        // 1. Initial: old=None, new=(term=1, node_id=0, committed=true)
+        // 2. New leader: old=(term=1, node_id=0, committed=true), new=(term=2, node_id=2, committed=false)
+        //    Note: committed=false because callback fires at leader change moment, before vote is committed
+        let want = vec![(None, (1, 0, true)), (Some((1, 0, true)), (2, 2, false))];
+        assert_eq!(got, want);
+    }
+
+    tracing::info!("--- close the watch handle");
+    handle.close().await;
+
+    // Wait for leader lease to expire
+    tokio::time::sleep(Duration::from_millis(700)).await;
+
+    tracing::info!("--- trigger election on node 1 after handle closed (node 2 still running for quorum)");
+    n1.trigger().elect().await?;
+
+    n1.wait(Some(Duration::from_millis(2000)))
+        .state(ServerState::Leader, "wait for node 1 to become leader")
+        .await?;
+
+    // Give some time for any potential callback to be invoked
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    tracing::info!("--- verify no new events after handle closed");
+    {
+        let got = changes.lock().unwrap().clone();
+        // Should still be only 2 events - callback not invoked after close even though leader changed
+        let want = vec![(None, (1, 0, true)), (Some((1, 0, true)), (2, 2, false))];
+        assert_eq!(got, want);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### feat: add `on_leader_change()` API to monitor leader changes
Add a callback-based API for monitoring leader changes on a Raft node.
The callback is invoked whenever the leader_id changes, providing both
the old and new leader state including commit status.

Changes:
- Add `on_leader_change()` method to `Raft` for callback-based leader monitoring
- Add FAQ entry explaining how to start/stop services when becoming leader

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1547)
<!-- Reviewable:end -->
