### PR TITLE
refactor: move thread-conditional box types to `openraft-rt` crate

### DIFF
--- a/openraft/src/base/mod.rs
+++ b/openraft/src/base/mod.rs
@@ -33,57 +33,16 @@ pub(crate) mod histogram;
 pub(crate) mod shared_id_generator;
 
 pub(crate) use batch::Batch;
+pub use openraft_rt::BoxAny;
+pub use openraft_rt::BoxAsyncOnceMut;
+pub use openraft_rt::BoxFuture;
+pub use openraft_rt::BoxIterator;
+pub use openraft_rt::BoxMaybeAsyncOnceMut;
+pub use openraft_rt::BoxOnce;
+pub use openraft_rt::BoxStream;
 pub use openraft_rt::OptionalSend;
 pub use openraft_rt::OptionalSync;
 pub use serde_able::OptionalSerde;
-pub use threaded::BoxAny;
-pub use threaded::BoxAsyncOnceMut;
-pub use threaded::BoxFuture;
-pub use threaded::BoxIterator;
-pub use threaded::BoxMaybeAsyncOnceMut;
-pub use threaded::BoxOnce;
-pub use threaded::BoxStream;
-
-#[cfg(not(feature = "single-threaded"))]
-mod threaded {
-    use std::any::Any;
-    use std::future::Future;
-    use std::pin::Pin;
-
-    use futures::Stream;
-
-    /// Type alias for a boxed iterator that is `Send`.
-    pub type BoxIterator<'a, T> = Box<dyn Iterator<Item = T> + Send + 'a>;
-    /// Type alias for a boxed pinned future that is `Send`.
-    pub type BoxFuture<'a, T = ()> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-    /// Type alias for a boxed pinned stream that is `Send`.
-    pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
-    /// Type alias for a boxed async function that mutates its argument and is `Send`.
-    pub type BoxAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> BoxFuture<T> + Send + 'a>;
-    /// Type alias for a boxed function that optionally returns an async future.
-    pub type BoxMaybeAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> Option<BoxFuture<T>> + Send + 'a>;
-    /// Type alias for a boxed function that takes an argument and is `Send`.
-    pub type BoxOnce<'a, A, T = ()> = Box<dyn FnOnce(&A) -> T + Send + 'a>;
-    /// Type alias for a boxed value that is `Send` and can be any type.
-    pub type BoxAny = Box<dyn Any + Send>;
-}
-
-#[cfg(feature = "single-threaded")]
-mod threaded {
-    use std::any::Any;
-    use std::future::Future;
-    use std::pin::Pin;
-
-    use futures::Stream;
-
-    pub type BoxIterator<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
-    pub type BoxFuture<'a, T = ()> = Pin<Box<dyn Future<Output = T> + 'a>>;
-    pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
-    pub type BoxAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> BoxFuture<T> + 'a>;
-    pub type BoxMaybeAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> Option<BoxFuture<T>> + 'a>;
-    pub type BoxOnce<'a, A, T = ()> = Box<dyn FnOnce(&A) -> T + 'a>;
-    pub type BoxAny = Box<dyn Any>;
-}
 
 #[cfg(not(feature = "serde"))]
 mod serde_able {

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -35,7 +35,12 @@ pub use mpsc::TryRecvError;
 pub use mutex::Mutex;
 pub use oneshot::Oneshot;
 pub use oneshot::OneshotSender;
+pub use threaded::BoxAny;
+pub use threaded::BoxAsyncOnceMut;
 pub use threaded::BoxFuture;
+pub use threaded::BoxIterator;
+pub use threaded::BoxMaybeAsyncOnceMut;
+pub use threaded::BoxOnce;
 pub use threaded::BoxStream;
 pub use threaded::OptionalSend;
 pub use threaded::OptionalSync;
@@ -46,6 +51,7 @@ pub use watch::WatchSender;
 
 #[cfg(not(feature = "single-threaded"))]
 mod threaded {
+    use std::any::Any;
     use std::future::Future;
     use std::pin::Pin;
 
@@ -61,14 +67,25 @@ mod threaded {
     pub trait OptionalSync: Sync {}
     impl<T: Sync + ?Sized> OptionalSync for T {}
 
+    /// Type alias for a boxed iterator that is `Send`.
+    pub type BoxIterator<'a, T> = Box<dyn Iterator<Item = T> + Send + 'a>;
     /// Type alias for a boxed pinned future that is `Send`.
     pub type BoxFuture<'a, T = ()> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
     /// Type alias for a boxed pinned stream that is `Send`.
     pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
+    /// Type alias for a boxed async function that mutates its argument and is `Send`.
+    pub type BoxAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> BoxFuture<T> + Send + 'a>;
+    /// Type alias for a boxed function that optionally returns an async future.
+    pub type BoxMaybeAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> Option<BoxFuture<T>> + Send + 'a>;
+    /// Type alias for a boxed function that takes an argument and is `Send`.
+    pub type BoxOnce<'a, A, T = ()> = Box<dyn FnOnce(&A) -> T + Send + 'a>;
+    /// Type alias for a boxed value that is `Send` and can be any type.
+    pub type BoxAny = Box<dyn Any + Send>;
 }
 
 #[cfg(feature = "single-threaded")]
 mod threaded {
+    use std::any::Any;
     use std::future::Future;
     use std::pin::Pin;
 
@@ -84,8 +101,18 @@ mod threaded {
     pub trait OptionalSync {}
     impl<T: ?Sized> OptionalSync for T {}
 
+    /// Type alias for a boxed iterator.
+    pub type BoxIterator<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
     /// Type alias for a boxed pinned future.
     pub type BoxFuture<'a, T = ()> = Pin<Box<dyn Future<Output = T> + 'a>>;
     /// Type alias for a boxed pinned stream.
     pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
+    /// Type alias for a boxed async function that mutates its argument.
+    pub type BoxAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> BoxFuture<T> + 'a>;
+    /// Type alias for a boxed function that optionally returns an async future.
+    pub type BoxMaybeAsyncOnceMut<'a, A, T = ()> = Box<dyn FnOnce(&mut A) -> Option<BoxFuture<T>> + 'a>;
+    /// Type alias for a boxed function that takes an argument.
+    pub type BoxOnce<'a, A, T = ()> = Box<dyn FnOnce(&A) -> T + 'a>;
+    /// Type alias for a boxed value that can be any type.
+    pub type BoxAny = Box<dyn Any>;
 }


### PR DESCRIPTION

## Changelog

##### refactor: move thread-conditional box types to `openraft-rt` crate
Consolidate all `#[cfg(feature = "single-threaded")]` type aliases in
the `openraft-rt` crate. The `openraft` crate now re-exports these types
instead of defining them locally, eliminating duplicated conditional logic.

Changes:
- Add `BoxIterator`, `BoxAsyncOnceMut`, `BoxMaybeAsyncOnceMut`, `BoxOnce`, `BoxAny` to `openraft-rt`
- Remove local `threaded` module from `openraft/src/base/mod.rs`
- Re-export all box types from `openraft_rt` in `openraft::base`

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1607)
<!-- Reviewable:end -->
