### PR TITLE
perf: use Vec instead of HashMap for RuntimeStats counters

### DIFF
--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -13,6 +13,10 @@ pub enum ExternalCommandName {
 }
 
 impl ExternalCommandName {
+    /// Total number of variants.
+    #[allow(dead_code)]
+    pub const COUNT: usize = 8;
+
     /// All variants in canonical order.
     #[allow(dead_code)]
     pub const ALL: &'static [ExternalCommandName] = &[
@@ -25,6 +29,21 @@ impl ExternalCommandName {
         ExternalCommandName::AllowNextRevert,
         ExternalCommandName::StateMachineCommand,
     ];
+
+    /// Returns the index of this variant for array-based storage.
+    #[allow(dead_code)]
+    pub const fn index(&self) -> usize {
+        match self {
+            ExternalCommandName::Elect => 0,
+            ExternalCommandName::Heartbeat => 1,
+            ExternalCommandName::Snapshot => 2,
+            ExternalCommandName::GetSnapshot => 3,
+            ExternalCommandName::PurgeLog => 4,
+            ExternalCommandName::TriggerTransferLeader => 5,
+            ExternalCommandName::AllowNextRevert => 6,
+            ExternalCommandName::StateMachineCommand => 7,
+        }
+    }
 
     #[allow(dead_code)]
     pub const fn as_str(&self) -> &'static str {
@@ -69,6 +88,9 @@ pub enum RaftMsgName {
 }
 
 impl RaftMsgName {
+    /// Total number of variants (including expanded ExternalCommand variants).
+    pub const COUNT: usize = 19;
+
     /// All variants in canonical order.
     ///
     /// ExternalCommand variants are expanded to include all ExternalCommandName variants.
@@ -94,6 +116,24 @@ impl RaftMsgName {
         RaftMsgName::GetRuntimeStats,
     ];
 
+    /// Returns the index of this variant for array-based storage.
+    pub const fn index(&self) -> usize {
+        match self {
+            RaftMsgName::AppendEntries => 0,
+            RaftMsgName::RequestVote => 1,
+            RaftMsgName::InstallFullSnapshot => 2,
+            RaftMsgName::BeginReceivingSnapshot => 3,
+            RaftMsgName::ClientWriteRequest => 4,
+            RaftMsgName::EnsureLinearizableRead => 5,
+            RaftMsgName::Initialize => 6,
+            RaftMsgName::ChangeMembership => 7,
+            RaftMsgName::HandleTransferLeader => 8,
+            RaftMsgName::ExternalCoreRequest => 9,
+            RaftMsgName::ExternalCommand(ext) => 10 + ext.index(),
+            RaftMsgName::GetRuntimeStats => 10 + ExternalCommandName::COUNT,
+        }
+    }
+
     /// Returns the string representation of the message name.
     #[allow(dead_code)]
     pub fn as_str(&self) -> &'static str {
@@ -117,5 +157,42 @@ impl RaftMsgName {
 impl std::fmt::Display for RaftMsgName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_external_command_name_index() {
+        assert_eq!(ExternalCommandName::COUNT, ExternalCommandName::ALL.len());
+
+        for (i, name) in ExternalCommandName::ALL.iter().enumerate() {
+            assert_eq!(
+                name.index(),
+                i,
+                "ExternalCommandName::{:?} index mismatch: expected {}, got {}",
+                name,
+                i,
+                name.index()
+            );
+        }
+    }
+
+    #[test]
+    fn test_raft_msg_name_index() {
+        assert_eq!(RaftMsgName::COUNT, RaftMsgName::ALL.len());
+
+        for (i, name) in RaftMsgName::ALL.iter().enumerate() {
+            assert_eq!(
+                name.index(),
+                i,
+                "RaftMsgName::{:?} index mismatch: expected {}, got {}",
+                name,
+                i,
+                name.index()
+            );
+        }
     }
 }

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -12,6 +12,10 @@ pub enum SMCommandName {
 }
 
 impl SMCommandName {
+    /// Total number of variants.
+    #[allow(dead_code)]
+    pub const COUNT: usize = 6;
+
     /// All variants in canonical order.
     #[allow(dead_code)]
     pub const ALL: &'static [SMCommandName] = &[
@@ -22,6 +26,12 @@ impl SMCommandName {
         SMCommandName::Apply,
         SMCommandName::Func,
     ];
+
+    /// Returns the index of this variant for array-based storage.
+    #[allow(dead_code)]
+    pub const fn index(&self) -> usize {
+        *self as usize
+    }
 
     #[allow(dead_code)]
     pub const fn as_str(&self) -> &'static str {
@@ -68,6 +78,9 @@ pub enum CommandName {
 }
 
 impl CommandName {
+    /// Total number of variants (including expanded StateMachine variants).
+    pub const COUNT: usize = 21;
+
     /// All variants in canonical order.
     ///
     /// StateMachine variants are expanded to include all SMCommandName variants.
@@ -94,6 +107,28 @@ impl CommandName {
         CommandName::StateMachine(SMCommandName::Func),
         CommandName::Respond,
     ];
+
+    /// Returns the index of this variant for array-based storage.
+    pub const fn index(&self) -> usize {
+        match self {
+            CommandName::UpdateIOProgress => 0,
+            CommandName::AppendEntries => 1,
+            CommandName::ReplicateCommitted => 2,
+            CommandName::BroadcastHeartbeat => 3,
+            CommandName::SaveCommittedAndApply => 4,
+            CommandName::Replicate => 5,
+            CommandName::ReplicateSnapshot => 6,
+            CommandName::BroadcastTransferLeader => 7,
+            CommandName::CloseReplicationStreams => 8,
+            CommandName::RebuildReplicationStreams => 9,
+            CommandName::SaveVote => 10,
+            CommandName::SendVote => 11,
+            CommandName::PurgeLog => 12,
+            CommandName::TruncateLog => 13,
+            CommandName::StateMachine(sm) => 14 + sm.index(),
+            CommandName::Respond => 14 + SMCommandName::COUNT,
+        }
+    }
 
     /// Returns the string representation of the command name.
     #[allow(dead_code)]
@@ -311,5 +346,37 @@ mod tests {
         assert_eq!(SMCommandName::InstallFullSnapshot.as_str(), "SM::InstallFullSnapshot");
         assert_eq!(SMCommandName::Apply.as_str(), "SM::Apply");
         assert_eq!(SMCommandName::Func.as_str(), "SM::Func");
+    }
+
+    #[test]
+    fn test_sm_command_name_index() {
+        assert_eq!(SMCommandName::COUNT, SMCommandName::ALL.len());
+
+        for (i, name) in SMCommandName::ALL.iter().enumerate() {
+            assert_eq!(
+                name.index(),
+                i,
+                "SMCommandName::{:?} index mismatch: expected {}, got {}",
+                name,
+                i,
+                name.index()
+            );
+        }
+    }
+
+    #[test]
+    fn test_command_name_index() {
+        assert_eq!(CommandName::COUNT, CommandName::ALL.len());
+
+        for (i, name) in CommandName::ALL.iter().enumerate() {
+            assert_eq!(
+                name.index(),
+                i,
+                "CommandName::{:?} index mismatch: expected {}, got {}",
+                name,
+                i,
+                name.index()
+            );
+        }
     }
 }


### PR DESCRIPTION

## Changelog

##### perf: use Vec instead of HashMap for RuntimeStats counters
Replace HashMap-based counting with Vec and direct indexing for better
performance. Each Name enum now has an `index()` method and `COUNT`
constant for O(1) array access instead of hash lookups.

Changes:
- Add `COUNT` and `index()` to `RaftMsgName`, `CommandName`, `ExternalCommandName`, `SMCommandName`
- Replace `HashMap<Name, u64>` with `Vec<u64>` in `RuntimeStats`
- Add tests to verify index-to-name mappings are correct

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1570)
<!-- Reviewable:end -->
