### PR TITLE
refactor: add `BatchRaftMsgReceiver` to batch consecutive client writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ minimized store and network. This is **NOT a real world** application benchmark!
 
 | clients | put/s     |
 | --:     | --:       |
-| 4096    | 3,373,000 |
+| 4096    | 3,548,000 |
 | 1024    | 3,006,000 |
 | 256     | 1,808,000 |
 | 64      |   912,000 |

--- a/benchmarks/minimal/README.md
+++ b/benchmarks/minimal/README.md
@@ -16,7 +16,7 @@ and an in-process network that uses function calls to simulate RPC.
 | 256     | 1,808,000 |
 | 512     | 2,543,000 |
 | 1024    | 3,006,000 |
-| 4096    | 3,373,000 |
+| 4096    | 3,548,000 |
 
 The benchmark is carried out with varying numbers of clients because:
 - The `1 client` benchmark shows the average **latency** to commit each log.

--- a/openraft/src/core/merged_raft_msg_receiver.rs
+++ b/openraft/src/core/merged_raft_msg_receiver.rs
@@ -1,0 +1,136 @@
+use crate::RaftTypeConfig;
+use crate::async_runtime::MpscReceiver;
+use crate::async_runtime::TryRecvError;
+use crate::core::raft_msg::RaftMsg;
+use crate::error::Fatal;
+use crate::type_config::alias::MpscReceiverOf;
+
+pub(crate) struct BatchRaftMsgReceiver<C>
+where C: RaftTypeConfig
+{
+    buffered: Option<RaftMsg<C>>,
+    inner: MpscReceiverOf<C, RaftMsg<C>>,
+}
+
+impl<C> BatchRaftMsgReceiver<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(receiver: MpscReceiverOf<C, RaftMsg<C>>) -> Self {
+        Self {
+            buffered: None,
+            inner: receiver,
+        }
+    }
+
+    pub(crate) async fn ensure_buffered(&mut self) -> Result<(), Fatal<C>> {
+        if self.buffered.is_some() {
+            return Ok(());
+        }
+
+        let msg = self.inner_recv().await?;
+        self.buffered = Some(msg);
+
+        Ok(())
+    }
+
+    pub(crate) fn try_recv(&mut self) -> Result<Option<RaftMsg<C>>, Fatal<C>> {
+        let msg = self.buffered_try_recv()?;
+
+        let Some(mut msg) = msg else {
+            return Ok(None);
+        };
+
+        self.merge_client_writes(&mut msg)?;
+
+        Ok(Some(msg))
+    }
+
+    fn buffered_try_recv(&mut self) -> Result<Option<RaftMsg<C>>, Fatal<C>> {
+        if let Some(msg) = self.buffered.take() {
+            return Ok(Some(msg));
+        }
+
+        self.inner_try_recv()
+    }
+
+    async fn inner_recv(&mut self) -> Result<RaftMsg<C>, Fatal<C>> {
+        let Some(msg) = self.inner.recv().await else {
+            tracing::info!("all rx_api senders are dropped");
+            return Err(Fatal::Stopped);
+        };
+
+        Ok(msg)
+    }
+
+    fn inner_try_recv(&mut self) -> Result<Option<RaftMsg<C>>, Fatal<C>> {
+        let res = self.inner.try_recv();
+
+        match res {
+            Ok(msg) => Ok(Some(msg)),
+            Err(e) => match e {
+                TryRecvError::Empty => {
+                    tracing::debug!("all RaftMsg are processed, wait for more");
+                    Ok(None)
+                }
+                TryRecvError::Disconnected => {
+                    tracing::debug!("rx_api is disconnected, quit");
+                    Err(Fatal::Stopped)
+                }
+            },
+        }
+    }
+
+    /// Merge as many consecutive RaftMsg::ClientWrite as possible, if they have the same
+    /// expected_leader arg.
+    ///
+    /// When a unmergable RaftMsg is found, it saves it in self.next_raft_msg for next polling
+    ///
+    /// This method does not check `next`, and may leave a unmerged RaftMsg in `next`.
+    fn merge_client_writes(&mut self, msg: &mut RaftMsg<C>) -> Result<(), Fatal<C>> {
+        debug_assert!(self.buffered.is_none());
+
+        let (batch_data, batch_responders, batch_leader) = match msg {
+            RaftMsg::ClientWrite {
+                app_data,
+                responders,
+                expected_leader,
+            } => (app_data, responders, expected_leader),
+            _ => return Ok(()),
+        };
+
+        // TODO: make it configurable
+        let max_batch_size = 4096;
+
+        for _i in 0..max_batch_size {
+            let next = self.inner_try_recv()?;
+
+            let Some(next) = next else {
+                break;
+            };
+
+            let RaftMsg::ClientWrite {
+                app_data,
+                responders,
+                expected_leader,
+            } = next
+            else {
+                self.buffered = Some(next);
+                break;
+            };
+
+            if &expected_leader == batch_leader {
+                batch_data.extend(app_data);
+                batch_responders.extend(responders);
+            } else {
+                self.buffered = Some(RaftMsg::ClientWrite {
+                    app_data,
+                    responders,
+                    expected_leader,
+                });
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -28,6 +28,7 @@ mod client_responder_queue;
 pub(crate) mod core_state;
 pub(crate) mod heartbeat;
 pub(crate) mod io_flush_tracking;
+pub(crate) mod merged_raft_msg_receiver;
 pub(crate) mod notification;
 mod notification_name;
 mod raft_core;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -35,6 +35,7 @@ use crate::core::core_state::CoreState;
 use crate::core::heartbeat::event::HeartbeatEvent;
 use crate::core::heartbeat::handle::HeartbeatWorkersHandle;
 use crate::core::io_flush_tracking::IoProgressSender;
+use crate::core::merged_raft_msg_receiver::BatchRaftMsgReceiver;
 use crate::core::notification::Notification;
 use crate::core::raft_msg::AppendEntriesTx;
 use crate::core::raft_msg::ClientReadTx;
@@ -188,7 +189,7 @@ where
 
     #[allow(dead_code)]
     pub(crate) tx_api: MpscSenderOf<C, RaftMsg<C>>,
-    pub(crate) rx_api: MpscReceiverOf<C, RaftMsg<C>>,
+    pub(crate) rx_api: BatchRaftMsgReceiver<C>,
 
     /// A Sender to send callback by other components to [`RaftCore`], when an action is finished,
     /// such as flushing log to disk, or applying log entries to state machine.
@@ -1148,7 +1149,7 @@ where
             // `select!` without `biased` provides a random fairness.
             // We want to check shutdown prior to other channels.
             // See: https://docs.rs/tokio/latest/tokio/macro.select.html#fairness
-            let got_raft_msg = futures::select_biased! {
+            futures::select_biased! {
                 _ = (&mut rx_shutdown).fuse() => {
                     tracing::info!("recv from rx_shutdown");
                     return Err(Fatal::Stopped);
@@ -1162,29 +1163,14 @@ where
                             return Err(Fatal::Stopped);
                         }
                     };
-                    None
                 }
 
-                msg_res = self.rx_api.recv().fuse() => {
-                    match msg_res {
-                        Some(msg) => Some(msg),
-                        None => {
-                            tracing::info!("all rx_api senders are dropped");
-                            return Err(Fatal::Stopped);
-                        }
-                    }
+                msg_res = self.rx_api.ensure_buffered().fuse() => {
+                    msg_res?;
                 }
             };
 
             self.run_engine_commands().await?;
-
-            if let Some(msg) = got_raft_msg {
-                // TODO: try to merge message for batching
-                self.handle_api_msg(msg).await;
-                self.runtime_stats.raft_msg_batch.record(1);
-                self.runtime_stats.raft_msg_usage_permille.record(1000);
-                self.run_engine_commands().await?;
-            }
 
             // There is a message waking up the loop, process channels one by one.
 
@@ -1219,25 +1205,33 @@ where
         self.runtime_stats.raft_msg_budget.record(at_most);
 
         let mut processed = 0u64;
+        let mut total = 0u64;
+        // Being 0 disabled batch msg processing.
+        // TODO: make it configurable
+        let run_command_threshold = 0;
+        let mut last_log_index = 0;
 
         for _i in 0..at_most {
-            let res = self.rx_api.try_recv();
-            let msg = match res {
-                Ok(msg) => msg,
-                Err(e) => match e {
-                    TryRecvError::Empty => {
-                        tracing::debug!("all RaftMsg are processed, wait for more");
-                        break;
-                    }
-                    TryRecvError::Disconnected => {
-                        tracing::debug!("rx_api is disconnected, quit");
-                        return Err(Fatal::Stopped);
-                    }
-                },
+            let res = self.rx_api.try_recv()?;
+            let Some(msg) = res else {
+                break;
             };
 
             self.handle_api_msg(msg).await;
             processed += 1;
+            total += 1;
+
+            let index = self.engine.state.last_log_id().next_index();
+
+            if index.saturating_sub(last_log_index) >= run_command_threshold {
+                // After handling all the inputs, batch run all the commands for better performance
+                self.runtime_stats.raft_msg_batch.record(processed);
+                self.runtime_stats.raft_msg_usage_permille.record(processed * 1000 / at_most);
+                self.run_engine_commands().await?;
+
+                last_log_index = index;
+                processed = 0;
+            }
         }
 
         // After handling all the inputs, batch run all the commands for better performance
@@ -1245,11 +1239,11 @@ where
         self.runtime_stats.raft_msg_usage_permille.record(processed * 1000 / at_most);
         self.run_engine_commands().await?;
 
-        if processed == at_most {
+        if total == at_most {
             tracing::debug!("at_most({}) reached, there are more queued RaftMsg to process", at_most);
         }
 
-        Ok(processed)
+        Ok(total)
     }
 
     /// Process Notification as many as possible.

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -87,6 +87,7 @@ use crate::core::io_flush_tracking::IoProgressWatcher;
 use crate::core::io_flush_tracking::LogProgress;
 use crate::core::io_flush_tracking::SnapshotProgress;
 use crate::core::io_flush_tracking::VoteProgress;
+use crate::core::merged_raft_msg_receiver::BatchRaftMsgReceiver;
 use crate::core::notification::Notification;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::raft_msg::external_command::ExternalCommand;
@@ -496,7 +497,7 @@ where C: RaftTypeConfig
 
             heartbeat_handle: HeartbeatWorkersHandle::new(id.clone(), config.clone()),
             tx_api: tx_api.clone(),
-            rx_api,
+            rx_api: BatchRaftMsgReceiver::new(rx_api),
 
             tx_notification: tx_notify,
             rx_notification: rx_notify,


### PR DESCRIPTION

## Changelog

##### refactor: add `BatchRaftMsgReceiver` to batch consecutive client writes
Introduce a receiver wrapper that merges consecutive `RaftMsg::ClientWrite`
messages with the same `expected_leader` into a single batched message.
This reduces per-message overhead and improves write throughput.

Changes:
- Add `BatchRaftMsgReceiver` that buffers and merges up to 4096 consecutive client writes
- Update `RaftCore` to use `BatchRaftMsgReceiver` instead of raw mpsc receiver
- Refactor main loop to use `ensure_buffered()` + `try_recv()` pattern for message processing

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1585)
<!-- Reviewable:end -->
