### PR TITLE
refactor: use runtime-agnostic `TypeConfig::sleep()` in tests

### DIFF
--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -10,8 +10,9 @@ use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::VoteRequest;
+use openraft::type_config::TypeConfigExt;
 use openraft_memstore::ClientRequest;
-use tokio::time::sleep;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -39,7 +40,7 @@ async fn append_sees_higher_vote() -> Result<()> {
     tracing::info!(log_index, "--- upgrade vote on node-1");
     {
         // Let leader lease expire
-        sleep(Duration::from_millis(800)).await;
+        TypeConfig::sleep(Duration::from_millis(800)).await;
 
         let option = RPCOption::new(Duration::from_millis(1_000));
 
@@ -78,7 +79,7 @@ async fn append_sees_higher_vote() -> Result<()> {
             tracing::debug!("--- client_write res: {:?}", res);
         });
 
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
 
         router
             .wait(&0, timeout())

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -9,7 +9,8 @@ use openraft::Instant;
 use openraft::TokioInstant;
 use openraft::Vote;
 use openraft::raft::VoteRequest;
-use tokio::time::sleep;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -31,7 +32,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
     let mut router = RaftRouter::new(config.clone());
 
     let now = TokioInstant::now();
-    sleep(Duration::from_millis(1)).await;
+    TypeConfig::sleep(Duration::from_millis(1)).await;
 
     let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
 
@@ -49,7 +50,7 @@ async fn heartbeat_reject_vote() -> Result<()> {
             .await?;
 
         let now = TokioInstant::now();
-        sleep(Duration::from_millis(700)).await;
+        TypeConfig::sleep(Duration::from_millis(700)).await;
 
         let m = vote_modified_time.clone();
 
@@ -74,14 +75,14 @@ async fn heartbeat_reject_vote() -> Result<()> {
     tracing::info!(log_index, "--- ensures no more blank-log heartbeat is used");
     {
         // TODO: this part can be removed when blank-log heartbeat is removed.
-        sleep(Duration::from_millis(1500)).await;
+        TypeConfig::sleep(Duration::from_millis(1500)).await;
         router.wait(&1, timeout()).applied_index(Some(log_index), "no log is written").await?;
     }
 
     tracing::info!(log_index, "--- disable heartbeat, vote request will be granted");
     {
         node0.runtime_config().heartbeat(false);
-        sleep(Duration::from_millis(1500)).await;
+        TypeConfig::sleep(Duration::from_millis(1500)).await;
 
         router.wait(&1, timeout()).applied_index(Some(log_index), "no log is written").await?;
 

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -13,6 +13,8 @@ use openraft::async_runtime::WatchReceiver;
 use openraft::base::BoxFuture;
 use openraft::error::NetworkError;
 use openraft::error::RPCError;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::rpc_request::RpcRequest;
@@ -130,7 +132,7 @@ async fn get_read_log_id() -> Result<()> {
     router.set_rpc_pre_hook(RPCTypes::AppendEntries, block_to_n0).await;
 
     // Expire current leader
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    TypeConfig::sleep(Duration::from_millis(200)).await;
 
     tracing::info!("--- let node 1 to become leader, append a blank log");
     let n1 = router.get_raft_handle(&1).unwrap();
@@ -296,7 +298,7 @@ async fn ensure_linearizable_with_lease_read() -> Result<()> {
 
     // There may be some ongoing replication requests that sending the commit log ID.
     //Wait for them to finish.
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    TypeConfig::sleep(Duration::from_millis(300)).await;
 
     let leader_handle = router.get_raft_handle(&leader).unwrap();
 
@@ -321,7 +323,7 @@ async fn ensure_linearizable_with_lease_read() -> Result<()> {
         );
 
         // lease time elapsed, lease read will return error.
-        tokio::time::sleep(Duration::from_millis(config.election_timeout_max)).await;
+        TypeConfig::sleep(Duration::from_millis(config.election_timeout_max)).await;
         let rst = router.ensure_linearizable(leader, ReadPolicy::LeaseRead).await;
         tracing::debug!(?rst, "ensure_linearizable with LeaseRead after lease expired");
 

--- a/tests/tests/client_api/t51_write_when_leader_quit.rs
+++ b/tests/tests/client_api/t51_write_when_leader_quit.rs
@@ -9,8 +9,10 @@ use openraft::error::ClientWriteError;
 use openraft::error::ForwardToLeader;
 use openraft::error::RaftError;
 use openraft::raft::AppendEntriesRequest;
+use openraft::type_config::TypeConfigExt;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::IntoMemClientRequest;
+use openraft_memstore::TypeConfig;
 use tokio::sync::oneshot;
 
 use crate::fixtures::RaftRouter;
@@ -56,7 +58,7 @@ async fn write_when_leader_quit_and_log_revert() -> Result<()> {
     }
 
     // wait for log to be appended on leader, and response channel is installed.
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    TypeConfig::sleep(Duration::from_millis(500)).await;
 
     tracing::info!(log_index, "--- force node 0 to give up leadership");
     {
@@ -131,7 +133,7 @@ async fn write_when_leader_switched() -> Result<()> {
     }
 
     // wait for log to be appended on leader, and response channel is installed.
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    TypeConfig::sleep(Duration::from_millis(500)).await;
 
     tracing::info!(log_index, "--- force node 0 to give up leadership, inform it to commit");
     {

--- a/tests/tests/elect/t11_elect_seize_leadership.rs
+++ b/tests/tests/elect/t11_elect_seize_leadership.rs
@@ -5,6 +5,8 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::ut_harness;
@@ -31,7 +33,7 @@ async fn elect_seize_leadership() -> Result<()> {
     n0.wait(timeout()).state(ServerState::Leader, "node 0 becomes leader").await?;
 
     tracing::info!(log_index, "--- sleep to wait for leadership to expire");
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    TypeConfig::sleep(Duration::from_secs(2)).await;
 
     tracing::info!(log_index, "--- trigger election on node 1");
     {

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -52,6 +52,7 @@ use openraft::raft::TransferLeaderRequest;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
 use openraft::storage::Snapshot;
+use openraft::type_config::TypeConfigExt;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::ClientResponse;
 use openraft_memstore::IntoMemClientRequest;
@@ -305,7 +306,7 @@ impl TypedRaftRouter {
 
         let r = rand::random::<u64>() % send_delay;
         let timeout = Duration::from_millis(r);
-        tokio::time::sleep(timeout).await;
+        TypeConfig::sleep(timeout).await;
     }
 
     pub fn set_append_entries_quota(&mut self, quota: Option<u64>) {

--- a/tests/tests/membership/t11_add_learner.rs
+++ b/tests/tests/membership/t11_add_learner.rs
@@ -13,7 +13,8 @@ use openraft::async_runtime::WatchReceiver;
 use openraft::error::ChangeMembershipError;
 use openraft::error::ClientWriteError;
 use openraft::error::InProgress;
-use tokio::time::sleep;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -153,7 +154,7 @@ async fn add_learner_non_blocking() -> Result<()> {
             if n1_repl.is_none() {
                 tracing::info!("--- no replication attempt is made, sleep and retry: {}-th attempt", i);
 
-                sleep(Duration::from_millis(500)).await;
+                TypeConfig::sleep(Duration::from_millis(500)).await;
                 continue;
             }
             assert_eq!(Some(&None), n1_repl, "no replication state to the learner is reported");
@@ -229,7 +230,7 @@ async fn add_learner_when_previous_membership_not_committed() -> Result<()> {
             unreachable!("do not expect any res");
         });
 
-        sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
     }
 
     tracing::info!(log_index, "--- add new node node-1, in non blocking mode");

--- a/tests/tests/membership/t30_elect_with_new_config.rs
+++ b/tests/tests/membership/t30_elect_with_new_config.rs
@@ -5,7 +5,8 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::LogIdOptionExt;
-use tokio::time::sleep;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::ut_harness;
@@ -42,7 +43,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     router.set_network_error(0, true);
 
     // Wait for leader lease to expire
-    sleep(Duration::from_millis(700)).await;
+    TypeConfig::sleep(Duration::from_millis(700)).await;
 
     // Let node-1 become leader.
     let node_1 = router.get_raft_handle(&1)?;

--- a/tests/tests/membership/t31_remove_leader.rs
+++ b/tests/tests/membership/t31_remove_leader.rs
@@ -6,8 +6,10 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
 use openraft::error::ClientWriteError;
+use openraft::type_config::TypeConfigExt;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::IntoMemClientRequest;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -161,7 +163,7 @@ async fn remove_leader_and_convert_to_learner() -> Result<()> {
 
     tracing::info!(log_index, "--- wait 1 sec, old leader(non-voter) stays as a leader");
     {
-        tokio::time::sleep(Duration::from_millis(1_000)).await;
+        TypeConfig::sleep(Duration::from_millis(1_000)).await;
 
         router
             .wait(&0, timeout())

--- a/tests/tests/metrics/t30_leader_metrics.rs
+++ b/tests/tests/metrics/t30_leader_metrics.rs
@@ -6,11 +6,12 @@ use maplit::btreemap;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 #[allow(unused_imports)]
 use pretty_assertions::assert_eq;
 #[allow(unused_imports)]
 use pretty_assertions::assert_ne;
-use tokio::time::sleep;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -150,7 +151,7 @@ async fn leader_metrics() -> Result<()> {
     tracing::info!(log_index, "--- let node-1 to elect to take leadership from node-0");
     {
         // Let the leader lease expire
-        sleep(Duration::from_millis(700)).await;
+        TypeConfig::sleep(Duration::from_millis(700)).await;
 
         n1.trigger().elect().await?;
         n1.wait(timeout()).state(ServerState::Leader, "node-1 becomes leader").await?;

--- a/tests/tests/metrics/t50_log_progress_api.rs
+++ b/tests/tests/metrics/t50_log_progress_api.rs
@@ -7,7 +7,8 @@ use openraft::Config;
 use openraft::ServerState;
 use openraft::Vote;
 use openraft::raft::FlushPoint;
-use tokio::time::sleep;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -129,7 +130,7 @@ async fn log_progress_with_leader_change() -> Result<()> {
     n0.shutdown().await?;
 
     // ensure node 0 is down and leader lease expire
-    sleep(Duration::from_millis(500)).await;
+    TypeConfig::sleep(Duration::from_millis(500)).await;
 
     let n1_clone = router.get_raft_handle(&1)?;
     let handle = tokio::spawn(async move {
@@ -206,7 +207,7 @@ async fn vote_progress_api() -> Result<()> {
         n0.shutdown().await?;
 
         // ensure node 0 is down and leader lease expire
-        sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
     }
 
     tracing::info!("--- spawn task to wait for term 2");

--- a/tests/tests/metrics/t50_watch_leader_api.rs
+++ b/tests/tests/metrics/t50_watch_leader_api.rs
@@ -8,7 +8,9 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
+use openraft::type_config::TypeConfigExt;
 use openraft::vote::RaftLeaderId;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::ut_harness;
@@ -55,7 +57,7 @@ async fn on_cluster_leader_change_api() -> Result<()> {
     });
 
     // Give some time for the initial callback to be invoked
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify initial leader change event");
     {
@@ -69,7 +71,7 @@ async fn on_cluster_leader_change_api() -> Result<()> {
     router.remove_node(0);
 
     // Wait for leader lease to expire so other nodes accept new vote
-    tokio::time::sleep(Duration::from_millis(700)).await;
+    TypeConfig::sleep(Duration::from_millis(700)).await;
 
     tracing::info!("--- trigger election on node 2");
     let n2 = router.get_raft_handle(&2)?;
@@ -86,7 +88,7 @@ async fn on_cluster_leader_change_api() -> Result<()> {
         .await?;
 
     // Give some time for the callback to be invoked
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify leader change events after election");
     {
@@ -103,7 +105,7 @@ async fn on_cluster_leader_change_api() -> Result<()> {
     handle.close().await;
 
     // Wait for leader lease to expire
-    tokio::time::sleep(Duration::from_millis(700)).await;
+    TypeConfig::sleep(Duration::from_millis(700)).await;
 
     tracing::info!("--- trigger election on node 1 after handle closed (node 2 still running for quorum)");
     n1.trigger().elect().await?;
@@ -113,7 +115,7 @@ async fn on_cluster_leader_change_api() -> Result<()> {
         .await?;
 
     // Give some time for any potential callback to be invoked
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify no new events after handle closed");
     {
@@ -173,7 +175,7 @@ async fn on_leader_change_api() -> Result<()> {
     );
 
     // Give some time for the initial callback to be invoked
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify `start` was called for node 0");
     {
@@ -187,7 +189,7 @@ async fn on_leader_change_api() -> Result<()> {
     }
 
     // Wait for leader lease to expire so other nodes accept new vote
-    tokio::time::sleep(Duration::from_millis(700)).await;
+    TypeConfig::sleep(Duration::from_millis(700)).await;
 
     tracing::info!("--- trigger election on node 2");
     let n2 = router.get_raft_handle(&2)?;
@@ -204,7 +206,7 @@ async fn on_leader_change_api() -> Result<()> {
         .await?;
 
     // Give some time for the callback to be invoked
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify `stop` was called for node 0");
     {
@@ -273,7 +275,7 @@ async fn on_leader_change_future_is_awaited() -> Result<()> {
     );
 
     // Give time for the callback future to be awaited
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify start callback future was awaited");
     assert_eq!(
@@ -288,7 +290,7 @@ async fn on_leader_change_future_is_awaited() -> Result<()> {
     );
 
     // Wait for leader lease to expire
-    tokio::time::sleep(Duration::from_millis(700)).await;
+    TypeConfig::sleep(Duration::from_millis(700)).await;
 
     tracing::info!("--- trigger election on node 2 to cause leadership change");
     let n2 = router.get_raft_handle(&2)?;
@@ -303,7 +305,7 @@ async fn on_leader_change_future_is_awaited() -> Result<()> {
         .await?;
 
     // Give time for the stop callback future to be awaited
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify stop callback future was awaited");
     assert_eq!(start_counter.load(Ordering::SeqCst), 1, "start count should still be 1");
@@ -353,7 +355,7 @@ async fn on_cluster_leader_change_future_is_awaited() -> Result<()> {
     });
 
     // Give time for the callback future to be awaited
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify callback future was awaited for initial leader");
     assert_eq!(
@@ -363,7 +365,7 @@ async fn on_cluster_leader_change_future_is_awaited() -> Result<()> {
     );
 
     // Wait for leader lease to expire
-    tokio::time::sleep(Duration::from_millis(700)).await;
+    TypeConfig::sleep(Duration::from_millis(700)).await;
 
     tracing::info!("--- trigger election on node 2");
     let n2 = router.get_raft_handle(&2)?;
@@ -378,7 +380,7 @@ async fn on_cluster_leader_change_future_is_awaited() -> Result<()> {
         .await?;
 
     // Give time for the callback future to be awaited
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    TypeConfig::sleep(Duration::from_millis(100)).await;
 
     tracing::info!("--- verify callback future was awaited for new leader");
     assert_eq!(

--- a/tests/tests/replication/t50_append_entries_backoff_rejoin.rs
+++ b/tests/tests/replication/t50_append_entries_backoff_rejoin.rs
@@ -5,6 +5,8 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::ut_harness;
@@ -44,7 +46,7 @@ async fn append_entries_backoff_rejoin() -> Result<()> {
     tracing::info!(log_index, "--- elect node-1");
     {
         // Timeout leader lease otherwise vote-request will be rejected by node-2
-        tokio::time::sleep(Duration::from_millis(1_000)).await;
+        TypeConfig::sleep(Duration::from_millis(1_000)).await;
 
         n1.trigger().elect().await?;
         n1.wait(timeout()).state(ServerState::Leader, "node-1 elect").await?;

--- a/tests/tests/replication/t99_issue_1500_heartbeat_cause_reversion_panic.rs
+++ b/tests/tests/replication/t99_issue_1500_heartbeat_cause_reversion_panic.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::RPCTypes;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::rpc_request::RpcRequest;
@@ -64,7 +66,7 @@ async fn t99_issue_1500_heartbeat_cause_reversion_panic() -> anyhow::Result<()> 
             let fu = async move {
                 if sleep_ms > 0 {
                     tracing::debug!("Post-hook for target {}: delaying response by {}ms", target, sleep_ms);
-                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                    TypeConfig::sleep(Duration::from_millis(sleep_ms)).await;
                     tracing::debug!("Post-hook for target {}: delay complete", target);
                 }
                 Ok::<_, _>(())

--- a/tests/tests/snapshot_building/t11_snapshot_builder_control.rs
+++ b/tests/tests/snapshot_building/t11_snapshot_builder_control.rs
@@ -7,6 +7,8 @@ use openraft::Config;
 use openraft::SnapshotMeta;
 use openraft::SnapshotPolicy;
 use openraft::storage::RaftStateMachine;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -64,7 +66,7 @@ async fn sm_can_refuse_snapshot_building() -> Result<()> {
         n0.trigger().snapshot().await?;
 
         // Wait a bit to ensure the snapshot building attempt completes
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        TypeConfig::sleep(Duration::from_millis(200)).await;
 
         // Verify no snapshot was created in storage
         let (_, mut sm) = router.get_storage_handle(&0)?;
@@ -134,7 +136,7 @@ async fn sm_can_refuse_snapshot_building() -> Result<()> {
         let n0 = router.get_raft_handle(&0)?;
         n0.trigger().snapshot().await?;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        TypeConfig::sleep(Duration::from_millis(200)).await;
 
         // The old snapshot should still be there in storage
         let snapshot = sm.get_current_snapshot().await?;
@@ -236,7 +238,7 @@ async fn sm_refuse_with_logs_since_last_policy() -> Result<()> {
 
     tracing::info!(log_index, "--- applied upto index=4 logs");
 
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    TypeConfig::sleep(Duration::from_millis(300)).await;
 
     let first_count = take_snapshot_builder_count(&router, 0)?;
 
@@ -251,7 +253,7 @@ async fn sm_refuse_with_logs_since_last_policy() -> Result<()> {
     take_snapshot_builder_count(&router, 0)?;
 
     // Apply a small write to trigger routine actions during the idle period
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    TypeConfig::sleep(Duration::from_millis(300)).await;
     log_index += router.client_request_many(0, "0", 1).await?;
     router.wait(&0, timeout()).applied_index(Some(log_index), "trigger check").await?;
 

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
@@ -10,7 +10,9 @@ use openraft::network::RaftNetworkFactory;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
+use openraft::type_config::TypeConfigExt;
 use openraft_memstore::BlockOperation;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -47,7 +49,7 @@ async fn building_snapshot_does_not_block_append() -> Result<()> {
         follower.trigger().snapshot().await?;
 
         tracing::info!(log_index, "--- sleep 500 ms to make sure snapshot is started");
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
 
         let res = router
             .wait(&1, Some(Duration::from_millis(500)))

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
@@ -10,7 +10,9 @@ use openraft::network::RaftNetworkFactory;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
+use openraft::type_config::TypeConfigExt;
 use openraft_memstore::BlockOperation;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -49,7 +51,7 @@ async fn building_snapshot_does_not_block_apply() -> Result<()> {
         follower.trigger().snapshot().await?;
 
         tracing::info!(log_index, "--- sleep 500 ms to make sure snapshot is started");
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
 
         let res = router
             .wait(&1, Some(Duration::from_millis(500)))

--- a/tests/tests/snapshot_streaming/t30_purge_in_snapshot_logs.rs
+++ b/tests/tests/snapshot_streaming/t30_purge_in_snapshot_logs.rs
@@ -5,7 +5,8 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::RaftLogReader;
-use tokio::time::sleep;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -45,7 +46,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
         let (mut sto0, mut _sm0) = router.get_storage_handle(&0)?;
 
         // Wait for purge to complete.
-        sleep(Duration::from_millis(500)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
 
         let logs = sto0.try_get_log_entries(..).await?;
         assert_eq!(max_keep as usize, logs.len());
@@ -66,7 +67,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
 
     // There may be a cached append-entries request that already loads log 10..15 from the store,
     // just before building snapshot.
-    sleep(Duration::from_millis(2_000)).await;
+    TypeConfig::sleep(Duration::from_millis(2_000)).await;
 
     tracing::info!(
         log_index,

--- a/tests/tests/snapshot_streaming/t34_replication_does_not_block_purge.rs
+++ b/tests/tests/snapshot_streaming/t34_replication_does_not_block_purge.rs
@@ -5,7 +5,8 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::RaftLogReader;
-use tokio::time::sleep;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::log_id;
@@ -49,7 +50,7 @@ async fn replication_does_not_block_purge() -> Result<()> {
         leader.trigger().snapshot().await?;
         leader.wait(timeout()).snapshot(log_id(1, 0, log_index), "built snapshot").await?;
 
-        sleep(Duration::from_millis(2_000)).await;
+        TypeConfig::sleep(Duration::from_millis(2_000)).await;
 
         let (mut sto0, mut _sm0) = router.get_storage_handle(&0)?;
         let logs = sto0.try_get_log_entries(..).await?;


### PR DESCRIPTION

## Changelog

##### refactor: use runtime-agnostic `TypeConfig::sleep()` in tests
Replace direct `tokio::time::sleep()` calls with `TypeConfig::sleep()`
to use the runtime-agnostic sleep function provided by the `TypeConfigExt`
trait. This aligns tests with the async runtime abstraction.

Changes:
- Replace `tokio::time::sleep()` with `TypeConfig::sleep()` in test files
- Add `TypeConfigExt` import where needed

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1610)
<!-- Reviewable:end -->
