### PR TITLE
refactor: redesign `LeaderLogIds` with explicit fields and iterator support

### DIFF
--- a/openraft/src/engine/leader_log_ids.rs
+++ b/openraft/src/engine/leader_log_ids.rs
@@ -1,54 +1,261 @@
 use std::fmt;
-use std::ops::RangeInclusive;
 
 use crate::RaftTypeConfig;
+use crate::engine::leader_log_ids_iter::LeaderLogIdsIter;
+use crate::log_id::ref_log_id::RefLogId;
+use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::LogIdOf;
 
-/// The first and the last log id belonging to a Leader.
+/// A non-empty range of log IDs belonging to a Leader.
+///
+/// This struct represents a contiguous range of log IDs that share the same
+/// committed leader ID. It provides efficient access to the first and last
+/// log IDs, and can be iterated over to produce all log IDs in the range.
+///
+/// The range is `[first, last]` (both inclusive).
+/// This struct always represents a non-empty range; use `Option<LeaderLogIds>`
+/// when an empty range is needed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LeaderLogIds<C: RaftTypeConfig> {
-    log_id_range: Option<RangeInclusive<LogIdOf<C>>>,
+    committed_leader_id: CommittedLeaderIdOf<C>,
+
+    /// First index (inclusive).
+    first: u64,
+
+    /// Last index (inclusive).
+    last: u64,
 }
 
 impl<C> fmt::Display for LeaderLogIds<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.log_id_range {
-            None => write!(f, "None"),
-            Some(rng) => write!(f, "({}, {})", rng.start(), rng.end()),
-        }
+        write!(f, "{}:[{}, {}]", self.committed_leader_id, self.first, self.last)
     }
 }
 
 impl<C> LeaderLogIds<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(log_id_range: Option<RangeInclusive<LogIdOf<C>>>) -> Self {
-        Self { log_id_range }
+    /// Create a new log ID range `[first, last]`.
+    pub(crate) fn new(committed_leader_id: CommittedLeaderIdOf<C>, first: u64, last: u64) -> Self {
+        debug_assert!(first <= last, "first {} must be <= last {}", first, last);
+        Self {
+            committed_leader_id,
+            first,
+            last,
+        }
     }
 
-    /// Used only in tests
-    #[allow(dead_code)]
     pub(crate) fn new_single(log_id: LogIdOf<C>) -> Self {
+        let index = log_id.index();
         Self {
-            log_id_range: Some(log_id.clone()..=log_id),
+            committed_leader_id: log_id.committed_leader_id().clone(),
+            first: index,
+            last: index,
         }
     }
 
-    /// Used only in tests
+    /// Returns the first log ID in the range.
     #[allow(dead_code)]
-    pub(crate) fn new_start_end(first: LogIdOf<C>, last: LogIdOf<C>) -> Self {
-        Self {
-            log_id_range: Some(first..=last),
+    pub(crate) fn first_log_id(&self) -> LogIdOf<C> {
+        LogIdOf::<C>::new(self.committed_leader_id.clone(), self.first)
+    }
+
+    /// Returns a reference to the first log ID in the range.
+    pub(crate) fn first_ref(&self) -> RefLogId<'_, C> {
+        RefLogId::new(&self.committed_leader_id, self.first)
+    }
+
+    /// Returns the last log ID in the range.
+    #[allow(dead_code)]
+    pub(crate) fn last_log_id(&self) -> LogIdOf<C> {
+        LogIdOf::<C>::new(self.committed_leader_id.clone(), self.last)
+    }
+
+    /// Returns a reference to the last log ID in the range.
+    pub(crate) fn last_ref(&self) -> RefLogId<'_, C> {
+        RefLogId::new(&self.committed_leader_id, self.last)
+    }
+
+    /// Returns the log ID at the specified index.
+    ///
+    /// # Panics
+    /// Panics if `index` is out of range `[first, last]`.
+    #[allow(dead_code)]
+    pub(crate) fn get(&self, index: u64) -> LogIdOf<C> {
+        debug_assert!(
+            index >= self.first && index <= self.last,
+            "index {} out of range [{}, {}]",
+            index,
+            self.first,
+            self.last
+        );
+        LogIdOf::<C>::new(self.committed_leader_id.clone(), index)
+    }
+
+    /// Returns a reference to the log ID at the specified index.
+    ///
+    /// # Panics
+    /// Panics if `index` is out of range `[first, last]`.
+    #[allow(dead_code)]
+    pub(crate) fn ref_at(&self, index: u64) -> RefLogId<'_, C> {
+        debug_assert!(
+            index >= self.first && index <= self.last,
+            "index {} out of range [{}, {}]",
+            index,
+            self.first,
+            self.last
+        );
+        RefLogId::new(&self.committed_leader_id, index)
+    }
+
+    /// Returns the number of log IDs in the range.
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        if self.first > self.last {
+            0
+        } else {
+            (self.last - self.first + 1) as usize
         }
     }
+}
 
-    pub(crate) fn first(&self) -> Option<&LogIdOf<C>> {
-        self.log_id_range.as_ref().map(|x| x.start())
+impl<C> IntoIterator for LeaderLogIds<C>
+where C: RaftTypeConfig
+{
+    type Item = LogIdOf<C>;
+    type IntoIter = LeaderLogIdsIter<C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        LeaderLogIdsIter::new(
+            self.committed_leader_id,
+            self.first,
+            self.last + 1, // half-open: [start, end)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::testing::UTConfig;
+    use crate::engine::testing::log_id;
+
+    fn committed_leader_id(term: u64, node_id: u64) -> CommittedLeaderIdOf<UTConfig> {
+        *log_id(term, node_id, 0).committed_leader_id()
     }
 
-    pub(crate) fn last(&self) -> Option<&LogIdOf<C>> {
-        self.log_id_range.as_ref().map(|x| x.end())
+    #[test]
+    fn test_single_element() {
+        // [5, 5] is a single element range
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 5, 5);
+        assert_eq!(range.len(), 1);
+        assert_eq!(range.first_log_id(), log_id(1, 2, 5));
+        assert_eq!(range.last_log_id(), log_id(1, 2, 5));
+    }
+
+    #[test]
+    fn test_multiple_elements() {
+        // [10, 14] is 5 elements
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(2, 3), 10, 14);
+        assert_eq!(range.len(), 5);
+        assert_eq!(range.first_log_id(), log_id(2, 3, 10));
+        assert_eq!(range.last_log_id(), log_id(2, 3, 14));
+    }
+
+    #[test]
+    fn test_iterator() {
+        // [5, 7] is 3 elements: 5, 6, 7
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 5, 7);
+        let ids: Vec<_> = range.into_iter().collect();
+        assert_eq!(ids, vec![log_id(1, 2, 5), log_id(1, 2, 6), log_id(1, 2, 7)]);
+    }
+
+    #[test]
+    fn test_double_ended_iterator() {
+        // [5, 7] is 3 elements: 5, 6, 7
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 5, 7);
+        let mut iter = range.into_iter();
+
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 7)));
+        assert_eq!(iter.next(), Some(log_id(1, 2, 5)));
+        assert_eq!(iter.next(), Some(log_id(1, 2, 6)));
+        assert!(iter.next().is_none());
+        assert!(iter.next_back().is_none());
+    }
+
+    #[test]
+    fn test_clone_iter() {
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 5, 7);
+        let iter1 = range.into_iter();
+        let iter2 = iter1.clone();
+
+        let ids1: Vec<_> = iter1.collect();
+        let ids2: Vec<_> = iter2.collect();
+        assert_eq!(ids1, vec![log_id(1, 2, 5), log_id(1, 2, 6), log_id(1, 2, 7)]);
+        assert_eq!(ids1, ids2);
+    }
+
+    #[test]
+    fn test_iterator_starting_at_zero() {
+        // Edge case: range starting at index 0
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 0, 2);
+        let mut iter = range.into_iter();
+
+        // Consume from back first to test the edge case
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 2)));
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 1)));
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 0)));
+
+        // Iterator should be exhausted
+        assert!(iter.next_back().is_none());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_single_element_at_zero() {
+        // Edge case: single element at index 0
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 0, 0);
+        let mut iter = range.into_iter();
+
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 0)));
+        assert!(iter.next_back().is_none());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_new_single() {
+        let range = LeaderLogIds::<UTConfig>::new_single(log_id(1, 2, 5));
+        assert_eq!(range.len(), 1);
+        assert_eq!(range.first_log_id(), log_id(1, 2, 5));
+        assert_eq!(range.last_log_id(), log_id(1, 2, 5));
+    }
+
+    #[test]
+    fn test_display() {
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 1), 5, 7);
+        assert_eq!(format!("{}", range), "T1-N1:[5, 7]");
+    }
+
+    #[test]
+    fn test_first_ref() {
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 5, 10);
+        assert_eq!(range.first_ref().into_log_id(), log_id(1, 2, 5));
+    }
+
+    #[test]
+    fn test_last_ref() {
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 5, 10);
+        assert_eq!(range.last_ref().into_log_id(), log_id(1, 2, 10));
+    }
+
+    #[test]
+    fn test_ref_at() {
+        let range = LeaderLogIds::<UTConfig>::new(committed_leader_id(1, 2), 5, 10);
+
+        assert_eq!(range.ref_at(5).into_log_id(), log_id(1, 2, 5));
+        assert_eq!(range.ref_at(7).into_log_id(), log_id(1, 2, 7));
+        assert_eq!(range.ref_at(10).into_log_id(), log_id(1, 2, 10));
     }
 }

--- a/openraft/src/engine/leader_log_ids_iter.rs
+++ b/openraft/src/engine/leader_log_ids_iter.rs
@@ -1,0 +1,177 @@
+use crate::RaftTypeConfig;
+use crate::type_config::alias::CommittedLeaderIdOf;
+use crate::type_config::alias::LogIdOf;
+
+/// Iterator over log IDs in a [`LeaderLogIds`](super::leader_log_ids::LeaderLogIds) range.
+///
+/// Uses half-open range `[start, end)` where `start` is inclusive and `end` is exclusive.
+/// When `start == end`, the iterator is exhausted.
+/// Implements `DoubleEndedIterator` and `ExactSizeIterator`.
+#[derive(Debug, Clone)]
+pub(crate) struct LeaderLogIdsIter<C: RaftTypeConfig> {
+    committed_leader_id: CommittedLeaderIdOf<C>,
+
+    /// Next index to yield from the front (inclusive).
+    start: u64,
+
+    /// One past the last index to yield (exclusive).
+    end: u64,
+}
+
+impl<C: RaftTypeConfig> LeaderLogIdsIter<C> {
+    pub(crate) fn new(committed_leader_id: CommittedLeaderIdOf<C>, start: u64, end: u64) -> Self {
+        Self {
+            committed_leader_id,
+            start,
+            end,
+        }
+    }
+
+    fn len(&self) -> usize {
+        if self.start >= self.end {
+            0
+        } else {
+            (self.end - self.start) as usize
+        }
+    }
+}
+
+impl<C: RaftTypeConfig> Iterator for LeaderLogIdsIter<C> {
+    type Item = LogIdOf<C>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start >= self.end {
+            return None;
+        }
+
+        let index = self.start;
+        self.start += 1;
+        Some(LogIdOf::<C>::new(self.committed_leader_id.clone(), index))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<C: RaftTypeConfig> DoubleEndedIterator for LeaderLogIdsIter<C> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start >= self.end {
+            return None;
+        }
+
+        self.end -= 1;
+        Some(LogIdOf::<C>::new(self.committed_leader_id.clone(), self.end))
+    }
+}
+
+impl<C: RaftTypeConfig> ExactSizeIterator for LeaderLogIdsIter<C> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::testing::UTConfig;
+    use crate::engine::testing::log_id;
+    use crate::type_config::alias::CommittedLeaderIdOf;
+
+    fn committed_leader_id(term: u64, node_id: u64) -> CommittedLeaderIdOf<UTConfig> {
+        *log_id(term, node_id, 0).committed_leader_id()
+    }
+
+    #[test]
+    fn test_empty_range() {
+        // start == end means empty
+        let iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 1), 5, 5);
+        assert_eq!(iter.len(), 0);
+        let ids: Vec<_> = iter.collect();
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_single_element() {
+        // [0, 1) is a single element at index 0
+        let iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 2), 0, 1);
+        assert_eq!(iter.len(), 1);
+        let ids: Vec<_> = iter.collect();
+        assert_eq!(ids, vec![log_id(1, 2, 0)]);
+    }
+
+    #[test]
+    fn test_forward_iteration() {
+        let iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 2), 5, 8);
+        let ids: Vec<_> = iter.collect();
+        assert_eq!(ids, vec![log_id(1, 2, 5), log_id(1, 2, 6), log_id(1, 2, 7)]);
+    }
+
+    #[test]
+    fn test_backward_iteration() {
+        let mut iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 2), 5, 8);
+
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 7)));
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 6)));
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 5)));
+        assert!(iter.next_back().is_none());
+    }
+
+    #[test]
+    fn test_mixed_iteration() {
+        let mut iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 2), 5, 8);
+
+        assert_eq!(iter.next(), Some(log_id(1, 2, 5)));
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 7)));
+        assert_eq!(iter.next(), Some(log_id(1, 2, 6)));
+        assert!(iter.next().is_none());
+        assert!(iter.next_back().is_none());
+    }
+
+    #[test]
+    fn test_start_at_zero_forward() {
+        let iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 2), 0, 3);
+        let ids: Vec<_> = iter.collect();
+        assert_eq!(ids, vec![log_id(1, 2, 0), log_id(1, 2, 1), log_id(1, 2, 2)]);
+    }
+
+    #[test]
+    fn test_start_at_zero_backward() {
+        let mut iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 2), 0, 3);
+
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 2)));
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 1)));
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 0)));
+        assert!(iter.next_back().is_none());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_single_element_at_zero() {
+        let mut iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 2), 0, 1);
+
+        assert_eq!(iter.next_back(), Some(log_id(1, 2, 0)));
+        assert!(iter.next_back().is_none());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_exact_size() {
+        let iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 1), 10, 15);
+        assert_eq!(iter.len(), 5);
+
+        let mut iter = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 1), 10, 15);
+        assert_eq!(iter.len(), 5);
+        iter.next();
+        assert_eq!(iter.len(), 4);
+        iter.next_back();
+        assert_eq!(iter.len(), 3);
+    }
+
+    #[test]
+    fn test_clone() {
+        let iter1 = LeaderLogIdsIter::<UTConfig>::new(committed_leader_id(1, 1), 5, 8);
+        let iter2 = iter1.clone();
+
+        let ids1: Vec<_> = iter1.collect();
+        let ids2: Vec<_> = iter2.collect();
+        assert_eq!(ids1, ids2);
+    }
+}

--- a/openraft/src/engine/log_id_list_test.rs
+++ b/openraft/src/engine/log_id_list_test.rs
@@ -358,27 +358,27 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
 fn test_log_id_list_by_last_leader() -> anyhow::Result<()> {
     // len == 0
     let ids = LogIdList::<UTConfig>::default();
-    assert_eq!(ids.by_last_leader(), LeaderLogIds::new(None));
+    assert_eq!(ids.by_last_leader(), None);
 
     // len == 1
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1)]);
-    assert_eq!(LeaderLogIds::new_single(log_id(1, 1, 1)), ids.by_last_leader());
+    assert_eq!(Some(LeaderLogIds::new_single(log_id(1, 1, 1))), ids.by_last_leader());
 
     // len == 2, the last leader has only one log
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
-    assert_eq!(LeaderLogIds::new_single(log_id(3, 1, 3)), ids.by_last_leader());
+    assert_eq!(Some(LeaderLogIds::new_single(log_id(3, 1, 3))), ids.by_last_leader());
 
     // len == 2, the last leader has two logs
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
     assert_eq!(
-        LeaderLogIds::new_start_end(log_id(1, 1, 1), log_id(1, 1, 3)),
+        Some(LeaderLogIds::new(*log_id(1, 1, 0).committed_leader_id(), 1, 3)),
         ids.by_last_leader()
     );
 
     // len > 2, the last leader has only more than one logs
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
     assert_eq!(
-        LeaderLogIds::new_start_end(log_id(7, 1, 8), log_id(7, 1, 10)),
+        Some(LeaderLogIds::new(*log_id(7, 1, 0).committed_leader_id(), 8, 10)),
         ids.by_last_leader()
     );
 

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -38,6 +38,7 @@ mod respond_command;
 pub(crate) mod command;
 pub(crate) mod handler;
 pub(crate) mod leader_log_ids;
+pub(crate) mod leader_log_ids_iter;
 pub(crate) mod log_id_list;
 pub(crate) mod pending_responds;
 pub(crate) mod replication_progress;

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -122,13 +122,13 @@ where
         //       Thus the first() is ignored.
         //       But we should not fake the first() there.
         let last = self.last_log_id();
-        let last_leader_log_ids = LeaderLogIds::new(last.map(|last| last.clone()..=last.clone()));
+        let last_leader_log_ids = last.cloned().map(LeaderLogIds::new_single);
 
         Leader::new(
             vote,
             self.quorum_set.clone(),
             self.learner_ids,
-            last_leader_log_ids,
+            last_leader_log_ids, // already Option<LeaderLogIds>
             self.progress_id_gen,
         )
     }

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -292,9 +292,10 @@ where C: RaftTypeConfig
     /// Append a list of `log_id`.
     ///
     /// The log ids in the input has to be continuous.
-    pub(crate) fn extend_log_ids_from_same_leader<'a, I>(&mut self, new_log_ids: I)
+    pub(crate) fn extend_log_ids_from_same_leader<LID, I>(&mut self, new_log_ids: I)
     where
-        I: IntoIterator<Item = RefLogId<'a, C>>,
+        LID: RaftLogId<C>,
+        I: IntoIterator<Item = LID>,
         <I as IntoIterator>::IntoIter: DoubleEndedIterator,
     {
         self.log_ids.extend_from_same_leader(new_log_ids)


### PR DESCRIPTION

## Changelog

##### refactor: redesign `LeaderLogIds` with explicit fields and iterator support
Replace the internal `Option<RangeInclusive<LogIdOf<C>>>` representation with
explicit `committed_leader_id`, `first`, and `last` fields. The struct now
always represents a non-empty closed range `[first, last]`, with `Option<LeaderLogIds>`
used at call sites when an empty range is needed.

Changes:
- Change `LeaderLogIds` to store `committed_leader_id`, `first`, `last` explicitly
- Add `first_ref()`, `last_ref()`, `ref_at()` methods returning `RefLogId`
- Add `first_log_id()`, `last_log_id()`, `get()`, `len()` methods
- Implement `IntoIterator` yielding `LogIdOf<C>` with `DoubleEndedIterator` support
- Update `assign_log_ids()` to return `Option<LeaderLogIds>`

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1577)
<!-- Reviewable:end -->
