### PR TITLE
refactor: remove redundant `purged_next` field from `RaftState`

### DIFF
--- a/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
+++ b/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
@@ -65,7 +65,6 @@ fn test_calc_purge_upto() -> anyhow::Result<()> {
 
         if let Some(last_purged) = last_purged {
             eng.state.log_ids.purge(&last_purged);
-            eng.state.purged_next = last_purged.index() + 1;
         }
         eng.state.snapshot_meta.last_log_id = snapshot_last_log_id;
         let got = eng.log_handler().calc_purge_upto();

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -11,7 +11,6 @@ fn eng() -> Engine<UTConfig> {
 
     // Setup: purged at 2 (leader 2), leader 2's logs at 3-4, leader 4's logs at 5-6
     eng.state.log_ids = LogIdList::new(Some(log_id(2, 1, 2)), vec![log_id(2, 1, 4), log_id(4, 1, 6)]);
-    eng.state.purged_next = 3;
     eng
 }
 

--- a/openraft/src/raft_state/tests/log_state_reader_test.rs
+++ b/openraft/src/raft_state/tests/log_state_reader_test.rs
@@ -29,7 +29,6 @@ fn test_raft_state_prev_log_id() -> anyhow::Result<()> {
     {
         let rs = RaftState::<UTConfig> {
             log_ids: LogIdList::new(Some(log_id(0, 0)), vec![log_id(1, 3), log_id(3, 4)]),
-            purged_next: 1,
             ..Default::default()
         };
 
@@ -131,18 +130,9 @@ fn test_raft_state_last_purged_log_id() -> anyhow::Result<()> {
     };
     assert_eq!(None, rs.last_purged_log_id());
 
-    // Purged at index 2 (with purged_next = 3)
+    // Purged at index 2
     let rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(Some(log_id(1, 2)), vec![log_id(3, 4)]),
-        purged_next: 3,
-        ..Default::default()
-    };
-    assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());
-
-    // Purged at index 2, logs at 3-4
-    let rs = RaftState::<UTConfig> {
-        log_ids: LogIdList::new(Some(log_id(1, 2)), vec![log_id(3, 4)]),
-        purged_next: 3,
         ..Default::default()
     };
     assert_eq!(Some(log_id(1, 2)), rs.last_purged_log_id().copied());

--- a/openraft/src/raft_state/tests/validate_test.rs
+++ b/openraft/src/raft_state/tests/validate_test.rs
@@ -19,7 +19,6 @@ fn test_raft_state_validate_snapshot_is_none() -> anyhow::Result<()> {
 
     let mut rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(Some(log_id(1, 1)), vec![log_id(3, 4)]),
-        purged_next: 2,
         purge_upto: Some(log_id(1, 1)),
         snapshot_meta: SnapshotMeta::default(),
         ..Default::default()

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -211,7 +211,6 @@ where
             //       When lease based read is added, the restarted node must sleep for a while,
             //       before serving.
             vote: Leased::new(now, Duration::default(), vote),
-            purged_next: last_purged_log_id.next_index(),
             log_ids: log_id_list,
             membership_state: mem_state,
             snapshot_meta,


### PR DESCRIPTION

## Changelog

##### refactor: remove redundant `purged_next` field from `RaftState`
The `purged_next` field duplicated information already available from
`log_ids.purged()`. Removing it eliminates potential inconsistency and
simplifies the state structure.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1609)
<!-- Reviewable:end -->
