### PR TITLE
refactor: add `StreamId` for unique replication stream identification

### DIFF
--- a/openraft/src/base/mod.rs
+++ b/openraft/src/base/mod.rs
@@ -29,6 +29,7 @@
 
 pub(crate) mod finalized;
 pub(crate) mod histogram;
+pub(crate) mod shared_id_generator;
 
 pub use serde_able::OptionalSerde;
 pub use threaded::BoxAny;

--- a/openraft/src/base/shared_id_generator.rs
+++ b/openraft/src/base/shared_id_generator.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SharedIdGenerator {
+    next_id: Arc<AtomicU64>,
+}
+
+impl Default for SharedIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for SharedIdGenerator {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.next_id, &other.next_id)
+    }
+}
+
+impl Eq for SharedIdGenerator {}
+
+impl SharedIdGenerator {
+    pub(crate) fn new() -> Self {
+        Self {
+            next_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+    pub(crate) fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_next_id_sequential() {
+        let id_gen = SharedIdGenerator::new();
+
+        assert_eq!(1, id_gen.next_id());
+        assert_eq!(2, id_gen.next_id());
+        assert_eq!(3, id_gen.next_id());
+    }
+
+    #[test]
+    fn test_clones_share_counter() {
+        let id_gen1 = SharedIdGenerator::new();
+        let id_gen2 = id_gen1.clone();
+
+        assert_eq!(1, id_gen1.next_id());
+        assert_eq!(2, id_gen2.next_id());
+        assert_eq!(3, id_gen1.next_id());
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let id_gen1 = SharedIdGenerator::new();
+        let id_gen2 = id_gen1.clone();
+        let id_gen3 = SharedIdGenerator::new();
+
+        assert_eq!(id_gen1, id_gen2);
+        assert_ne!(id_gen1, id_gen3);
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        use std::thread;
+
+        let id_gen = SharedIdGenerator::new();
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let g = id_gen.clone();
+            handles.push(thread::spawn(move || (0..100).map(|_| g.next_id()).collect::<Vec<_>>()));
+        }
+
+        let mut all_ids: Vec<u64> = handles.into_iter().flat_map(|h| h.join().unwrap()).collect();
+
+        all_ids.sort();
+
+        // All IDs should be unique and sequential from 1 to 1000
+        let expected: Vec<u64> = (1..=1000).collect();
+        assert_eq!(expected, all_ids);
+    }
+}

--- a/openraft/src/core/heartbeat/event.rs
+++ b/openraft/src/core/heartbeat/event.rs
@@ -4,7 +4,6 @@ use crate::LogId;
 use crate::RaftTypeConfig;
 use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
-use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
 
@@ -19,13 +18,6 @@ where C: RaftTypeConfig
     /// The Leader uses this sending time to calculate the quorum acknowledge time, but not the
     /// receiving timestamp.
     pub(crate) time: InstantOf<C>,
-
-    /// The vote of the Leader that submits this heartbeat and the log id of the cluster config.
-    ///
-    /// The response that matches this session id is considered as a valid response.
-    /// Otherwise, it is considered as an outdated response from older leader or older cluster
-    /// membership config and will be ignored.
-    pub(crate) session_id: ReplicationSessionId<C>,
 
     /// The last known matching log id that has been confirmed replicated to the target follower.
     ///
@@ -46,9 +38,8 @@ where C: RaftTypeConfig
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "(time={}, leader_vote: {}, matching: {}, committed: {})",
+            "(time={}, matching: {}, committed: {})",
             self.time.display(),
-            self.session_id,
             self.matching.display(),
             self.committed.display()
         )

--- a/openraft/src/core/heartbeat/handle.rs
+++ b/openraft/src/core/heartbeat/handle.rs
@@ -12,11 +12,14 @@ use crate::async_runtime::watch::WatchSender;
 use crate::core::heartbeat::event::HeartbeatEvent;
 use crate::core::heartbeat::worker::HeartbeatWorker;
 use crate::core::notification::Notification;
+use crate::engine::ReplicationProgress;
+use crate::progress::stream_id::StreamId;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::JoinHandleOf;
 use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::WatchSenderOf;
+use crate::vote::committed::CommittedVote;
 
 /// Handle for a single heartbeat worker task.
 pub(crate) struct WorkerHandle<C>
@@ -24,6 +27,9 @@ where C: RaftTypeConfig
 {
     /// Channel to send heartbeat events to the worker.
     event_tx: WatchSenderOf<C, Option<HeartbeatEvent<C>>>,
+
+    #[allow(dead_code)]
+    stream_id: StreamId,
 
     /// Channel to signal shutdown to the worker.
     ///
@@ -62,48 +68,66 @@ where C: RaftTypeConfig
         }
     }
 
+    pub(crate) fn close_workers(&mut self) {
+        self.workers = Default::default();
+    }
+
     pub(crate) async fn spawn_workers<NF>(
         &mut self,
+        leader_vote: CommittedVote<C>,
         network_factory: &mut NF,
         tx_notification: &MpscSenderOf<C, Notification<C>>,
-        targets: impl IntoIterator<Item = (C::NodeId, C::Node)>,
+        progresses: impl IntoIterator<Item = &ReplicationProgress<C>>,
+        close_old: bool,
     ) where
         NF: RaftNetworkFactory<C>,
     {
-        for (target, node) in targets {
-            tracing::debug!("id={} spawn HeartbeatWorker target={}", self.id, target);
-            let network = network_factory.new_client(target.clone(), &node).await;
+        let mut new_workers = BTreeMap::new();
 
-            let (tx, rx) = C::watch_channel(None);
+        for prog in progresses {
+            tracing::debug!("id={} spawn HeartbeatWorker target={}", self.id, prog.target);
 
-            let worker = HeartbeatWorker {
-                id: self.id.clone(),
-                rx,
-                network,
-                target: target.clone(),
-                node,
-                config: self.config.clone(),
-                tx_notification: tx_notification.clone(),
+            let removed = self.workers.remove(&prog.target);
+
+            let handle = removed.filter(|_removed| !close_old);
+
+            let handle = if let Some(handle) = handle {
+                handle
+            } else {
+                let network = network_factory.new_client(prog.target.clone(), &prog.target_node).await;
+
+                let (tx, rx) = C::watch_channel(None);
+
+                let worker = HeartbeatWorker {
+                    id: self.id.clone(),
+                    leader_vote: leader_vote.clone(),
+                    stream_id: prog.progress.stream_id,
+                    rx,
+                    network,
+                    target: prog.target.clone(),
+                    node: prog.target_node.clone(),
+                    config: self.config.clone(),
+                    tx_notification: tx_notification.clone(),
+                };
+
+                let span = tracing::span!(parent: &Span::current(), Level::DEBUG, "heartbeat", id=display(&self.id), target=display(&prog.target));
+
+                let (tx_shutdown, rx_shutdown) = C::oneshot();
+
+                let worker_handle = C::spawn(worker.run(rx_shutdown).instrument(span));
+
+                WorkerHandle {
+                    event_tx: tx,
+                    stream_id: prog.progress.stream_id,
+                    _shutdown_tx: tx_shutdown,
+                    _join_handle: worker_handle,
+                }
             };
 
-            let span = tracing::span!(parent: &Span::current(), Level::DEBUG, "heartbeat", id=display(&self.id), target=display(&target));
-
-            let (tx_shutdown, rx_shutdown) = C::oneshot();
-
-            let worker_handle = C::spawn(worker.run(rx_shutdown).instrument(span));
-
-            let handle = WorkerHandle {
-                event_tx: tx,
-                _shutdown_tx: tx_shutdown,
-                _join_handle: worker_handle,
-            };
-
-            self.workers.insert(target, handle);
+            new_workers.insert(prog.target.clone(), handle);
         }
-    }
 
-    pub(crate) fn shutdown(&mut self) {
-        self.workers.clear();
-        tracing::info!("id={} HeartbeatWorker are shutdown", self.id);
+        // All the left are dropped and closed.
+        let _left = std::mem::replace(&mut self.workers, new_workers);
     }
 }

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -6,10 +6,10 @@ use crate::core::sm;
 use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::display_option::DisplayOptionExt;
 use crate::progress::inflight_id::InflightId;
+use crate::progress::stream_id::StreamId;
 use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
 use crate::replication;
-use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
@@ -39,9 +39,6 @@ where C: RaftTypeConfig
 
         /// The Leader that sent the replication request.
         leader_vote: CommittedVote<C>,
-        // TODO: need this?
-        // /// The cluster this replication works for.
-        // membership_log_id: Option<LogIdOf<C>>,
     },
 
     /// [`StorageError`] error has taken place locally(not on remote node),
@@ -68,7 +65,7 @@ where C: RaftTypeConfig
     },
 
     HeartbeatProgress {
-        session_id: ReplicationSessionId<C>,
+        stream_id: StreamId,
         sending_time: InstantOf<C>,
         target: C::NodeId,
     },
@@ -124,7 +121,7 @@ where C: RaftTypeConfig
                 write!(f, "{}, inflight_id: {}", progress, inflight_id.display())
             }
             Self::HeartbeatProgress {
-                session_id: leader_vote,
+                stream_id: leader_vote,
                 sending_time,
                 target,
             } => {

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -74,7 +74,7 @@ use crate::network::RPCTypes;
 use crate::network::RaftNetworkFactory;
 use crate::network::v2::RaftNetworkV2;
 use crate::progress::Progress;
-use crate::progress::entry::ProgressEntry;
+use crate::progress::stream_id::StreamId;
 use crate::quorum::QuorumSet;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::ClientWriteResult;
@@ -893,23 +893,20 @@ where
     #[allow(clippy::type_complexity)]
     pub(crate) async fn spawn_replication_stream(
         &mut self,
-        target: C::NodeId,
-        progress_entry: ProgressEntry<C>,
+        leader_vote: CommittedVote<C>,
+        prog: &ReplicationProgress<C>,
     ) -> ReplicationHandle<C> {
-        // Safe unwrap(): target must be in membership
-        let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
-
-        let network = self.network_factory.new_client(target.clone(), target_node).await;
+        let network = self.network_factory.new_client(prog.target.clone(), &prog.target_node).await;
 
         let (replicate_tx, replicate_rx) = C::watch_channel(Replicate::default());
 
         let event_watcher = self.new_event_watcher(replicate_rx);
 
-        let (mut replication_handle, replication_context) = self.new_replication(target.clone(), replicate_tx);
+        let (mut replication_handle, replication_context) = self.new_replication(leader_vote, prog, replicate_tx);
 
         let progress = replication_progress::ReplicationProgress {
             local_committed: self.engine.state.committed().cloned(),
-            remote_matched: progress_entry.matching.clone(),
+            remote_matched: prog.progress.matching.clone(),
         };
 
         let join_handel = ReplicationCore::<C, NF, LS>::spawn(
@@ -918,7 +915,7 @@ where
             network,
             self.log_store.get_log_reader().await,
             event_watcher,
-            tracing::span!(parent: &self.span, Level::DEBUG, "replication", id=display(&self.id), target=display(&target)),
+            tracing::span!(parent: &self.span, Level::DEBUG, "replication", id=display(&self.id), target=display(&prog.target)),
         );
 
         replication_handle.join_handle = Some(join_handel);
@@ -928,32 +925,32 @@ where
 
     fn new_replication(
         &self,
-        target: C::NodeId,
+        leader_vote: CommittedVote<C>,
+        prog: &ReplicationProgress<C>,
         replicate_tx: WatchSenderOf<C, Replicate<C>>,
     ) -> (ReplicationHandle<C>, ReplicationContext<C>) {
         let (cancel_tx, cancel_rx) = C::watch_channel(());
 
-        let context = self.new_replication_context(target.clone(), cancel_rx);
+        let context = self.new_replication_context(leader_vote, prog, cancel_rx);
 
-        let handle = ReplicationHandle::new(context.session_id.clone(), replicate_tx, cancel_tx);
+        let handle = ReplicationHandle::new(prog.progress.stream_id, replicate_tx, cancel_tx);
 
         (handle, context)
     }
 
-    fn new_replication_context(&self, target: C::NodeId, cancel_rx: WatchReceiverOf<C, ()>) -> ReplicationContext<C> {
+    fn new_replication_context(
+        &self,
+        leader_vote: CommittedVote<C>,
+        prog: &ReplicationProgress<C>,
+        cancel_rx: WatchReceiverOf<C, ()>,
+    ) -> ReplicationContext<C> {
         let id = self.id.clone();
-
-        let membership_log_id = self.engine.state.membership_state.effective().log_id();
-
-        let session_id = {
-            let leader = self.engine.leader.as_ref().unwrap();
-            ReplicationSessionId::new(leader.committed_vote.clone(), membership_log_id.clone())
-        };
 
         ReplicationContext {
             id,
-            target,
-            session_id: session_id.clone(),
+            target: prog.target.clone(),
+            leader_vote,
+            stream_id: prog.progress.stream_id,
             config: self.config.clone(),
             tx_notify: self.tx_notification.clone(),
             cancel_rx,
@@ -1541,11 +1538,11 @@ where
                 leader_vote,
             } => {
                 tracing::info!(
-                    target = display(target),
-                    higher_vote = display(&higher),
-                    sending_vote = display(&leader_vote),
-                    "received Notification::HigherVote: {}",
-                    func_name!()
+                    "{}: received Notification::HigherVote, target: {}, higher_vote: {}, sending_vote: {}",
+                    func_name!(),
+                    target,
+                    higher,
+                    leader_vote
                 );
 
                 if self.does_leader_vote_match(&leader_vote, "HigherVote") {
@@ -1631,28 +1628,18 @@ where
             Notification::ReplicationProgress { progress, inflight_id } => {
                 tracing::debug!(progress = display(&progress), "recv Notification::ReplicationProgress");
 
-                // replication_handler() won't panic because:
-                // The leader is still valid because progress.session_id.leader_vote does not change.
-                if self.engine.leader.is_some() {
-                    self.engine.replication_handler().update_progress(progress.target, progress.result, inflight_id);
+                if let Some(mut rh) = self.engine.try_replication_handler() {
+                    rh.update_progress(progress.target, progress.result, inflight_id);
                 }
             }
 
             Notification::HeartbeatProgress {
-                session_id,
+                stream_id,
                 sending_time,
                 target,
             } => {
-                if self.does_replication_session_match(&session_id, "HeartbeatProgress") {
-                    tracing::debug!(
-                        session_id = display(&session_id),
-                        target = display(&target),
-                        sending_time = display(sending_time.display()),
-                        "HeartbeatProgress"
-                    );
-                    // replication_handler() won't panic because:
-                    // The leader is still valid because progress.session_id.leader_vote does not change.
-                    self.engine.replication_handler().update_leader_clock(target, sending_time);
+                if let Some(mut rh) = self.engine.try_replication_handler() {
+                    rh.try_update_leader_clock(stream_id, target, sending_time);
                 }
             }
 
@@ -1807,29 +1794,6 @@ where
         }
     }
 
-    /// If a message is sent by a previous replication session but is received by current server
-    /// state, it is a stale message and should be just ignored.
-    fn does_replication_session_match(
-        &self,
-        session_id: &ReplicationSessionId<C>,
-        msg: impl fmt::Display + Copy,
-    ) -> bool {
-        if !self.does_leader_vote_match(&session_id.committed_vote(), msg) {
-            return false;
-        }
-
-        if &session_id.membership_log_id != self.engine.state.membership_state.effective().log_id() {
-            tracing::warn!(
-                "membership_log_id changed: msg sent by: {}; curr: {}; ignore when ({})",
-                session_id.membership_log_id.display(),
-                self.engine.state.membership_state.effective().log_id().display(),
-                msg
-            );
-            return false;
-        }
-        true
-    }
-
     /// Broadcast heartbeat to all followers with per-follower matching log ids.
     ///
     /// This method validates the session and sends heartbeat events only if the current
@@ -1861,7 +1825,6 @@ where
                 .map(|progress_entry| {
                     (progress_entry.id.clone(), HeartbeatEvent {
                         time: now,
-                        session_id: session_id.clone(),
                         matching: progress_entry.val.matching.clone(),
                         committed: committed.clone(),
                     })
@@ -1876,14 +1839,16 @@ where
     /// cancellation channel. Dropping the sender signals the task to stop.
     pub(crate) fn new_replication_task_context(
         &self,
-        session_id: ReplicationSessionId<C>,
+        leader_vote: CommittedVote<C>,
+        stream_id: StreamId,
         target: C::NodeId,
     ) -> (ReplicationContext<C>, WatchSenderOf<C, ()>) {
         let (cancel_tx, cancel_rx) = C::watch_channel(());
         let ctx = ReplicationContext {
             id: self.id.clone(),
             target,
-            session_id,
+            leader_vote,
+            stream_id,
             config: self.config.clone(),
             tx_notify: self.tx_notification.clone(),
             cancel_rx,
@@ -2044,13 +2009,17 @@ where
                 let node = self.replications.get(&target).expect("replication to target node exists");
                 let _ = node.replicate_tx.send(req);
             }
-            Command::ReplicateSnapshot { target, inflight_id } => {
+            Command::ReplicateSnapshot {
+                leader_vote,
+                target,
+                inflight_id,
+            } => {
                 let node = self.replications.get(&target).expect("replication to target node exists");
 
                 let snapshot_reader = self.sm_handle.new_snapshot_reader();
-                let session_id = node.session_id.clone();
+                let stream_id = node.stream_id;
                 let (replication_task_context, cancel_tx) =
-                    self.new_replication_task_context(session_id, target.clone());
+                    self.new_replication_task_context(leader_vote, stream_id, target.clone());
 
                 let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
                 let snapshot_network = self.network_factory.new_client(target.clone(), target_node).await;
@@ -2069,29 +2038,52 @@ where
             }
             Command::BroadcastTransferLeader { req } => self.broadcast_transfer_leader(req).await,
 
+            Command::CloseReplicationStreams => {
+                self.heartbeat_handle.close_workers();
+
+                let left = std::mem::take(&mut self.replications);
+                for (target, s) in left {
+                    Self::close_replication(&target, s).await;
+                }
+            }
             Command::RebuildReplicationStreams {
+                leader_vote,
                 targets,
                 close_old_streams,
             } => {
-                self.heartbeat_handle.shutdown();
+                self.heartbeat_handle
+                    .spawn_workers(
+                        leader_vote.clone(),
+                        &mut self.network_factory,
+                        &self.tx_notification,
+                        &targets,
+                        close_old_streams,
+                    )
+                    .await;
 
                 let mut new_replications = BTreeMap::new();
 
-                for ReplicationProgress(target, matching) in targets.iter() {
-                    let removed = self.replications.remove(target);
+                for prog in targets.iter() {
+                    let removed = self.replications.remove(&prog.target);
 
                     let handle = if let Some(removed) = removed {
                         if close_old_streams {
-                            Self::close_replication(target, removed).await;
-                            self.spawn_replication_stream(target.clone(), matching.clone()).await
+                            Self::close_replication(&prog.target, removed).await;
+                            None
                         } else {
-                            removed
+                            Some(removed)
                         }
                     } else {
-                        self.spawn_replication_stream(target.clone(), matching.clone()).await
+                        None
                     };
 
-                    new_replications.insert(target.clone(), handle);
+                    let handle = if let Some(handle) = handle {
+                        handle
+                    } else {
+                        self.spawn_replication_stream(leader_vote.clone(), prog).await
+                    };
+
+                    new_replications.insert(prog.target.clone(), handle);
                 }
 
                 tracing::debug!("removing unused replications");
@@ -2101,17 +2093,6 @@ where
                 for (target, s) in left {
                     Self::close_replication(&target, s).await;
                 }
-
-                //
-
-                let effective = self.engine.state.membership_state.effective().clone();
-
-                let nodes = targets.into_iter().map(|p| {
-                    let node_id = p.0;
-                    (node_id.clone(), effective.get_node(&node_id).unwrap().clone())
-                });
-
-                self.heartbeat_handle.spawn_workers(&mut self.network_factory, &self.tx_notification, nodes).await;
             }
             Command::StateMachine { command } => {
                 let io_id = command.get_log_progress();

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -128,6 +128,7 @@ where C: RaftTypeConfig
             last_log_id,
             membership.to_quorum_set(),
             membership.learner_ids(),
+            self.state.progress_id_gen.clone(),
         ));
 
         self.candidate.as_mut().unwrap()
@@ -836,6 +837,20 @@ where C: RaftTypeConfig
             state: &mut self.state,
             output: &mut self.output,
         })
+    }
+
+    /// Return ReplicationHandler if it is Leader.
+    pub(crate) fn try_replication_handler(&mut self) -> Option<ReplicationHandler<'_, C>> {
+        let leader = self.leader.as_mut()?;
+
+        let rh = ReplicationHandler {
+            config: &mut self.config,
+            leader,
+            state: &mut self.state,
+            output: &mut self.output,
+        };
+
+        Some(rh)
     }
 
     pub(crate) fn replication_handler(&mut self) -> ReplicationHandler<'_, C> {

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -23,6 +23,7 @@ use crate::entry::RaftEntry;
 use crate::log_id_range::LogIdRange;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
+use crate::progress::stream_id::StreamId;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::replication::replicate::Replicate;
@@ -276,7 +277,12 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
                 ]
             },
             Command::RebuildReplicationStreams {
-                targets: vec![ReplicationProgress(2, ProgressEntry::empty(7))],
+                leader_vote: Vote::new(3, 1).into_committed(),
+                targets: vec![ReplicationProgress {
+                    target: 2,
+                    target_node: (),
+                    progress: ProgressEntry::empty(StreamId::new(8), 7),
+                }],
                 close_old_streams: false,
             },
             Command::Replicate {

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -84,10 +84,7 @@ fn test_accept_vote_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::SaveVote { vote: Vote::new(3, 3) },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
         ],
         eng.output.take_commands()
     );

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -16,6 +16,7 @@ use crate::engine::testing::log_id;
 use crate::entry::RaftEntry;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
+use crate::progress::stream_id::StreamId;
 use crate::raft_state::IOId;
 use crate::replication::payload::Payload;
 use crate::replication::replicate::Replicate;
@@ -65,7 +66,12 @@ fn test_become_leader() -> anyhow::Result<()> {
             io_id: IOId::new_log_io(Vote::new(2, 1).into_committed(), None)
         },
         Command::RebuildReplicationStreams {
-            targets: vec![ReplicationProgress(0, ProgressEntry::empty(0))],
+            leader_vote: Vote::new(2, 1).into_committed(),
+            targets: vec![ReplicationProgress {
+                target: 0,
+                target_node: (),
+                progress: ProgressEntry::empty(StreamId::new(1), 0),
+            }],
             close_old_streams: true,
         },
         Command::AppendEntries {

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -83,10 +83,7 @@ fn test_handle_message_vote_committed_vote() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(3, 2)
             },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
         ],
         eng.output.take_commands()
     );
@@ -114,13 +111,7 @@ fn test_handle_message_vote_granted_equal_vote() -> anyhow::Result<()> {
     assert!(Some(now) <= eng.state.vote_last_modified());
     assert!(eng.state.vote_last_modified() <= Some(now + Duration::from_millis(20)));
 
-    assert_eq!(
-        vec![Command::RebuildReplicationStreams {
-            targets: vec![],
-            close_old_streams: true,
-        }],
-        eng.output.take_commands()
-    );
+    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
     Ok(())
 }
 
@@ -142,10 +133,7 @@ fn test_handle_message_vote_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::SaveVote { vote: Vote::new(3, 1) },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
         ],
         eng.output.take_commands()
     );
@@ -174,10 +162,7 @@ fn test_handle_message_vote_granted_follower_learner_does_not_emit_update_server
         assert_eq!(
             vec![
                 Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::RebuildReplicationStreams {
-                    targets: vec![],
-                    close_old_streams: true,
-                },
+                Command::CloseReplicationStreams,
             ],
             eng.output.take_commands()
         );
@@ -200,10 +185,7 @@ fn test_handle_message_vote_granted_follower_learner_does_not_emit_update_server
         assert_eq!(
             vec![
                 Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::RebuildReplicationStreams {
-                    targets: vec![],
-                    close_old_streams: true,
-                },
+                Command::CloseReplicationStreams,
             ],
             eng.output.take_commands()
         );

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -229,6 +229,7 @@ where C: RaftTypeConfig
     ///
     /// This node then becomes raft-follower or raft-learner.
     pub(crate) fn become_following(&mut self) {
+        // TODO: if it is already in following state, nothing to do.
         debug_assert!(
             self.state.vote_ref().to_leader_id().node_id() != &self.config.id
                 || !self.state.membership_state.effective().membership().is_voter(&self.config.id),
@@ -238,10 +239,7 @@ where C: RaftTypeConfig
         *self.leader = None;
         *self.candidate = None;
 
-        self.output.push_command(Command::RebuildReplicationStreams {
-            targets: vec![],
-            close_old_streams: true,
-        });
+        self.output.push_command(Command::CloseReplicationStreams);
 
         self.server_state_handler().update_server_state_if_changed();
     }

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -31,7 +31,6 @@ mod command_kind;
 mod engine_config;
 mod engine_impl;
 mod engine_output;
-mod replication_progress;
 mod respond_command;
 
 pub(crate) mod command;
@@ -39,6 +38,7 @@ pub(crate) mod handler;
 pub(crate) mod leader_log_ids;
 pub(crate) mod log_id_list;
 pub(crate) mod pending_responds;
+pub(crate) mod replication_progress;
 pub(crate) mod time_state;
 
 #[cfg(test)]

--- a/openraft/src/engine/replication_progress.rs
+++ b/openraft/src/engine/replication_progress.rs
@@ -5,12 +5,16 @@ use crate::progress::entry::ProgressEntry;
 
 #[derive(Debug)]
 #[derive(PartialEq, Eq)]
-pub(crate) struct ReplicationProgress<C: RaftTypeConfig>(pub C::NodeId, pub ProgressEntry<C>);
+pub(crate) struct ReplicationProgress<C: RaftTypeConfig> {
+    pub(crate) target: C::NodeId,
+    pub(crate) target_node: C::Node,
+    pub(crate) progress: ProgressEntry<C>,
+}
 
 impl<C> fmt::Display for ReplicationProgress<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ReplicationProgress({}={})", self.0, self.1)
+        write!(f, "ReplicationProgress({}={})", self.target, self.progress)
     }
 }

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -118,10 +118,7 @@ fn test_append_entries_prev_log_id_is_applied() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
             Command::UpdateIOProgress {
                 when: Some(Condition::IOFlushed {
                     io_id: IOId::new_log_io(Vote::new(2, 1).into_committed(), None)
@@ -173,10 +170,7 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
             Command::TruncateLog { since: log_id(1, 1, 2) },
         ],
         eng.output.take_commands()
@@ -217,10 +211,7 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
             Command::TruncateLog { since: log_id(1, 1, 2) },
             Command::AppendEntries {
                 committed_vote: Vote::new(2, 1).into_committed(),
@@ -273,10 +264,7 @@ fn test_append_entries_prev_log_id_not_exists() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
         ],
         eng.output.take_commands()
     );
@@ -321,10 +309,7 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
             Command::TruncateLog { since: log_id(2, 1, 3) },
             Command::AppendEntries {
                 committed_vote: Vote::new(2, 1).into_committed(),

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -129,13 +129,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     assert!(eng.leader.is_none());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
-    assert_eq!(
-        vec![Command::RebuildReplicationStreams {
-            targets: vec![],
-            close_old_streams: true,
-        }],
-        eng.output.take_commands()
-    );
+    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
     Ok(())
 }
 
@@ -165,10 +159,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::SaveVote { vote: Vote::new(3, 1) },
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
         ],
         eng.output.take_commands()
     );
@@ -198,10 +189,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         assert_eq!(
             vec![
                 Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::RebuildReplicationStreams {
-                    targets: vec![],
-                    close_old_streams: true,
-                },
+                Command::CloseReplicationStreams,
             ],
             eng.output.take_commands()
         );
@@ -225,10 +213,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         assert_eq!(
             vec![
                 Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::RebuildReplicationStreams {
-                    targets: vec![],
-                    close_old_streams: true,
-                },
+                Command::CloseReplicationStreams,
             ],
             eng.output.take_commands()
         );

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -94,16 +94,10 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
 
     let (dummy_tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
-        vec![
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
-            Command::Respond {
-                when: None,
-                resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
-            },
-        ],
+        vec![Command::CloseReplicationStreams, Command::Respond {
+            when: None,
+            resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
+        },],
         eng.output.take_commands()
     );
 
@@ -146,10 +140,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
     let (dummy_tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
         vec![
-            Command::RebuildReplicationStreams {
-                targets: vec![],
-                close_old_streams: true,
-            },
+            Command::CloseReplicationStreams,
             Command::from(sm::Command::install_full_snapshot(
                 Snapshot {
                     meta: SnapshotMeta {

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -20,6 +20,7 @@ use crate::log_id_range::LogIdRange;
 use crate::progress::Inflight;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
+use crate::progress::stream_id::StreamId;
 use crate::raft_state::IOId;
 use crate::replication::replicate::Replicate;
 use crate::type_config::TypeConfigExt;
@@ -76,12 +77,18 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
                 io_id: IOId::new_log_io(Vote::new(2, 2).into_committed(), Some(log_id(1, 1, 3)))
             },
             Command::RebuildReplicationStreams {
-                targets: vec![ReplicationProgress(3, ProgressEntry {
-                    matching: None,
-                    inflight: Inflight::None,
-                    searching_end: 4,
-                    allow_log_reversion: false,
-                })],
+                leader_vote: Vote::new(2, 2).into_committed(),
+                targets: vec![ReplicationProgress {
+                    target: 3,
+                    target_node: (),
+                    progress: ProgressEntry {
+                        stream_id: StreamId::new(2),
+                        matching: None,
+                        inflight: Inflight::None,
+                        searching_end: 4,
+                        allow_log_reversion: false,
+                    },
+                }],
                 close_old_streams: true,
             },
             Command::AppendEntries {
@@ -129,12 +136,18 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
                 io_id: IOId::new_log_io(Vote::new(1, 2).into_committed(), Some(log_id(1, 2, 6)))
             },
             Command::RebuildReplicationStreams {
-                targets: vec![ReplicationProgress(3, ProgressEntry {
-                    matching: None,
-                    inflight: Inflight::None,
-                    searching_end: 7,
-                    allow_log_reversion: false,
-                })],
+                leader_vote: Vote::new(1, 2).into_committed(),
+                targets: vec![ReplicationProgress {
+                    target: 3,
+                    target_node: (),
+                    progress: ProgressEntry {
+                        stream_id: StreamId::new(2),
+                        matching: None,
+                        inflight: Inflight::None,
+                        searching_end: 7,
+                        allow_log_reversion: false,
+                    },
+                }],
                 close_old_streams: true,
             },
             Command::Replicate {

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod id_val;
 pub(crate) mod inflight;
 pub(crate) mod inflight_id;
 pub(crate) mod progress_stats;
+pub(crate) mod stream_id;
 pub(crate) mod vec_progress;
 
 use std::borrow::Borrow;

--- a/openraft/src/progress/stream_id.rs
+++ b/openraft/src/progress/stream_id.rs
@@ -1,0 +1,37 @@
+use std::fmt;
+use std::fmt::Formatter;
+use std::ops::Deref;
+
+/// Unique identifier for an inflight replication request.
+///
+/// Each time the leader sends logs or a snapshot to a follower, it assigns an `InflightId`.
+/// When the follower responds, the response carries the same `InflightId`, allowing the leader
+/// to correctly match responses to their corresponding requests.
+///
+/// This prevents stale responses from incorrectly updating the progress state. For example,
+/// if a slow response from a previous request arrives after a new request has been sent,
+/// the mismatched `InflightId` causes the stale response to be ignored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StreamId {
+    id: u64,
+}
+
+impl StreamId {
+    pub(crate) fn new(id: u64) -> Self {
+        Self { id }
+    }
+}
+
+impl Deref for StreamId {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.id
+    }
+}
+
+impl fmt::Display for StreamId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "StreamId({})", self.id)
+    }
+}

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crate::RaftTypeConfig;
+use crate::base::shared_id_generator::SharedIdGenerator;
 use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
 use crate::engine::leader_log_ids::LeaderLogIds;
@@ -36,6 +37,8 @@ where
     quorum_set: QS,
 
     learner_ids: Vec<C::NodeId>,
+
+    progress_id_gen: SharedIdGenerator,
 }
 
 impl<C, QS> fmt::Display for Candidate<C, QS>
@@ -66,6 +69,7 @@ where
         last_log_id: Option<LogIdOf<C>>,
         quorum_set: QS,
         learner_ids: impl IntoIterator<Item = C::NodeId>,
+        progress_id_gen: SharedIdGenerator,
     ) -> Self {
         Self {
             starting_time,
@@ -74,6 +78,7 @@ where
             progress: VecProgress::new(quorum_set.clone(), [], || false),
             quorum_set,
             learner_ids: learner_ids.into_iter().collect::<Vec<_>>(),
+            progress_id_gen,
         }
     }
 
@@ -119,6 +124,12 @@ where
         let last = self.last_log_id();
         let last_leader_log_ids = LeaderLogIds::new(last.map(|last| last.clone()..=last.clone()));
 
-        Leader::new(vote, self.quorum_set.clone(), self.learner_ids, last_leader_log_ids)
+        Leader::new(
+            vote,
+            self.quorum_set.clone(),
+            self.learner_ids,
+            last_leader_log_ids,
+            self.progress_id_gen,
+        )
     }
 }

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -39,6 +39,7 @@ pub(crate) use log_state_reader::LogStateReader;
 pub use membership_state::MembershipState;
 pub(crate) use vote_state_reader::VoteStateReader;
 
+use crate::base::shared_id_generator::SharedIdGenerator;
 use crate::display_ext::DisplayOptionExt;
 use crate::entry::RaftEntry;
 use crate::entry::raft_entry_ext::RaftEntryExt;
@@ -91,6 +92,8 @@ where C: RaftTypeConfig
     /// If a log is in use by a replication task, the purge is postponed and is stored in this
     /// field.
     pub(crate) purge_upto: Option<LogIdOf<C>>,
+
+    pub(crate) progress_id_gen: SharedIdGenerator,
 }
 
 /// This impl is only for testing, require in the test NodeId has default value.
@@ -112,6 +115,7 @@ where
             server_state: ServerState::default(),
             io_state: Valid::new(IOState::default()),
             purge_upto: None,
+            progress_id_gen: Default::default(),
         }
     }
 }
@@ -213,6 +217,7 @@ where C: RaftTypeConfig
             server_state: ServerState::default(),
             io_state: Valid::new(IOState::default()),
             purge_upto: None,
+            progress_id_gen: Default::default(),
         }
     }
 
@@ -488,6 +493,7 @@ where C: RaftTypeConfig
             em.to_quorum_set(),
             em.learner_ids(),
             last_leader_log_ids,
+            self.progress_id_gen.clone(),
         )
     }
 

--- a/openraft/src/replication/replication_context.rs
+++ b/openraft/src/replication/replication_context.rs
@@ -5,9 +5,10 @@ use crate::Config;
 use crate::RaftTypeConfig;
 use crate::core::SharedRuntimeState;
 use crate::core::notification::Notification;
-use crate::replication::ReplicationSessionId;
+use crate::progress::stream_id::StreamId;
 use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::WatchReceiverOf;
+use crate::vote::committed::CommittedVote;
 
 /// Shared context for replication tasks.
 ///
@@ -25,8 +26,11 @@ where C: RaftTypeConfig
     /// The ID of the target Raft node which replication events are to be sent to.
     pub(crate) target: C::NodeId,
 
+    /// The leader this replication works for
+    pub(crate) leader_vote: CommittedVote<C>,
+
     /// Identifies which session this replication belongs to.
-    pub(crate) session_id: ReplicationSessionId<C>,
+    pub(crate) stream_id: StreamId,
 
     /// The Raft's runtime config.
     pub(crate) config: Arc<Config>,
@@ -48,7 +52,7 @@ impl<C> fmt::Display for ReplicationContext<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{id: {}, target: {}, {}}}", self.id, self.target, self.session_id)
+        write!(f, "{{id: {}, target: {}, {}}}", self.id, self.target, self.stream_id)
     }
 }
 
@@ -59,7 +63,7 @@ where C: RaftTypeConfig
         f.debug_struct("ReplicationContext")
             .field("id", &self.id)
             .field("target", &self.target)
-            .field("session_id", &self.session_id)
+            .field("session_id", &self.stream_id)
             .field("config", &self.config)
             .finish_non_exhaustive()
     }

--- a/openraft/src/replication/replication_handle.rs
+++ b/openraft/src/replication/replication_handle.rs
@@ -1,6 +1,6 @@
 use crate::RaftTypeConfig;
 use crate::error::ReplicationClosed;
-use crate::replication::ReplicationSessionId;
+use crate::progress::stream_id::StreamId;
 use crate::replication::replicate::Replicate;
 use crate::replication::snapshot_transmitter_handle::SnapshotTransmitterHandle;
 use crate::type_config::alias::JoinHandleOf;
@@ -11,7 +11,7 @@ pub(crate) struct ReplicationHandle<C>
 where C: RaftTypeConfig
 {
     /// Identifies this replication session (leader vote + target node).
-    pub(crate) session_id: ReplicationSessionId<C>,
+    pub(crate) stream_id: StreamId,
 
     /// The channel used for communicating with the replication task.
     pub(crate) replicate_tx: WatchSenderOf<C, Replicate<C>>,
@@ -30,12 +30,12 @@ impl<C> ReplicationHandle<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(
-        session_id: ReplicationSessionId<C>,
+        stream_id: StreamId,
         replicate_tx: WatchSenderOf<C, Replicate<C>>,
         cancel_tx: WatchSenderOf<C, ()>,
     ) -> Self {
         Self {
-            session_id,
+            stream_id,
             join_handle: None,
             replicate_tx,
             snapshot_transmit_handle: None,

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -3,10 +3,7 @@ use std::fmt::Formatter;
 
 use crate::RaftTypeConfig;
 use crate::display_ext::DisplayOptionExt;
-use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::LogIdOf;
-use crate::type_config::alias::VoteOf;
-use crate::vote::RaftVote;
 use crate::vote::committed::CommittedVote;
 
 /// Uniquely identifies a replication session.
@@ -52,17 +49,5 @@ where C: RaftTypeConfig
             leader_vote: vote,
             membership_log_id,
         }
-    }
-
-    pub(crate) fn committed_vote(&self) -> CommittedVote<C> {
-        self.leader_vote.clone()
-    }
-
-    pub(crate) fn vote(&self) -> VoteOf<C> {
-        self.leader_vote.clone().into_vote()
-    }
-
-    pub(crate) fn leader_id(&self) -> &LeaderIdOf<C> {
-        self.leader_vote.leader_id()
     }
 }

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use crate::RaftTypeConfig;
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplayResultExt;
-use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::LogIdOf;
 
 /// The response of replication command.
@@ -26,15 +25,6 @@ where C: RaftTypeConfig
     ///
     /// The result also tracks the time when this request is sent.
     pub(crate) result: Result<ReplicationResult<C>, String>,
-
-    /// In which session this message is sent.
-    ///
-    /// This session id identifies a certain leader(by vote) that is replicating to a certain
-    /// group of nodes.
-    ///
-    /// A message should be discarded if it does not match the present vote and
-    /// membership_log_id.
-    pub(crate) session_id: ReplicationSessionId<C>,
 }
 
 impl<C> fmt::Display for Progress<C>
@@ -43,10 +33,9 @@ where C: RaftTypeConfig
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "replication::Progress: target={}, result: {}, session_id: {}",
+            "replication::Progress: target={}, result: {}",
             self.target,
             self.result.display(),
-            self.session_id
         )
     }
 }

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -15,6 +15,7 @@ use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::StoredMembership;
+use crate::base::shared_id_generator::SharedIdGenerator;
 use crate::display_ext::DisplayOptionExt;
 use crate::engine::LogIdList;
 use crate::entry::RaftEntry;
@@ -220,6 +221,7 @@ where
             server_state: Default::default(),
             io_state: Valid::new(io_state),
             purge_upto: last_purged_log_id,
+            progress_id_gen: SharedIdGenerator::new(),
         })
     }
 

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -479,6 +479,8 @@ where
         want.apply_progress_mut().set_id(NODE_ID.to_string());
         want.snapshot_progress_mut().set_id(NODE_ID.to_string());
 
+        want.progress_id_gen = initial.progress_id_gen.clone();
+
         assert_eq!(want, initial, "uninitialized state");
         Ok(())
     }


### PR DESCRIPTION

## Changelog

##### refactor: add `StreamId` for unique replication stream identification
This change introduces `StreamId` and `SharedIdGenerator` to uniquely identify
replication streams, replacing the previous session-based identification.
Adds `CloseReplicationStreams` command variant for when there are no replication
targets, and adds `leader_vote` field to `RebuildReplicationStreams` and
`ReplicateSnapshot` commands for proper leader identification.

Why:

Before this commit, we used a replication session ID to determine if a
notification message is valid. With this approach, when the membership changes
(e.g., a new membership is appended to the local log), the replication session
ID changes, causing all ongoing replication notifications to be considered
invalid.

This approach is too aggressive - it invalidates notifications that are actually
still valid. For example, if the membership changes from {1,2,3} to {1,2,3,4},
ongoing replication to node 2 or node 3 is still valid because these nodes
remain unchanged in the new membership. But before this commit, these
notifications were simply discarded.

This resulted in fake message loss: valid notification messages were discarded,
causing some tests to fail spuriously.

With this commit, we switch to a new approach: instead of using leader vote and
membership ID to identify notification validity, we assign a unique `StreamId`
to each replication stream. For example, replication to node 2 has a unique
stream ID. As long as this node is present in the membership configuration, the
stream ID remains valid. With this new approach, notification messages won't be
discarded even during membership changes, eliminating the spurious test
failures.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1558)
<!-- Reviewable:end -->
