### PR TITLE
feat: add P1, P5, P10 percentiles to PercentileStats

### DIFF
--- a/openraft/src/base/histogram/histogram.rs
+++ b/openraft/src/base/histogram/histogram.rs
@@ -208,12 +208,15 @@ impl Histogram {
         0
     }
 
-    /// Returns common percentile statistics: total, P50, P90, P99.
+    /// Returns common percentile statistics: total, P1, P5, P10, P50, P90, P99.
     #[allow(dead_code)]
     pub fn percentile_stats(&self) -> PercentileStats {
         let total = self.total();
         PercentileStats {
             total,
+            p1: self.percentile_with_total(0.01, total),
+            p5: self.percentile_with_total(0.05, total),
+            p10: self.percentile_with_total(0.10, total),
             p50: self.percentile_with_total(0.50, total),
             p90: self.percentile_with_total(0.90, total),
             p99: self.percentile_with_total(0.99, total),
@@ -367,6 +370,9 @@ mod tests {
         assert_eq!(hist.percentile(0.5), 0);
         assert_eq!(hist.percentile_stats(), PercentileStats {
             total: 0,
+            p1: 0,
+            p5: 0,
+            p10: 0,
             p50: 0,
             p90: 0,
             p99: 0

--- a/openraft/src/base/histogram/percentile_stats.rs
+++ b/openraft/src/base/histogram/percentile_stats.rs
@@ -5,6 +5,12 @@ use std::fmt;
 pub struct PercentileStats {
     /// Total number of samples recorded
     pub total: u64,
+    /// 1st percentile (99% of values >= this)
+    pub p1: u64,
+    /// 5th percentile (95% of values >= this)
+    pub p5: u64,
+    /// 10th percentile (90% of values >= this)
+    pub p10: u64,
     /// 50th percentile (median)
     pub p50: u64,
     /// 90th percentile
@@ -17,8 +23,8 @@ impl fmt::Display for PercentileStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "[total: {}, P50: {}, P90: {}, P99: {}]",
-            self.total, self.p50, self.p90, self.p99
+            "[total: {}, P1: {}, P5: {}, P10: {}, P50: {}, P90: {}, P99: {}]",
+            self.total, self.p1, self.p5, self.p10, self.p50, self.p90, self.p99
         )
     }
 }


### PR DESCRIPTION

## Changelog

##### feat: add P1, P5, P10 percentiles to PercentileStats
Add lower percentiles to help track batch size distribution from the
"bigger is better" perspective. P1/P5/P10 show what values 99%/95%/90%
of samples exceed.

Changes:
- Add `p1`, `p5`, `p10` fields to `PercentileStats`
- Update `percentile_stats()` to calculate all 7 percentiles
- Update `Display` format to show all percentiles

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1567)
<!-- Reviewable:end -->
