### PR TITLE
refactor: add notification counting to RuntimeStats

### DIFF
--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod core_state;
 pub(crate) mod heartbeat;
 pub(crate) mod io_flush_tracking;
 pub(crate) mod notification;
+mod notification_name;
 mod raft_core;
 pub(crate) mod raft_msg;
 mod replication_state;
@@ -39,6 +40,7 @@ pub(crate) mod sm;
 mod tick;
 
 pub(crate) use client_responder_queue::ClientResponderQueue;
+pub use notification_name::NotificationName;
 pub(crate) use raft_core::ApplyResult;
 pub use raft_core::RaftCore;
 pub(crate) use replication_state::replication_lag;

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::RaftTypeConfig;
 use crate::StorageError;
+use crate::core::NotificationName;
 use crate::core::sm;
 use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::display_option::DisplayOptionExt;
@@ -85,6 +86,20 @@ where C: RaftTypeConfig
 {
     pub(crate) fn sm(command_result: sm::CommandResult<C>) -> Self {
         Self::StateMachine { command_result }
+    }
+
+    /// Returns the name of this notification variant.
+    pub(crate) fn name(&self) -> NotificationName {
+        match self {
+            Self::VoteResponse { .. } => NotificationName::VoteResponse,
+            Self::HigherVote { .. } => NotificationName::HigherVote,
+            Self::StorageError { .. } => NotificationName::StorageError,
+            Self::LocalIO { .. } => NotificationName::LocalIO,
+            Self::ReplicationProgress { .. } => NotificationName::ReplicationProgress,
+            Self::HeartbeatProgress { .. } => NotificationName::HeartbeatProgress,
+            Self::StateMachine { .. } => NotificationName::StateMachine,
+            Self::Tick { .. } => NotificationName::Tick,
+        }
     }
 }
 

--- a/openraft/src/core/notification_name.rs
+++ b/openraft/src/core/notification_name.rs
@@ -1,0 +1,91 @@
+/// Enum representing the name of each `Notification` variant.
+///
+/// This provides an efficient way to identify notification types without
+/// string comparisons, useful for logging, metrics, and debugging.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NotificationName {
+    VoteResponse,
+    HigherVote,
+    StorageError,
+    LocalIO,
+    ReplicationProgress,
+    HeartbeatProgress,
+    StateMachine,
+    Tick,
+}
+
+impl NotificationName {
+    /// Total number of variants.
+    #[allow(dead_code)]
+    pub const COUNT: usize = 8;
+
+    /// All variants in canonical order.
+    #[allow(dead_code)]
+    pub const ALL: &'static [NotificationName] = &[
+        NotificationName::VoteResponse,
+        NotificationName::HigherVote,
+        NotificationName::StorageError,
+        NotificationName::LocalIO,
+        NotificationName::ReplicationProgress,
+        NotificationName::HeartbeatProgress,
+        NotificationName::StateMachine,
+        NotificationName::Tick,
+    ];
+
+    /// Returns the index of this variant for array-based storage.
+    #[allow(dead_code)]
+    pub const fn index(&self) -> usize {
+        match self {
+            NotificationName::VoteResponse => 0,
+            NotificationName::HigherVote => 1,
+            NotificationName::StorageError => 2,
+            NotificationName::LocalIO => 3,
+            NotificationName::ReplicationProgress => 4,
+            NotificationName::HeartbeatProgress => 5,
+            NotificationName::StateMachine => 6,
+            NotificationName::Tick => 7,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            NotificationName::VoteResponse => "Notify::VoteResponse",
+            NotificationName::HigherVote => "Notify::HigherVote",
+            NotificationName::StorageError => "Notify::StorageError",
+            NotificationName::LocalIO => "Notify::LocalIO",
+            NotificationName::ReplicationProgress => "Notify::ReplicationProgress",
+            NotificationName::HeartbeatProgress => "Notify::HeartbeatProgress",
+            NotificationName::StateMachine => "Notify::StateMachine",
+            NotificationName::Tick => "Notify::Tick",
+        }
+    }
+}
+
+impl std::fmt::Display for NotificationName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_notification_name_index() {
+        assert_eq!(NotificationName::COUNT, NotificationName::ALL.len());
+
+        for (i, name) in NotificationName::ALL.iter().enumerate() {
+            assert_eq!(
+                name.index(),
+                i,
+                "NotificationName::{:?} index mismatch: expected {}, got {}",
+                name,
+                i,
+                name.index()
+            );
+        }
+    }
+}

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1537,6 +1537,8 @@ where
     pub(crate) fn handle_notification(&mut self, notify: Notification<C>) -> Result<(), Fatal<C>> {
         tracing::debug!("RAFT_event id={:<2} notify: {}", self.id, notify);
 
+        self.runtime_stats.record_notification(notify.name());
+
         match notify {
             Notification::VoteResponse {
                 target,

--- a/openraft/src/stats.rs
+++ b/openraft/src/stats.rs
@@ -13,6 +13,7 @@
 
 pub use crate::base::histogram::Histogram;
 pub use crate::base::histogram::PercentileStats;
+pub use crate::core::NotificationName;
 pub use crate::core::RuntimeStats;
 pub use crate::core::RuntimeStatsDisplay;
 pub use crate::core::raft_msg::ExternalCommandName;


### PR DESCRIPTION

## Changelog

##### refactor: add notification counting to RuntimeStats
Add counting for `Notification` types received by RaftCore, following
the same Vec-based pattern as `RaftMsgName` and `CommandName` counting
for O(1) performance.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1571)
<!-- Reviewable:end -->
