### PR TITLE
feat: add optional tokio-console support for cluster benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,19 @@ tokio              = { version = "1.39", default-features = false, features = [
     "rt-multi-thread",
     "sync",
     "time",
+    "tracing",
 ] }
 tracing            = { version = "0.1.40" }
 tracing-appender   = { version = "0.2.0" }
 tracing-futures    = { version = "0.2.4" }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 validit            = { version = "0.2.2" }
+
+
+[profile.release]
+debug = 2
+split-debuginfo = "packed"
+
 
 [workspace]
 

--- a/Makefile
+++ b/Makefile
@@ -47,14 +47,19 @@ test-examples:
 bench:
 	cargo bench --features bench
 
+# Set TOKIO_CONSOLE=1 to enable tokio-console support
+# Example: TOKIO_CONSOLE=1 make bench_cluster_of_3
+BENCH_FEATURES := $(if $(TOKIO_CONSOLE),--features tokio-console,)
+BENCH_RUSTFLAGS := $(if $(TOKIO_CONSOLE),RUSTFLAGS="--cfg tokio_unstable",)
+
 bench_cluster_of_1:
-	cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release bench_cluster_of_1 -- --ignored --nocapture
+	$(BENCH_RUSTFLAGS) cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release $(BENCH_FEATURES) bench_cluster_of_1 -- --ignored --nocapture
 
 bench_cluster_of_3:
-	cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release bench_cluster_of_3 -- --ignored --nocapture
+	$(BENCH_RUSTFLAGS) cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release $(BENCH_FEATURES) bench_cluster_of_3 -- --ignored --nocapture
 
 bench_cluster_of_5:
-	cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release bench_cluster_of_5 -- --ignored --nocapture
+	$(BENCH_RUSTFLAGS) cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release $(BENCH_FEATURES) bench_cluster_of_5 -- --ignored --nocapture
 
 fmt:
 	cargo fmt

--- a/cluster_benchmark/Cargo.toml
+++ b/cluster_benchmark/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
+console-subscriber = { version = "0.5", optional = true }
 
 [dev-dependencies]
 openraft = { path = "../openraft", version = "0.10.0", features = ["serde", "type-alias"] }
@@ -26,16 +27,16 @@ futures    = { version = "0.3" }
 maplit     = { version = "1.0.2" }
 serde      = { version = "1.0.114", features = ["derive", "rc"] }
 serde_json = { version = "1.0.57" }
-tokio      = { version = "1.39", default-features = false, features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio      = { version = "1.39", default-features = false, features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time", "tracing"] }
 tracing    = { version = "0.1.29" }
 
 [features]
-
 bt = ["openraft/bt"]
 single-term-leader = []
+tokio-console = ["console-subscriber"]
 
 [profile.release]
 debug = 2
+split-debuginfo = "packed"
 lto = "thin"
-overflow-checks = false
 codegen-units = 1

--- a/cluster_benchmark/tests/benchmark/bench_cluster.rs
+++ b/cluster_benchmark/tests/benchmark/bench_cluster.rs
@@ -67,6 +67,15 @@ fn bench_cluster_of_5() -> anyhow::Result<()> {
 }
 
 fn bench_with_config(bench_config: &BenchConfig) -> anyhow::Result<()> {
+    #[cfg(feature = "tokio-console")]
+    {
+        console_subscriber::ConsoleLayer::builder()
+            .server_addr(([127, 0, 0, 1], 6669))
+            .with_default_env()
+            .init();
+        eprintln!("tokio-console server started on 127.0.0.1:6669");
+    }
+
     let rt = Builder::new_multi_thread()
         .worker_threads(bench_config.worker_threads)
         .enable_all()


### PR DESCRIPTION

## Changelog

##### feat: add optional tokio-console support for cluster benchmarks
Add a `tokio-console` feature flag to enable runtime task introspection
during benchmark runs. This allows debugging async task behavior without
impacting normal benchmark performance.

Changes:
- Add `tokio-console` feature flag with `console-subscriber` dependency
- Add `TOKIO_CONSOLE=1` env var support in Makefile for benchmark targets
- Set `RUSTFLAGS="--cfg tokio_unstable"` when tokio-console is enabled
- Add `tracing` feature to tokio for instrumentation support
- Add release profile with debug symbols and `split-debuginfo`
- Remove unsafe `overflow-checks = false` from release profile

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1552)
<!-- Reviewable:end -->
