### PR TITLE
refactor: add display modes to `RuntimeStatsDisplay`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ semver             = { version = "1.0.14" }
 serde              = { version = "1.0.114", features = ["derive", "rc"] }
 serde_json         = { version = "1.0.57" }
 syn                = { version = "2.0" }
+tabled             = { version = "0.17" }
 tempfile           = { version = "3.4.0" }
 test-harness       = { version = "0.3.0" }
 thiserror          = { version = "1.0.49" }

--- a/benchmarks/minimal/src/bin/bench.rs
+++ b/benchmarks/minimal/src/bin/bench.rs
@@ -188,7 +188,7 @@ async fn do_bench(bench_config: &BenchConfig, leader: BenchRaft) -> anyhow::Resu
         loop {
             tokio::time::sleep(Duration::from_secs(5)).await;
             if let Ok(stats) = stats_leader.runtime_stats().await {
-                eprintln!("[{:>6.2}s] {}", now.elapsed().as_secs_f64(), stats.display());
+                eprintln!("[{:>6.2}s] {}", now.elapsed().as_secs_f64(), stats.display().multiline());
             }
         }
     });
@@ -223,7 +223,7 @@ async fn do_bench(bench_config: &BenchConfig, leader: BenchRaft) -> anyhow::Resu
 
     // Print final stats
     let stats = leader.runtime_stats().await?;
-    eprintln!("[{:>6.2}s] Final: {}", elapsed.as_secs_f64(), stats.display());
+    eprintln!("[{:>6.2}s] Final:\n{}", elapsed.as_secs_f64(), stats.display().human_readable());
 
     let millis = elapsed.as_millis().max(1);
     println!(

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -28,6 +28,7 @@ maplit          = { workspace = true }
 rand            = { workspace = true }
 serde           = { workspace = true, optional = true }
 serde_json      = { workspace = true, optional = true }
+tabled          = { workspace = true, optional = true }
 thiserror       = { workspace = true }
 tokio           = { workspace = true, optional = true }
 tracing         = { workspace = true }
@@ -111,7 +112,7 @@ tracing-log = [ "tracing/log" ]
 
 # Expose runtime statistics types (`RuntimeStats`, `SharedRuntimeState`, `Histogram`)
 # and add `Raft::runtime_stats()` method for accessing runtime statistics.
-runtime-stats = []
+runtime-stats = ["dep:tabled"]
 
 [package.metadata.docs.rs]
 


### PR DESCRIPTION

## Changelog

##### refactor: add display modes to `RuntimeStatsDisplay`
Add three display modes for runtime statistics: Compact (default single-line),
Multiline (one item per line), and HumanReadable (formatted tables with
`tabled` crate). The human-readable mode uses rounded table borders,
right-aligned numbers, and thousand separators for better readability.

Changes:
- Add `DisplayMode` enum with `Compact`, `Multiline`, `HumanReadable` variants
- Add mode switching methods: `compact()`, `multiline()`, `human_readable()`
- Add `tabled` dependency for table formatting (optional, with `runtime-stats` feature)
- Update benchmark to use `multiline()` for periodic stats and `human_readable()` for final stats

Example output:

Multiline mode:
```
RuntimeStats:
  apply_batch: [total: 135314, P1: 1, P5: 1, P10: 10, P50: 80, P90: 224, P99: 640]
  append_batch: [total: 249302, P1: 1, P5: 1, P10: 1, P50: 28, P90: 128, P99: 512]
  replicate_batch: [total: 413453, P1: 0, P5: 0, P10: 0, P50: 24, P90: 192, P99: 640]
  commands:
    AppendEntries: 249302
    ReplicateCommitted: 135314
    ...
  raft_msgs:
    ClientWrite: 15681065
    ...
  notifications:
    Notify::VoteResponse: 3
    ...
```

HumanReadable mode:
```
Batch Sizes:
╭───────────┬─────────┬────┬────┬─────┬─────┬─────┬─────╮
│           │   Total │ P1 │ P5 │ P10 │ P50 │ P90 │ P99 │
├───────────┼─────────┼────┼────┼─────┼─────┼─────┼─────┤
│ Apply     │ 174,352 │  1 │  1 │  10 │  80 │ 224 │ 640 │
│ Append    │ 321,033 │  1 │  1 │   1 │  28 │ 128 │ 512 │
│ Replicate │ 532,942 │  0 │  0 │   0 │  24 │ 192 │ 640 │
╰───────────┴─────────┴────┴────┴─────┴─────┴─────┴─────╯
Commands:
╭───────────────────────────┬─────────╮
│ Command                   │   Count │
├───────────────────────────┼─────────┤
│ AppendEntries             │ 321,033 │
│ ReplicateCommitted        │ 174,352 │
│ ...                       │         │
╰───────────────────────────┴─────────╯
Raft Messages:
╭─────────────────┬────────────╮
│ Message         │      Count │
├─────────────────┼────────────┤
│ ClientWrite     │ 19,996,672 │
│ ...             │            │
╰─────────────────┴────────────╯
Notifications:
╭─────────────────────────────┬─────────╮
│ Notification                │   Count │
├─────────────────────────────┼─────────┤
│ Notify::VoteResponse        │       3 │
│ Notify::LocalIO             │ 106,898 │
│ ...                         │         │
╰─────────────────────────────┴─────────╯
```

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1582)
<!-- Reviewable:end -->
