### PR TITLE
refactor: change `LogIdList` to last-per-leader storage format

### DIFF
--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -59,11 +59,11 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
         blank_ent(3, 1, 5),
     ]);
 
+    assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(
         &[
             log_id(1, 1, 1), //
             log_id(2, 1, 3),
-            log_id(3, 1, 4),
             log_id(3, 1, 5),
         ],
         eng.state.log_ids.key_log_ids()

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -91,6 +91,7 @@ fn test_leader_append_entries_empty() -> anyhow::Result<()> {
         eng.state.accepted_log_io(),
         "no accepted log updated for empty entries"
     );
+    assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(
         &[
             log_id(1, 1, 1), //
@@ -134,11 +135,11 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
         )),
         eng.state.accepted_log_io()
     );
+    assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(
         &[
             log_id(1, 1, 1), //
             log_id(2, 1, 3),
-            log_id(3, 1, 4),
             log_id(3, 1, 6),
         ],
         eng.state.log_ids.key_log_ids()
@@ -205,11 +206,11 @@ fn test_leader_append_entries_single_node_leader() -> anyhow::Result<()> {
         )),
         eng.state.accepted_log_io()
     );
+    assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(
         &[
             log_id(1, 1, 1), //
             log_id(2, 1, 3),
-            log_id(3, 1, 4),
             log_id(3, 1, 6),
         ],
         eng.state.log_ids.key_log_ids()
@@ -268,11 +269,11 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
         )),
         eng.state.accepted_log_io()
     );
+    assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(
         &[
             log_id(1, 1, 1), //
             log_id(2, 1, 3),
-            log_id(3, 1, 4),
             log_id(3, 1, 6),
         ],
         eng.state.log_ids.key_log_ids()

--- a/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
+++ b/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
@@ -17,13 +17,12 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
-    eng.state.log_ids = LogIdList::new(vec![
-        //
-        log_id(0, 0),
-        log_id(1, 1),
-        log_id(3, 3),
-        log_id(5, 5),
-    ]);
+    // Last-per-leader format:
+    // - leader 0: index 0
+    // - leader 1: indices 1-2
+    // - leader 3: indices 3-4
+    // - leader 5: index 5
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(0, 0), log_id(1, 2), log_id(3, 4), log_id(5, 5)]);
     eng
 }
 

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -9,13 +9,15 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 2), log_id(4, 1, 4), log_id(4, 1, 6)]);
+    // Setup: purged at 2 (leader 2), leader 2's logs at 3-4, leader 4's logs at 5-6
+    eng.state.log_ids = LogIdList::new(Some(log_id(2, 1, 2)), vec![log_id(2, 1, 4), log_id(4, 1, 6)]);
     eng.state.purged_next = 3;
     eng
 }
 
 #[test]
 fn test_purge_log_already_purged() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
@@ -23,7 +25,8 @@ fn test_purge_log_already_purged() -> anyhow::Result<()> {
     lh.purge_log();
 
     assert_eq!(Some(&log_id(2, 1, 2)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(2, 1, 2), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(2, 1, 2)), lh.state.log_ids.purged());
+    assert_eq!(log_id(2, 1, 4), lh.state.log_ids.key_log_ids()[0]);
     assert_eq!(Some(&log_id(4, 1, 6)), lh.state.last_log_id());
 
     assert_eq!(0, lh.output.take_commands().len());
@@ -33,6 +36,7 @@ fn test_purge_log_already_purged() -> anyhow::Result<()> {
 
 #[test]
 fn test_purge_log_equal_prev_last_purged() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
@@ -40,15 +44,19 @@ fn test_purge_log_equal_prev_last_purged() -> anyhow::Result<()> {
     lh.purge_log();
 
     assert_eq!(Some(&log_id(2, 1, 2)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(2, 1, 2), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(2, 1, 2)), lh.state.log_ids.purged());
+    assert_eq!(log_id(2, 1, 4), lh.state.log_ids.key_log_ids()[0]);
     assert_eq!(Some(&log_id(4, 1, 6)), lh.state.last_log_id());
 
     assert_eq!(0, lh.output.take_commands().len());
 
     Ok(())
 }
+
 #[test]
 fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
+    // Purge to 3 (within leader 2's range)
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
@@ -56,7 +64,9 @@ fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
     lh.purge_log();
 
     assert_eq!(Some(&log_id(2, 1, 3)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(2, 1, 3), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(2, 1, 3)), lh.state.log_ids.purged());
+    // key_log_ids still has leader 2's last at 4, leader 4's last at 6
+    assert_eq!(log_id(2, 1, 4), lh.state.log_ids.key_log_ids()[0]);
     assert_eq!(Some(&log_id(4, 1, 6)), lh.state.last_log_id());
 
     assert_eq!(
@@ -69,18 +79,22 @@ fn test_purge_log_same_leader_as_prev_last_purged() -> anyhow::Result<()> {
 
 #[test]
 fn test_purge_log_to_last_key_log() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
+    // Purge to 4 (at leader 2's last)
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
-    lh.state.purge_upto = Some(log_id(4, 1, 4));
+    lh.state.purge_upto = Some(log_id(2, 1, 4));
     lh.purge_log();
 
-    assert_eq!(Some(&log_id(4, 1, 4)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 1, 4), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(2, 1, 4)), lh.state.last_purged_log_id());
+    assert_eq!(Some(&log_id(2, 1, 4)), lh.state.log_ids.purged());
+    // leader 2 is completely purged, only leader 4 remains
+    assert_eq!(log_id(4, 1, 6), lh.state.log_ids.key_log_ids()[0]);
     assert_eq!(Some(&log_id(4, 1, 6)), lh.state.last_log_id());
 
     assert_eq!(
-        vec![Command::PurgeLog { upto: log_id(4, 1, 4) }],
+        vec![Command::PurgeLog { upto: log_id(2, 1, 4) }],
         lh.output.take_commands()
     );
 
@@ -89,6 +103,8 @@ fn test_purge_log_to_last_key_log() -> anyhow::Result<()> {
 
 #[test]
 fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
+    // Purge to 5 (within leader 4's range)
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
@@ -96,7 +112,9 @@ fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
     lh.purge_log();
 
     assert_eq!(Some(&log_id(4, 1, 5)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 1, 5), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(4, 1, 5)), lh.state.log_ids.purged());
+    // Only leader 4's log at 6 remains
+    assert_eq!(log_id(4, 1, 6), lh.state.log_ids.key_log_ids()[0]);
     assert_eq!(Some(&log_id(4, 1, 6)), lh.state.last_log_id());
 
     assert_eq!(
@@ -109,6 +127,8 @@ fn test_purge_log_go_pass_last_key_log() -> anyhow::Result<()> {
 
 #[test]
 fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
+    // Purge to 6 (at last log)
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
@@ -116,7 +136,10 @@ fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
     lh.purge_log();
 
     assert_eq!(Some(&log_id(4, 1, 6)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 1, 6), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(4, 1, 6)), lh.state.log_ids.purged());
+    // All logs purged, key_log_ids is empty
+    assert!(lh.state.log_ids.key_log_ids().is_empty());
+    // last_log_id returns the purged log when all logs are purged
     assert_eq!(Some(&log_id(4, 1, 6)), lh.state.last_log_id());
 
     assert_eq!(
@@ -129,6 +152,8 @@ fn test_purge_log_to_last_log_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
+    // Purge to 7 (beyond last log)
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
@@ -136,7 +161,10 @@ fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
     lh.purge_log();
 
     assert_eq!(Some(&log_id(4, 1, 7)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(4, 1, 7), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(4, 1, 7)), lh.state.log_ids.purged());
+    // All logs purged, key_log_ids is empty
+    assert!(lh.state.log_ids.key_log_ids().is_empty());
+    // last_log_id returns the purged log when all logs are purged
     assert_eq!(Some(&log_id(4, 1, 7)), lh.state.last_log_id());
 
     assert_eq!(
@@ -149,6 +177,8 @@ fn test_purge_log_go_pass_last_log_id() -> anyhow::Result<()> {
 
 #[test]
 fn test_purge_log_to_higher_leader_lgo() -> anyhow::Result<()> {
+    // Setup: purged at 2, leader 2 at 3-4, leader 4 at 5-6
+    // Purge to 7 with higher leader (installing snapshot scenario)
     let mut eng = eng();
 
     let mut lh = eng.log_handler();
@@ -156,7 +186,10 @@ fn test_purge_log_to_higher_leader_lgo() -> anyhow::Result<()> {
     lh.purge_log();
 
     assert_eq!(Some(&log_id(5, 1, 7)), lh.state.last_purged_log_id());
-    assert_eq!(log_id(5, 1, 7), lh.state.log_ids.key_log_ids()[0],);
+    assert_eq!(Some(&log_id(5, 1, 7)), lh.state.log_ids.purged());
+    // All logs purged, key_log_ids is empty
+    assert!(lh.state.log_ids.key_log_ids().is_empty());
+    // last_log_id returns the purged log when all logs are purged
     assert_eq!(Some(&log_id(5, 1, 7)), lh.state.last_log_id());
 
     assert_eq!(

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -138,7 +138,9 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
     // learner or vice versa.
 
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new([log_id(0, 0, 0), log_id(1, 1, 1), log_id(5, 1, 10)]);
+    // Last-per-leader format: leader (0,0) last at 0, leader (1,1) last at 9, leader (5,1) last at 10
+    // This preserves the original ranges: (1,1) covers indices 1-9, (5,1) covers index 10
+    eng.state.log_ids = LogIdList::new(None, [log_id(0, 0, 0), log_id(1, 1, 9), log_id(5, 1, 10)]);
 
     eng.state
         .membership_state

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -65,7 +65,7 @@ fn test_handle_message_vote_reject_smaller_vote() -> anyhow::Result<()> {
 #[test]
 fn test_handle_message_vote_committed_vote() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 3)]);
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(2, 1, 3)]);
     let now = TokioInstant::now();
 
     let resp = eng.vote_handler().update_vote(&Vote::new_committed(3, 2));
@@ -97,7 +97,7 @@ fn test_handle_message_vote_granted_equal_vote() -> anyhow::Result<()> {
     // Equal vote should not emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 3)]);
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(2, 1, 3)]);
     let now = TokioInstant::now();
 
     let resp = eng.vote_handler().update_vote(&Vote::new(2, 1));
@@ -121,7 +121,7 @@ fn test_handle_message_vote_granted_greater_vote() -> anyhow::Result<()> {
     // A greater vote should emit a SaveVote command.
 
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 3)]);
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(2, 1, 3)]);
 
     let resp = eng.vote_handler().update_vote(&Vote::new(3, 1));
 

--- a/openraft/src/engine/log_id_list_test.rs
+++ b/openraft/src/engine/log_id_list_test.rs
@@ -1,7 +1,65 @@
+use std::collections::HashMap;
+
+use crate::RaftLogReader;
 use crate::engine::LogIdList;
 use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
+use crate::entry::RaftEntry;
+use crate::log_id::raft_log_id_ext::RaftLogIdExt;
+use crate::type_config::alias::LogIdOf;
+
+/// Mock RaftLogReader for testing get_key_log_ids
+struct MockLogReader {
+    logs: HashMap<u64, LogIdOf<UTConfig>>,
+}
+
+impl MockLogReader {
+    fn new(logs: Vec<LogIdOf<UTConfig>>) -> Self {
+        let mut map = HashMap::new();
+        for log_id in logs {
+            map.insert(log_id.index(), log_id);
+        }
+        Self { logs: map }
+    }
+}
+
+impl RaftLogReader<UTConfig> for MockLogReader {
+    async fn try_get_log_entries<RNG>(
+        &mut self,
+        range: RNG,
+    ) -> Result<Vec<<UTConfig as crate::RaftTypeConfig>::Entry>, std::io::Error>
+    where
+        RNG: std::ops::RangeBounds<u64> + Clone + std::fmt::Debug + crate::OptionalSend,
+    {
+        use std::ops::Bound;
+
+        let start = match range.start_bound() {
+            Bound::Included(&s) => s,
+            Bound::Excluded(&s) => s + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(&e) => e + 1,
+            Bound::Excluded(&e) => e,
+            Bound::Unbounded => u64::MAX,
+        };
+
+        let mut entries = Vec::new();
+        for i in start..end {
+            if let Some(log_id) = self.logs.get(&i) {
+                // Create a blank entry with this log_id
+                entries.push(crate::Entry::new_blank(*log_id));
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<<UTConfig as crate::RaftTypeConfig>::Vote>, std::io::Error> {
+        Ok(None)
+    }
+}
 
 #[test]
 fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
@@ -13,23 +71,20 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
     assert_eq!(vec![log_id(1, 1, 2)], ids.key_log_ids());
 
     // Extend two log ids that are adjacent to the last stored one.
-    // It should append only one log id as the new ending log id.
+    // Same leader: only keep the last log id.
 
     ids.extend_from_same_leader([
         log_id(1, 1, 3), //
         log_id(1, 1, 4),
     ]);
     assert_eq!(
-        vec![
-            log_id(1, 1, 2), //
-            log_id(1, 1, 4)
-        ],
+        vec![log_id(1, 1, 4)],
         ids.key_log_ids(),
-        "same leader as the last"
+        "same leader as the last, replace with last"
     );
 
     // Extend 3 log id with new leader id.
-    // It should just store every log id for each leader, plus one last-log-id.
+    // Different leader: push new entry (last log of new leader).
 
     ids.extend_from_same_leader([
         log_id(2, 1, 5), //
@@ -38,8 +93,7 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
     ]);
     assert_eq!(
         vec![
-            log_id(1, 1, 2), //
-            log_id(2, 1, 5),
+            log_id(1, 1, 4), //
             log_id(2, 1, 7)
         ],
         ids.key_log_ids(),
@@ -59,23 +113,18 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     assert_eq!(vec![log_id(1, 1, 2)], ids.key_log_ids());
 
     // Extend two log ids that are adjacent to the last stored one.
-    // It should append only one log id as the new ending log id.
+    // Same leader: replace with the last.
 
     ids.extend([
         log_id(1, 1, 3), //
         log_id(1, 1, 4),
     ]);
-    assert_eq!(
-        vec![
-            log_id(1, 1, 2), //
-            log_id(1, 1, 4)
-        ],
-        ids.key_log_ids(),
-        "same leader as the last"
-    );
+    assert_eq!(vec![log_id(1, 1, 4)], ids.key_log_ids(), "same leader as the last");
 
     // Extend 3 log id with different leader id.
-    // Last two has the same leader id.
+    // First one (1,1,5) same leader -> replace: [log_id(1,1,5)]
+    // Second (2,1,6) different leader -> push: [log_id(1,1,5), log_id(2,1,6)]
+    // Third (2,1,7) same leader -> replace: [log_id(1,1,5), log_id(2,1,7)]
 
     ids.extend([
         log_id(1, 1, 5), //
@@ -84,8 +133,7 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     ]);
     assert_eq!(
         vec![
-            log_id(1, 1, 2), //
-            log_id(2, 1, 6),
+            log_id(1, 1, 5), //
             log_id(2, 1, 7)
         ],
         ids.key_log_ids(),
@@ -93,7 +141,9 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     );
 
     // Extend 3 log id with different leader id.
-    // Last two have different leader id.
+    // (2,1,8) same leader -> replace: [log_id(1,1,5), log_id(2,1,8)]
+    // (2,1,9) same leader -> replace: [log_id(1,1,5), log_id(2,1,9)]
+    // (3,1,10) different leader -> push: [log_id(1,1,5), log_id(2,1,9), log_id(3,1,10)]
 
     ids.extend([
         log_id(2, 1, 8), //
@@ -102,8 +152,8 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     ]);
     assert_eq!(
         vec![
-            log_id(1, 1, 2), //
-            log_id(2, 1, 6),
+            log_id(1, 1, 5), //
+            log_id(2, 1, 9),
             log_id(3, 1, 10),
         ],
         ids.key_log_ids(),
@@ -118,14 +168,15 @@ fn test_log_id_list_append() -> anyhow::Result<()> {
     let mut ids = LogIdList::<UTConfig>::default();
 
     // Append log id one by one, check the internally constructed `key_log_id` as expected.
+    // With last-per-leader: same leader replaces, different leader pushes.
 
     let cases = vec![
-        (log_id(1, 1, 2), vec![log_id(1, 1, 2)]), //
-        (log_id(1, 1, 3), vec![log_id(1, 1, 2), log_id(1, 1, 3)]),
-        (log_id(1, 1, 4), vec![log_id(1, 1, 2), log_id(1, 1, 4)]),
-        (log_id(2, 1, 5), vec![log_id(1, 1, 2), log_id(2, 1, 5)]),
-        (log_id(2, 1, 7), vec![log_id(1, 1, 2), log_id(2, 1, 5), log_id(2, 1, 7)]),
-        (log_id(2, 1, 9), vec![log_id(1, 1, 2), log_id(2, 1, 5), log_id(2, 1, 9)]),
+        (log_id(1, 1, 2), vec![log_id(1, 1, 2)]),
+        (log_id(1, 1, 3), vec![log_id(1, 1, 3)]), // same leader, replace
+        (log_id(1, 1, 4), vec![log_id(1, 1, 4)]), // same leader, replace
+        (log_id(2, 1, 5), vec![log_id(1, 1, 4), log_id(2, 1, 5)]), // different leader, push
+        (log_id(2, 1, 7), vec![log_id(1, 1, 4), log_id(2, 1, 7)]), // same leader, replace
+        (log_id(2, 1, 9), vec![log_id(1, 1, 4), log_id(2, 1, 9)]), // same leader, replace
     ];
 
     for (new_log_id, want) in cases {
@@ -138,88 +189,58 @@ fn test_log_id_list_append() -> anyhow::Result<()> {
 
 #[test]
 fn test_log_id_list_truncate() -> anyhow::Result<()> {
-    // Sample data for test
+    // Sample data for test (last-per-leader format)
+    // With purged=None, first log is at index 0
+    // Represents logs:
+    // - Leader 2: indices 0-2
+    // - Leader 3: indices 3-5
+    // - Leader 6: indices 6-8
+    // - Leader 9: indices 9-11
     let make_ids = || {
-        LogIdList::<UTConfig>::new(vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
+        LogIdList::<UTConfig>::new(None, vec![
+            log_id(2, 1, 2),  // last of leader 2
+            log_id(3, 1, 5),  // last of leader 3
+            log_id(6, 1, 8),  // last of leader 6
+            log_id(9, 1, 11), // last of leader 9
         ])
     };
 
+    // truncate(at) removes logs from index `at` onwards, keeps 0..(at-1)
     let cases = vec![
-        (0, vec![
-            //
-        ]),
-        (1, vec![
-            //
-        ]),
-        (2, vec![
-            //
-        ]),
-        (3, vec![
-            log_id(2, 1, 2), //
-        ]),
-        (4, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-        ]),
-        (5, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(3, 1, 4),
-        ]),
-        (6, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(3, 1, 5),
-        ]),
-        (7, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-        ]),
-        (8, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(6, 1, 7),
-        ]),
-        (9, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(6, 1, 8),
-        ]),
+        (0, vec![]),                                                  // keep nothing
+        (1, vec![log_id(2, 1, 0)]),                                   // keep 0
+        (2, vec![log_id(2, 1, 1)]),                                   // keep 0-1
+        (3, vec![log_id(2, 1, 2)]),                                   // keep 0-2
+        (4, vec![log_id(2, 1, 2), log_id(3, 1, 3)]),                  // keep 0-3
+        (5, vec![log_id(2, 1, 2), log_id(3, 1, 4)]),                  // keep 0-4
+        (6, vec![log_id(2, 1, 2), log_id(3, 1, 5)]),                  // keep 0-5
+        (7, vec![log_id(2, 1, 2), log_id(3, 1, 5), log_id(6, 1, 6)]), // keep 0-6
+        (8, vec![log_id(2, 1, 2), log_id(3, 1, 5), log_id(6, 1, 7)]), // keep 0-7
+        (9, vec![log_id(2, 1, 2), log_id(3, 1, 5), log_id(6, 1, 8)]), // keep 0-8
         (10, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
+            log_id(2, 1, 2),
+            log_id(3, 1, 5),
+            log_id(6, 1, 8),
             log_id(9, 1, 9),
-        ]),
+        ]), // keep 0-9
         (11, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
+            log_id(2, 1, 2),
+            log_id(3, 1, 5),
+            log_id(6, 1, 8),
             log_id(9, 1, 10),
-        ]),
+        ]), // keep 0-10
         (12, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
+            log_id(2, 1, 2),
+            log_id(3, 1, 5),
+            log_id(6, 1, 8),
             log_id(9, 1, 11),
-        ]),
+        ]), // keep all
         (13, vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
+            log_id(2, 1, 2),
+            log_id(3, 1, 5),
+            log_id(6, 1, 8),
             log_id(9, 1, 11),
-        ]),
+        ]), // keep all
     ];
 
     for (at, want) in cases {
@@ -236,82 +257,94 @@ fn test_log_id_list_truncate() -> anyhow::Result<()> {
 fn test_log_id_list_purge() -> anyhow::Result<()> {
     // Purge on an empty log id list:
     {
-        let mut ids = LogIdList::<UTConfig>::new(vec![]);
+        let mut ids = LogIdList::<UTConfig>::new(None, vec![]);
         ids.purge(&log_id(2, 1, 2));
-        assert_eq!(vec![log_id(2, 1, 2)], ids.key_log_ids());
+        assert_eq!(Some(&log_id(2, 1, 2)), ids.purged());
+        assert!(ids.key_log_ids().is_empty());
     }
 
-    // Sample data for test
+    // Sample data for test (last-per-leader format)
+    // Represents logs:
+    // - Leader 2: index 2
+    // - Leader 3: indices 3-5
+    // - Leader 6: indices 6-8
+    // - Leader 9: indices 9-11
     let make_ids = || {
-        LogIdList::<UTConfig>::new(vec![
-            log_id(2, 1, 2), //
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
+        LogIdList::<UTConfig>::new(None, vec![
+            log_id(2, 1, 2),  // last of leader 2
+            log_id(3, 1, 5),  // last of leader 3
+            log_id(6, 1, 8),  // last of leader 6
+            log_id(9, 1, 11), // last of leader 9
         ])
     };
 
-    let cases = vec![
-        (log_id(2, 1, 1), vec![
+    // Test cases: (purge_upto, expected_purged, expected_key_log_ids)
+    let cases: Vec<(_, Option<_>, Vec<_>)> = vec![
+        // Purge before first log - still sets purged field
+        (log_id(2, 1, 1), Some(log_id(2, 1, 1)), vec![
             log_id(2, 1, 2),
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
-        ]),
-        (log_id(2, 1, 2), vec![
-            log_id(2, 1, 2),
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
-        ]),
-        (log_id(3, 1, 3), vec![
-            log_id(3, 1, 3),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
-        ]),
-        (log_id(3, 1, 4), vec![
-            log_id(3, 1, 4),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
-        ]),
-        (log_id(3, 1, 5), vec![
             log_id(3, 1, 5),
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
-        ]),
-        (log_id(6, 1, 6), vec![
-            log_id(6, 1, 6),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
-        ]),
-        (log_id(6, 1, 7), vec![
-            log_id(6, 1, 7),
-            log_id(9, 1, 9),
-            log_id(9, 1, 11),
-        ]),
-        (log_id(6, 1, 8), vec![
             log_id(6, 1, 8),
-            log_id(9, 1, 9),
             log_id(9, 1, 11),
         ]),
-        (log_id(9, 1, 9), vec![log_id(9, 1, 9), log_id(9, 1, 11)]),
-        (log_id(9, 1, 10), vec![log_id(9, 1, 10), log_id(9, 1, 11)]),
-        (log_id(9, 1, 11), vec![log_id(9, 1, 11)]),
-        (log_id(9, 1, 12), vec![log_id(9, 1, 12)]),
-        (log_id(10, 1, 12), vec![log_id(10, 1, 12)]),
+        // Purge exactly at first entry (index 2, leader 2's last)
+        (log_id(2, 1, 2), Some(log_id(2, 1, 2)), vec![
+            log_id(3, 1, 5),
+            log_id(6, 1, 8),
+            log_id(9, 1, 11),
+        ]),
+        // Purge within leader 3's range
+        (log_id(3, 1, 3), Some(log_id(3, 1, 3)), vec![
+            log_id(3, 1, 5),
+            log_id(6, 1, 8),
+            log_id(9, 1, 11),
+        ]),
+        (log_id(3, 1, 4), Some(log_id(3, 1, 4)), vec![
+            log_id(3, 1, 5),
+            log_id(6, 1, 8),
+            log_id(9, 1, 11),
+        ]),
+        // Purge at leader 3's last index
+        (log_id(3, 1, 5), Some(log_id(3, 1, 5)), vec![
+            log_id(6, 1, 8),
+            log_id(9, 1, 11),
+        ]),
+        // Purge within leader 6's range
+        (log_id(6, 1, 6), Some(log_id(6, 1, 6)), vec![
+            log_id(6, 1, 8),
+            log_id(9, 1, 11),
+        ]),
+        (log_id(6, 1, 7), Some(log_id(6, 1, 7)), vec![
+            log_id(6, 1, 8),
+            log_id(9, 1, 11),
+        ]),
+        // Purge at leader 6's last index
+        (log_id(6, 1, 8), Some(log_id(6, 1, 8)), vec![log_id(9, 1, 11)]),
+        // Purge within leader 9's range
+        (log_id(9, 1, 9), Some(log_id(9, 1, 9)), vec![log_id(9, 1, 11)]),
+        (log_id(9, 1, 10), Some(log_id(9, 1, 10)), vec![log_id(9, 1, 11)]),
+        // Purge at/beyond last log
+        (log_id(9, 1, 11), Some(log_id(9, 1, 11)), vec![]),
+        (log_id(9, 1, 12), Some(log_id(9, 1, 12)), vec![]),
+        (log_id(10, 1, 12), Some(log_id(10, 1, 12)), vec![]),
     ];
 
-    for (upto, want) in cases {
+    for (upto, want_purged, want_key_log_ids) in cases {
         let mut ids = make_ids();
 
         ids.purge(&upto);
-        assert_eq!(want, ids.key_log_ids(), "purge upto: {}", upto);
+        assert_eq!(
+            want_purged.as_ref(),
+            ids.purged(),
+            "purge upto: {} - purged field",
+            upto
+        );
+        assert_eq!(
+            want_key_log_ids,
+            ids.key_log_ids(),
+            "purge upto: {} - key_log_ids",
+            upto
+        );
     }
 
     Ok(())
@@ -328,17 +361,20 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
     assert!(ids.get(2).is_none());
 
     // Get log id that is a key log id or not.
+    // Last-per-leader format:
+    // - Leader 1: indices 0-2 (last at 2)
+    // - Leader 3: indices 3-5 (last at 5)
+    // - Leader 5: indices 6-7 (last at 7)
+    // - Leader 7: indices 8-10 (last at 10)
 
-    let ids = LogIdList::<UTConfig>::new(vec![
-        log_id(1, 1, 1),
-        log_id(1, 1, 2),
-        log_id(3, 1, 3),
-        log_id(5, 1, 6),
-        log_id(7, 1, 8),
-        log_id(7, 1, 10),
+    let ids = LogIdList::<UTConfig>::new(None, vec![
+        log_id(1, 1, 2),  // last of leader 1
+        log_id(3, 1, 5),  // last of leader 3
+        log_id(5, 1, 7),  // last of leader 5
+        log_id(7, 1, 10), // last of leader 7
     ]);
 
-    assert_eq!(None, ids.get(0));
+    assert_eq!(Some(log_id(1, 1, 0)), ids.get(0));
     assert_eq!(Some(log_id(1, 1, 1)), ids.get(1));
     assert_eq!(Some(log_id(1, 1, 2)), ids.get(2));
     assert_eq!(Some(log_id(3, 1, 3)), ids.get(3));
@@ -360,27 +396,573 @@ fn test_log_id_list_by_last_leader() -> anyhow::Result<()> {
     let ids = LogIdList::<UTConfig>::default();
     assert_eq!(ids.by_last_leader(), None);
 
-    // len == 1
-    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1)]);
-    assert_eq!(Some(LeaderLogIds::new_single(log_id(1, 1, 1))), ids.by_last_leader());
-
-    // len == 2, the last leader has only one log
-    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
-    assert_eq!(Some(LeaderLogIds::new_single(log_id(3, 1, 3))), ids.by_last_leader());
-
-    // len == 2, the last leader has two logs
-    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
+    // len == 1, leader's range starts at 0 (no purged)
+    // Last-per-leader: [log_id(1,1,1)] means leader 1's last log is at index 1
+    // First index is purged.index+1 = 0
+    let ids = LogIdList::<UTConfig>::new(None, [log_id(1, 1, 1)]);
     assert_eq!(
-        Some(LeaderLogIds::new(*log_id(1, 1, 0).committed_leader_id(), 1, 3)),
+        Some(LeaderLogIds::new(*log_id(1, 1, 0).committed_leader_id(), 0, 1)),
         ids.by_last_leader()
     );
 
-    // len > 2, the last leader has only more than one logs
-    let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
+    // len == 2, different leaders
+    // [log_id(1,1,1), log_id(3,1,3)] means:
+    // - Leader 1: indices 0-1 (last at 1)
+    // - Leader 3: indices 2-3 (last at 3)
+    // by_last_leader returns leader 3's range: first_index = 1+1 = 2, last_index = 3
+    let ids = LogIdList::<UTConfig>::new(None, [log_id(1, 1, 1), log_id(3, 1, 3)]);
     assert_eq!(
-        Some(LeaderLogIds::new(*log_id(7, 1, 0).committed_leader_id(), 8, 10)),
+        Some(LeaderLogIds::new(*log_id(3, 1, 0).committed_leader_id(), 2, 3)),
         ids.by_last_leader()
     );
 
+    // len == 1 with purged
+    // purged at index 2, leader 1's last at index 5
+    // Leader 1's range: first_index = 2+1 = 3, last_index = 5
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), [log_id(1, 1, 5)]);
+    assert_eq!(
+        Some(LeaderLogIds::new(*log_id(1, 1, 0).committed_leader_id(), 3, 5)),
+        ids.by_last_leader()
+    );
+
+    // len > 1
+    // [log_id(1,1,2), log_id(7,1,10)] means:
+    // - Leader 1: indices 0-2 (last at 2)
+    // - Leader 7: indices 3-10 (last at 10)
+    // by_last_leader returns leader 7's range: first_index = 2+1 = 3, last_index = 10
+    let ids = LogIdList::<UTConfig>::new(None, [log_id(1, 1, 2), log_id(7, 1, 10)]);
+    assert_eq!(
+        Some(LeaderLogIds::new(*log_id(7, 1, 0).committed_leader_id(), 3, 10)),
+        ids.by_last_leader()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_last() -> anyhow::Result<()> {
+    // Test last() which returns key_log_ids.last().or(purged.as_ref())
+
+    // 0 elements, no purged
+    let ids = LogIdList::<UTConfig>::default();
+    assert_eq!(None, ids.last());
+
+    // 0 elements, with purged
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(2, 1, 5)), vec![]);
+    assert_eq!(Some(&log_id(2, 1, 5)), ids.last());
+
+    // 1 element, no purged
+    let ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3)]);
+    assert_eq!(Some(&log_id(1, 1, 3)), ids.last());
+
+    // 1 element, with purged
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 5)]);
+    assert_eq!(Some(&log_id(1, 1, 5)), ids.last());
+
+    // 2 elements, no purged
+    let ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3), log_id(2, 1, 6)]);
+    assert_eq!(Some(&log_id(2, 1, 6)), ids.last());
+
+    // 2 elements, with purged
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 5), log_id(2, 1, 8)]);
+    assert_eq!(Some(&log_id(2, 1, 8)), ids.last());
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_first() -> anyhow::Result<()> {
+    // Test first() which returns first log id
+    // Leader comes from key_log_ids[0], index is purged.index + 1 (or 0)
+
+    // 0 elements, no purged
+    let ids = LogIdList::<UTConfig>::default();
+    assert_eq!(None, ids.first());
+
+    // 0 elements, with purged - returns None (no key_log_ids)
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(2, 1, 5)), vec![]);
+    assert_eq!(None, ids.first());
+
+    // 1 element, no purged - first index is 0
+    let ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3)]);
+    assert_eq!(Some(log_id(1, 1, 0).to_ref()), ids.first());
+
+    // 1 element, with purged - first index is purged.index + 1 = 3
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 5)]);
+    assert_eq!(Some(log_id(1, 1, 3).to_ref()), ids.first());
+
+    // 2 elements, no purged - first index is 0
+    let ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3), log_id(2, 1, 6)]);
+    assert_eq!(Some(log_id(1, 1, 0).to_ref()), ids.first());
+
+    // 2 elements, with purged - first index is purged.index + 1 = 3
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 5), log_id(2, 1, 8)]);
+    assert_eq!(Some(log_id(1, 1, 3).to_ref()), ids.first());
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_ref_at_with_purged() -> anyhow::Result<()> {
+    // Test ref_at() accessing various indices when purged is set
+    // Setup: purged at 5 (leader 2), key_log_ids = [log_id(2,1,8)]
+    // This means: leader 2's logs span indices 6-8
+
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(2, 1, 5)), vec![log_id(2, 1, 8)]);
+
+    // Access before purged - None
+    assert_eq!(None, ids.ref_at(4));
+
+    // Access at purged index - returns purged
+    assert_eq!(Some(log_id(2, 1, 5).to_ref()), ids.ref_at(5));
+
+    // Access after purged, in range (6, 7)
+    assert_eq!(Some(log_id(2, 1, 6).to_ref()), ids.ref_at(6));
+    assert_eq!(Some(log_id(2, 1, 7).to_ref()), ids.ref_at(7));
+
+    // Access at last
+    assert_eq!(Some(log_id(2, 1, 8).to_ref()), ids.ref_at(8));
+
+    // Access beyond last - None
+    assert_eq!(None, ids.ref_at(9));
+
+    // All purged, access purged index
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(2, 1, 5)), vec![]);
+    assert_eq!(Some(log_id(2, 1, 5).to_ref()), ids.ref_at(5));
+
+    // All purged, access other indices - None
+    assert_eq!(None, ids.ref_at(4));
+    assert_eq!(None, ids.ref_at(6));
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_get_with_purged() -> anyhow::Result<()> {
+    // Test get() with purged set
+    // Setup: purged at 2 (leader 1), key_log_ids = [log_id(1,1,5), log_id(3,1,8)]
+    // Logs: leader 1 at 3-5, leader 3 at 6-8
+
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 5), log_id(3, 1, 8)]);
+
+    // Before purged - None
+    assert_eq!(None, ids.get(0));
+    assert_eq!(None, ids.get(1));
+
+    // At purged index
+    assert_eq!(Some(log_id(1, 1, 2)), ids.get(2));
+
+    // Within leader 1's range (3-5)
+    assert_eq!(Some(log_id(1, 1, 3)), ids.get(3));
+    assert_eq!(Some(log_id(1, 1, 4)), ids.get(4));
+    assert_eq!(Some(log_id(1, 1, 5)), ids.get(5));
+
+    // Within leader 3's range (6-8)
+    assert_eq!(Some(log_id(3, 1, 6)), ids.get(6));
+    assert_eq!(Some(log_id(3, 1, 7)), ids.get(7));
+    assert_eq!(Some(log_id(3, 1, 8)), ids.get(8));
+
+    // Beyond last - None
+    assert_eq!(None, ids.get(9));
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_truncate_with_purged() -> anyhow::Result<()> {
+    // Test truncate() when purged is set
+    // Setup: purged at 2 (leader 1), key_log_ids = [log_id(1,1,5), log_id(2,1,8)]
+    // Logs: purged at 2, leader 1: 3-5, leader 2: 6-8
+
+    let make_ids = || LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 5), log_id(2, 1, 8)]);
+
+    // truncate(3) - keep nothing in key_log_ids (truncate from first available index)
+    {
+        let mut ids = make_ids();
+        ids.truncate(3);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert!(ids.key_log_ids().is_empty());
+    }
+
+    // truncate(4) - keep index 3
+    {
+        let mut ids = make_ids();
+        ids.truncate(4);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 3)], ids.key_log_ids());
+    }
+
+    // truncate(5) - keep indices 3-4
+    {
+        let mut ids = make_ids();
+        ids.truncate(5);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 4)], ids.key_log_ids());
+    }
+
+    // truncate(6) - keep indices 3-5 (all of leader 1)
+    {
+        let mut ids = make_ids();
+        ids.truncate(6);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 5)], ids.key_log_ids());
+    }
+
+    // truncate(7) - keep indices 3-6
+    {
+        let mut ids = make_ids();
+        ids.truncate(7);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 5), log_id(2, 1, 6)], ids.key_log_ids());
+    }
+
+    // truncate(8) - keep indices 3-7
+    {
+        let mut ids = make_ids();
+        ids.truncate(8);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 5), log_id(2, 1, 7)], ids.key_log_ids());
+    }
+
+    // truncate(9) - keep all (indices 3-8)
+    {
+        let mut ids = make_ids();
+        ids.truncate(9);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 5), log_id(2, 1, 8)], ids.key_log_ids());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_append_with_purged() -> anyhow::Result<()> {
+    // Test append() when starting with purged set and empty key_log_ids
+    // Setup: purged at 2 (leader 1), key_log_ids = []
+
+    let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+
+    // Append same leader as purged - should push (not compare with purged)
+    ids.append(log_id(1, 1, 3));
+    assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+    assert_eq!(vec![log_id(1, 1, 3)], ids.key_log_ids());
+
+    // Append same leader again - replaces
+    ids.append(log_id(1, 1, 4));
+    assert_eq!(vec![log_id(1, 1, 4)], ids.key_log_ids());
+
+    // Append different leader - pushes
+    ids.append(log_id(2, 1, 5));
+    assert_eq!(vec![log_id(1, 1, 4), log_id(2, 1, 5)], ids.key_log_ids());
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_append_with_purged_different_leader() -> anyhow::Result<()> {
+    // Test append() when purged is Some, key_log_ids is empty, and new log has different leader
+    // Setup: purged at 2 (leader 1), key_log_ids = []
+
+    let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+
+    // Append different leader than purged - should push
+    ids.append(log_id(2, 1, 3));
+    assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+    assert_eq!(vec![log_id(2, 1, 3)], ids.key_log_ids());
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_extend_with_purged() -> anyhow::Result<()> {
+    // Test extend() when purged is Some and key_log_ids is empty
+
+    // Case 1: Extend with same leader as purged
+    {
+        let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+        ids.extend([log_id(1, 1, 3), log_id(1, 1, 4)]);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 4)], ids.key_log_ids());
+    }
+
+    // Case 2: Extend with different leader than purged
+    {
+        let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+        ids.extend([log_id(2, 1, 3), log_id(2, 1, 4)]);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(2, 1, 4)], ids.key_log_ids());
+    }
+
+    // Case 3: Extend with mixed leaders, starting with same as purged
+    {
+        let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+        ids.extend([log_id(1, 1, 3), log_id(2, 1, 4), log_id(2, 1, 5)]);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 3), log_id(2, 1, 5)], ids.key_log_ids());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_extend_from_same_leader_with_purged() -> anyhow::Result<()> {
+    // Test extend_from_same_leader() when purged is Some and key_log_ids is empty
+
+    // Case 1: Extend with same leader as purged
+    {
+        let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+        ids.extend_from_same_leader([log_id(1, 1, 3), log_id(1, 1, 4), log_id(1, 1, 5)]);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 5)], ids.key_log_ids());
+    }
+
+    // Case 2: Extend with different leader than purged
+    {
+        let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+        ids.extend_from_same_leader([log_id(2, 1, 3), log_id(2, 1, 4), log_id(2, 1, 5)]);
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(2, 1, 5)], ids.key_log_ids());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_purge_edge_cases() -> anyhow::Result<()> {
+    // Additional purge edge cases with 0, 1, 2 elements
+
+    // 0 elements: Purge on empty with prior purge (should update purged)
+    {
+        let mut ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![]);
+        ids.purge(&log_id(2, 1, 5));
+        assert_eq!(Some(&log_id(2, 1, 5)), ids.purged());
+        assert!(ids.key_log_ids().is_empty());
+    }
+
+    // 1 element: Purge before the single entry's range
+    // Setup: purged=None, key_log_ids=[log_id(1,1,3)] means logs at 0-3
+    {
+        let mut ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3)]);
+        ids.purge(&log_id(1, 1, 1));
+        assert_eq!(Some(&log_id(1, 1, 1)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 3)], ids.key_log_ids());
+    }
+
+    // 1 element: Purge at the single entry's last index
+    {
+        let mut ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3)]);
+        ids.purge(&log_id(1, 1, 3));
+        assert_eq!(Some(&log_id(1, 1, 3)), ids.purged());
+        assert!(ids.key_log_ids().is_empty());
+    }
+
+    // 1 element: Purge beyond the single entry
+    {
+        let mut ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3)]);
+        ids.purge(&log_id(1, 1, 5));
+        assert_eq!(Some(&log_id(1, 1, 5)), ids.purged());
+        assert!(ids.key_log_ids().is_empty());
+    }
+
+    // 2 elements: Purge within first leader's range
+    // [log_id(1,1,3), log_id(2,1,6)] means leader 1: 0-3, leader 2: 4-6
+    {
+        let mut ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3), log_id(2, 1, 6)]);
+        ids.purge(&log_id(1, 1, 2));
+        assert_eq!(Some(&log_id(1, 1, 2)), ids.purged());
+        assert_eq!(vec![log_id(1, 1, 3), log_id(2, 1, 6)], ids.key_log_ids());
+    }
+
+    // 2 elements: Purge at boundary between leaders
+    {
+        let mut ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3), log_id(2, 1, 6)]);
+        ids.purge(&log_id(1, 1, 3));
+        assert_eq!(Some(&log_id(1, 1, 3)), ids.purged());
+        assert_eq!(vec![log_id(2, 1, 6)], ids.key_log_ids());
+    }
+
+    // 2 elements: Purge within second leader's range
+    {
+        let mut ids = LogIdList::<UTConfig>::new(None, vec![log_id(1, 1, 3), log_id(2, 1, 6)]);
+        ids.purge(&log_id(2, 1, 5));
+        assert_eq!(Some(&log_id(2, 1, 5)), ids.purged());
+        assert_eq!(vec![log_id(2, 1, 6)], ids.key_log_ids());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_log_id_list_by_last_leader_edge_cases() -> anyhow::Result<()> {
+    // Additional edge cases for by_last_leader()
+
+    // 0 elements, with purged - should return purged info
+    // purged at 5 means the last leader's range is just index 5
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 5)), vec![]);
+    assert_eq!(
+        Some(LeaderLogIds::new(*log_id(1, 1, 0).committed_leader_id(), 5, 5)),
+        ids.by_last_leader()
+    );
+
+    // 1 element, purged same leader
+    // purged at 2, leader 1's last at 5 -> range 3-5
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 5)]);
+    assert_eq!(
+        Some(LeaderLogIds::new(*log_id(1, 1, 0).committed_leader_id(), 3, 5)),
+        ids.by_last_leader()
+    );
+
+    // 1 element, purged different leader
+    // purged at 2, leader 2's last at 5 -> range 3-5
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(2, 1, 5)]);
+    assert_eq!(
+        Some(LeaderLogIds::new(*log_id(2, 1, 0).committed_leader_id(), 3, 5)),
+        ids.by_last_leader()
+    );
+
+    // 2 elements, with purged
+    // purged at 2, leader 1 at 3-4, leader 2 at 5-7 -> last leader range 5-7
+    let ids = LogIdList::<UTConfig>::new(Some(log_id(1, 1, 2)), vec![log_id(1, 1, 4), log_id(2, 1, 7)]);
+    assert_eq!(
+        Some(LeaderLogIds::new(*log_id(2, 1, 0).committed_leader_id(), 5, 7)),
+        ids.by_last_leader()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_single_log() -> anyhow::Result<()> {
+    // Single log: [(1,0)]
+    let logs = vec![log_id(1, 1, 0)];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(1, 1, 0), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 0)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_all_same_leader() -> anyhow::Result<()> {
+    // All same leader: [(1,0), (1,1), (1,2)]
+    // Expected: [(1,2)] - last of leader 1
+    // This tests Case AA with empty res (None branch)
+    let logs = vec![log_id(1, 1, 0), log_id(1, 1, 1), log_id(1, 1, 2)];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(1, 1, 2), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 2)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_two_adjacent_leaders() -> anyhow::Result<()> {
+    // Two adjacent logs with different leaders: [(1,0), (2,1)]
+    // Expected: [(1,0), (2,1)]
+    let logs = vec![log_id(1, 1, 0), log_id(2, 1, 1)];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(2, 1, 1), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 0), log_id(2, 1, 1)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_case_aac() -> anyhow::Result<()> {
+    // Case AAC: first.leader == mid.leader != last.leader
+    // Logs: [(1,0), (1,1), (2,2)]
+    // Expected: [(1,1), (2,2)]
+    let logs = vec![log_id(1, 1, 0), log_id(1, 1, 1), log_id(2, 1, 2)];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(2, 1, 2), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 1), log_id(2, 1, 2)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_case_acc() -> anyhow::Result<()> {
+    // Case ACC: first.leader != mid.leader == last.leader
+    // This is the bug case! Must search both halves.
+    // Logs: [(1,0), (2,1), (2,2), (2,3)]
+    // Expected: [(1,0), (2,3)]
+    let logs = vec![log_id(1, 1, 0), log_id(2, 1, 1), log_id(2, 1, 2), log_id(2, 1, 3)];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(2, 1, 3), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 0), log_id(2, 1, 3)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_case_abc() -> anyhow::Result<()> {
+    // Case ABC: first.leader != mid.leader != last.leader
+    // Logs: [(1,0), (2,1), (3,2)]
+    // Expected: [(1,0), (2,1), (3,2)]
+    let logs = vec![log_id(1, 1, 0), log_id(2, 1, 1), log_id(3, 1, 2)];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(3, 1, 2), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 0), log_id(2, 1, 1), log_id(3, 1, 2)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_many_same_leader() -> anyhow::Result<()> {
+    // Many logs from same leader: [(1,0), (2,1), (2,2), (2,3), (2,4)]
+    // Expected: [(1,0), (2,4)] - last of each leader
+    // This tests Case ACC with multiple logs in right half
+    let logs = vec![
+        log_id(1, 1, 0),
+        log_id(2, 1, 1),
+        log_id(2, 1, 2),
+        log_id(2, 1, 3),
+        log_id(2, 1, 4),
+    ];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(2, 1, 4), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 0), log_id(2, 1, 4)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_three_leaders() -> anyhow::Result<()> {
+    // Three leaders with varying counts: [(1,0), (2,1), (2,2), (2,3), (3,4), (3,5)]
+    // Expected: [(1,0), (2,3), (3,5)]
+    let logs = vec![
+        log_id(1, 1, 0),
+        log_id(2, 1, 1),
+        log_id(2, 1, 2),
+        log_id(2, 1, 3),
+        log_id(3, 1, 4),
+        log_id(3, 1, 5),
+    ];
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(3, 1, 5), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 0), log_id(2, 1, 3), log_id(3, 1, 5)], result);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_key_log_ids_long_same_leader() -> anyhow::Result<()> {
+    // Many logs from same leader: [(1,0), (1,1), ..., (1,9)]
+    // Expected: [(1,9)]
+    // Stresses binary search with many subdivisions
+    let logs: Vec<_> = (0..10).map(|i| log_id(1, 1, i)).collect();
+    let mut reader = MockLogReader::new(logs);
+
+    let result = LogIdList::get_key_log_ids(log_id(1, 1, 0)..=log_id(1, 1, 9), &mut reader).await?;
+
+    assert_eq!(vec![log_id(1, 1, 9)], result);
     Ok(())
 }

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -28,7 +28,7 @@ fn m12() -> Membership<UTConfig> {
 
 fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
-    eng.state.log_ids = LogIdList::new([log_id(0, 0, 0)]);
+    eng.state.log_ids = LogIdList::new(None, [log_id(0, 0, 0)]);
     eng.state.enable_validation(false); // Disable validation for incomplete state
     eng
 }
@@ -123,7 +123,7 @@ fn test_elect_multi_node_enter_candidate() -> anyhow::Result<()> {
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(0, 1, 1)), m12())));
-        eng.state.log_ids = LogIdList::new(vec![log_id(1, 1, 1)]);
+        eng.state.log_ids = LogIdList::new(None, vec![log_id(1, 1, 1)]);
 
         eng.elect();
 

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -89,7 +89,7 @@ fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
 #[test]
 fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 3)]);
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(2, 1, 3)]);
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 2),
@@ -114,7 +114,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     let mut eng = eng();
     eng.config.id = 0;
     eng.vote_handler().update_internal_server_state();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 3)]);
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(2, 1, 3)]);
 
     eng.output.clear_commands();
 
@@ -140,7 +140,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     let mut eng = eng();
     eng.config.id = 0;
     eng.vote_handler().update_internal_server_state();
-    eng.state.log_ids = LogIdList::new(vec![log_id(2, 1, 3)]);
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(2, 1, 3)]);
 
     eng.output.clear_commands();
 

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -40,7 +40,7 @@ fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
-    eng.state.log_ids = LogIdList::new([log_id(0, 0, 0)]);
+    eng.state.log_ids = LogIdList::new(None, [log_id(0, 0, 0)]);
     eng
 }
 
@@ -103,7 +103,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         let mut eng = eng();
         eng.config.id = 1;
         eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
-        eng.state.log_ids = LogIdList::new(vec![log_id(3, 1, 3)]);
+        eng.state.log_ids = LogIdList::new(None, vec![log_id(3, 1, 3)]);
         eng.state
             .membership_state
             .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m12())));

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -113,7 +113,7 @@ fn test_initialize() -> anyhow::Result<()> {
     tracing::info!("--- not allowed because of last_log_id");
     {
         let mut eng = eng();
-        eng.state.log_ids = LogIdList::new(vec![existing_log_id]);
+        eng.state.log_ids = LogIdList::new(None, vec![existing_log_id]);
 
         assert_eq!(
             Err(InitializeError::NotAllowed(NotAllowed {

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -40,11 +40,10 @@ fn eng() -> Engine<UTConfig> {
         Vote::new_committed(2, 1),
     );
     eng.state.apply_progress_mut().accept(log_id(4, 1, 5));
-    eng.state.log_ids = LogIdList::new(vec![
+    eng.state.log_ids = LogIdList::new(None, vec![
         //
-        log_id(2, 1, 2),
+        log_id(2, 1, 4),
         log_id(3, 1, 5),
-        log_id(4, 1, 6),
         log_id(4, 1, 8),
     ]);
     eng.state.snapshot_meta = SnapshotMeta {

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -56,7 +56,7 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
     eng.state
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 3)), m23())));
-    eng.state.log_ids = LogIdList::new([log_id(1, 1, 3)]);
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 3)]);
     // Committed vote makes it a leader at startup.
     eng.state.vote = Leased::new(
         UTConfig::<()>::now(),
@@ -114,8 +114,8 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
     eng.state
         .membership_state
         .set_effective(Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())));
-    // Fake existing log ids
-    eng.state.log_ids = LogIdList::new([log_id(1, 1, 2), log_id(1, 2, 4), log_id(1, 2, 6)]);
+    // Last-per-leader format: leader (1,1) last at index 3, leader (1,2) last at index 6
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 3), log_id(1, 2, 6)]);
     // Committed vote makes it a leader at startup.
     eng.state.vote = Leased::new(
         UTConfig::<()>::now(),

--- a/openraft/src/engine/tests/trigger_purge_log_test.rs
+++ b/openraft/src/engine/tests/trigger_purge_log_test.rs
@@ -31,7 +31,7 @@ fn eng() -> Engine<UTConfig> {
         EffectiveMembership::new_arc(Some(log_id(1, 0, 1)), m12()),
     );
 
-    eng.state.log_ids = LogIdList::new([log_id(0, 0, 0)]);
+    eng.state.log_ids = LogIdList::new(None, [log_id(0, 0, 0)]);
     eng
 }
 
@@ -78,7 +78,7 @@ fn test_trigger_purge_log_delete_only_in_snapshot_logs() -> anyhow::Result<()> {
     };
     eng.state.purge_upto = Some(log_id(1, 0, 2));
     eng.state.io_state.purged = Some(log_id(1, 0, 2));
-    eng.state.log_ids = LogIdList::new([log_id(1, 0, 2), log_id(1, 0, 10)]);
+    eng.state.log_ids = LogIdList::new(Some(log_id(1, 0, 2)), [log_id(1, 0, 10)]);
 
     eng.trigger_purge_log(5);
 
@@ -106,7 +106,7 @@ fn test_trigger_purge_log_in_used_wont_be_delete() -> anyhow::Result<()> {
     };
     eng.state.purge_upto = Some(log_id(1, 0, 2));
     eng.state.io_state.purged = Some(log_id(1, 0, 2));
-    eng.state.log_ids = LogIdList::new([log_id(1, 0, 2), log_id(1, 0, 10)]);
+    eng.state.log_ids = LogIdList::new(Some(log_id(1, 0, 2)), [log_id(1, 0, 10)]);
     eng.state.vote = Leased::new(
         UTConfig::<()>::now(),
         Duration::from_millis(500),

--- a/openraft/src/log_id/option_raft_log_id_ext.rs
+++ b/openraft/src/log_id/option_raft_log_id_ext.rs
@@ -19,6 +19,7 @@ where C: RaftTypeConfig
     /// Returns the leader id that proposed this log id.
     ///
     /// In standard raft, committed leader id is just `term`.
+    #[allow(dead_code)]
     fn committed_leader_id(&self) -> Option<&CommittedLeaderIdOf<C>>;
 
     /// Converts this `Option<T: RaftLogId>` into a reference-based log ID.

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -111,7 +111,7 @@ fn new_raft_state(purge_upto: u64, snap_last: u64, last: u64) -> RaftState<UTCon
         snapshot_id: "".to_string(),
     };
 
-    st.log_ids = LogIdList::new([log_id(purge_upto - 1), log_id(last)]);
+    st.log_ids = LogIdList::new(None, [log_id(purge_upto - 1), log_id(last)]);
 
     st
 }

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -159,7 +159,7 @@ where C: RaftTypeConfig
         if self.purged_next == 0 {
             return None;
         }
-        self.log_ids.first()
+        self.log_ids.purged()
     }
 }
 
@@ -176,9 +176,11 @@ where C: RaftTypeConfig
 {
     fn validate(&self) -> Result<(), Box<dyn Error>> {
         if self.purged_next == 0 {
-            validit::less_equal!(self.log_ids.first().index(), Some(0));
+            // Nothing purged - first log should exist at index 0 or later
+            validit::less_equal!(self.log_ids.first().map(|r| r.index()), Some(0));
         } else {
-            validit::equal!(self.purged_next, self.log_ids.first().next_index());
+            // Something purged - purged_next should equal purged.index + 1
+            validit::equal!(self.purged_next, self.log_ids.purged().next_index());
         }
 
         validit::less_equal!(self.last_purged_log_id(), self.purge_upto());

--- a/openraft/src/raft_state/tests/is_initialized_test.rs
+++ b/openraft/src/raft_state/tests/is_initialized_test.rs
@@ -40,7 +40,7 @@ fn test_is_initialized() {
     // Logs are non-empty
     {
         let rs = RaftState::<UTConfig> {
-            log_ids: LogIdList::new([log_id(0, 0, 0)]),
+            log_ids: LogIdList::new(None, [log_id(0, 0, 0)]),
             ..Default::default()
         };
 

--- a/openraft/src/raft_state/tests/log_state_reader_test.rs
+++ b/openraft/src/raft_state/tests/log_state_reader_test.rs
@@ -11,9 +11,10 @@ fn log_id(term: u64, index: u64) -> LogIdOf<UTConfig> {
 #[test]
 fn test_raft_state_prev_log_id() -> anyhow::Result<()> {
     // There is log id at 0
+    // Last-per-leader: leader 0 at 0, leader 1 at 1-3, leader 3 at 4
     {
         let rs = RaftState::<UTConfig> {
-            log_ids: LogIdList::new(vec![log_id(0, 0), log_id(1, 1), log_id(3, 4)]),
+            log_ids: LogIdList::new(None, vec![log_id(0, 0), log_id(1, 3), log_id(3, 4)]),
             ..Default::default()
         };
 
@@ -23,15 +24,17 @@ fn test_raft_state_prev_log_id() -> anyhow::Result<()> {
         assert_eq!(Some(log_id(3, 4)), rs.prev_log_id(5));
     }
 
-    // There is no log id at 0
+    // First log at index 1 (purged at 0)
+    // Last-per-leader: leader 1 at 1-3, leader 3 at 4
     {
         let rs = RaftState::<UTConfig> {
-            log_ids: LogIdList::new(vec![log_id(1, 1), log_id(3, 4)]),
+            log_ids: LogIdList::new(Some(log_id(0, 0)), vec![log_id(1, 3), log_id(3, 4)]),
+            purged_next: 1,
             ..Default::default()
         };
 
         assert_eq!(None, rs.prev_log_id(0));
-        assert_eq!(None, rs.prev_log_id(1));
+        assert_eq!(Some(log_id(0, 0)), rs.prev_log_id(1));
         assert_eq!(Some(log_id(1, 1)), rs.prev_log_id(2));
         assert_eq!(Some(log_id(1, 3)), rs.prev_log_id(4));
         assert_eq!(Some(log_id(3, 4)), rs.prev_log_id(5));
@@ -63,14 +66,15 @@ fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
+    // Last-per-leader: leader 1 at 0-3, leader 3 at 4
     let mut rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
+        log_ids: LogIdList::new(None, vec![log_id(1, 3), log_id(3, 4)]),
         ..Default::default()
     };
 
     rs.apply_progress_mut().accept(log_id(2, 1));
 
-    assert!(rs.has_log_id(log_id(0, 0)));
+    assert!(rs.has_log_id(log_id(1, 0)));
     assert!(rs.has_log_id(log_id(2, 1)));
     assert!(rs.has_log_id(log_id(1, 3)));
     assert!(rs.has_log_id(log_id(3, 4)));
@@ -85,20 +89,20 @@ fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
 #[test]
 fn test_raft_state_last_log_id() -> anyhow::Result<()> {
     let rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![]),
+        log_ids: LogIdList::new(None, vec![]),
         ..Default::default()
     };
 
     assert_eq!(None, rs.last_log_id());
 
     let rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![log_id(1, 2)]),
+        log_ids: LogIdList::new(None, vec![log_id(1, 2)]),
         ..Default::default()
     };
     assert_eq!(Some(&log_id(1, 2)), rs.last_log_id());
 
     let rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
+        log_ids: LogIdList::new(None, vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
     assert_eq!(Some(&log_id(3, 4)), rs.last_log_id());
@@ -120,22 +124,24 @@ fn test_raft_state_purge_upto() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
+    // No purged logs
     let rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![]),
+        log_ids: LogIdList::new(None, vec![]),
         ..Default::default()
     };
-
     assert_eq!(None, rs.last_purged_log_id());
 
+    // Purged at index 2 (with purged_next = 3)
     let rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![log_id(1, 2)]),
+        log_ids: LogIdList::new(Some(log_id(1, 2)), vec![log_id(3, 4)]),
         purged_next: 3,
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());
 
+    // Purged at index 2, logs at 3-4
     let rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
+        log_ids: LogIdList::new(Some(log_id(1, 2)), vec![log_id(3, 4)]),
         purged_next: 3,
         ..Default::default()
     };

--- a/openraft/src/raft_state/tests/validate_test.rs
+++ b/openraft/src/raft_state/tests/validate_test.rs
@@ -14,9 +14,11 @@ fn log_id(term: u64, index: u64) -> LogIdOf<UTConfig> {
 fn test_raft_state_validate_snapshot_is_none() -> anyhow::Result<()> {
     // Some app does not persist snapshot, when restarted, purged is not None but snapshot_last_log_id
     // is None. This is a valid state and should not emit error.
+    //
+    // Last-per-leader: purged at 1, leader 3's logs at 2-4
 
     let mut rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(vec![log_id(1, 1), log_id(3, 4)]),
+        log_ids: LogIdList::new(Some(log_id(1, 1)), vec![log_id(3, 4)]),
         purged_next: 2,
         purge_upto: Some(log_id(1, 1)),
         snapshot_meta: SnapshotMeta::default(),


### PR DESCRIPTION

## Changelog

##### refactor: change `LogIdList` to last-per-leader storage format
Refactor `LogIdList` to store only the last log ID of each leader instead
of tracking individual log boundaries. This simplifies the storage model.

Changes:
- Change `LogIdList::new()` to accept separate `purged` and `key_log_ids` parameters
- Add `first_index()` method to get the first available log index

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1606)
<!-- Reviewable:end -->
