### PR TITLE
refactor: convert `TokioInstant` from type alias to wrapper struct

### DIFF
--- a/openraft/src/display_ext/display_instant.rs
+++ b/openraft/src/display_ext/display_instant.rs
@@ -89,6 +89,7 @@ where T: Instant
 #[cfg(test)]
 mod tests {
 
+    use crate::Instant;
     use crate::TokioInstant;
     use crate::display_ext::DisplayInstantExt;
 

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::EffectiveMembership;
+use crate::Instant;
 use crate::Membership;
 use crate::TokioInstant;
 use crate::Vote;

--- a/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime/instant.rs
+++ b/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime/instant.rs
@@ -1,0 +1,65 @@
+//! Instant wrapper type and its trait impl.
+
+use std::ops::Add;
+use std::ops::AddAssign;
+use std::ops::Sub;
+use std::ops::SubAssign;
+use std::time::Duration;
+
+use crate::async_runtime::instant;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct TokioInstant(pub(crate) tokio::time::Instant);
+
+impl Add<Duration> for TokioInstant {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0.add(rhs))
+    }
+}
+
+impl AddAssign<Duration> for TokioInstant {
+    #[inline]
+    fn add_assign(&mut self, rhs: Duration) {
+        self.0.add_assign(rhs)
+    }
+}
+
+impl Sub<Duration> for TokioInstant {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Duration) -> Self::Output {
+        Self(self.0.sub(rhs))
+    }
+}
+
+impl Sub<Self> for TokioInstant {
+    type Output = Duration;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0.sub(rhs.0)
+    }
+}
+
+impl SubAssign<Duration> for TokioInstant {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Duration) {
+        self.0.sub_assign(rhs)
+    }
+}
+
+impl instant::Instant for TokioInstant {
+    #[inline]
+    fn now() -> Self {
+        Self(tokio::time::Instant::now())
+    }
+
+    #[inline]
+    fn elapsed(&self) -> Duration {
+        self.0.elapsed()
+    }
+}

--- a/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime/mod.rs
+++ b/openraft/src/type_config/async_runtime/tokio_impls/tokio_runtime/mod.rs
@@ -2,28 +2,19 @@ use std::future::Future;
 use std::time::Duration;
 
 use crate::AsyncRuntime;
-use crate::Instant;
 use crate::OptionalSend;
 
+mod instant;
 mod mpsc;
 mod mutex;
 mod oneshot;
 mod watch;
 
+pub use instant::TokioInstant;
 use mpsc::TokioMpsc;
 use mutex::TokioMutex;
 use oneshot::TokioOneshot;
 use watch::TokioWatch;
-
-/// Type alias for tokio's Instant type.
-pub type TokioInstant = tokio::time::Instant;
-
-impl Instant for tokio::time::Instant {
-    #[inline]
-    fn now() -> Self {
-        tokio::time::Instant::now()
-    }
-}
 
 /// `Tokio` is the default asynchronous executor.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -61,7 +52,7 @@ impl AsyncRuntime for TokioRuntime {
 
     #[inline]
     fn sleep_until(deadline: Self::Instant) -> Self::Sleep {
-        tokio::time::sleep_until(deadline)
+        tokio::time::sleep_until(deadline.0)
     }
 
     #[inline]
@@ -71,7 +62,7 @@ impl AsyncRuntime for TokioRuntime {
 
     #[inline]
     fn timeout_at<R, F: Future<Output = R> + OptionalSend>(deadline: Self::Instant, future: F) -> Self::Timeout<R, F> {
-        tokio::time::timeout_at(deadline, future)
+        tokio::time::timeout_at(deadline.0, future)
     }
 
     #[inline]

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::Instant;
 use openraft::TokioInstant;
 use openraft::Vote;
 use openraft::raft::VoteRequest;

--- a/tests/tests/metrics/t10_leader_last_ack.rs
+++ b/tests/tests/metrics/t10_leader_last_ack.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::Instant;
 use openraft::type_config::TypeConfigExt;
 use openraft_memstore::TypeConfig;
 


### PR DESCRIPTION

## Changelog

##### refactor: convert `TokioInstant` from type alias to wrapper struct
Convert `TokioInstant` to a newtype wrapper around `tokio::time::Instant`
instead of a type alias. This allows implementing the `Instant` trait on
the wrapper type, following the same pattern as `MonoioInstant`.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1594)
<!-- Reviewable:end -->
