### PR TITLE
refactor: convert cluster benchmark from test to binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,18 +48,21 @@ bench:
 	cargo bench --features bench
 
 # Set TOKIO_CONSOLE=1 to enable tokio-console support
+# Set FLAMEGRAPH=1 to enable flamegraph profiling
 # Example: TOKIO_CONSOLE=1 make bench_cluster_of_3
-BENCH_FEATURES := $(if $(TOKIO_CONSOLE),--features tokio-console,)
+comma := ,
+BENCH_FEATURES := $(if $(TOKIO_CONSOLE),tokio-console,)$(if $(FLAMEGRAPH),$(if $(TOKIO_CONSOLE),$(comma))flamegraph,)
+BENCH_FEATURES_FLAG := $(if $(BENCH_FEATURES),--features $(BENCH_FEATURES),)
 BENCH_RUSTFLAGS := $(if $(TOKIO_CONSOLE),RUSTFLAGS="--cfg tokio_unstable",)
 
 bench_cluster_of_1:
-	$(BENCH_RUSTFLAGS) cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release $(BENCH_FEATURES) bench_cluster_of_1 -- --ignored --nocapture
+	$(BENCH_RUSTFLAGS) cargo run --manifest-path cluster_benchmark/Cargo.toml --release --bin bench $(BENCH_FEATURES_FLAG) -- -m 1
 
 bench_cluster_of_3:
-	$(BENCH_RUSTFLAGS) cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release $(BENCH_FEATURES) bench_cluster_of_3 -- --ignored --nocapture
+	$(BENCH_RUSTFLAGS) cargo run --manifest-path cluster_benchmark/Cargo.toml --release --bin bench $(BENCH_FEATURES_FLAG) -- -m 3
 
 bench_cluster_of_5:
-	$(BENCH_RUSTFLAGS) cargo test --manifest-path cluster_benchmark/Cargo.toml --test benchmark --release $(BENCH_FEATURES) bench_cluster_of_5 -- --ignored --nocapture
+	$(BENCH_RUSTFLAGS) cargo run --manifest-path cluster_benchmark/Cargo.toml --release --bin bench $(BENCH_FEATURES_FLAG) -- -m 5
 
 fmt:
 	cargo fmt

--- a/cluster_benchmark/Cargo.toml
+++ b/cluster_benchmark/Cargo.toml
@@ -17,20 +17,22 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-console-subscriber = { version = "0.5", optional = true }
-tracing-flame = { version = "0.2", optional = true }
-tracing-subscriber = { version = "0.3", optional = true }
-
-[dev-dependencies]
 openraft = { path = "../openraft", version = "0.10.0", features = ["serde", "type-alias", "runtime-stats"] }
 
 anyhow     = { version = "1.0.63" }
+clap       = { version = "4.2", features = ["derive"] }
 futures    = { version = "0.3" }
 maplit     = { version = "1.0.2" }
 serde      = { version = "1.0.114", features = ["derive", "rc"] }
 serde_json = { version = "1.0.57" }
 tokio      = { version = "1.39", default-features = false, features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time", "tracing"] }
 tracing    = { version = "0.1.29" }
+
+console-subscriber  = { version = "0.5", optional = true }
+tracing-flame       = { version = "0.2", optional = true }
+tracing-subscriber  = { version = "0.3", optional = true }
+
+[dev-dependencies]
 
 [features]
 bt = ["openraft/bt"]

--- a/cluster_benchmark/README.md
+++ b/cluster_benchmark/README.md
@@ -32,5 +32,25 @@ The benchmark is conducted with the following settings:
 `make bench_cluster_of_3` in repo root folder, or in this folder:
 
 ```sh
-cargo test --test benchmark --release bench_cluster_of_3 -- --ignored --nocapture
+# Run with default settings (32 workers, 256 clients, 50000 ops/client, 3 members)
+cargo run --release --bin bench
+
+# Customize parameters
+cargo run --release --bin bench -- -w 32 -c 1024 -n 100000 -m 3
+
+# With tokio-console (for async task debugging)
+RUSTFLAGS="--cfg tokio_unstable" cargo run --release --bin bench --features tokio-console
+
+# With flamegraph profiling
+cargo run --release --bin bench --features flamegraph
+# Then generate SVG: inferno-flamegraph flamegraph.folded > flamegraph.svg
+```
+
+### CLI Options
+
+```
+-w, --workers     Number of worker threads [default: 32]
+-c, --clients     Number of client tasks [default: 256]
+-n, --operations  Operations per client [default: 50000]
+-m, --members     Cluster size (1, 3, or 5) [default: 3]
 ```

--- a/cluster_benchmark/src/bin/bench.rs
+++ b/cluster_benchmark/src/bin/bench.rs
@@ -1,3 +1,7 @@
+//! Openraft cluster benchmark binary.
+//!
+//! Run with: cargo run --release --bin bench -- --help
+
 use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -5,29 +9,37 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
-use maplit::btreeset;
+use clap::Parser;
+use cluster_benchmark::network::Router;
+use cluster_benchmark::store::ClientRequest;
 use openraft::Config;
 use tokio::runtime::Builder;
+
 #[cfg(feature = "flamegraph")]
 use tracing_flame::FlushGuard;
 
-use crate::network::Router;
-use crate::store::ClientRequest;
+/// Openraft cluster benchmark
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Number of worker threads for the tokio runtime
+    #[arg(short = 'w', long, default_value_t = 32)]
+    workers: usize,
 
-#[cfg(feature = "flamegraph")]
-fn init_flamegraph(path: &str) -> Result<FlushGuard<std::io::BufWriter<std::fs::File>>, tracing_flame::Error> {
-    use tracing_flame::FlameLayer;
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::util::SubscriberInitExt;
+    /// Number of client tasks to spawn
+    #[arg(short = 'c', long, default_value_t = 256)]
+    clients: u64,
 
-    let (flame_layer, guard) = FlameLayer::with_file(path)?;
-    tracing_subscriber::registry().with(flame_layer).init();
-    eprintln!("flamegraph profiling enabled, output: {}", path);
-    Ok(guard)
+    /// Number of operations per client
+    #[arg(short = 'n', long, default_value_t = 50000)]
+    operations: u64,
+
+    /// Number of raft cluster members (1, 3, or 5)
+    #[arg(short = 'm', long, default_value_t = 3)]
+    members: u64,
 }
 
 struct BenchConfig {
-    /// Worker threads for both client and server tasks
     pub worker_threads: usize,
     pub n_operations: u64,
     pub n_client: u64,
@@ -44,40 +56,33 @@ impl Display for BenchConfig {
     }
 }
 
-#[test]
-#[ignore]
-fn bench_cluster_of_1() -> anyhow::Result<()> {
-    bench_with_config(&BenchConfig {
-        worker_threads: 32,
-        n_operations: 100_000,
-        n_client: 256,
-        members: btreeset! {0},
-    })?;
-    Ok(())
+#[cfg(feature = "flamegraph")]
+fn init_flamegraph(path: &str) -> Result<FlushGuard<std::io::BufWriter<std::fs::File>>, tracing_flame::Error> {
+    use tracing_flame::FlameLayer;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    let (flame_layer, guard) = FlameLayer::with_file(path)?;
+    tracing_subscriber::registry().with(flame_layer).init();
+    eprintln!("flamegraph profiling enabled, output: {}", path);
+    Ok(guard)
 }
 
-#[test]
-#[ignore]
-fn bench_cluster_of_3() -> anyhow::Result<()> {
-    bench_with_config(&BenchConfig {
-        worker_threads: 32,
-        n_operations: 100_000,
-        n_client: 1024 * 4,
-        members: btreeset! {0,1,2},
-    })?;
-    Ok(())
-}
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
 
-#[test]
-#[ignore]
-fn bench_cluster_of_5() -> anyhow::Result<()> {
-    bench_with_config(&BenchConfig {
-        worker_threads: 32,
-        n_operations: 100_000,
-        n_client: 256,
-        members: btreeset! {0,1,2,3,4},
-    })?;
-    Ok(())
+    let members: BTreeSet<u64> = (0..args.members).collect();
+
+    let bench_config = BenchConfig {
+        worker_threads: args.workers,
+        n_operations: args.operations,
+        n_client: args.clients,
+        members,
+    };
+
+    eprintln!("Benchmark config: {}", bench_config);
+
+    bench_with_config(&bench_config)
 }
 
 fn bench_with_config(bench_config: &BenchConfig) -> anyhow::Result<()> {
@@ -100,7 +105,6 @@ fn bench_with_config(bench_config: &BenchConfig) -> anyhow::Result<()> {
         .thread_stack_size(3 * 1024 * 1024)
         .build()?;
 
-    // Run client_write benchmark
     rt.block_on(do_bench(bench_config))
 }
 

--- a/cluster_benchmark/src/lib.rs
+++ b/cluster_benchmark/src/lib.rs
@@ -1,0 +1,10 @@
+#![deny(unused_crate_dependencies)]
+#![deny(unused_qualifications)]
+#![cfg_attr(feature = "bt", feature(error_generic_member_access))]
+
+// Used by bin/bench.rs
+use clap as _;
+use maplit as _;
+
+pub mod network;
+pub mod store;

--- a/cluster_benchmark/src/store.rs
+++ b/cluster_benchmark/src/store.rs
@@ -1,4 +1,4 @@
-mod test;
+//! A minimized store with least cost for benchmarking Openraft.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -14,7 +14,6 @@ use futures::Stream;
 use openraft::alias::LogIdOf;
 use openraft::alias::SnapshotDataOf;
 use openraft::entry::RaftEntry;
-use openraft::storage::EntryResponder;
 use openraft::storage::IOFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogReader;
@@ -28,6 +27,7 @@ use openraft::OptionalSend;
 use openraft::SnapshotMeta;
 use openraft::StoredMembership;
 use openraft::Vote;
+use openraft::storage::EntryResponder;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::RwLock;
@@ -115,6 +115,12 @@ impl StateMachineStore {
             snapshot_idx: AtomicU64::new(0),
             current_snapshot: RwLock::new(None),
         }
+    }
+}
+
+impl Default for StateMachineStore {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/cluster_benchmark/tests/benchmark/main.rs
+++ b/cluster_benchmark/tests/benchmark/main.rs
@@ -1,8 +1,3 @@
-#![deny(unused_crate_dependencies)]
-#![deny(unused_qualifications)]
 #![cfg_attr(feature = "bt", feature(error_generic_member_access))]
 
-pub(crate) mod network;
-pub(crate) mod store;
-
-mod bench_cluster;
+mod store_test;

--- a/cluster_benchmark/tests/benchmark/store_test.rs
+++ b/cluster_benchmark/tests/benchmark/store_test.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
+use cluster_benchmark::store::LogStore;
+use cluster_benchmark::store::StateMachineStore;
+use cluster_benchmark::store::TypeConfig;
 use openraft::testing::log::StoreBuilder;
 use openraft::testing::log::Suite;
 use openraft::StorageError;
-
-use crate::store::LogStore;
-use crate::store::StateMachineStore;
-use crate::store::TypeConfig;
 
 struct Builder {}
 


### PR DESCRIPTION

## Changelog

##### refactor: convert cluster benchmark from test to binary
Convert the cluster benchmark from a Rust test format to a standalone
binary program. This makes the benchmark easier to run, profile, and
customize via command-line arguments.

Changes:
- Add `clap` for CLI argument parsing with `-w`, `-c`, `-n`, `-m` options
- Update Makefile targets to use `cargo run --bin bench`


##### feat: add flamegraph profiling support to cluster benchmark
Add tracing-flame based profiling to generate flamegraph data for
performance analysis. The profiling is gated behind the `flamegraph`
feature flag to avoid adding dependencies for normal builds.

Changes:
- Add `flamegraph` feature flag to enable profiling

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1555)
<!-- Reviewable:end -->
