### PR TITLE
feat: improve `RaftVote` with `to_owned_vote()` and safer vote comparison

### DIFF
--- a/openraft/src/vote/ref_vote.rs
+++ b/openraft/src/vote/ref_vote.rs
@@ -48,9 +48,7 @@ where C: RaftTypeConfig
                     (false, false) => None,
                     (true, false) => Some(Ordering::Greater),
                     (false, true) => Some(Ordering::Less),
-                    (true, true) => {
-                        unreachable!("two incomparable leaders cannot be both committed: {} {}", self, other)
-                    }
+                    (true, true) => None,
                 }
             }
             // Some(non-equal)

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -153,8 +153,6 @@ mod tests {
     }
 
     mod feature_single_term_leader {
-        use std::panic::UnwindSafe;
-
         use crate::Vote;
         use crate::declare_raft_types;
         use crate::vote::leader_id_std::LeaderId;
@@ -216,17 +214,13 @@ mod tests {
             assert!(!(vote(2, 2) <= vote(2, 3)));
             assert!(!(vote(2, 2) == vote(2, 3)));
 
-            // Incomparable committed
-            {
-                fn assert_panic<T, F: FnOnce() -> T + UnwindSafe>(f: F) {
-                    let res = std::panic::catch_unwind(f);
-                    assert!(res.is_err());
-                }
-                assert_panic(|| committed(2, 2) > committed(2, 3));
-                assert_panic(|| committed(2, 2) >= committed(2, 3));
-                assert_panic(|| committed(2, 2) < committed(2, 3));
-                assert_panic(|| committed(2, 2) <= committed(2, 3));
-            }
+            // Incomparable committed: returns None, not panic
+            assert!(!(committed(2, 2) > committed(2, 3)));
+            assert!(!(committed(2, 2) >= committed(2, 3)));
+            assert!(!(committed(2, 2) < committed(2, 3)));
+            assert!(!(committed(2, 2) <= committed(2, 3)));
+            assert!(!(committed(2, 2) == committed(2, 3)));
+            assert_eq!(committed(2, 2).partial_cmp(&committed(2, 3)), None);
 
             Ok(())
         }


### PR DESCRIPTION

## Changelog

##### feat: improve `RaftVote` with `to_owned_vote()` and safer vote comparison
Add `to_owned_vote()` method to convert any `RaftVote` implementation to
the openraft-provided `Vote<C>` struct. Also make vote comparison more
defensive by returning `None` instead of panicking for incomparable
committed votes.

Changes:
- Add `RaftVote::to_owned_vote()` to convert to standard `Vote<C>` struct
- Change `RefVote::partial_cmp()` to return `None` for incomparable committed votes
- Update test to expect `None` instead of panic

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1623)
<!-- Reviewable:end -->
