### PR TITLE
refactor: move async-runtime test suite to `openraft-rt` crate

### DIFF
--- a/openraft/src/testing/mod.rs
+++ b/openraft/src/testing/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! - [`common`] - Common test utilities and assertions
 //! - [`log`] - Log storage test suite
-//! - [`runtime`] - Runtime test utilities
+//! - [`runtime`] - Runtime test utilities (re-exported from `openraft_rt::testing`)
 //!
 //! ## Overview
 //!
@@ -30,6 +30,10 @@
 
 pub mod common;
 pub mod log;
-pub mod runtime;
 
 pub use common::*;
+
+/// Runtime test utilities re-exported from `openraft_rt::testing`.
+pub mod runtime {
+    pub use openraft_rt::testing::Suite;
+}

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -21,6 +21,7 @@ pub mod instant;
 pub mod mpsc;
 pub mod mutex;
 pub mod oneshot;
+pub mod testing;
 pub mod watch;
 
 pub use async_runtime::AsyncRuntime;

--- a/rt/src/testing.rs
+++ b/rt/src/testing.rs
@@ -2,25 +2,26 @@
 
 #![allow(missing_docs)]
 
+use std::future::Future;
 use std::pin::Pin;
 use std::pin::pin;
 use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
 
-use crate::async_runtime::Mpsc;
-use crate::async_runtime::MpscReceiver;
-use crate::async_runtime::MpscSender;
-use crate::async_runtime::MpscWeakSender;
-use crate::async_runtime::TryRecvError;
-use crate::async_runtime::watch::WatchReceiver;
-use crate::async_runtime::watch::WatchSender;
-use crate::type_config::async_runtime::AsyncRuntime;
-use crate::type_config::async_runtime::Instant;
-use crate::type_config::async_runtime::mutex::Mutex;
-use crate::type_config::async_runtime::oneshot::Oneshot;
-use crate::type_config::async_runtime::oneshot::OneshotSender;
-use crate::type_config::async_runtime::watch::Watch;
+use crate::AsyncRuntime;
+use crate::Instant;
+use crate::Mutex;
+use crate::Oneshot;
+use crate::OneshotSender;
+use crate::Watch;
+use crate::mpsc::Mpsc;
+use crate::mpsc::MpscReceiver;
+use crate::mpsc::MpscSender;
+use crate::mpsc::MpscWeakSender;
+use crate::mpsc::TryRecvError;
+use crate::watch::WatchReceiver;
+use crate::watch::WatchSender;
 
 /// Test suite to ensure a runtime impl works as expected.
 ///


### PR DESCRIPTION

## Changelog

##### refactor: move async-runtime test suite to `openraft-rt` crate
Move the `Suite` test harness from openraft to openraft-rt where it
belongs. This allows other async runtime implementations to use the
same test suite without depending on the entire openraft crate.

Changes:
- Move `testing::runtime::Suite` from openraft to `openraft_rt::testing`
- Update imports to use local crate paths in openraft-rt
- Re-export `Suite` from `openraft::testing::runtime` for backward compatibility

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1604)
<!-- Reviewable:end -->
