### PR TITLE
test: replace `assert_storage_state()` with explicit inline assertions in tests

### DIFF
--- a/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
+++ b/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
@@ -4,11 +4,14 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::RaftLogReader;
 use openraft::Vote;
 use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
+use openraft::storage::RaftLogStorage;
+use openraft::storage::RaftStateMachine;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -35,7 +38,14 @@ async fn append_entries_with_bigger_term() -> Result<()> {
     let log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     // before append entries, check hard state in term 1 and vote for node 0
-    router.assert_storage_state(1, log_index, Some(0), log_id(1, 0, log_index), None).await?;
+    for id in [0, 1] {
+        let (mut sto, mut sm) = router.get_storage_handle(&id)?;
+        assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+        assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(1, 0)));
+
+        let (last_applied, _) = sm.applied_state().await?;
+        assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+    }
 
     // append entries with term 2 and leader_id, this MUST cause hard state changed in node 0
     let req = AppendEntriesRequest::<openraft_memstore::TypeConfig> {
@@ -51,20 +61,12 @@ async fn append_entries_with_bigger_term() -> Result<()> {
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1
-    let (mut store, mut sm) = router.get_storage_handle(&0)?;
+    let (mut sto, mut sm) = router.get_storage_handle(&0)?;
+    assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+    assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(2, 1)));
 
-    router
-        .assert_storage_state_with_sto(
-            &mut store,
-            &mut sm,
-            &0,
-            2,
-            log_index,
-            Some(1),
-            log_id(1, 0, log_index),
-            &None,
-        )
-        .await?;
+    let (last_applied, _) = sm.applied_state().await?;
+    assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
 
     Ok(())
 }

--- a/tests/tests/snapshot_building/t10_build_snapshot.rs
+++ b/tests/tests/snapshot_building/t10_build_snapshot.rs
@@ -14,7 +14,9 @@ use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
+use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftLogStorageExt;
+use openraft::storage::RaftStateMachine;
 use openraft::testing::blank_ent;
 
 use crate::fixtures::RaftRouter;
@@ -61,15 +63,17 @@ async fn build_snapshot() -> Result<()> {
     router.wait(&0, timeout()).applied_index(Some(log_index), "write").await?;
     router.wait(&0, None).snapshot(log_id(1, 0, log_index), "snapshot").await?;
 
-    router
-        .assert_storage_state(
-            1,
-            log_index,
-            Some(0),
-            log_id(1, 0, log_index),
-            Some((log_index.into(), 1)),
-        )
-        .await?;
+    {
+        let (mut sto, mut sm) = router.get_storage_handle(&0)?;
+        assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+        assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(1, 0)));
+
+        let (last_applied, _) = sm.applied_state().await?;
+        assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+
+        let snap = sm.get_current_snapshot().await?.unwrap();
+        assert_eq!(snap.meta.last_log_id, Some(log_id(1, 0, log_index)));
+    }
 
     // Add a new node and assert that it received the same snapshot.
     let (mut sto1, sm1) = router.new_store();
@@ -107,16 +111,17 @@ async fn build_snapshot() -> Result<()> {
     }
 
     // log 0 counts
-    let expected_snap = Some(((snapshot_threshold - 1).into(), 1));
-    router
-        .assert_storage_state(
-            1,
-            log_index,
-            None, /* learner does not vote */
-            log_id(1, 0, log_index),
-            expected_snap,
-        )
-        .await?;
+    for id in [0, 1] {
+        let (mut sto, mut sm) = router.get_storage_handle(&id)?;
+        assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+        assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(1, 0)));
+
+        let (last_applied, _) = sm.applied_state().await?;
+        assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+
+        let snap = sm.get_current_snapshot().await?.unwrap();
+        assert_eq!(snap.meta.last_log_id, Some(log_id(1, 0, snapshot_threshold - 1)));
+    }
 
     tracing::info!(
         "--- send a heartbeat with prev_log_id to be some value <= last_applied to ensure the commit index is updated"

--- a/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
+++ b/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::RaftLogReader;
 use openraft::SnapshotPolicy;
+use openraft::Vote;
+use openraft::storage::RaftLogStorage;
+use openraft::storage::RaftStateMachine;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -42,15 +46,16 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
         router.wait(&0, None).applied_index(Some(log_index), "send log to trigger snapshot").await?;
 
         router.wait(&0, None).snapshot(log_id(1, 0, log_index), "snapshot").await?;
-        router
-            .assert_storage_state(
-                1,
-                log_index,
-                Some(0),
-                log_id(1, 0, log_index),
-                Some((log_index.into(), 1)),
-            )
-            .await?;
+
+        let (mut sto, mut sm) = router.get_storage_handle(&0)?;
+        assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+        assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(1, 0)));
+
+        let (last_applied, _) = sm.applied_state().await?;
+        assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+
+        let snap = sm.get_current_snapshot().await?.unwrap();
+        assert_eq!(snap.meta.last_log_id, Some(log_id(1, 0, log_index)));
     }
 
     tracing::info!(
@@ -72,16 +77,18 @@ async fn switch_to_snapshot_replication_when_lacking_log() -> Result<()> {
             router.wait(&id, None).applied_index(Some(log_index), "add learner").await?;
         }
         router.wait(&1, None).snapshot(log_id(1, 0, snapshot_threshold - 1), "").await?;
-        let expected_snap = Some(((snapshot_threshold - 1).into(), 1));
-        router
-            .assert_storage_state(
-                1,
-                log_index,
-                None, /* learner does not vote */
-                log_id(1, 0, log_index),
-                expected_snap,
-            )
-            .await?;
+
+        for id in [0, 1] {
+            let (mut sto, mut sm) = router.get_storage_handle(&id)?;
+            assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+            assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(1, 0)));
+
+            let (last_applied, _) = sm.applied_state().await?;
+            assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+
+            let snap = sm.get_current_snapshot().await?.unwrap();
+            assert_eq!(snap.meta.last_log_id, Some(log_id(1, 0, snapshot_threshold - 1)));
+        }
     }
 
     Ok(())

--- a/tests/tests/snapshot_streaming/t51_after_snapshot_add_learner_and_request_a_log.rs
+++ b/tests/tests/snapshot_streaming/t51_after_snapshot_add_learner_and_request_a_log.rs
@@ -4,7 +4,11 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::RaftLogReader;
 use openraft::SnapshotPolicy;
+use openraft::Vote;
+use openraft::storage::RaftLogStorage;
+use openraft::storage::RaftStateMachine;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -45,15 +49,15 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
             .snapshot(log_id(1, 0, snapshot_index), "leader-0 has built snapshot")
             .await?;
 
-        router
-            .assert_storage_state(
-                1,
-                log_index,
-                Some(0),
-                log_id(1, 0, log_index),
-                Some((log_index.into(), 1)),
-            )
-            .await?;
+        let (mut sto, mut sm) = router.get_storage_handle(&0)?;
+        assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+        assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(1, 0)));
+
+        let (last_applied, _) = sm.applied_state().await?;
+        assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+
+        let snap = sm.get_current_snapshot().await?.unwrap();
+        assert_eq!(snap.meta.last_log_id, Some(log_id(1, 0, log_index)));
     }
 
     tracing::info!(
@@ -82,17 +86,17 @@ async fn after_snapshot_add_learner_and_request_a_log() -> Result<()> {
                 .await?;
         }
 
-        let expected_snap = Some((snapshot_index.into(), 1));
+        for id in [0, 1] {
+            let (mut sto, mut sm) = router.get_storage_handle(&id)?;
+            assert_eq!(sto.get_log_state().await?.last_log_id, Some(log_id(1, 0, log_index)));
+            assert_eq!(sto.read_vote().await?, Some(Vote::new_committed(1, 0)));
 
-        router
-            .assert_storage_state(
-                1,
-                log_index,
-                None, /* learner does not vote */
-                log_id(1, 0, log_index),
-                expected_snap,
-            )
-            .await?;
+            let (last_applied, _) = sm.applied_state().await?;
+            assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+
+            let snap = sm.get_current_snapshot().await?.unwrap();
+            assert_eq!(snap.meta.last_log_id, Some(log_id(1, 0, snapshot_index)));
+        }
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### test: replace `assert_storage_state()` with explicit inline assertions in tests
Replace the generic `assert_storage_state()` helper function with explicit,
standalone assertions directly in each test file. This makes tests clearer by
allowing each test to check only the fields it needs, while ensuring all
original checks are preserved.


##### test: adjust expected snapshot log ID range for delayed commit-apply
The commit and apply command is now progress-driven which may cause
delays. The snapshot trigger still uses the `accepted` committed log ID
value, so snapshot building may execute before the committed log ID
is actually applied to the state machine. This results in the snapshot's
last log ID being one commit behind the expected value.

Changes:
- Widen expected snapshot log ID range from 499..600 to 450..600 in t10_client_writes

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1578)
<!-- Reviewable:end -->
