### PR TITLE
refactor: improve RuntimeStats display with categories and comments

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1225,7 +1225,7 @@ where
 
             if index.saturating_sub(last_log_index) >= run_command_threshold {
                 // After handling all the inputs, batch run all the commands for better performance
-                self.runtime_stats.raft_msg_batch.record(processed);
+                self.runtime_stats.raft_msg_per_run.record(processed);
                 self.runtime_stats.raft_msg_usage_permille.record(processed * 1000 / at_most);
                 self.run_engine_commands().await?;
 
@@ -1235,7 +1235,7 @@ where
         }
 
         // After handling all the inputs, batch run all the commands for better performance
-        self.runtime_stats.raft_msg_batch.record(processed);
+        self.runtime_stats.raft_msg_per_run.record(processed);
         self.runtime_stats.raft_msg_usage_permille.record(processed * 1000 / at_most);
         self.run_engine_commands().await?;
 


### PR DESCRIPTION

## Changelog

##### refactor: improve RuntimeStats display with categories and comments
Reorganize runtime statistics display for better clarity. Rename
`raft_msg_batch` to `raft_msg_per_run` to clarify its meaning, split
histograms into logical categories, and add descriptive comments.

Changes:
- Rename `raft_msg_batch` to `raft_msg_per_run`
- Split human-readable output into "Batch Sizes" and "Budget & Utilization" tables
- Add comment column explaining each histogram metric

Example output:

Batch Sizes:
╭─────────────┬───────────┬──────┬────┬────┬─────┬─────┬─────┬─────┬───────┬────────────────────────────────────╮
│             │     Total │ P0.1 │ P1 │ P5 │ P10 │ P50 │ P90 │ P99 │ P99.9 │                                    │
├─────────────┼───────────┼──────┼────┼────┼─────┼─────┼─────┼─────┼───────┼────────────────────────────────────┤
│ Apply       │    70,963 │    1 │  8 │ 28 │  48 │ 256 │ 512 │ 896 │  1024 │ Entries per state machine apply    │
│ Append      │ 1,062,604 │    1 │  1 │  2 │   2 │   5 │  48 │ 160 │   448 │ Entries per storage append         │
│ Replicate   │   254,906 │    0 │  0 │  0 │   0 │  40 │ 448 │ 896 │  1024 │ Entries per replication RPC        │
│ RaftMsg/run │ 1,146,843 │    0 │  0 │  0 │   1 │   1 │   1 │   1 │     1 │ RaftMsgs per run_engine_commands() │
│ Write       │ 1,062,602 │    1 │  1 │  2 │   2 │   5 │  48 │ 160 │   448 │ Client writes merged per batch     │
╰─────────────┴───────────┴──────┴────┴────┴─────┴─────┴─────┴─────┴───────┴────────────────────────────────────╯
Budget & Utilization:
╭───────────────┬───────────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┬───────┬─────────────────────────────────────╮
│               │     Total │ P0.1 │   P1 │   P5 │  P10 │  P50 │  P90 │  P99 │ P99.9 │                                     │
├───────────────┼───────────┼──────┼──────┼──────┼──────┼──────┼──────┼──────┼───────┼─────────────────────────────────────┤
│ RaftMsgBudget │    84,240 │  896 │  896 │  896 │  896 │  896 │  896 │  896 │   896 │ Max RaftMsgs allowed per loop       │
│ NotifyBudget  │    84,239 │ 8192 │ 8192 │ 8192 │ 8192 │ 8192 │ 8192 │ 8192 │  8192 │ Max Notifications allowed per loop  │
│ RaftMsgUsage‰ │ 1,146,843 │    0 │    0 │    0 │    1 │    1 │    1 │    1 │     1 │ RaftMsg budget utilization (‰)      │
│ NotifyUsage‰  │    84,239 │    0 │    0 │    0 │    0 │    1 │    1 │    2 │     2 │ Notification budget utilization (‰) │
╰───────────────┴───────────┴──────┴──────┴──────┴──────┴──────┴──────┴──────┴───────┴─────────────────────────────────────╯


##### refactor: add `write_batch` histogram to track merged client writes
Add histogram to track how many client write entries are merged together
in each `RaftMsg::ClientWrite` batch, helping identify batching efficiency.

Changes:
- Add `write_batch` histogram field to `RuntimeStats`
- Record batch size when handling `ClientWrite` messages
- Include `write_batch` in all display formats

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1586)
<!-- Reviewable:end -->
