### PR TITLE
feat: add RaftMsg tracking to runtime statistics

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1371,6 +1371,8 @@ where
     pub(crate) async fn handle_api_msg(&mut self, msg: RaftMsg<C>) {
         tracing::debug!("RAFT_event id={:<2}  input: {}", self.id, msg);
 
+        self.runtime_stats.with_mut(|s| s.record_raft_msg(msg.name()));
+
         match msg {
             RaftMsg::AppendEntries { rpc, tx } => {
                 self.handle_append_entries_request(rpc, tx);

--- a/openraft/src/core/raft_msg/external_command.rs
+++ b/openraft/src/core/raft_msg/external_command.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use crate::RaftTypeConfig;
 use crate::Snapshot;
+use crate::core::raft_msg::ExternalCommandName;
 use crate::core::raft_msg::ResultSender;
 use crate::core::sm;
 use crate::error::AllowNextRevertError;
@@ -50,6 +51,22 @@ pub(crate) enum ExternalCommand<C: RaftTypeConfig> {
     /// Send a [`sm::Command`] to [`sm::worker::Worker`].
     /// This command is run in the sm task.
     StateMachineCommand { sm_cmd: sm::Command<C> },
+}
+
+impl<C: RaftTypeConfig> ExternalCommand<C> {
+    /// Returns the name of this command variant.
+    pub fn name(&self) -> ExternalCommandName {
+        match self {
+            ExternalCommand::Elect => ExternalCommandName::Elect,
+            ExternalCommand::Heartbeat => ExternalCommandName::Heartbeat,
+            ExternalCommand::Snapshot => ExternalCommandName::Snapshot,
+            ExternalCommand::GetSnapshot { .. } => ExternalCommandName::GetSnapshot,
+            ExternalCommand::PurgeLog { .. } => ExternalCommandName::PurgeLog,
+            ExternalCommand::TriggerTransferLeader { .. } => ExternalCommandName::TriggerTransferLeader,
+            ExternalCommand::AllowNextRevert { .. } => ExternalCommandName::AllowNextRevert,
+            ExternalCommand::StateMachineCommand { .. } => ExternalCommandName::StateMachineCommand,
+        }
+    }
 }
 
 impl<C> fmt::Debug for ExternalCommand<C>

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -27,6 +27,10 @@ use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::alias::VoteOf;
 
 pub(crate) mod external_command;
+mod raft_msg_name;
+
+pub use raft_msg_name::ExternalCommandName;
+pub use raft_msg_name::RaftMsgName;
 
 /// A oneshot TX to send result from `RaftCore` to external caller, e.g. `Raft::append_entries`.
 pub(crate) type ResultSender<C, T, E = Infallible> = OneshotSenderOf<C, Result<T, E>>;
@@ -116,6 +120,25 @@ where C: RaftTypeConfig
     ExternalCommand {
         cmd: ExternalCommand<C>,
     },
+}
+
+impl<C: RaftTypeConfig> RaftMsg<C> {
+    /// Returns the name of this message variant.
+    pub fn name(&self) -> RaftMsgName {
+        match self {
+            RaftMsg::AppendEntries { .. } => RaftMsgName::AppendEntries,
+            RaftMsg::RequestVote { .. } => RaftMsgName::RequestVote,
+            RaftMsg::InstallFullSnapshot { .. } => RaftMsgName::InstallFullSnapshot,
+            RaftMsg::BeginReceivingSnapshot { .. } => RaftMsgName::BeginReceivingSnapshot,
+            RaftMsg::ClientWriteRequest { .. } => RaftMsgName::ClientWriteRequest,
+            RaftMsg::EnsureLinearizableRead { .. } => RaftMsgName::EnsureLinearizableRead,
+            RaftMsg::Initialize { .. } => RaftMsgName::Initialize,
+            RaftMsg::ChangeMembership { .. } => RaftMsgName::ChangeMembership,
+            RaftMsg::HandleTransferLeader { .. } => RaftMsgName::HandleTransferLeader,
+            RaftMsg::ExternalCoreRequest { .. } => RaftMsgName::ExternalCoreRequest,
+            RaftMsg::ExternalCommand { cmd } => RaftMsgName::ExternalCommand(cmd.name()),
+        }
+    }
 }
 
 impl<C> fmt::Display for RaftMsg<C>

--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -1,0 +1,118 @@
+/// Enum representing the name of each `ExternalCommand` variant.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ExternalCommandName {
+    Elect,
+    Heartbeat,
+    Snapshot,
+    GetSnapshot,
+    PurgeLog,
+    TriggerTransferLeader,
+    AllowNextRevert,
+    StateMachineCommand,
+}
+
+impl ExternalCommandName {
+    /// All variants in canonical order.
+    #[allow(dead_code)]
+    pub const ALL: &'static [ExternalCommandName] = &[
+        ExternalCommandName::Elect,
+        ExternalCommandName::Heartbeat,
+        ExternalCommandName::Snapshot,
+        ExternalCommandName::GetSnapshot,
+        ExternalCommandName::PurgeLog,
+        ExternalCommandName::TriggerTransferLeader,
+        ExternalCommandName::AllowNextRevert,
+        ExternalCommandName::StateMachineCommand,
+    ];
+
+    #[allow(dead_code)]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            ExternalCommandName::Elect => "Ext::Elect",
+            ExternalCommandName::Heartbeat => "Ext::Heartbeat",
+            ExternalCommandName::Snapshot => "Ext::Snapshot",
+            ExternalCommandName::GetSnapshot => "Ext::GetSnapshot",
+            ExternalCommandName::PurgeLog => "Ext::PurgeLog",
+            ExternalCommandName::TriggerTransferLeader => "Ext::TriggerTransferLeader",
+            ExternalCommandName::AllowNextRevert => "Ext::AllowNextRevert",
+            ExternalCommandName::StateMachineCommand => "Ext::StateMachineCommand",
+        }
+    }
+}
+
+impl std::fmt::Display for ExternalCommandName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Enum representing the name of each `RaftMsg` variant.
+///
+/// This provides an efficient way to identify message types without
+/// string comparisons, useful for logging, metrics, and debugging.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RaftMsgName {
+    AppendEntries,
+    RequestVote,
+    InstallFullSnapshot,
+    BeginReceivingSnapshot,
+    ClientWriteRequest,
+    EnsureLinearizableRead,
+    Initialize,
+    ChangeMembership,
+    HandleTransferLeader,
+    ExternalCoreRequest,
+    ExternalCommand(ExternalCommandName),
+}
+
+impl RaftMsgName {
+    /// All variants in canonical order.
+    ///
+    /// ExternalCommand variants are expanded to include all ExternalCommandName variants.
+    pub const ALL: &'static [RaftMsgName] = &[
+        RaftMsgName::AppendEntries,
+        RaftMsgName::RequestVote,
+        RaftMsgName::InstallFullSnapshot,
+        RaftMsgName::BeginReceivingSnapshot,
+        RaftMsgName::ClientWriteRequest,
+        RaftMsgName::EnsureLinearizableRead,
+        RaftMsgName::Initialize,
+        RaftMsgName::ChangeMembership,
+        RaftMsgName::HandleTransferLeader,
+        RaftMsgName::ExternalCoreRequest,
+        RaftMsgName::ExternalCommand(ExternalCommandName::Elect),
+        RaftMsgName::ExternalCommand(ExternalCommandName::Heartbeat),
+        RaftMsgName::ExternalCommand(ExternalCommandName::Snapshot),
+        RaftMsgName::ExternalCommand(ExternalCommandName::GetSnapshot),
+        RaftMsgName::ExternalCommand(ExternalCommandName::PurgeLog),
+        RaftMsgName::ExternalCommand(ExternalCommandName::TriggerTransferLeader),
+        RaftMsgName::ExternalCommand(ExternalCommandName::AllowNextRevert),
+        RaftMsgName::ExternalCommand(ExternalCommandName::StateMachineCommand),
+    ];
+
+    /// Returns the string representation of the message name.
+    #[allow(dead_code)]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RaftMsgName::AppendEntries => "AppendEntries",
+            RaftMsgName::RequestVote => "RequestVote",
+            RaftMsgName::InstallFullSnapshot => "InstallFullSnapshot",
+            RaftMsgName::BeginReceivingSnapshot => "BeginReceivingSnapshot",
+            RaftMsgName::ClientWriteRequest => "ClientWriteRequest",
+            RaftMsgName::EnsureLinearizableRead => "EnsureLinearizableRead",
+            RaftMsgName::Initialize => "Initialize",
+            RaftMsgName::ChangeMembership => "ChangeMembership",
+            RaftMsgName::HandleTransferLeader => "HandleTransferLeader",
+            RaftMsgName::ExternalCoreRequest => "ExternalCoreRequest",
+            RaftMsgName::ExternalCommand(ext) => ext.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for RaftMsgName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/openraft/src/stats.rs
+++ b/openraft/src/stats.rs
@@ -18,5 +18,7 @@ pub use crate::base::histogram::PercentileStats;
 pub use crate::core::RuntimeStats;
 pub use crate::core::RuntimeStatsDisplay;
 pub use crate::core::SharedRuntimeState;
+pub use crate::core::raft_msg::ExternalCommandName;
+pub use crate::core::raft_msg::RaftMsgName;
 pub use crate::engine::CommandName;
 pub use crate::engine::SMCommandName;


### PR DESCRIPTION

## Changelog

##### feat: add RaftMsg tracking to runtime statistics
Add efficient name types for RaftMsg variants and track their execution
counts in RuntimeStats, following the same pattern as Command tracking.
This enables monitoring API usage patterns and debugging.

Changes:
- Add `RaftMsgName` enum with hierarchical `ExternalCommand(ExternalCommandName)` variant
- Add `name()` method to `RaftMsg` and `ExternalCommand`
- Add `raft_msg_counts` field and `record_raft_msg()` to `RuntimeStats`
- Track RaftMsg in `handle_api_msg()`
- Export `RaftMsgName` and `ExternalCommandName` in stats module

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1568)
<!-- Reviewable:end -->
