### PR TITLE
refactor: add `#[track_caller]` to async runtime and time trait methods

### DIFF
--- a/openraft/src/instant.rs
+++ b/openraft/src/instant.rs
@@ -34,11 +34,13 @@ pub trait Instant:
     + 'static
 {
     /// Return the current instant.
+    #[track_caller]
     fn now() -> Self;
 
     /// Return the amount of time since the instant.
     ///
     /// The returned duration is guaranteed to be non-negative.
+    #[track_caller]
     fn elapsed(&self) -> Duration {
         let now = Self::now();
         if now > *self {

--- a/openraft/src/type_config/async_runtime/mod.rs
+++ b/openraft/src/type_config/async_runtime/mod.rs
@@ -76,24 +76,30 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     type ThreadLocalRng: rand::Rng;
 
     /// Spawn a new task.
+    #[track_caller]
     fn spawn<T>(future: T) -> Self::JoinHandle<T::Output>
     where
         T: Future + OptionalSend + 'static,
         T::Output: OptionalSend + 'static;
 
     /// Wait until `duration` has elapsed.
+    #[track_caller]
     fn sleep(duration: Duration) -> Self::Sleep;
 
     /// Wait until `deadline` is reached.
+    #[track_caller]
     fn sleep_until(deadline: Self::Instant) -> Self::Sleep;
 
     /// Require a [`Future`] to complete before the specified duration has elapsed.
+    #[track_caller]
     fn timeout<R, F: Future<Output = R> + OptionalSend>(duration: Duration, future: F) -> Self::Timeout<R, F>;
 
     /// Require a [`Future`] to complete before the specified instant in time.
+    #[track_caller]
     fn timeout_at<R, F: Future<Output = R> + OptionalSend>(deadline: Self::Instant, future: F) -> Self::Timeout<R, F>;
 
     /// Check if the [`Self::JoinError`] is `panic`.
+    #[track_caller]
     fn is_panic(join_error: &Self::JoinError) -> bool;
 
     /// Get the random number generator to use for generating random numbers.
@@ -102,6 +108,7 @@ pub trait AsyncRuntime: Debug + Default + PartialEq + Eq + OptionalSend + Option
     ///
     /// This is a per-thread instance, which cannot be shared across threads or
     /// sent to another thread.
+    #[track_caller]
     fn thread_rng() -> Self::ThreadLocalRng;
 
     /// The bounded MPSC channel implementation.

--- a/openraft/src/type_config/async_runtime/mpsc/mod.rs
+++ b/openraft/src/type_config/async_runtime/mpsc/mod.rs
@@ -21,6 +21,7 @@ pub trait Mpsc: Sized + OptionalSend {
 
     /// Creates a bounded mpsc channel for communicating between asynchronous tasks with
     /// backpressure.
+    #[track_caller]
     fn channel<T: OptionalSend>(buffer: usize) -> (Self::Sender<T>, Self::Receiver<T>);
 }
 
@@ -34,12 +35,14 @@ where
     ///
     /// If the receiving half of the channel is closed, this
     /// function returns an error. The error includes the value passed to `send`.
+    #[track_caller]
     fn send(&self, msg: T) -> impl Future<Output = Result<(), SendError<T>>> + OptionalSend;
 
     /// Converts the [`MpscSender`] to a [`MpscWeakSender`] that does not count
     /// towards RAII semantics, i.e., if all `Sender` instances of the
     /// channel were dropped and only `WeakSender` instances remain,
     /// the channel is closed.
+    #[track_caller]
     fn downgrade(&self) -> MU::WeakSender<T>;
 }
 
@@ -49,6 +52,7 @@ pub trait MpscReceiver<T>: OptionalSend + OptionalSync {
     ///
     /// This method returns `None` if the channel has been closed and there are
     /// no remaining messages in the channel's buffer.
+    #[track_caller]
     fn recv(&mut self) -> impl Future<Output = Option<T>> + OptionalSend;
 
     /// Tries to receive the next value for this receiver.
@@ -58,6 +62,7 @@ pub trait MpscReceiver<T>: OptionalSend + OptionalSync {
     ///
     /// This method returns the [`TryRecvError::Disconnected`] error if the channel is
     /// currently empty, and there are no outstanding senders.
+    #[track_caller]
     fn try_recv(&mut self) -> Result<T, TryRecvError>;
 }
 
@@ -74,5 +79,6 @@ where
     ///
     /// This will return `Some` if there are other `Sender` instances alive and
     /// the channel wasn't previously dropped, otherwise `None` is returned.
+    #[track_caller]
     fn upgrade(&self) -> Option<MU::Sender<T>>;
 }

--- a/openraft/src/type_config/async_runtime/mpsc_unbounded/mod.rs
+++ b/openraft/src/type_config/async_runtime/mpsc_unbounded/mod.rs
@@ -19,6 +19,7 @@ pub trait MpscUnbounded: Sized + OptionalSend {
     type WeakSender<T: OptionalSend>: MpscUnboundedWeakSender<Self, T>;
 
     /// Creates an unbounded MPSC channel for communicating between asynchronous tasks.
+    #[track_caller]
     fn channel<T: OptionalSend>() -> (Self::Sender<T>, Self::Receiver<T>);
 }
 
@@ -32,12 +33,14 @@ where
     ///
     /// If the receiving half of the channel is closed, this
     /// function returns an error. The error includes the value passed to `send`.
+    #[track_caller]
     fn send(&self, msg: T) -> Result<(), SendError<T>>;
 
     /// Converts the [`MpscUnboundedSender`] to a [`MpscUnboundedWeakSender`] that does not count
     /// towards RAII semantics, i.e., if all `Sender` instances of the
     /// channel were dropped and only `WeakSender` instances remain,
     /// the channel is closed.
+    #[track_caller]
     fn downgrade(&self) -> MU::WeakSender<T>;
 }
 
@@ -47,6 +50,7 @@ pub trait MpscUnboundedReceiver<T>: OptionalSend + OptionalSync {
     ///
     /// This method returns `None` if the channel has been closed and there are
     /// no remaining messages in the channel's buffer.
+    #[track_caller]
     fn recv(&mut self) -> impl Future<Output = Option<T>> + OptionalSend;
 
     /// Tries to receive the next value for this receiver.
@@ -56,6 +60,7 @@ pub trait MpscUnboundedReceiver<T>: OptionalSend + OptionalSync {
     ///
     /// This method returns the [`TryRecvError::Disconnected`] error if the channel is
     /// currently empty, and there are no outstanding senders.
+    #[track_caller]
     fn try_recv(&mut self) -> Result<T, TryRecvError>;
 }
 
@@ -72,5 +77,6 @@ where
     ///
     /// This will return `Some` if there are other `Sender` instances alive and
     /// the channel wasn't previously dropped, otherwise `None` is returned.
+    #[track_caller]
     fn upgrade(&self) -> Option<MU::Sender<T>>;
 }

--- a/openraft/src/type_config/async_runtime/mutex.rs
+++ b/openraft/src/type_config/async_runtime/mutex.rs
@@ -13,8 +13,10 @@ pub trait Mutex<T: OptionalSend + 'static>: OptionalSend + OptionalSync {
     where Self: 'a;
 
     /// Creates a new lock.
+    #[track_caller]
     fn new(value: T) -> Self;
 
     /// Locks this Mutex.
+    #[track_caller]
     fn lock(&self) -> impl Future<Output = Self::Guard<'_>> + OptionalSend;
 }

--- a/openraft/src/type_config/async_runtime/oneshot.rs
+++ b/openraft/src/type_config/async_runtime/oneshot.rs
@@ -24,6 +24,7 @@ pub trait Oneshot {
     /// used by the consumer to receive the value.
     ///
     /// Each handle can be used on separate tasks.
+    #[track_caller]
     fn channel<T>() -> (Self::Sender<T>, Self::Receiver<T>)
     where T: OptionalSend;
 }
@@ -40,5 +41,6 @@ where T: OptionalSend
     /// channel never requires any form of waiting.  Because of this, the `send`
     /// method can be used in both synchronous and asynchronous code without
     /// problems.
+    #[track_caller]
     fn send(self, t: T) -> Result<(), T>;
 }

--- a/openraft/src/type_config/async_runtime/watch/mod.rs
+++ b/openraft/src/type_config/async_runtime/watch/mod.rs
@@ -51,6 +51,7 @@ pub trait Watch: Sized + OptionalSend {
     /// All values sent by [`WatchSender`] should become visible to the [`WatchReceiver`] handles.
     /// Only the last value sent should be made available to the [`WatchReceiver`] half. All
     /// intermediate values should be dropped.
+    #[track_caller]
     fn channel<T: OptionalSend + OptionalSync>(init: T) -> (Self::Sender<T>, Self::Receiver<T>);
 }
 
@@ -64,6 +65,7 @@ where
     ///
     /// This method should fail if the channel is closed, which is the case when
     /// every receiver has been dropped.
+    #[track_caller]
     fn send(&self, value: T) -> Result<(), SendError<T>>;
 
     /// Modifies the watched value **conditionally** in-place,
@@ -79,6 +81,7 @@ where
     /// in a *silent modification*, i.e., the modified value will be visible
     /// in subsequent calls to `borrow_watched`, but receivers will not receive
     /// a change notification.
+    #[track_caller]
     fn send_if_modified<F>(&self, modify: F) -> bool
     where F: FnOnce(&mut T) -> bool;
 
@@ -87,11 +90,13 @@ where
     /// If the implementation of `Ref` holds a lock on the inner value, it means that
     /// long-lived borrows could cause the producer half to block.
     /// See: [`Watch::Ref`]
+    #[track_caller]
     fn borrow_watched(&self) -> W::Ref<'_, T>;
 
     /// Creates a new Receiver connected to this Sender.
     ///
     /// All messages sent after this call will be visible to the new Receiver.
+    #[track_caller]
     fn subscribe(&self) -> W::Receiver<T>;
 
     /// Sends a new value only if it differs from the current value.
@@ -156,6 +161,7 @@ where
     /// If the implementation of `Ref` holds a lock on the inner value, it means that
     /// long-lived borrows could cause the producer half to block.
     /// See: [`Watch::Ref`]
+    #[track_caller]
     fn borrow_watched(&self) -> W::Ref<'_, T>;
 
     /// Waits until the watched value is greater than or equal to the given value.

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -38,26 +38,31 @@ pub trait TypeConfigExt: RaftTypeConfig {
     // Time related methods
 
     /// Returns the current time.
+    #[track_caller]
     fn now() -> InstantOf<Self> {
         InstantOf::<Self>::now()
     }
 
     /// Wait until `duration` has elapsed.
+    #[track_caller]
     fn sleep(duration: Duration) -> SleepOf<Self> {
         AsyncRuntimeOf::<Self>::sleep(duration)
     }
 
     /// Wait until `deadline` is reached.
+    #[track_caller]
     fn sleep_until(deadline: InstantOf<Self>) -> SleepOf<Self> {
         AsyncRuntimeOf::<Self>::sleep_until(deadline)
     }
 
     /// Require a [`Future`] to complete before the specified duration has elapsed.
+    #[track_caller]
     fn timeout<R, F: Future<Output = R> + OptionalSend>(duration: Duration, future: F) -> TimeoutOf<Self, R, F> {
         AsyncRuntimeOf::<Self>::timeout(duration, future)
     }
 
     /// Require a [`Future`] to complete before the specified instant in time.
+    #[track_caller]
     fn timeout_at<R, F: Future<Output = R> + OptionalSend>(
         deadline: InstantOf<Self>,
         future: F,
@@ -71,6 +76,7 @@ pub trait TypeConfigExt: RaftTypeConfig {
     ///
     /// This is just a wrapper of
     /// [`AsyncRuntime::Oneshot::channel()`](`crate::async_runtime::Oneshot::channel`).
+    #[track_caller]
     fn oneshot<T>() -> (OneshotSenderOf<Self, T>, OneshotReceiverOf<Self, T>)
     where T: OptionalSend {
         OneshotOf::<Self>::channel()
@@ -81,6 +87,7 @@ pub trait TypeConfigExt: RaftTypeConfig {
     ///
     /// This is just a wrapper of
     /// [`AsyncRuntime::Mpsc::channel()`](`crate::async_runtime::Mpsc::channel`).
+    #[track_caller]
     fn mpsc<T>(buffer: usize) -> (MpscSenderOf<Self, T>, MpscReceiverOf<Self, T>)
     where T: OptionalSend {
         MpscOf::<Self>::channel(buffer)
@@ -91,6 +98,7 @@ pub trait TypeConfigExt: RaftTypeConfig {
     ///
     /// This is just a wrapper of
     /// [`AsyncRuntime::MpscUnbounded::channel()`](`crate::async_runtime::MpscUnbounded::channel`).
+    #[track_caller]
     fn mpsc_unbounded<T>() -> (MpscUnboundedSenderOf<Self, T>, MpscUnboundedReceiverOf<Self, T>)
     where T: OptionalSend {
         MpscUnboundedOf::<Self>::channel()
@@ -101,6 +109,7 @@ pub trait TypeConfigExt: RaftTypeConfig {
     ///
     /// This is just a wrapper of
     /// [`AsyncRuntime::Watch::channel()`](`crate::async_runtime::Watch::channel`).
+    #[track_caller]
     fn watch_channel<T>(init: T) -> (WatchSenderOf<Self, T>, WatchReceiverOf<Self, T>)
     where T: OptionalSend + OptionalSync {
         WatchOf::<Self>::channel(init)
@@ -110,6 +119,7 @@ pub trait TypeConfigExt: RaftTypeConfig {
     ///
     /// This is just a wrapper of
     /// [`AsyncRuntime::Mutex::new()`](`crate::async_runtime::Mutex::new`).
+    #[track_caller]
     fn mutex<T>(value: T) -> MutexOf<Self, T>
     where T: OptionalSend {
         MutexOf::<Self, T>::new(value)
@@ -118,6 +128,7 @@ pub trait TypeConfigExt: RaftTypeConfig {
     // Task methods
 
     /// Spawn a new task.
+    #[track_caller]
     fn spawn<T>(future: T) -> JoinHandleOf<Self, T::Output>
     where
         T: Future + OptionalSend + 'static,


### PR DESCRIPTION

## Changelog

##### refactor: add `#[track_caller]` to async runtime and time trait methods
Add `#[track_caller]` attribute to trait method definitions so all
implementations automatically inherit caller location tracking.

Changes:
- Add to `AsyncRuntime`: `spawn`, `sleep`, `sleep_until`, `timeout`, `timeout_at`, `is_panic`, `thread_rng`
- Add to `Mpsc`, `MpscSender`, `MpscReceiver`, `MpscWeakSender` methods
- Add to `MpscUnbounded`, `MpscUnboundedSender`, `MpscUnboundedReceiver`, `MpscUnboundedWeakSender` methods
- Add to `Watch`, `WatchSender`, `WatchReceiver` methods
- Add to `Oneshot`, `OneshotSender` methods
- Add to `Mutex`: `new`, `lock`
- Add to `Instant`: `now`, `elapsed`
- Add to `TypeConfigExt` wrapper methods

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1551)
<!-- Reviewable:end -->
