### PR TITLE
docs: clarify `Raft::initialize()` usage for cluster formation

### DIFF
--- a/openraft/src/docs/cluster_control/cluster-formation.md
+++ b/openraft/src/docs/cluster_control/cluster-formation.md
@@ -21,18 +21,23 @@ This method will:
 
 - The leader will commit a blank log to commit all previous logs.
 
+### Recommended Usage
+
+The simplest and most appropriate way to initialize a cluster is to call `initialize()`
+on **exactly one node**. The other nodes should remain empty and wait for the initialized
+node to replicate logs to them.
+
+Calling `initialize()` on multiple nodes with **identical configuration** is also
+acceptable and will not cause any consistency issues — the Raft voting protocol ensures
+that only one leader will be elected.
+
+However, calling `initialize()` with **different configurations** on different nodes
+may lead to a split-brain condition and must be avoided.
+
 ### Errors and Failures
 
 - If this method is called on a node that has already been initialized, it will simply return an error and remain safe,
   i.e., if `last_log_id` on this node is not `None`, or `vote` on this node is not `(0,0)`.
-
-- If this method is called on more than one node simultaneously:
-
-    - with the same `membership`, it is safe,
-      as the voting protocol ensures consistency.
-
-    - with different `membership`, it is **ILLEGAL** and will lead to an undefined
-      state, also known as the **split-brain** state.
 
 ### Preconditions for Initialization
 

--- a/openraft/src/docs/faq/01-getting-started/01-initialize-cluster.md
+++ b/openraft/src/docs/faq/01-getting-started/01-initialize-cluster.md
@@ -1,18 +1,21 @@
 ### How to initialize a cluster?
 
-There are two ways to initialize a raft cluster, assuming there are three nodes,
-`n1, n2, n3`:
+The simplest and most appropriate way to initialize a cluster is to call
+`Raft::initialize()` on **exactly one node**. The other nodes should remain
+empty and wait for the initialized node to replicate logs to them.
 
-1. Single-step method:
-   Call `Raft::initialize()` on any one of the nodes with the configuration of
-   all three nodes, e.g. `n2.initialize(btreeset! {1,2,3})`.
+Assuming there are three nodes `n1, n2, n3`, there are two approaches:
 
-2. Incremental method:
-   First, call `Raft::initialize()` on `n1` with configuration containing `n1`
-   itself, e.g., `n1.initialize(btreeset! {1})`.
+1. **Single-step method**:
+   Call `Raft::initialize()` on one node (e.g., `n1`) with the configuration of
+   all three nodes: `n1.initialize(btreeset! {1,2,3})`.
+   The initialized node will then replicate the membership to the other nodes.
+
+2. **Incremental method**:
+   First, call `Raft::initialize()` on `n1` with configuration containing only `n1`
+   itself: `n1.initialize(btreeset! {1})`.
    Subsequently use `Raft::change_membership()` on `n1` to add `n2` and `n3`
    into the cluster.
 
-Employing the second method provides the flexibility to start with a single-node
-cluster for testing purposes and subsequently expand it to a three-node cluster
-for deployment in a production environment.
+The incremental method provides flexibility to start with a single-node
+cluster for testing and expand it later for production.

--- a/openraft/src/docs/faq/01-getting-started/03-initialize-multiple-nodes.md
+++ b/openraft/src/docs/faq/01-getting-started/03-initialize-multiple-nodes.md
@@ -1,0 +1,8 @@
+### Can I call `initialize()` on multiple nodes?
+
+Calling `initialize()` on multiple nodes with **identical configuration** is
+acceptable and will not cause consistency issues — the Raft voting protocol
+ensures that only one leader will be elected.
+
+However, calling `initialize()` with **different configurations** on different
+nodes may lead to a split-brain condition and must be avoided.

--- a/openraft/src/docs/faq/faq-toc.md
+++ b/openraft/src/docs/faq/faq-toc.md
@@ -1,6 +1,7 @@
 - [Getting Started](#getting-started)
   * [How to initialize a cluster?](#how-to-initialize-a-cluster)
   * [Are there any issues with running a single node service?](#are-there-any-issues-with-running-a-single-node-service)
+  * [Can I call `initialize()` on multiple nodes?](#can-i-call-initialize-on-multiple-nodes)
 - [Core Concepts](#core-concepts)
   * [What are the differences between Openraft and standard Raft?](#what-are-the-differences-between-openraft-and-standard-raft)
   * [Why is log id a tuple of `(term, node_id, log_index)`?](#why-is-log-id-a-tuple-of-term-node_id-log_index)

--- a/openraft/src/docs/faq/faq.md
+++ b/openraft/src/docs/faq/faq.md
@@ -2,22 +2,25 @@
 
 ### How to initialize a cluster?
 
-There are two ways to initialize a raft cluster, assuming there are three nodes,
-`n1, n2, n3`:
+The simplest and most appropriate way to initialize a cluster is to call
+`Raft::initialize()` on **exactly one node**. The other nodes should remain
+empty and wait for the initialized node to replicate logs to them.
 
-1. Single-step method:
-   Call `Raft::initialize()` on any one of the nodes with the configuration of
-   all three nodes, e.g. `n2.initialize(btreeset! {1,2,3})`.
+Assuming there are three nodes `n1, n2, n3`, there are two approaches:
 
-2. Incremental method:
-   First, call `Raft::initialize()` on `n1` with configuration containing `n1`
-   itself, e.g., `n1.initialize(btreeset! {1})`.
+1. **Single-step method**:
+   Call `Raft::initialize()` on one node (e.g., `n1`) with the configuration of
+   all three nodes: `n1.initialize(btreeset! {1,2,3})`.
+   The initialized node will then replicate the membership to the other nodes.
+
+2. **Incremental method**:
+   First, call `Raft::initialize()` on `n1` with configuration containing only `n1`
+   itself: `n1.initialize(btreeset! {1})`.
    Subsequently use `Raft::change_membership()` on `n1` to add `n2` and `n3`
    into the cluster.
 
-Employing the second method provides the flexibility to start with a single-node
-cluster for testing purposes and subsequently expand it to a three-node cluster
-for deployment in a production environment.
+The incremental method provides flexibility to start with a single-node
+cluster for testing and expand it later for production.
 
 
 ### Are there any issues with running a single node service?
@@ -28,6 +31,16 @@ Running a cluster with just one node is a standard approach for testing or as an
 
 A single node functions exactly the same as cluster mode.
 It will consistently maintain the `Leader` status and never transition to `Candidate` or `Follower` states.
+
+
+### Can I call `initialize()` on multiple nodes?
+
+Calling `initialize()` on multiple nodes with **identical configuration** is
+acceptable and will not cause consistency issues — the Raft voting protocol
+ensures that only one leader will be elected.
+
+However, calling `initialize()` with **different configurations** on different
+nodes may lead to a split-brain condition and must be avoided.
 
 
 ## Core Concepts

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -1133,19 +1133,24 @@ where C: RaftTypeConfig
     /// if the cluster is initialized with [`Raft::is_initialized()`] and then avoid re-initialize
     /// it in case you want to get rid of this error.
     ///
-    /// This command will work for single-node or multi-node cluster formation. This command
-    /// should be called with all discovered nodes which need to be part of cluster, and as such
-    /// it is recommended that applications be configured with an initial cluster formation delay
-    /// which will allow time for the initial members of the cluster to be discovered (by the
-    /// parent application) for this call.
+    /// ## Recommended Usage
     ///
-    /// Once a node successfully initialized it will commit a new membership config
-    /// log entry to store.
-    /// Then it starts to work, i.e., entering Candidate state and try electing itself as the
+    /// The simplest and most appropriate way to initialize a cluster is to call `initialize()`
+    /// on **exactly one node**. The other nodes should remain empty and wait for the initialized
+    /// node to replicate logs to them.
+    ///
+    /// Calling `initialize()` on multiple nodes with **identical configuration** is also
+    /// acceptable and will not cause any consistency issues — the Raft voting protocol ensures
+    /// that only one leader will be elected.
+    ///
+    /// However, calling `initialize()` with **different configurations** on different nodes
+    /// may lead to a split-brain condition and must be avoided.
+    ///
+    /// ## Behavior
+    ///
+    /// Once a node is successfully initialized, it will commit a new membership config
+    /// log entry to store, then enter Candidate state and attempt to elect itself as the
     /// leader.
-    ///
-    /// More than one node performing `initialize()` with the same config is safe,
-    /// with different config will result in split brain condition.
     ///
     /// # Examples
     ///


### PR DESCRIPTION

## Changelog

##### docs: clarify `Raft::initialize()` usage for cluster formation
Updated documentation to clarify that calling `initialize()` on exactly
one node is the simplest and recommended approach. Also documented that
calling `initialize()` on multiple nodes with identical configuration is
acceptable, while different configurations may lead to split-brain.

Changes:
- Add "Recommended Usage" section to `Raft::initialize()` doc comment
- Add "Recommended Usage" section to cluster-formation.md
- Update FAQ to emphasize single-node initialization as the preferred approach
- Add new FAQ entry for multi-node `initialize()` usage

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1557)
<!-- Reviewable:end -->
