### PR TITLE
refactor: optimize `leader_append_entries()` to single traversal

### DIFF
--- a/openraft/src/base/batch/mod.rs
+++ b/openraft/src/base/batch/mod.rs
@@ -37,7 +37,6 @@ impl<T> Batch<T> {
     ///
     /// If the iterator has exactly one element, returns `Single` variant.
     /// Otherwise, collects into `Vec` variant.
-    #[allow(dead_code)]
     pub fn from_iter(iter: impl ExactSizeIterator<Item = T>) -> Self {
         if iter.len() == 1 {
             let mut iter = iter;


### PR DESCRIPTION

## Changelog

##### refactor: optimize `leader_append_entries()` to single traversal
Combine entry creation and membership detection into a single pass using
`Batch::from_iter()`. This improves performance through better cache
locality and avoids heap allocation for single-entry appends.


##### refactor: add `from_iter()` constructor to `Batch<T>`
Add a method to create a `Batch` from an `ExactSizeIterator`, optimizing
for single-element iterators by using the `Single` variant.

Changes:
- Add `from_iter()` method that creates `Single` variant for single-element iterators
- Add unit test for `from_iter()` covering single, multiple, and empty cases

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1580)
<!-- Reviewable:end -->
