### PR TITLE
change: remove `SnapshotTransport` trait, make `Chunked` generic

### DIFF
--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -16,7 +16,6 @@ mod tokio_rt {
     use tokio::io::AsyncWriteExt;
 
     use super::Chunked;
-    use super::SnapshotTransport;
     use super::Streaming;
     use crate::ErrorSubject;
     use crate::ErrorVerb;
@@ -40,11 +39,23 @@ mod tokio_rt {
     use crate::type_config::alias::VoteOf;
     use crate::vote::raft_vote::RaftVoteExt;
 
-    /// This chunk-based implementation requires `SnapshotData` to be `AsyncRead + AsyncSeek`.
-    impl<C: RaftTypeConfig> SnapshotTransport<C> for Chunked
-    where C::SnapshotData: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin
+    impl<C> Chunked<C>
+    where
+        C: RaftTypeConfig,
+        C::SnapshotData: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin,
     {
-        async fn send_snapshot<Net>(
+        /// Send a snapshot to a target node via `Net`.
+        ///
+        /// This function is for backward compatibility and provides a default implement for
+        /// `RaftNetwork::full_snapshot()` upon `RafNetwork::install_snapshot()`.
+        ///
+        /// The argument `vote` is the leader's(the caller's) vote,
+        /// which is used to check if the leader is still valid by a follower.
+        ///
+        /// `cancel` is a future that is polled by this function to check if the caller decides to
+        /// cancel.
+        /// It returns `Ready` if the caller decides to cancel this snapshot transmission.
+        pub async fn send_snapshot<Net>(
             net: &mut Net,
             vote: VoteOf<C>,
             mut snapshot: Snapshot<C>,
@@ -162,7 +173,15 @@ mod tokio_rt {
             }
         }
 
-        async fn receive_snapshot(
+        /// Receive a chunk of snapshot. If the snapshot is done receiving, return the snapshot.
+        ///
+        /// This method provides a default implementation for chunk-based snapshot transport
+        /// and requires the caller to provide two things:
+        ///
+        /// - The receiving state `streaming` is maintained by the caller.
+        /// - And it depends on `Raft::begin_receiving_snapshot()` to create a `SnapshotData` for
+        ///   receiving data.
+        pub async fn receive_snapshot(
             streaming: &mut Option<Streaming<C>>,
             raft: &Raft<C>,
             req: InstallSnapshotRequest<C>,
@@ -256,88 +275,39 @@ mod tokio_rt {
     }
 }
 
-use std::future::Future;
 use std::sync::Arc;
 
-use openraft_macros::add_async_trait;
 use openraft_macros::since;
 
-use crate::OptionalSend;
-use crate::Raft;
-use crate::RaftNetwork;
 use crate::RaftTypeConfig;
 use crate::SnapshotId;
-use crate::error::InstallSnapshotError;
-use crate::error::RaftError;
-use crate::error::ReplicationClosed;
-use crate::error::StreamingError;
-use crate::network::RPCOption;
-use crate::raft::InstallSnapshotRequest;
-use crate::raft::SnapshotResponse;
-use crate::storage::Snapshot;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::MutexOf;
-use crate::type_config::alias::VoteOf;
 
-/// Send and Receive snapshot by chunks.
-pub struct Chunked {}
-
-/// Defines the sending and receiving API for snapshot transport.
-#[add_async_trait]
-pub trait SnapshotTransport<C: RaftTypeConfig> {
-    /// Send a snapshot to a target node via `Net`.
-    ///
-    /// This function is for backward compatibility and provides a default implement for
-    /// `RaftNetwork::full_snapshot()` upon `RafNetwork::install_snapshot()`.
-    ///
-    /// The argument `vote` is the leader's(the caller's) vote,
-    /// which is used to check if the leader is still valid by a follower.
-    ///
-    /// `cancel` is a future that is polled by this function to check if the caller decides to
-    /// cancel.
-    /// It returns `Ready` if the caller decides to cancel this snapshot transmission.
-    // TODO: consider removing dependency on RaftNetwork
-    async fn send_snapshot<Net>(
-        net: &mut Net,
-        vote: VoteOf<C>,
-        snapshot: Snapshot<C>,
-        cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
-        option: RPCOption,
-    ) -> Result<SnapshotResponse<C>, StreamingError<C>>
-    where
-        Net: RaftNetwork<C> + ?Sized;
-
-    /// Receive a chunk of snapshot. If the snapshot is done receiving, return the snapshot.
-    ///
-    /// This method provides a default implementation for chunk-based snapshot transport
-    /// and requires the caller to provide two things:
-    ///
-    /// - The receiving state `streaming` is maintained by the caller.
-    /// - And it depends on `Raft::begin_receiving_snapshot()` to create a `SnapshotData` for
-    ///   receiving data.
-    ///
-    /// Example usage:
-    /// ```ignore
-    /// struct App<C> {
-    ///     raft: Raft<C>
-    ///     streaming: Option<Streaming<C>>,
-    /// }
-    ///
-    /// impl<C> App<C> {
-    ///     fn handle_install_snapshot_request(&mut self, req: InstallSnapshotRequest<C>) {
-    ///         let res = Chunked::receive_snapshot(&mut self.streaming, &self.raft, req).await?;
-    ///         if let Some(snapshot) = res {
-    ///             self.raft.install_snapshot(snapshot).await?;
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    async fn receive_snapshot(
-        streaming: &mut Option<Streaming<C>>,
-        raft: &Raft<C>,
-        req: InstallSnapshotRequest<C>,
-    ) -> Result<Option<Snapshot<C>>, RaftError<C, InstallSnapshotError>>;
-}
+/// Chunk-based snapshot transport.
+///
+/// This implementation splits snapshots into chunks and sends/receives them incrementally.
+/// It requires `SnapshotData` to implement `AsyncRead + AsyncWrite + AsyncSeek + Unpin`.
+///
+/// # Example
+///
+/// ```ignore
+/// struct App<C> {
+///     raft: Raft<C>
+///     streaming: Option<Streaming<C>>,
+/// }
+///
+/// impl<C> App<C> {
+///     fn handle_install_snapshot_request(&mut self, req: InstallSnapshotRequest<C>) {
+///         let res = Chunked::<C>::receive_snapshot(&mut self.streaming, &self.raft, req).await?;
+///         if let Some(snapshot) = res {
+///             self.raft.install_snapshot(snapshot).await?;
+///         }
+///     }
+/// }
+/// ```
+pub struct Chunked<C>(std::marker::PhantomData<C>)
+where C: RaftTypeConfig;
 
 /// The Raft node is streaming in a snapshot from the leader.
 #[since(version = "0.10.0", change = "SnapshotData without Box")]
@@ -423,7 +393,6 @@ mod tests {
     use crate::error::SnapshotMismatch;
     use crate::network::RPCOption;
     use crate::network::snapshot_transport::Chunked;
-    use crate::network::snapshot_transport::SnapshotTransport;
     use crate::raft::AppendEntriesRequest;
     use crate::raft::AppendEntriesResponse;
     use crate::raft::InstallSnapshotRequest;
@@ -505,10 +474,10 @@ mod tests {
             opt.snapshot_chunk_size = Some(1);
             let cancel = futures::future::pending();
 
-            Chunked::send_snapshot(
+            Chunked::<UTConfig>::send_snapshot(
                 &mut net,
                 Vote::new(1, 0),
-                Snapshot::<UTConfig>::new(
+                Snapshot::new(
                     SnapshotMeta {
                         last_log_id: None,
                         last_membership: StoredMembership::default(),

--- a/openraft/src/network/v2/adapt_v1.rs
+++ b/openraft/src/network/v2/adapt_v1.rs
@@ -44,9 +44,8 @@ where
         option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
         use crate::network::snapshot_transport::Chunked;
-        use crate::network::snapshot_transport::SnapshotTransport;
 
-        let resp = Chunked::send_snapshot(self, vote, snapshot, cancel, option).await?;
+        let resp = Chunked::<C>::send_snapshot(self, vote, snapshot, cancel, option).await?;
         Ok(resp)
     }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -918,12 +918,11 @@ where C: RaftTypeConfig
 
         let finished_snapshot = {
             use crate::network::snapshot_transport::Chunked;
-            use crate::network::snapshot_transport::SnapshotTransport;
             use crate::network::snapshot_transport::StreamingState;
 
             let streaming_state = self.inner.extensions.get_or_default::<StreamingState<C>>();
             let mut streaming = streaming_state.streaming.lock().await;
-            Chunked::receive_snapshot(&mut *streaming, self, req).await?
+            Chunked::<C>::receive_snapshot(&mut *streaming, self, req).await?
         };
 
         if let Some(snapshot) = finished_snapshot {


### PR DESCRIPTION

## Changelog

##### change: remove `SnapshotTransport` trait, make `Chunked` generic
Remove the `SnapshotTransport` trait and move its methods directly onto
`Chunked<C>` as inherent methods. This simplifies the API by eliminating
the trait indirection.

Changes:
- Make `Chunked` generic over `C: RaftTypeConfig`
- Remove `SnapshotTransport` trait definition

Upgrade tip:

Replace trait method calls with inherent method calls:
- `Chunked::send_snapshot(...)` → `Chunked::<C>::send_snapshot(...)`
- `Chunked::receive_snapshot(...)` → `Chunked::<C>::receive_snapshot(...)`

Remove `use SnapshotTransport` imports as the trait no longer exists.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1620)
<!-- Reviewable:end -->
