### PR TITLE
refactor: use TypeConfig::mpsc() instead of futures::channel::mpsc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ repository = "https://github.com/databendlabs/openraft"
 [workspace.dependencies]
 anyerror           = { version = "0.1.10" }
 anyhow             = { version = "1.0.63" }
-async-entry        = { version = "0.3.1" }
 byte-unit          = { version = "5.1.4" }
 bytes              = { version = "1.0" }
 chrono             = { version = "0.4" }

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,18 @@ lint:
 
 unused_dep:
 	cargo machete
+	cargo machete examples/raft-kv-memstore
+	cargo machete examples/raft-kv-rocksdb
+	cargo machete examples/raft-kv-memstore-grpc
+	cargo machete examples/raft-kv-memstore-single-threaded
+	cargo machete examples/raft-kv-memstore-opendal-snapshot-data
+	cargo machete examples/raft-kv-memstore-network-v2
+	cargo machete examples/multi-raft-kv
+	cargo machete examples/rocksstore
+	cargo machete multiraft
+	cargo machete rt-compio
+	cargo machete rt-monoio
+	cargo machete rt-tokio
 
 typos:
 	# cargo install typos-cli

--- a/examples/client-http/Cargo.toml
+++ b/examples/client-http/Cargo.toml
@@ -20,7 +20,6 @@ openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 reqwest    = { version = "0.12.5", features = ["json"] }
 serde      = { version = "1.0.114", features = ["derive"] }
 serde_json = { version = "1.0.57" }
-tokio      = { version = "1.35.1", features = ["full"] }
 tracing    = { version = "0.1.40" }
 
 [features]

--- a/examples/mem-log/Cargo.toml
+++ b/examples/mem-log/Cargo.toml
@@ -15,9 +15,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
+futures = "0.3.31"
 openraft = { path = "../../openraft", default-features = false, features = ["type-alias", "tokio-rt"] }
-
-tokio = { version = "1.0", default-features = false, features = ["sync"] }
 
 [features]
 

--- a/examples/mem-log/src/log_store.rs
+++ b/examples/mem-log/src/log_store.rs
@@ -7,16 +7,16 @@ use std::io;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
+use futures::lock::Mutex;
 use openraft::LogState;
 use openraft::RaftTypeConfig;
 use openraft::alias::LogIdOf;
 use openraft::alias::VoteOf;
 use openraft::entry::RaftEntry;
 use openraft::storage::IOFlushed;
-use tokio::sync::Mutex;
 
 /// RaftLogStore implementation with a in-memory storage
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct LogStore<C: RaftTypeConfig> {
     inner: Arc<Mutex<LogStoreInner<C>>>,
 }

--- a/examples/multi-raft-kv/Cargo.toml
+++ b/examples/multi-raft-kv/Cargo.toml
@@ -22,7 +22,6 @@ openraft-multi = { path = "../../multiraft" }
 futures            = { version = "0.3" }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = { version = "1" }
-tokio              = { version = "1", default-features = false, features = ["sync"] }
 tracing            = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/multi-raft-kv/src/app.rs
+++ b/examples/multi-raft-kv/src/app.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use openraft::async_runtime::OneshotSender;
-use tokio::sync::mpsc;
+use futures::StreamExt;
+use futures::channel::mpsc;
 
 use crate::GroupId;
 use crate::NodeId;
@@ -28,7 +28,7 @@ pub struct Node {
 
 impl Node {
     pub fn new(node_id: NodeId, router: Router) -> (Self, NodeTx) {
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1024);
 
         // Register this node's shared connection
         router.register_node(node_id, tx.clone());
@@ -63,7 +63,7 @@ impl Node {
     /// Routes incoming messages to the correct group based on group_id.
     pub async fn run(mut self) -> Option<()> {
         loop {
-            let msg = self.rx.recv().await?;
+            let msg = self.rx.next().await?;
 
             let NodeMessage {
                 group_id,

--- a/examples/multi-raft-kv/src/store.rs
+++ b/examples/multi-raft-kv/src/store.rs
@@ -3,10 +3,11 @@ use std::fmt;
 use std::fmt::Debug;
 use std::io;
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::Mutex as StdMutex;
 
 use futures::Stream;
 use futures::TryStreamExt;
+use futures::lock::Mutex;
 use openraft::EntryPayload;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
@@ -15,7 +16,6 @@ use openraft::storage::RaftStateMachine;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::TypeConfig;
 use crate::typ::*;
 
 pub type LogStore = mem_log::LogStore<TypeConfig>;
@@ -69,12 +69,12 @@ pub struct StateMachineData {
 /// Each group may have its own independent state machine instance.
 #[derive(Debug, Default)]
 pub struct StateMachineStore {
-    pub state_machine: tokio::sync::Mutex<StateMachineData>,
+    pub state_machine: Mutex<StateMachineData>,
 
-    snapshot_idx: Mutex<u64>,
+    snapshot_idx: StdMutex<u64>,
 
     /// The last received snapshot.
-    current_snapshot: Mutex<Option<StoredSnapshot>>,
+    current_snapshot: StdMutex<Option<StoredSnapshot>>,
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {

--- a/examples/network-v1-http/Cargo.toml
+++ b/examples/network-v1-http/Cargo.toml
@@ -19,7 +19,6 @@ openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 
 reqwest    = { version = "0.12.5", features = ["json"] }
 serde      = { version = "1.0.114", features = ["derive"] }
-serde_json = { version = "1.0.57" }
 tokio      = { version = "1.35.1", features = ["full"] }
 tracing    = { version = "0.1.40" }
 

--- a/examples/raft-kv-memstore-grpc/Cargo.toml
+++ b/examples/raft-kv-memstore-grpc/Cargo.toml
@@ -23,14 +23,9 @@ mem-log  = { path = "../mem-log", features = [] }
 openraft = { path = "../../openraft", features = ["type-alias"] }
 
 clap               = { version = "4.1.11", features = ["derive", "env"] }
-dashmap            = { version = "6.1.0" }
 futures            = { version = "0.3.31" }
 prost              = { version = "0.13.4" }
-serde              = { version = "1.0.114", features = ["derive"] }
-serde_json         = { version = "1.0.57" }
-tokio              = { version = "1.39", default-features = false, features = ["sync"] }
 tonic              = { version = "0.12.3" }
-tonic-build        = { version = "0.12.3" }
 tracing            = { version = "0.1.29" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 

--- a/examples/raft-kv-memstore-grpc/src/app.rs
+++ b/examples/raft-kv-memstore-grpc/src/app.rs
@@ -14,7 +14,10 @@ use crate::store::LogStore;
 use crate::store::StateMachineStore;
 use crate::typ::*;
 
-pub async fn start_raft_app(node_id: NodeId, http_addr: String) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn start_raft_app(
+    node_id: NodeId,
+    http_addr: String,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create a configuration for the raft instance.
     let config = Arc::new(
         Config {

--- a/examples/raft-kv-memstore-grpc/src/bin/main.rs
+++ b/examples/raft-kv-memstore-grpc/src/bin/main.rs
@@ -1,4 +1,6 @@
 use clap::Parser;
+use openraft::AsyncRuntime;
+use raft_kv_memstore_grpc::TypeConfig;
 use raft_kv_memstore_grpc::app::start_raft_app;
 
 #[derive(Parser, Clone, Debug)]
@@ -12,8 +14,7 @@ pub struct Opt {
     pub addr: String,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Initialize tracing first, before any logging happens
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
@@ -24,5 +25,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the parameters passed by arguments.
     let options = Opt::parse();
 
-    start_raft_app(options.id, options.addr).await
+    let mut rt = <TypeConfig as openraft::RaftTypeConfig>::AsyncRuntime::new(1);
+    rt.block_on(start_raft_app(options.id, options.addr))
 }

--- a/examples/raft-kv-memstore-grpc/src/store/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/store/mod.rs
@@ -1,17 +1,17 @@
 use std::fmt::Debug;
 use std::io;
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::Mutex as StdMutex;
 
 use futures::Stream;
 use futures::TryStreamExt;
+use futures::lock::Mutex;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
 use openraft::entry::RaftEntry;
 use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 
-use crate::TypeConfig;
 use crate::protobuf as pb;
 use crate::protobuf::Response;
 use crate::typ::*;
@@ -31,12 +31,12 @@ pub struct StoredSnapshot {
 #[derive(Debug, Default)]
 pub struct StateMachineStore {
     /// The Raft state machine.
-    pub state_machine: tokio::sync::Mutex<pb::StateMachineData>,
+    pub state_machine: Mutex<pb::StateMachineData>,
 
-    snapshot_idx: Mutex<u64>,
+    snapshot_idx: StdMutex<u64>,
 
     /// The last received snapshot.
-    current_snapshot: Mutex<Option<StoredSnapshot>>,
+    current_snapshot: StdMutex<Option<StoredSnapshot>>,
 }
 
 impl StateMachineStore {

--- a/examples/raft-kv-memstore-grpc/tests/test_cluster.rs
+++ b/examples/raft-kv-memstore-grpc/tests/test_cluster.rs
@@ -5,12 +5,13 @@ use std::thread;
 use std::time::Duration;
 
 use maplit::btreemap;
+use openraft::async_runtime::AsyncRuntime;
 use openraft::type_config::TypeConfigExt;
+use openraft::type_config::alias::AsyncRuntimeOf;
 use raft_kv_memstore_grpc::TypeConfig;
 use raft_kv_memstore_grpc::app::start_raft_app;
 use raft_kv_memstore_grpc::protobuf as pb;
 use raft_kv_memstore_grpc::protobuf::app_service_client::AppServiceClient;
-use tokio::runtime::Runtime;
 use tonic::transport::Channel;
 use tracing_subscriber::EnvFilter;
 
@@ -58,19 +59,19 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
     // --- Start 3 raft node in 3 threads.
 
     let _h1 = thread::spawn(|| {
-        let rt = Runtime::new().unwrap();
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
         let x = rt.block_on(start_raft_app(1, get_addr(1)));
         println!("raft app exit result: {:?}", x);
     });
 
     let _h2 = thread::spawn(|| {
-        let rt = Runtime::new().unwrap();
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
         let x = rt.block_on(start_raft_app(2, get_addr(2)));
         println!("raft app exit result: {:?}", x);
     });
 
     let _h3 = thread::spawn(|| {
-        let rt = Runtime::new().unwrap();
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
         let x = rt.block_on(start_raft_app(3, get_addr(3)));
         println!("raft app exit result: {:?}", x);
     });

--- a/examples/raft-kv-memstore-network-v2/Cargo.toml
+++ b/examples/raft-kv-memstore-network-v2/Cargo.toml
@@ -22,7 +22,6 @@ openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 futures            = { version = "0.3" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }
-tokio              = { version = "1.0", default-features = false, features = ["sync"] }
 tracing            = { version = "0.1.29" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 

--- a/examples/raft-kv-memstore-network-v2/src/app.rs
+++ b/examples/raft-kv-memstore-network-v2/src/app.rs
@@ -1,20 +1,20 @@
 use std::sync::Arc;
 
-use openraft::async_runtime::OneshotSender;
-use openraft::type_config::alias::OneshotSenderOf;
-use tokio::sync::mpsc;
+use futures::StreamExt;
+use futures::channel::mpsc;
+use futures::channel::oneshot;
 
 use crate::NodeId;
 use crate::StateMachineStore;
-use crate::TypeConfig;
 use crate::api;
 use crate::router::Router;
 use crate::typ;
 
 pub type Path = String;
 pub type Payload = String;
-pub type ResponseTx = OneshotSenderOf<TypeConfig, String>;
-pub type RequestTx = mpsc::UnboundedSender<(Path, Payload, ResponseTx)>;
+pub type ResponseTx = oneshot::Sender<String>;
+pub type RequestTx = mpsc::Sender<(Path, Payload, ResponseTx)>;
+pub type RequestRx = mpsc::Receiver<(Path, Payload, ResponseTx)>;
 
 /// Representation of an application state.
 pub struct App {
@@ -22,7 +22,7 @@ pub struct App {
     pub raft: typ::Raft,
 
     /// Receive application requests, Raft protocol request or management requests.
-    pub rx: mpsc::UnboundedReceiver<(Path, Payload, ResponseTx)>,
+    pub rx: RequestRx,
     pub router: Router,
 
     pub state_machine: Arc<StateMachineStore>,
@@ -30,7 +30,7 @@ pub struct App {
 
 impl App {
     pub fn new(id: NodeId, raft: typ::Raft, router: Router, state_machine: Arc<StateMachineStore>) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1024);
 
         {
             let mut targets = router.targets.lock().unwrap();
@@ -48,7 +48,7 @@ impl App {
 
     pub async fn run(mut self) -> Option<()> {
         loop {
-            let (path, payload, response_tx) = self.rx.recv().await?;
+            let (path, payload, response_tx) = self.rx.next().await?;
 
             let res = match path.as_str() {
                 // Application API

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -3,10 +3,11 @@ use std::fmt;
 use std::fmt::Debug;
 use std::io;
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::Mutex as StdMutex;
 
 use futures::Stream;
 use futures::TryStreamExt;
+use futures::lock::Mutex;
 use openraft::EntryPayload;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
@@ -15,7 +16,6 @@ use openraft::storage::RaftStateMachine;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::TypeConfig;
 use crate::typ::*;
 
 pub type LogStore = mem_log::LogStore<TypeConfig>;
@@ -75,12 +75,12 @@ pub struct StateMachineData {
 #[derive(Debug, Default)]
 pub struct StateMachineStore {
     /// The Raft state machine.
-    pub state_machine: tokio::sync::Mutex<StateMachineData>,
+    pub state_machine: Mutex<StateMachineData>,
 
-    snapshot_idx: Mutex<u64>,
+    snapshot_idx: StdMutex<u64>,
 
     /// The last received snapshot.
-    current_snapshot: Mutex<Option<StoredSnapshot>>,
+    current_snapshot: StdMutex<Option<StoredSnapshot>>,
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {

--- a/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
@@ -25,7 +25,6 @@ futures            = { version = "0.3" }
 opendal            = { version = "0.48.0" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }
-tokio              = { version = "1.39", default-features = false, features = ["sync"] }
 tracing            = { version = "0.1.29" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/app.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/app.rs
@@ -1,20 +1,20 @@
 use std::sync::Arc;
 
-use openraft::async_runtime::OneshotSender;
-use openraft::type_config::alias::OneshotSenderOf;
-use tokio::sync::mpsc;
+use futures::StreamExt;
+use futures::channel::mpsc;
+use futures::channel::oneshot;
 
 use crate::NodeId;
 use crate::StateMachineStore;
-use crate::TypeConfig;
 use crate::api;
 use crate::router::Router;
 use crate::typ;
 
 pub type Path = String;
 pub type Payload = String;
-pub type ResponseTx = OneshotSenderOf<TypeConfig, String>;
-pub type RequestTx = mpsc::UnboundedSender<(Path, Payload, ResponseTx)>;
+pub type ResponseTx = oneshot::Sender<String>;
+pub type RequestTx = mpsc::Sender<(Path, Payload, ResponseTx)>;
+pub type RequestRx = mpsc::Receiver<(Path, Payload, ResponseTx)>;
 
 /// Representation of an application state.
 pub struct App {
@@ -22,7 +22,7 @@ pub struct App {
     pub raft: typ::Raft,
 
     /// Receive application requests, Raft protocol request or management requests.
-    pub rx: mpsc::UnboundedReceiver<(Path, Payload, ResponseTx)>,
+    pub rx: RequestRx,
     pub router: Router,
 
     pub state_machine: Arc<StateMachineStore>,
@@ -30,7 +30,7 @@ pub struct App {
 
 impl App {
     pub fn new(id: NodeId, raft: typ::Raft, router: Router, state_machine: Arc<StateMachineStore>) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1024);
 
         {
             let mut targets = router.targets.lock().unwrap();
@@ -48,7 +48,7 @@ impl App {
 
     pub async fn run(mut self) -> Option<()> {
         loop {
-            let (path, payload, response_tx) = self.rx.recv().await?;
+            let (path, payload, response_tx) = self.rx.next().await?;
 
             let res = match path.as_str() {
                 // Application API

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -1,12 +1,12 @@
 use std::collections::BTreeMap;
 use std::fmt;
-use std::fmt::Debug;
 use std::io;
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::Mutex as StdMutex;
 
 use futures::Stream;
 use futures::TryStreamExt;
+use futures::lock::Mutex;
 use opendal::Operator;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
@@ -15,7 +15,6 @@ use openraft::storage::RaftStateMachine;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::TypeConfig;
 use crate::decode_buffer;
 use crate::encode;
 use crate::typ::*;
@@ -77,22 +76,22 @@ pub struct StateMachineData {
 #[derive(Debug)]
 pub struct StateMachineStore {
     /// The Raft state machine.
-    pub state_machine: tokio::sync::Mutex<StateMachineData>,
+    pub state_machine: Mutex<StateMachineData>,
 
-    snapshot_idx: Mutex<u64>,
+    snapshot_idx: StdMutex<u64>,
     storage: Operator,
 
     /// The last received snapshot.
-    current_snapshot: Mutex<Option<StoredSnapshot>>,
+    current_snapshot: StdMutex<Option<StoredSnapshot>>,
 }
 
 impl StateMachineStore {
     pub fn new(storage: Operator) -> Self {
         Self {
-            state_machine: tokio::sync::Mutex::new(StateMachineData::default()),
-            snapshot_idx: Mutex::new(0),
+            state_machine: Mutex::new(StateMachineData::default()),
+            snapshot_idx: StdMutex::new(0),
             storage,
-            current_snapshot: Mutex::new(None),
+            current_snapshot: StdMutex::new(None),
         }
     }
 }

--- a/examples/raft-kv-memstore-single-threaded/Cargo.toml
+++ b/examples/raft-kv-memstore-single-threaded/Cargo.toml
@@ -21,7 +21,6 @@ openraft = { path = "../../openraft", features = ["serde", "single-threaded", "t
 futures            = { version = "0.3" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }
-tokio              = { version = "1.0", default-features = false, features = ["sync"] }
 tracing            = { version = "0.1.29" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 

--- a/examples/raft-kv-memstore-single-threaded/src/app.rs
+++ b/examples/raft-kv-memstore-single-threaded/src/app.rs
@@ -1,20 +1,20 @@
 use std::rc::Rc;
 
-use openraft::async_runtime::OneshotSender;
-use openraft::type_config::alias::OneshotSenderOf;
-use tokio::sync::mpsc;
+use futures::StreamExt;
+use futures::channel::mpsc;
+use futures::channel::oneshot;
 
 use crate::NodeId;
 use crate::StateMachineStore;
-use crate::TypeConfig;
 use crate::api;
 use crate::router::Router;
 use crate::typ::Raft;
 
 pub type Path = String;
 pub type Payload = String;
-pub type ResponseTx = OneshotSenderOf<TypeConfig, String>;
-pub type RequestTx = mpsc::UnboundedSender<(Path, Payload, ResponseTx)>;
+pub type ResponseTx = oneshot::Sender<String>;
+pub type RequestTx = mpsc::Sender<(Path, Payload, ResponseTx)>;
+pub type RequestRx = mpsc::Receiver<(Path, Payload, ResponseTx)>;
 
 /// Representation of an application state.
 pub struct App {
@@ -22,7 +22,7 @@ pub struct App {
     pub raft: Raft,
 
     /// Receive application requests, Raft protocol request or management requests.
-    pub rx: mpsc::UnboundedReceiver<(Path, Payload, ResponseTx)>,
+    pub rx: RequestRx,
     pub router: Router,
 
     pub state_machine: Rc<StateMachineStore>,
@@ -30,7 +30,7 @@ pub struct App {
 
 impl App {
     pub fn new(id: NodeId, raft: Raft, router: Router, state_machine: Rc<StateMachineStore>) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1024);
 
         {
             let mut targets = router.targets.borrow_mut();
@@ -48,7 +48,7 @@ impl App {
 
     pub async fn run(mut self) -> Option<()> {
         loop {
-            let (path, payload, response_tx) = self.rx.recv().await?;
+            let (path, payload, response_tx) = self.rx.next().await?;
 
             let res = match path.as_str() {
                 // Application API

--- a/examples/raft-kv-memstore-single-threaded/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-single-threaded/tests/cluster/test_cluster.rs
@@ -19,8 +19,6 @@ use raft_kv_memstore_single_threaded::typ::ClientWriteResponse;
 use raft_kv_memstore_single_threaded::typ::InitializeError;
 use raft_kv_memstore_single_threaded::typ::LinearizableReadError;
 use raft_kv_memstore_single_threaded::typ::RaftMetrics;
-use tokio::task;
-use tokio::task::LocalSet;
 use tracing_subscriber::EnvFilter;
 
 pub fn log_panic(panic: &PanicHookInfo) {
@@ -63,17 +61,11 @@ fn test_cluster() {
 
         let router = Router::default();
 
-        let local = LocalSet::new();
+        TypeConfig::spawn(start_raft(NodeId::new(1), router.clone()));
+        TypeConfig::spawn(start_raft(NodeId::new(2), router.clone()));
+        TypeConfig::spawn(start_raft(NodeId::new(3), router.clone()));
 
-        local
-            .run_until(async move {
-                task::spawn_local(start_raft(NodeId::new(1), router.clone()));
-                task::spawn_local(start_raft(NodeId::new(2), router.clone()));
-                task::spawn_local(start_raft(NodeId::new(3), router.clone()));
-
-                run_test(router).await;
-            })
-            .await;
+        run_test(router).await;
     });
 }
 

--- a/examples/raft-kv-memstore/Cargo.toml
+++ b/examples/raft-kv-memstore/Cargo.toml
@@ -31,7 +31,6 @@ futures            = { version = "0.3" }
 reqwest            = { version = "0.12.5", features = ["json"] }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }
-tokio              = { version = "1.0", default-features = false, features = ["sync"] }
 tracing            = { version = "0.1.29" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -32,7 +32,7 @@ pub async fn write(app: Data<App>, req: Json<Request>) -> actix_web::Result<impl
 
 #[post("/read")]
 pub async fn read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl Responder> {
-    let state_machine = app.state_machine_store.state_machine.read().await;
+    let state_machine = app.state_machine_store.state_machine.lock().await;
     let key = req.0;
     let value = state_machine.data.get(&key).cloned();
 
@@ -48,7 +48,7 @@ pub async fn linearizable_read(app: Data<App>, req: Json<String>) -> actix_web::
         Ok(linearizer) => {
             linearizer.await_ready(&app.raft).await.unwrap();
 
-            let state_machine = app.state_machine_store.state_machine.read().await;
+            let state_machine = app.state_machine_store.state_machine.lock().await;
             let key = req.0;
             let value = state_machine.data.get(&key).cloned();
 
@@ -138,7 +138,7 @@ pub async fn follower_read(app: Data<App>, req: Json<String>) -> actix_web::Resu
     }
 
     // 5. Read from local state machine
-    let state_machine = app.state_machine_store.state_machine.read().await;
+    let state_machine = app.state_machine_store.state_machine.lock().await;
     let key = req.0;
     let value = state_machine.data.get(&key).cloned();
 

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::Ordering;
 
 use futures::Stream;
 use futures::TryStreamExt;
+use futures::lock::Mutex;
 use openraft::AnyError;
 use openraft::EntryPayload;
 use openraft::LogId;
@@ -23,7 +24,6 @@ use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::sync::RwLock;
 
 use crate::TypeConfig;
 
@@ -107,7 +107,7 @@ pub struct StateMachineData {
 #[derive(Debug, Default)]
 pub struct StateMachineStore {
     /// The Raft state machine.
-    pub state_machine: RwLock<StateMachineData>,
+    pub state_machine: Mutex<StateMachineData>,
 
     /// Used in identifier for snapshot.
     ///
@@ -117,14 +117,14 @@ pub struct StateMachineStore {
     snapshot_idx: AtomicU64,
 
     /// The last received snapshot.
-    current_snapshot: RwLock<Option<StoredSnapshot>>,
+    current_snapshot: Mutex<Option<StoredSnapshot>>,
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, io::Error> {
         // Serialize the data of the state machine.
-        let state_machine = self.state_machine.read().await;
+        let state_machine = self.state_machine.lock().await;
         let data =
             serde_json::to_vec(&state_machine.data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
@@ -133,7 +133,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         // Lock the current snapshot before releasing the lock on the state machine, to avoid a race
         // condition on the written snapshot
-        let mut current_snapshot = self.current_snapshot.write().await;
+        let mut current_snapshot = self.current_snapshot.lock().await;
         drop(state_machine);
 
         let snapshot_idx = self.snapshot_idx.fetch_add(1, Ordering::Relaxed) + 1;
@@ -167,14 +167,14 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     type SnapshotBuilder = Self;
 
     async fn applied_state(&mut self) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TypeConfig>), io::Error> {
-        let state_machine = self.state_machine.read().await;
+        let state_machine = self.state_machine.lock().await;
         Ok((state_machine.last_applied_log, state_machine.last_membership.clone()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
     async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
     where Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Unpin + OptionalSend {
-        let mut sm = self.state_machine.write().await;
+        let mut sm = self.state_machine.lock().await;
 
         while let Some((entry, responder)) = entries.try_next().await? {
             tracing::debug!(%entry.log_id, "replicate to sm");
@@ -233,12 +233,12 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
             last_membership: meta.last_membership.clone(),
             data: updated_state_machine_data,
         };
-        let mut state_machine = self.state_machine.write().await;
+        let mut state_machine = self.state_machine.lock().await;
         *state_machine = updated_state_machine;
 
         // Lock the current snapshot before releasing the lock on the state machine, to avoid a race
         // condition on the written snapshot
-        let mut current_snapshot = self.current_snapshot.write().await;
+        let mut current_snapshot = self.current_snapshot.lock().await;
         drop(state_machine);
 
         // Update current snapshot.
@@ -248,7 +248,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TypeConfig>>, io::Error> {
-        match &*self.current_snapshot.read().await {
+        match &*self.current_snapshot.lock().await {
             Some(snapshot) => {
                 let data = snapshot.data.clone();
                 Ok(Some(Snapshot {

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -8,11 +8,12 @@ use client_http::ExampleClient;
 use maplit::btreemap;
 use maplit::btreeset;
 use openraft::BasicNode;
+use openraft::async_runtime::AsyncRuntime;
 use openraft::type_config::TypeConfigExt;
+use openraft::type_config::alias::AsyncRuntimeOf;
 use raft_kv_memstore::TypeConfig;
 use raft_kv_memstore::start_example_raft_node;
 use raft_kv_memstore::store::Request;
-use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
 
 pub fn log_panic(panic: &PanicHookInfo) {
@@ -87,19 +88,19 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
     // --- Start 3 raft node in 3 threads.
 
     let _h1 = thread::spawn(|| {
-        let rt = Runtime::new().unwrap();
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
         let x = rt.block_on(start_example_raft_node(1, "127.0.0.1:21001".to_string()));
         println!("x: {:?}", x);
     });
 
     let _h2 = thread::spawn(|| {
-        let rt = Runtime::new().unwrap();
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
         let x = rt.block_on(start_example_raft_node(2, "127.0.0.1:21002".to_string()));
         println!("x: {:?}", x);
     });
 
     let _h3 = thread::spawn(|| {
-        let rt = Runtime::new().unwrap();
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
         let x = rt.block_on(start_example_raft_node(3, "127.0.0.1:21003".to_string()));
         println!("x: {:?}", x);
     });

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -32,7 +32,6 @@ futures            = { version = "0.3" }
 rocksdb            = { version = "0.22.0" }
 serde              = { version = "1.0.114", features = ["derive"] }
 serde_json         = { version = "1.0.57" }
-tokio              = { version = "1.35.1", features = ["full"] }
 tracing            = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 

--- a/examples/raft-kv-rocksdb/src/app.rs
+++ b/examples/raft-kv-rocksdb/src/app.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use futures::lock::Mutex;
 use openraft::Config;
-use tokio::sync::RwLock;
 
 use crate::NodeId;
 use crate::typ::Raft;
@@ -13,6 +13,6 @@ pub struct App {
     pub id: NodeId,
     pub addr: String,
     pub raft: Raft,
-    pub key_values: Arc<RwLock<BTreeMap<String, String>>>,
+    pub key_values: Arc<Mutex<BTreeMap<String, String>>>,
     pub config: Arc<Config>,
 }

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -21,7 +21,7 @@ pub async fn write(app: Data<App>, req: Json<Request>) -> actix_web::Result<impl
 #[post("/read")]
 pub async fn read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl Responder> {
     let key = req.0;
-    let kvs = app.key_values.read().await;
+    let kvs = app.key_values.lock().await;
     let value = kvs.get(&key);
 
     let res: Result<String, Infallible> = Ok(value.cloned().unwrap_or_default());
@@ -37,7 +37,7 @@ pub async fn linearizable_read(app: Data<App>, req: Json<String>) -> actix_web::
             linearizer.await_ready(&app.raft).await.unwrap();
 
             let key = req.0;
-            let kvs = app.key_values.read().await;
+            let kvs = app.key_values.lock().await;
             let value = kvs.get(&key);
 
             let res: Result<String, LinearizableReadError<TypeConfig>> = Ok(value.cloned().unwrap_or_default());

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -8,11 +8,12 @@ use client_http::ExampleClient;
 use maplit::btreemap;
 use maplit::btreeset;
 use openraft::BasicNode;
+use openraft::async_runtime::AsyncRuntime;
 use openraft::type_config::TypeConfigExt;
+use openraft::type_config::alias::AsyncRuntimeOf;
 use raft_kv_rocksdb::TypeConfig;
 use raft_kv_rocksdb::start_example_raft_node;
 use raft_kv_rocksdb::store::Request;
-use tokio::runtime::Handle;
 use tracing_subscriber::EnvFilter;
 
 pub fn log_panic(panic: &PanicHookInfo) {
@@ -75,21 +76,21 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
     let d2 = tempfile::TempDir::new()?;
     let d3 = tempfile::TempDir::new()?;
 
-    let handle = Handle::current();
-    let handle_clone = handle.clone();
     let _h1 = thread::spawn(move || {
-        let x = handle_clone.block_on(start_example_raft_node(1, d1.path(), get_addr(1)));
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let x = rt.block_on(start_example_raft_node(1, d1.path(), get_addr(1)));
         println!("x: {:?}", x);
     });
 
-    let handle_clone = handle.clone();
     let _h2 = thread::spawn(move || {
-        let x = handle_clone.block_on(start_example_raft_node(2, d2.path(), get_addr(2)));
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let x = rt.block_on(start_example_raft_node(2, d2.path(), get_addr(2)));
         println!("x: {:?}", x);
     });
 
     let _h3 = thread::spawn(move || {
-        let x = handle.block_on(start_example_raft_node(3, d3.path(), get_addr(3)));
+        let mut rt = AsyncRuntimeOf::<TypeConfig>::new(1);
+        let x = rt.block_on(start_example_raft_node(3, d3.path(), get_addr(3)));
         println!("x: {:?}", x);
     });
 

--- a/examples/rocksstore/Cargo.toml
+++ b/examples/rocksstore/Cargo.toml
@@ -26,15 +26,7 @@ rand       = { version = "0.9" }
 rocksdb    = { version = "0.22.0" }
 serde      = { version = "1.0.114", features = ["derive"] }
 serde_json = { version = "1.0.57" }
-tokio      = { version = "1.22", default-features = false, features = [
-    "io-util",
-    "macros",
-    "rt",
-    "rt-multi-thread",
-    "sync",
-    "time",
-] }
-tracing = { version = "0.1.40" }
+tracing    = { version = "0.1.40" }
 
 [dev-dependencies]
 tempfile = { version = "3.4.0" }

--- a/examples/utils/declare_types.rs
+++ b/examples/utils/declare_types.rs
@@ -1,7 +1,7 @@
 //! Declare the Raft type with the TypeConfig.
 
-// Reference the containing module's type config.
-use super::TypeConfig;
+// Reference the containing module's type config and re-export it.
+pub use super::TypeConfig;
 
 pub type Raft = openraft::Raft<TypeConfig>;
 

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -41,7 +41,6 @@ validit         = { workspace = true }
 
 [dev-dependencies]
 anyhow            = { workspace = true }
-async-entry       = { workspace = true }
 pretty_assertions = { workspace = true }
 serde_json        = { workspace = true }
 

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -153,10 +153,12 @@ pub trait TypeConfigExt: RaftTypeConfig {
     ///
     /// This is a convenience method for testing. It creates a runtime with
     /// default configuration and runs the future on it.
+    ///
+    /// This runs synchronously on the current thread, so `Send` is not required.
     #[track_caller]
     fn run<F, T>(future: F) -> T
     where
-        F: Future<Output = T> + OptionalSend,
+        F: Future<Output = T>,
         T: OptionalSend,
     {
         <AsyncRuntimeOf<Self> as AsyncRuntime>::run(future)

--- a/rt-compio/src/lib.rs
+++ b/rt-compio/src/lib.rs
@@ -170,7 +170,7 @@ impl AsyncRuntime for CompioRuntime {
 
     fn block_on<F, T>(&mut self, future: F) -> T
     where
-        F: Future<Output = T> + OptionalSend,
+        F: Future<Output = T>,
         T: OptionalSend,
     {
         self.rt.block_on(future)

--- a/rt-monoio/src/lib.rs
+++ b/rt-monoio/src/lib.rs
@@ -128,7 +128,7 @@ impl AsyncRuntime for MonoioRuntime {
 
     fn block_on<F, T>(&mut self, future: F) -> T
     where
-        F: Future<Output = T> + OptionalSend,
+        F: Future<Output = T>,
         T: OptionalSend,
     {
         self.rt.block_on(future)

--- a/rt-tokio/src/lib.rs
+++ b/rt-tokio/src/lib.rs
@@ -111,7 +111,7 @@ impl AsyncRuntime for TokioRuntime {
 
     fn block_on<F, T>(&mut self, future: F) -> T
     where
-        F: Future<Output = T> + OptionalSend,
+        F: Future<Output = T>,
         T: OptionalSend,
     {
         #[cfg(feature = "single-threaded")]

--- a/rt/src/async_runtime.rs
+++ b/rt/src/async_runtime.rs
@@ -113,9 +113,11 @@ pub trait AsyncRuntime: Debug + OptionalSend + OptionalSync + 'static {
     fn new(threads: usize) -> Self;
 
     /// Run a future to completion on this runtime.
+    ///
+    /// This runs synchronously on the current thread, so `Send` is not required.
     fn block_on<F, T>(&mut self, future: F) -> T
     where
-        F: Future<Output = T> + OptionalSend,
+        F: Future<Output = T>,
         T: OptionalSend;
 
     /// Convenience method: create a runtime and run the future to completion.
@@ -124,10 +126,12 @@ pub trait AsyncRuntime: Debug + OptionalSend + OptionalSync + 'static {
     /// For simple cases where you don't need to reuse the runtime.
     /// If you need to run multiple futures, consider using [`Self::new`] and
     /// [`Self::block_on`] directly.
+    ///
+    /// This runs synchronously on the current thread, so `Send` is not required.
     fn run<F, T>(future: F) -> T
     where
         Self: Sized,
-        F: Future<Output = T> + OptionalSend,
+        F: Future<Output = T>,
         T: OptionalSend,
     {
         Self::new(8).block_on(future)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,7 +23,6 @@ openraft-memstore  = { path = "../stores/memstore" }
 
 anyerror           = { workspace = true }
 anyhow             = { workspace = true }
-async-entry        = { workspace = true }
 derive_more        = { workspace = true }
 futures            = { workspace = true }
 lazy_static        = { workspace = true }
@@ -31,7 +30,6 @@ maplit             = { workspace = true }
 pretty_assertions  = { workspace = true }
 rand               = { workspace = true }
 test-harness       = { workspace = true }
-tokio              = { workspace = true }
 tracing            = { workspace = true }
 tracing-appender   = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION

## Changelog

##### refactor: use TypeConfig::mpsc() instead of futures::channel::mpsc
Replace direct use of futures::channel::mpsc with the runtime-agnostic
TypeConfig::mpsc() method from TypeConfigExt trait.

Changes:
- Replace mpsc::channel() with TypeConfig::mpsc()
- Replace mpsc::Sender/Receiver with MpscSenderOf/MpscReceiverOf
- Replace rx.next().await with MpscReceiver::recv()
- Replace tx.send().await with MpscSender::send()
- Remove Debug derive from Router (MpscSender does not impl Debug)


##### refactor: make examples runtime-agnostic by removing tokio-specific code
Replace tokio-specific primitives with runtime-agnostic alternatives
across all example crates.

Changes:
- Replace `tokio::sync::mpsc` with `futures::channel::mpsc` in router/app modules
- Replace `tokio::spawn_blocking` with `std::thread::spawn` + oneshot in rocksstore
- Remove unused `tokio` dependency from all example crates
- Remove unused `async-entry`, `serde_json`, `dashmap`, `serde` dependencies
- Update Makefile `unused_dep` target to check all example crates


##### feat: add `mpsc_to_stream()` method to `TypeConfigExt`
Add a runtime-agnostic method to convert an mpsc receiver to a Stream,
enabling examples to avoid tokio-specific `ReceiverStream`.

Changes:
- Add `mpsc_to_stream()` method using `futures::stream::unfold`

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1615)
<!-- Reviewable:end -->
