### PR TITLE
change: simplify `Extensions` API to single `get()` method

### DIFF
--- a/openraft/src/extensions.rs
+++ b/openraft/src/extensions.rs
@@ -3,8 +3,6 @@
 //! [`Extensions`] allows external crates to store arbitrary types associated with a Raft instance.
 //! Each type can have at most one value stored, keyed by its [`TypeId`].
 //!
-//! This follows the `http::Extensions` pattern.
-//!
 //! # Example
 //!
 //! ```ignore
@@ -15,13 +13,9 @@
 //! #[derive(Clone, Default)]
 //! pub struct MyCounter(Arc<AtomicU64>);
 //!
-//! // Insert at startup
-//! raft.extensions().insert(MyCounter::default());
-//!
-//! // Get a clone and use it
-//! if let Some(counter) = raft.extensions().get::<MyCounter>() {
-//!     counter.0.fetch_add(1, Ordering::Relaxed);
-//! }
+//! // Get a clone (auto-inserts default if not present)
+//! let counter = raft.extensions().get::<MyCounter>();
+//! counter.0.fetch_add(1, Ordering::Relaxed);
 //! ```
 
 use std::any::TypeId;
@@ -36,44 +30,18 @@ use crate::base::OptionalSend;
 /// Values are stored by their [`TypeId`], so each type can have at most one value.
 /// Access is thread-safe via internal [`Mutex`].
 ///
-/// Values must implement [`Clone`] - when retrieved via [`get()`](Self::get),
-/// a clone is returned to avoid holding locks.
+/// Values must implement [`Clone`] and [`Default`]. When retrieved via [`get()`](Self::get),
+/// a clone is returned. If no value exists, `T::default()` is inserted and returned.
 pub struct Extensions {
     map: Mutex<HashMap<TypeId, BoxAny>>,
 }
 
 impl Extensions {
-    /// Create a new empty Extensions.
-    pub fn new() -> Self {
-        Self {
-            map: Mutex::new(HashMap::new()),
-        }
-    }
-
-    /// Insert a value of type `T`.
-    ///
-    /// Returns the previous value if one existed.
-    pub fn insert<T>(&self, val: T) -> Option<T>
-    where T: OptionalSend + Clone + 'static {
-        let mut map = self.map.lock().unwrap();
-        map.insert(TypeId::of::<T>(), Box::new(val)).and_then(|boxed| boxed.downcast().ok().map(|b| *b))
-    }
-
     /// Get a clone of the value of type `T`.
     ///
-    /// Returns [`None`] if no value of type `T` has been inserted.
-    pub fn get<T>(&self) -> Option<T>
-    where T: Clone + 'static {
-        let map = self.map.lock().unwrap();
-        map.get(&TypeId::of::<T>()).and_then(|b| b.downcast_ref::<T>()).cloned()
-    }
-
-    /// Get a clone of the value of type `T`, or insert a default value if none exists.
-    ///
-    /// If no value of type `T` has been inserted, the provided closure is called
-    /// to create a default value, which is then inserted and returned.
-    pub fn get_or_insert_with<T>(&self, f: impl FnOnce() -> T) -> T
-    where T: OptionalSend + Clone + 'static {
+    /// If no value exists, `T::default()` is inserted and a clone is returned.
+    pub fn get<T>(&self) -> T
+    where T: OptionalSend + Clone + Default + 'static {
         let mut map = self.map.lock().unwrap();
         let type_id = TypeId::of::<T>();
 
@@ -81,17 +49,9 @@ impl Extensions {
             return val.clone();
         }
 
-        let val = f();
+        let val = T::default();
         map.insert(type_id, Box::new(val.clone()));
         val
-    }
-
-    /// Get a clone of the value of type `T`, or insert `T::default()` if none exists.
-    ///
-    /// This is a convenience method equivalent to `get_or_insert_with(T::default)`.
-    pub fn get_or_default<T>(&self) -> T
-    where T: OptionalSend + Clone + Default + 'static {
-        self.get_or_insert_with(T::default)
     }
 
     /// Check if a value of type `T` exists.
@@ -111,7 +71,9 @@ impl Extensions {
 
 impl Default for Extensions {
     fn default() -> Self {
-        Self::new()
+        Self {
+            map: Mutex::new(HashMap::new()),
+        }
     }
 }
 
@@ -131,43 +93,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_insert_and_get() {
-        let ext = Extensions::new();
+    fn test_get_inserts_default() {
+        let ext = Extensions::default();
 
-        ext.insert(42u32);
-        ext.insert("hello".to_string());
+        #[derive(Clone, Default, PartialEq, Debug)]
+        struct MyData(u32);
 
-        assert_eq!(ext.get::<u32>().unwrap(), 42);
-        assert_eq!(ext.get::<String>().unwrap(), "hello");
-        assert!(ext.get::<i64>().is_none());
-    }
+        // First call creates default value
+        let val = ext.get::<MyData>();
+        assert_eq!(val, MyData(0));
 
-    #[test]
-    fn test_insert_replaces() {
-        let ext = Extensions::new();
+        // Value is now stored
+        assert!(ext.contains::<MyData>());
 
-        assert!(ext.insert(1u32).is_none());
-        assert_eq!(ext.insert(2u32), Some(1));
-        assert_eq!(ext.get::<u32>().unwrap(), 2);
+        // Second call returns same value
+        let val2 = ext.get::<MyData>();
+        assert_eq!(val2, MyData(0));
     }
 
     #[test]
     fn test_shared_state_with_arc() {
-        let ext = Extensions::new();
+        let ext = Extensions::default();
 
-        // Use Arc for shared mutable state
         #[derive(Clone, Default)]
         struct Counter(Arc<AtomicU64>);
 
-        ext.insert(Counter::default());
-
         // Get clone and mutate
-        let counter1 = ext.get::<Counter>().unwrap();
+        let counter1 = ext.get::<Counter>();
         counter1.0.fetch_add(1, Ordering::Relaxed);
         counter1.0.fetch_add(1, Ordering::Relaxed);
 
         // Get another clone - shares the same Arc
-        let counter2 = ext.get::<Counter>().unwrap();
+        let counter2 = ext.get::<Counter>();
         assert_eq!(counter2.0.load(Ordering::Relaxed), 2);
 
         // More increments
@@ -177,55 +134,18 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let ext = Extensions::new();
-
-        ext.insert(42u32);
-        assert!(ext.contains::<u32>());
-
-        assert_eq!(ext.remove::<u32>(), Some(42));
-        assert!(!ext.contains::<u32>());
-        assert!(ext.remove::<u32>().is_none());
-    }
-
-    #[test]
-    fn test_get_or_insert_with() {
-        let ext = Extensions::new();
-
-        // First call creates the value
-        let val = ext.get_or_insert_with(|| 42u32);
-        assert_eq!(val, 42);
-
-        // Second call returns existing value, closure not called
-        let val = ext.get_or_insert_with(|| 100u32);
-        assert_eq!(val, 42);
-
-        // Works with Arc for shared state
-        #[derive(Clone, Default)]
-        struct Counter(Arc<AtomicU64>);
-
-        let c1 = ext.get_or_insert_with(Counter::default);
-        c1.0.fetch_add(1, Ordering::Relaxed);
-
-        let c2 = ext.get_or_insert_with(Counter::default);
-        assert_eq!(c2.0.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn test_get_or_default() {
-        let ext = Extensions::new();
+        let ext = Extensions::default();
 
         #[derive(Clone, Default, PartialEq, Debug)]
         struct MyData(u32);
 
-        // First call creates default value
-        let val = ext.get_or_default::<MyData>();
-        assert_eq!(val, MyData(0));
+        // Insert via get
+        let _ = ext.get::<MyData>();
+        assert!(ext.contains::<MyData>());
 
-        // Insert a different value
-        ext.insert(MyData(42));
-
-        // Now returns the inserted value
-        let val = ext.get_or_default::<MyData>();
-        assert_eq!(val, MyData(42));
+        // Remove
+        assert_eq!(ext.remove::<MyData>(), Some(MyData(0)));
+        assert!(!ext.contains::<MyData>());
+        assert!(ext.remove::<MyData>().is_none());
     }
 }


### PR DESCRIPTION

## Changelog

##### change: simplify `Extensions` API to single `get()` method
Simplify the `Extensions` type to require all stored values implement
`Default`. The `get()` method now auto-inserts `T::default()` if no
value exists.

Changes:
- Remove `new()` method, use `Default` impl instead
- Remove `insert()` method
- Remove `get_or_insert_with()` method
- Remove `get_or_default()` method
- Change `get()` to return `T` instead of `Option<T>`, auto-inserting default
- Require stored types to implement `Default`

Upgrade tip:

Replace method calls:
- `Extensions::new()` → `Extensions::default()`
- `extensions.insert(val)` → (remove, values are auto-inserted via `get()`)
- `extensions.get::<T>().unwrap()` → `extensions.get::<T>()`
- `extensions.get_or_default::<T>()` → `extensions.get::<T>()`
- `extensions.get_or_insert_with(|| val)` → `extensions.get::<T>()`

All types stored in Extensions must now implement `Default`.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1622)
<!-- Reviewable:end -->
