### PR TITLE
refactor: move snapshot streaming state from `RaftInner` to `Extensions`

### DIFF
--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -545,8 +545,6 @@ where C: RaftTypeConfig
             progress_watcher,
             tx_shutdown: Mutex::new(Some(tx_shutdown)),
             core_state: Mutex::new(CoreState::Running(core_handle)),
-
-            snapshot: C::mutex(None),
             extensions: Extensions::default(),
         };
 
@@ -921,8 +919,10 @@ where C: RaftTypeConfig
         let finished_snapshot = {
             use crate::network::snapshot_transport::Chunked;
             use crate::network::snapshot_transport::SnapshotTransport;
+            use crate::network::snapshot_transport::StreamingState;
 
-            let mut streaming = self.inner.snapshot.lock().await;
+            let streaming_state = self.inner.extensions.get_or_default::<StreamingState<C>>();
+            let mut streaming = streaming_state.streaming.lock().await;
             Chunked::receive_snapshot(&mut *streaming, self, req).await?
         };
 

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -28,7 +28,6 @@ use crate::type_config::AsyncRuntime;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::AsyncRuntimeOf;
 use crate::type_config::alias::MpscSenderOf;
-use crate::type_config::alias::MutexOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::WatchReceiverOf;
@@ -50,11 +49,6 @@ where C: RaftTypeConfig
 
     pub(in crate::raft) tx_shutdown: Mutex<Option<OneshotSenderOf<C, ()>>>,
     pub(in crate::raft) core_state: Mutex<CoreState<C>>,
-
-    /// The ongoing snapshot transmission.
-    #[cfg_attr(not(feature = "tokio-rt"), allow(dead_code))]
-    // This field will only be read when feature tokio-rt is on
-    pub(in crate::raft) snapshot: MutexOf<C, Option<crate::network::snapshot_transport::Streaming<C>>>,
 
     /// Type-map for storing user-defined extension data.
     ///


### PR DESCRIPTION

## Changelog

##### refactor: move snapshot streaming state from `RaftInner` to `Extensions`
Move the `snapshot` field from `RaftInner` to the `Extensions` type-map,
storing it as a `StreamingState<C>` wrapper. This decouples the snapshot
streaming state from the core Raft structure and demonstrates the
extensions pattern for internal use.

Changes:
- Add `StreamingState<C>` wrapper type in `snapshot_transport.rs`
- Add `get_or_insert_with()` and `get_or_default()` methods to `Extensions`
- Remove `snapshot` field from `RaftInner`
- Update `install_snapshot()` to lazily create `StreamingState` via extensions

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1619)
<!-- Reviewable:end -->
