### PR TITLE
feat: add `UserData` type to `RaftTypeConfig` for external crate storage

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/grpc/raft_service.rs
+++ b/examples/raft-kv-memstore-grpc/src/grpc/raft_service.rs
@@ -183,6 +183,7 @@ impl RaftService for RaftServiceImpl {
         let output = self.raft_node.stream_append(input_stream);
 
         // Convert StreamAppendResult to pb::AppendEntriesResponse
+        #[allow(clippy::result_large_err)]
         let output_stream = output.map(|result| Ok(result.into()));
 
         Ok(Response::new(Box::pin(output_stream)))

--- a/openraft/src/extensions.rs
+++ b/openraft/src/extensions.rs
@@ -1,0 +1,163 @@
+//! Type-map for storing user-defined extension data.
+//!
+//! [`Extensions`] allows external crates to store arbitrary types associated with a Raft instance.
+//! Each type can have at most one value stored, keyed by its [`TypeId`].
+//!
+//! This follows the `http::Extensions` pattern.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use std::sync::atomic::{AtomicU64, Ordering};
+//! use std::sync::Arc;
+//!
+//! // Use Arc for shared mutable state
+//! #[derive(Clone, Default)]
+//! pub struct MyCounter(Arc<AtomicU64>);
+//!
+//! // Insert at startup
+//! raft.extensions().insert(MyCounter::default());
+//!
+//! // Get a clone and use it
+//! if let Some(counter) = raft.extensions().get::<MyCounter>() {
+//!     counter.0.fetch_add(1, Ordering::Relaxed);
+//! }
+//! ```
+
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::base::BoxAny;
+use crate::base::OptionalSend;
+
+/// A type-map for storing user-defined extension data.
+///
+/// Values are stored by their [`TypeId`], so each type can have at most one value.
+/// Access is thread-safe via internal [`Mutex`].
+///
+/// Values must implement [`Clone`] - when retrieved via [`get()`](Self::get),
+/// a clone is returned to avoid holding locks.
+pub struct Extensions {
+    map: Mutex<HashMap<TypeId, BoxAny>>,
+}
+
+impl Extensions {
+    /// Create a new empty Extensions.
+    pub fn new() -> Self {
+        Self {
+            map: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Insert a value of type `T`.
+    ///
+    /// Returns the previous value if one existed.
+    pub fn insert<T>(&self, val: T) -> Option<T>
+    where T: OptionalSend + Clone + 'static {
+        let mut map = self.map.lock().unwrap();
+        map.insert(TypeId::of::<T>(), Box::new(val)).and_then(|boxed| boxed.downcast().ok().map(|b| *b))
+    }
+
+    /// Get a clone of the value of type `T`.
+    ///
+    /// Returns [`None`] if no value of type `T` has been inserted.
+    pub fn get<T>(&self) -> Option<T>
+    where T: Clone + 'static {
+        let map = self.map.lock().unwrap();
+        map.get(&TypeId::of::<T>()).and_then(|b| b.downcast_ref::<T>()).cloned()
+    }
+
+    /// Check if a value of type `T` exists.
+    pub fn contains<T>(&self) -> bool
+    where T: 'static {
+        let map = self.map.lock().unwrap();
+        map.contains_key(&TypeId::of::<T>())
+    }
+
+    /// Remove and return a value of type `T`.
+    pub fn remove<T>(&self) -> Option<T>
+    where T: 'static {
+        let mut map = self.map.lock().unwrap();
+        map.remove(&TypeId::of::<T>()).and_then(|boxed| boxed.downcast().ok().map(|b| *b))
+    }
+}
+
+impl Default for Extensions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for Extensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let count = self.map.lock().map(|m| m.len()).unwrap_or(0);
+        f.debug_struct("Extensions").field("count", &count).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    #[test]
+    fn test_insert_and_get() {
+        let ext = Extensions::new();
+
+        ext.insert(42u32);
+        ext.insert("hello".to_string());
+
+        assert_eq!(ext.get::<u32>().unwrap(), 42);
+        assert_eq!(ext.get::<String>().unwrap(), "hello");
+        assert!(ext.get::<i64>().is_none());
+    }
+
+    #[test]
+    fn test_insert_replaces() {
+        let ext = Extensions::new();
+
+        assert!(ext.insert(1u32).is_none());
+        assert_eq!(ext.insert(2u32), Some(1));
+        assert_eq!(ext.get::<u32>().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_shared_state_with_arc() {
+        let ext = Extensions::new();
+
+        // Use Arc for shared mutable state
+        #[derive(Clone, Default)]
+        struct Counter(Arc<AtomicU64>);
+
+        ext.insert(Counter::default());
+
+        // Get clone and mutate
+        let counter1 = ext.get::<Counter>().unwrap();
+        counter1.0.fetch_add(1, Ordering::Relaxed);
+        counter1.0.fetch_add(1, Ordering::Relaxed);
+
+        // Get another clone - shares the same Arc
+        let counter2 = ext.get::<Counter>().unwrap();
+        assert_eq!(counter2.0.load(Ordering::Relaxed), 2);
+
+        // More increments
+        counter2.0.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(counter1.0.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn test_remove() {
+        let ext = Extensions::new();
+
+        ext.insert(42u32);
+        assert!(ext.contains::<u32>());
+
+        assert_eq!(ext.remove::<u32>(), Some(42));
+        assert!(!ext.contains::<u32>());
+        assert!(ext.remove::<u32>().is_none());
+    }
+}

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -54,6 +54,7 @@ mod summary;
 mod try_as_ref;
 
 pub(crate) mod engine;
+mod extensions;
 pub(crate) mod log_id_range;
 pub(crate) mod proposer;
 pub(crate) mod raft_state;
@@ -122,6 +123,7 @@ pub use crate::config::SnapshotPolicy;
 pub use crate::core::ServerState;
 pub use crate::entry::Entry;
 pub use crate::entry::EntryPayload;
+pub use crate::extensions::Extensions;
 pub use crate::log_id::LogId;
 pub use crate::log_id::LogIdOptionExt;
 pub use crate::log_id::LogIndexOptionExt;

--- a/tests/tests/extensions/main.rs
+++ b/tests/tests/extensions/main.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "bt", feature(error_generic_member_access))]
+#![allow(clippy::uninlined_format_args)]
+
+#[macro_use]
+#[path = "../fixtures/mod.rs"]
+mod fixtures;
+
+mod t10_extensions_api;

--- a/tests/tests/extensions/t10_extensions_api.rs
+++ b/tests/tests/extensions/t10_extensions_api.rs
@@ -1,0 +1,78 @@
+//! Test `Raft::extensions()` API for storing user-defined data.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// Counter for testing extensions with interior mutability.
+#[derive(Clone, Default)]
+struct Counter(Arc<AtomicU64>);
+
+impl Counter {
+    fn inc(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn get(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// Test that extensions() allows storing and retrieving custom types
+/// with interior mutability.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn test_extensions_with_counter() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing single node cluster");
+    router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    let raft = router.get_raft_handle(&0)?;
+
+    // Insert counter into extensions
+    raft.extensions().insert(Counter::default());
+
+    // Access counter and verify it's initialized to 0
+    let counter = raft.extensions().get::<Counter>().expect("counter should exist");
+    assert_eq!(counter.get(), 0, "counter should start at 0");
+
+    // Test interior mutability
+    counter.inc();
+    counter.inc();
+    counter.inc();
+    assert_eq!(counter.get(), 3, "counter should be 3 after 3 increments");
+
+    // Get another clone - shares the same Arc
+    let counter2 = raft.extensions().get::<Counter>().expect("counter should still exist");
+    assert_eq!(counter2.get(), 3, "should see the same counter state");
+
+    // More increments
+    counter2.inc();
+    assert_eq!(counter2.get(), 4, "should see the increment");
+
+    // Test that non-existent types return None
+    #[derive(Clone)]
+    struct NonExistent;
+    assert!(raft.extensions().get::<NonExistent>().is_none());
+
+    // Test contains
+    assert!(raft.extensions().contains::<Counter>());
+    assert!(!raft.extensions().contains::<NonExistent>());
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### feat: add `UserData` type to `RaftTypeConfig` for external crate storage
Add a `UserData` associated type to `RaftTypeConfig` that allows external
crates to store singleton data in the Raft instance. The data is auto-
initialized via `Default::default()` when the Raft instance is created.

Changes:
- Add `type UserData: OptionalSend + OptionalSync + Default + 'static` to `RaftTypeConfig`
- Add `UserDataOf<C>` type alias
- Add `user_data` field to `RaftInner`
- Add `Raft::user_data()` accessor method
- Default type is `()` for zero overhead when unused
- Add tests for custom `UserData` with interior mutability

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1618)
<!-- Reviewable:end -->
