### PR TITLE
refactor: extract tokio runtime implementation into standalone `openraft-rt-tokio` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,5 +90,6 @@ exclude = [
 
     "rt-monoio",
     "rt-compio",
+    "rt-tokio",
     "multiraft"
 ]

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ lint:
 	cargo fmt --manifest-path multiraft/Cargo.toml
 	cargo fmt --manifest-path rt-compio/Cargo.toml
 	cargo fmt --manifest-path rt-monoio/Cargo.toml
+	cargo fmt --manifest-path rt-tokio/Cargo.toml
 	cargo fmt --manifest-path examples/mem-log/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
@@ -105,6 +106,7 @@ lint:
 	cargo clippy --no-deps --manifest-path multiraft/Cargo.toml                                       --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path rt-compio/Cargo.toml                                       --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path rt-monoio/Cargo.toml                                       --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path rt-tokio/Cargo.toml                                       --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/mem-log/Cargo.toml                                --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml            --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml --all-targets -- -D warnings
@@ -132,6 +134,7 @@ clean:
 	cargo clean --manifest-path multiraft/Cargo.toml
 	cargo clean --manifest-path rt-compio/Cargo.toml
 	cargo clean --manifest-path rt-monoio/Cargo.toml
+	cargo clean --manifest-path rt-tokio/Cargo.toml
 	cargo clean --manifest-path benchmarks/minimal/Cargo.toml
 	cargo clean --manifest-path examples/client-http/Cargo.toml
 	cargo clean --manifest-path examples/network-v1-http/Cargo.toml

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,12 @@
 #![doc = include_str!("lib_readme.md")]
 #![allow(clippy::uninlined_format_args)]
 
+#[cfg(feature = "singlethreaded")]
+compile_error!(
+    "The feature flag `singlethreaded` is renamed to `single-threaded`. \
+     Please update your Cargo.toml to use `single-threaded` instead."
+);
+
 mod expand;
 mod since;
 pub(crate) mod utils;

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -16,6 +16,7 @@ repository    = { workspace = true }
 
 [dependencies]
 openraft-rt = { path = "../rt", version = "0.10.0" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0", optional = true }
 openraft-macros = { path = "../macros", version = "0.10.0" }
 
 anyerror        = { workspace = true }
@@ -31,6 +32,7 @@ serde           = { workspace = true, optional = true }
 serde_json      = { workspace = true, optional = true }
 tabled          = { workspace = true, optional = true }
 thiserror       = { workspace = true }
+# Tokio is still needed for I/O traits (AsyncRead, AsyncWrite, AsyncSeek) when tokio-rt is enabled
 tokio           = { workspace = true, optional = true }
 tracing         = { workspace = true }
 tracing-futures = { workspace = true }
@@ -48,7 +50,7 @@ serde_json        = { workspace = true }
 default = ["tokio-rt", "adapt-network-v1"]
 
 # Enable the default Tokio runtime
-tokio-rt = ["dep:tokio"]
+tokio-rt = ["dep:openraft-rt-tokio", "dep:tokio"]
 
 # Enables benchmarks in unittest.
 #
@@ -91,7 +93,7 @@ compat = []
 adapt-network-v1 = []
 
 # Disallows applications to share a raft instance with multiple threads.
-single-threaded = ["openraft-rt/single-threaded", "openraft-macros/single-threaded"]
+single-threaded = ["openraft-rt/single-threaded", "openraft-rt-tokio?/single-threaded", "openraft-macros/single-threaded"]
 
 # Deprecated: use `single-threaded` instead.
 # This feature triggers a compile-time error with migration instructions.

--- a/openraft/src/impls/mod.rs
+++ b/openraft/src/impls/mod.rs
@@ -24,10 +24,7 @@
 //! Most applications can use these implementations directly without customization.
 
 #[cfg(feature = "tokio-rt")]
-pub(crate) mod tokio_runtime;
-
-#[cfg(feature = "tokio-rt")]
-pub use tokio_runtime::TokioRuntime;
+pub use openraft_rt_tokio::TokioRuntime;
 
 pub use crate::entry::Entry;
 pub use crate::node::BasicNode;

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -93,9 +93,9 @@ pub use error::storage_error::StorageIOError;
 pub use error::storage_error::ToStorageResult;
 #[cfg(feature = "tokio-rt")]
 pub use impls::TokioRuntime;
-#[cfg(feature = "tokio-rt")]
-pub use impls::tokio_runtime::TokioInstant;
 pub use openraft_macros::add_async_trait;
+#[cfg(feature = "tokio-rt")]
+pub use openraft_rt_tokio::TokioInstant;
 pub use type_config::AsyncRuntime;
 pub use type_config::async_runtime;
 pub use type_config::async_runtime::Instant;

--- a/openraft/src/type_config/async_runtime/mod.rs
+++ b/openraft/src/type_config/async_runtime/mod.rs
@@ -26,6 +26,5 @@ pub use openraft_rt::mpsc;
 pub use openraft_rt::mutex;
 pub use openraft_rt::oneshot;
 pub use openraft_rt::watch;
-
 #[cfg(feature = "tokio-rt")]
-pub use crate::impls::tokio_runtime::TokioInstant;
+pub use openraft_rt_tokio::TokioInstant;

--- a/rt-compio/Cargo.toml
+++ b/rt-compio/Cargo.toml
@@ -13,7 +13,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0", default-features = false, features = ["single-threaded"] }
 openraft-rt = { path = "../rt", version = "0.10.0", features = ["single-threaded"] }
 
 compio           = { version = ">=0.14.0", features = ["runtime", "time"] }

--- a/rt-compio/src/lib.rs
+++ b/rt-compio/src/lib.rs
@@ -11,7 +11,6 @@ use std::task::Poll;
 pub use compio;
 pub use futures;
 use futures::FutureExt;
-pub use openraft;
 use openraft_rt::AsyncRuntime;
 use openraft_rt::OptionalSend;
 pub use rand;
@@ -158,7 +157,7 @@ impl AsyncRuntime for CompioRuntime {
 
 #[cfg(test)]
 mod tests {
-    use openraft::testing::runtime::Suite;
+    use openraft_rt::testing::Suite;
 
     use super::*;
 

--- a/rt-compio/src/watch.rs
+++ b/rt-compio/src/watch.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
-use openraft_rt::OptionalSend;
-use openraft_rt::OptionalSync;
 use openraft_rt::watch;
 use openraft_rt::watch::RecvError;
 use openraft_rt::watch::SendError;
+use openraft_rt::OptionalSend;
+use openraft_rt::OptionalSync;
 use see::error::SendError as SeeSendError;
 use see::unsync as see_unsync;
 

--- a/rt-monoio/Cargo.toml
+++ b/rt-monoio/Cargo.toml
@@ -15,7 +15,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0", default-features = false, features = ["single-threaded"] }
 openraft-rt = { path = "../rt", version = "0.10.0", features = ["single-threaded"] }
 
 futures    = { version = "0.3" }

--- a/rt-monoio/src/lib.rs
+++ b/rt-monoio/src/lib.rs
@@ -46,7 +46,7 @@ pub struct MonoioRuntime;
 
 impl AsyncRuntime for MonoioRuntime {
     // Joining an async task on Monoio always succeeds
-    type JoinError = openraft::error::Infallible;
+    type JoinError = std::convert::Infallible;
     type JoinHandle<T: OptionalSend + 'static> = monoio::task::JoinHandle<Result<T, Self::JoinError>>;
     type Sleep = monoio::time::Sleep;
     type Instant = MonoioInstant;
@@ -101,7 +101,7 @@ impl AsyncRuntime for MonoioRuntime {
 
 #[cfg(test)]
 mod tests {
-    use openraft::testing::runtime::Suite;
+    use openraft_rt::testing::Suite;
 
     use super::*;
 

--- a/rt-monoio/src/watch.rs
+++ b/rt-monoio/src/watch.rs
@@ -2,11 +2,11 @@
 
 use std::ops::Deref;
 
-use openraft_rt::OptionalSend;
-use openraft_rt::OptionalSync;
 use openraft_rt::watch;
 use openraft_rt::watch::RecvError;
 use openraft_rt::watch::SendError;
+use openraft_rt::OptionalSend;
+use openraft_rt::OptionalSync;
 use tokio::sync::watch as tokio_watch;
 
 pub struct TokioWatch;

--- a/rt-tokio/Cargo.toml
+++ b/rt-tokio/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "openraft-rt-tokio"
+version = "0.10.0"
+edition = "2024"
+authors = [
+    "drdrxp <drdr.xp@gmail.com>",
+    "Databend Authors <opensource@datafuselabs.com>",
+]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/drmingdrmer/openraft"
+homepage = "https://github.com/drmingdrmer/openraft"
+readme = "README.md"
+description = "Tokio runtime implementation for Openraft"
+
+[dependencies]
+openraft-rt = { path = "../rt", version = "0.10.0" }
+tokio = { version = "1.39", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time"] }
+futures = { version = "0.3" }
+rand = { version = "0.9", default-features = false, features = ["std", "std_rng"] }
+
+[features]
+default = []
+single-threaded = ["openraft-rt/single-threaded"]

--- a/rt-tokio/README.md
+++ b/rt-tokio/README.md
@@ -1,0 +1,5 @@
+# openraft-rt-tokio
+
+Tokio [`AsyncRuntime`][rt_link] support for Openraft.
+
+[rt_link]: https://docs.rs/openraft/latest/openraft/async_runtime/trait.AsyncRuntime.html

--- a/rt-tokio/src/instant.rs
+++ b/rt-tokio/src/instant.rs
@@ -6,7 +6,7 @@ use std::ops::Sub;
 use std::ops::SubAssign;
 use std::time::Duration;
 
-use crate::async_runtime::instant;
+use openraft_rt::instant;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct TokioInstant(pub(crate) tokio::time::Instant);

--- a/rt-tokio/src/lib.rs
+++ b/rt-tokio/src/lib.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
 use std::time::Duration;
 
-use crate::AsyncRuntime;
-use crate::OptionalSend;
+use openraft_rt::AsyncRuntime;
+use openraft_rt::OptionalSend;
 
 mod instant;
 mod mpsc;
@@ -11,13 +11,19 @@ mod oneshot;
 mod watch;
 
 pub use instant::TokioInstant;
-use mpsc::TokioMpsc;
-use mutex::TokioMutex;
-use oneshot::TokioOneshot;
-use watch::TokioWatch;
+pub use mpsc::TokioMpsc;
+pub use mpsc::TokioMpscReceiver;
+pub use mpsc::TokioMpscSender;
+pub use mpsc::TokioMpscWeakSender;
+pub use mutex::TokioMutex;
+pub use oneshot::TokioOneshot;
+pub use oneshot::TokioOneshotSender;
+pub use watch::TokioWatch;
+pub use watch::TokioWatchReceiver;
+pub use watch::TokioWatchSender;
 
 /// `Tokio` is the default asynchronous executor.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct TokioRuntime;
 
 impl AsyncRuntime for TokioRuntime {
@@ -83,8 +89,9 @@ impl AsyncRuntime for TokioRuntime {
 
 #[cfg(test)]
 mod tests {
+    use openraft_rt::testing::Suite;
+
     use super::*;
-    use crate::testing::runtime::Suite;
 
     #[test]
     #[cfg(not(feature = "single-threaded"))]

--- a/rt-tokio/src/mpsc.rs
+++ b/rt-tokio/src/mpsc.rs
@@ -1,13 +1,14 @@
-use futures::TryFutureExt;
-use tokio::sync::mpsc;
+use std::future::Future;
 
-use crate::OptionalSend;
-use crate::async_runtime::Mpsc;
-use crate::async_runtime::MpscReceiver;
-use crate::async_runtime::MpscSender;
-use crate::async_runtime::MpscWeakSender;
-use crate::async_runtime::SendError;
-use crate::async_runtime::TryRecvError;
+use futures::TryFutureExt;
+use openraft_rt::Mpsc;
+use openraft_rt::MpscReceiver;
+use openraft_rt::MpscSender;
+use openraft_rt::MpscWeakSender;
+use openraft_rt::OptionalSend;
+use openraft_rt::SendError;
+use openraft_rt::TryRecvError;
+use tokio::sync::mpsc;
 
 pub struct TokioMpsc;
 

--- a/rt-tokio/src/mutex.rs
+++ b/rt-tokio/src/mutex.rs
@@ -1,5 +1,7 @@
-use crate::OptionalSend;
-use crate::async_runtime::mutex;
+use std::future::Future;
+
+use openraft_rt::OptionalSend;
+use openraft_rt::mutex;
 
 /// Wrapper around `tokio::sync::Mutex` to implement the `Mutex` trait.
 pub struct TokioMutex<T>(tokio::sync::Mutex<T>);

--- a/rt-tokio/src/oneshot.rs
+++ b/rt-tokio/src/oneshot.rs
@@ -1,6 +1,6 @@
-use crate::OptionalSend;
-use crate::async_runtime::OneshotSender;
-use crate::async_runtime::oneshot;
+use openraft_rt::OneshotSender;
+use openraft_rt::OptionalSend;
+use openraft_rt::oneshot;
 
 pub struct TokioOneshot;
 

--- a/rt-tokio/src/watch.rs
+++ b/rt-tokio/src/watch.rs
@@ -1,8 +1,7 @@
+use openraft_rt::OptionalSend;
+use openraft_rt::OptionalSync;
+use openraft_rt::watch;
 use tokio::sync::watch as tokio_watch;
-
-use crate::OptionalSend;
-use crate::OptionalSync;
-use crate::async_runtime::watch;
 
 pub struct TokioWatch;
 

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -15,7 +15,7 @@ repository    = { workspace = true }
 
 [features]
 default = []
-single-threaded = ["openraft-macros/singlethreaded"]
+single-threaded = ["openraft-macros/single-threaded"]
 
 [dependencies]
 futures         = { workspace = true }


### PR DESCRIPTION

## Changelog

##### refactor: extract tokio runtime implementation into standalone `openraft-rt-tokio` crate
Move the tokio runtime implementation from `openraft/src/impls/tokio_runtime/`
to a new standalone `rt-tokio` crate. This follows the same pattern as
`rt-compio` and `rt-monoio`, making all runtime implementations standalone.

Changes:
- Add `openraft-rt-tokio` crate with `TokioRuntime` implementation
- Update `openraft` to depend on `openraft-rt-tokio` via `tokio-rt` feature
- Update `rt-compio` and `rt-monoio` to use `openraft_rt::testing::Suite`
- Remove `openraft` dependency from `rt-compio` and `rt-monoio`
- Use `std::convert::Infallible` in `rt-monoio` instead of `openraft::error::Infallible`

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1605)
<!-- Reviewable:end -->
