### PR TITLE
refactor: convert structured logging to placeholder format

### DIFF
--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -266,7 +266,7 @@ where
             let cmd_res = CommandResult::new(res);
             resp_tx.send(Notification::sm(cmd_res)).await.ok();
         });
-        tracing::info!("{} returning; spawned building snapshot task", func_name!());
+        tracing::info!("{}: returning; spawned building snapshot task", func_name!());
     }
 
     #[tracing::instrument(level = "info", skip_all)]

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -120,7 +120,7 @@ where C: RaftTypeConfig
             && !self.state.has_log_id(prev)
         {
             let local = self.state.get_log_id(prev.index());
-            tracing::debug!(local = display(DisplayOption(&local)), "prev_log_id does not match");
+            tracing::debug!("prev_log_id does not match: local: {}", DisplayOption(&local));
 
             self.truncate_logs(prev.index());
             return Err(RejectAppendEntries::ByConflictingLogId {

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -172,12 +172,7 @@ where C: RaftTypeConfig
         log_id: Option<LogIdOf<C>>,
         inflight_id: Option<InflightId>,
     ) {
-        tracing::debug!(
-            node_id = display(&node_id),
-            log_id = display(log_id.display()),
-            "{}",
-            func_name!()
-        );
+        tracing::debug!("{}: node_id: {}, log_id: {}", func_name!(), node_id, log_id.display());
 
         debug_assert!(log_id.is_some(), "a valid update can never set matching to None");
 
@@ -193,8 +188,8 @@ where C: RaftTypeConfig
         let quorum_accepted = quorum_accepted.clone();
 
         tracing::debug!(
-            quorum_accepted = display(quorum_accepted.display()),
-            "after updating progress"
+            "after updating progress: quorum_accepted: {}",
+            quorum_accepted.display()
         );
 
         self.try_commit_quorum_accepted(quorum_accepted);
@@ -282,8 +277,9 @@ where C: RaftTypeConfig
         inflight_id: Option<InflightId>,
     ) {
         tracing::debug!(
-            "{}: target={target}, result={}, inflight_id={}, current progresses={}",
+            "{}: target: {}, result: {}, inflight_id: {}, current progresses: {}",
             func_name!(),
+            target,
             repl_res.display(),
             inflight_id.display(),
             self.leader.progress
@@ -347,7 +343,7 @@ where C: RaftTypeConfig
     /// `send_none` specifies whether to force to send a message even when there is no data to send.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn initiate_replication(&mut self) {
-        tracing::debug!(progress = debug(&self.leader.progress), "{}", func_name!());
+        tracing::debug!("{}: progress: {:?}", func_name!(), self.leader.progress);
 
         for item in self.leader.progress.iter_mut() {
             // TODO: update matching should be done here for leader
@@ -417,9 +413,9 @@ where C: RaftTypeConfig
         // TODO: test
 
         tracing::debug!(
-            last_purged_log_id = display(self.state.last_purged_log_id().display()),
-            purge_upto = display(self.state.purge_upto().display()),
-            "try_purge_log"
+            "try_purge_log: last_purged_log_id: {}, purge_upto: {}",
+            self.state.last_purged_log_id().display(),
+            self.state.purge_upto().display()
         );
 
         if self.state.purge_upto() <= self.state.last_purged_log_id() {
@@ -465,10 +461,7 @@ where C: RaftTypeConfig
 
         // The leader may not be in membership anymore
         if let Some(prog_entry) = self.leader.progress.get_mut(&id) {
-            tracing::debug!(
-                self_matching = display(prog_entry.matching().display()),
-                "update progress"
-            );
+            tracing::debug!("update progress: self_matching: {}", prog_entry.matching().display());
 
             if prog_entry.matching() >= upto.as_ref() {
                 return;

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -37,9 +37,9 @@ where C: RaftTypeConfig
         let is_leader = server_state == ServerState::Leader;
 
         if !was_leader && is_leader {
-            tracing::info!(id = display(&self.config.id), "become leader");
+            tracing::info!("become leader: id: {}", &self.config.id);
         } else if was_leader && !is_leader {
-            tracing::info!(id = display(&self.config.id), "quit leader");
+            tracing::info!("quit leader: id: {}", &self.config.id);
         } else {
             // nothing to do
         }

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -313,7 +313,7 @@ where C: RaftTypeConfig
     /// `retain` specifies whether to retain the removed voters as learners, i.e., nodes that
     /// continue to receive log replication from the leader.
     pub(crate) fn change(mut self, change: ChangeMembers<C>, retain: bool) -> Result<Self, ChangeMembershipError<C>> {
-        tracing::debug!(change = debug(&change), "{}", func_name!());
+        tracing::debug!("{}: change: {:?}", func_name!(), change);
 
         let Membership { mut configs, nodes } = self.clone().compute_target_membership(change);
 
@@ -323,7 +323,7 @@ where C: RaftTypeConfig
         self.nodes = nodes;
         let new_membership = self.next_coherent(target_voter_ids, retain);
 
-        tracing::debug!(new_membership = display(&new_membership), "new membership");
+        tracing::debug!("new membership: {}", new_membership);
 
         new_membership.ensure_valid()?;
 

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -113,7 +113,7 @@ mod tokio_rt {
                         Err(err) => {
                             let err: RPCError<C, RaftError<C, InstallSnapshotError>> = err;
 
-                            tracing::warn!(error=%err, "error sending InstallSnapshot RPC to target");
+                            tracing::warn!("failed to send InstallSnapshot RPC: {}", err);
 
                             match err {
                                 RPCError::Timeout(_) => {}
@@ -143,7 +143,7 @@ mod tokio_rt {
                         }
                     },
                     Err(err) => {
-                        tracing::warn!(error=%err, "timeout while sending InstallSnapshot RPC to target");
+                        tracing::warn!("timeout sending InstallSnapshot RPC: {}", err);
                         continue;
                     }
                 };
@@ -171,7 +171,7 @@ mod tokio_rt {
             let snapshot_meta = req.meta.clone();
             let done = req.done;
 
-            tracing::info!(req = display(&req), "{}", func_name!());
+            tracing::info!("{}: req: {}", func_name!(), req);
 
             let curr_id = streaming.as_ref().map(|s| s.snapshot_id());
 

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -98,7 +98,7 @@ where
     pub(crate) fn grant_by(&mut self, target: &C::NodeId) -> bool {
         let granted = *self.progress.update(target, true).expect("target not in quorum set");
 
-        tracing::info!(voting = display(&self), "{}", func_name!());
+        tracing::info!("{}: voting: {}", func_name!(), self);
 
         granted
     }

--- a/openraft/src/raft/api/protocol.rs
+++ b/openraft/src/raft/api/protocol.rs
@@ -78,7 +78,7 @@ where C: RaftTypeConfig
     #[since(version = "0.10.0")]
     #[tracing::instrument(level = "debug", skip(self, rpc))]
     pub(crate) async fn vote(&self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, Fatal<C>> {
-        tracing::info!(rpc = display(&rpc), "Raft::vote()");
+        tracing::info!("Raft::vote(): rpc: {}", rpc);
 
         let (tx, rx) = C::oneshot();
         self.inner.call_core(RaftMsg::RequestVote { rpc, tx }, rx).await
@@ -90,7 +90,7 @@ where C: RaftTypeConfig
         &self,
         rpc: AppendEntriesRequest<C>,
     ) -> Result<AppendEntriesResponse<C>, Fatal<C>> {
-        tracing::debug!(rpc = display(&rpc), "Raft::append_entries");
+        tracing::debug!("Raft::append_entries: rpc: {}", rpc);
 
         let (tx, rx) = C::oneshot();
         self.inner.call_core(RaftMsg::AppendEntries { rpc, tx }, rx).await

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -77,7 +77,7 @@ where C: RaftTypeConfig
             let msg = e.0;
 
             let fatal = self.get_core_stop_error().await;
-            tracing::error!("Failed to send RaftMsg: {msg} to RaftCore; error: {fatal}",);
+            tracing::error!("failed to send RaftMsg to RaftCore: {msg}, error: {fatal}",);
             return Err(fatal);
         }
         Ok(())
@@ -95,7 +95,7 @@ where C: RaftTypeConfig
 
         self.send_msg(mes).await?;
         self.recv_msg(rx).await.inspect_err(|_e| {
-            tracing::error!("Failed to receive from RaftCore: error when {}", sum.display());
+            tracing::error!("failed to receive from RaftCore: {}", sum.display());
         })
     }
 
@@ -106,13 +106,13 @@ where C: RaftTypeConfig
         E: OptionalSend,
     {
         let recv_res = rx.await;
-        tracing::debug!("{} receives result is error: {:?}", func_name!(), recv_res.is_err());
+        tracing::debug!("{}: receives result is error: {:?}", func_name!(), recv_res.is_err());
 
         match recv_res {
             Ok(x) => Ok(x),
             Err(_) => {
                 let fatal = self.get_core_stop_error().await;
-                tracing::error!(error = debug(&fatal), "error when {}", func_name!());
+                tracing::error!("{}: error: {}", func_name!(), fatal);
                 Err(fatal)
             }
         }
@@ -187,7 +187,7 @@ where C: RaftTypeConfig
             Ok((join_handle, tx)) => {
                 let join_res = join_handle.await;
 
-                tracing::info!(res = debug(&join_res), "RaftCore exited");
+                tracing::info!("RaftCore exited: {:?}", join_res);
 
                 let core_task_res = match join_res {
                     Err(err) => {

--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -76,7 +76,7 @@ where
         // In this case, still send one RPC, and set log_id_range in `update_log_id_range()`
         let log_id_range = self.get_log_id_range().await?;
 
-        tracing::debug!("{} log_id_range: {}", func_name!(), log_id_range);
+        tracing::debug!("{}: log_id_range: {}", func_name!(), log_id_range);
 
         let res = self.read_log_entries(log_id_range).await;
         let (entries, sending_range) = match res {

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -332,7 +332,12 @@ where
         let (last_applied, sm_mem) = self.state_machine.applied_state().await.sto_read_sm()?;
 
         let log_mem = self.last_membership_in_log(last_applied.next_index()).await?;
-        tracing::debug!(membership_in_sm=?sm_mem, membership_in_log=?log_mem, "{}", func_name!());
+        tracing::debug!(
+            "{}: membership_in_sm={:?}, membership_in_log={:?}",
+            func_name!(),
+            sm_mem,
+            log_mem
+        );
 
         // There 2 membership configs in logs.
         if log_mem.len() == 2 {


### PR DESCRIPTION

## Changelog

##### refactor: convert structured logging to placeholder format
Replace key-value structured logging with placeholder-based format for
improved readability and consistency. Error messages now use Display
formatting instead of Debug, and func_name() is consistently placed at
the start of log messages.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1562)
<!-- Reviewable:end -->
