### PR TITLE
refactor: simplify tests to call `append_entries` directly on Raft node

### DIFF
--- a/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -1,14 +1,10 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Result;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::Vote;
-use openraft::network::RPCOption;
-use openraft::network::RaftNetworkFactory;
-use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
 use openraft_memstore::ClientRequest;
@@ -59,8 +55,8 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(log_id(1, 0, 5)),
     };
 
-    let option = RPCOption::new(Duration::from_millis(1_000));
-    let resp = router.new_client(0, &()).await.append_entries(rpc, option).await?;
+    let node = router.get_raft_handle(&0)?;
+    let resp = node.append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 
@@ -80,9 +76,8 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(log_id(1, 0, 5)),
     };
 
-    let option = RPCOption::new(Duration::from_millis(1_000));
-
-    let resp = router.new_client(0, &()).await.append_entries(rpc, option).await?;
+    let node = router.get_raft_handle(&0)?;
+    let resp = node.append_entries(rpc).await?;
     assert!(resp.is_success());
     assert!(!resp.is_conflict());
 
@@ -95,9 +90,8 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_commit: Some(log_id(1, 0, 5)),
     };
 
-    let option = RPCOption::new(Duration::from_millis(1_000));
-
-    let resp = router.new_client(0, &()).await.append_entries(rpc, option).await?;
+    let node = router.get_raft_handle(&0)?;
+    let resp = node.append_entries(rpc).await?;
     assert!(!resp.is_success());
     assert!(resp.is_conflict());
 

--- a/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
+++ b/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
@@ -1,14 +1,10 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::RaftLogReader;
 use openraft::Vote;
-use openraft::network::RPCOption;
-use openraft::network::RaftNetworkFactory;
-use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
@@ -55,9 +51,8 @@ async fn append_entries_with_bigger_term() -> Result<()> {
         leader_commit: Some(log_id(1, 0, log_index)),
     };
 
-    let option = RPCOption::new(Duration::from_millis(1_000));
-
-    let resp = router.new_client(0, &()).await.append_entries(req, option).await?;
+    let node = router.get_raft_handle(&0)?;
+    let resp = node.append_entries(req).await?;
     assert!(resp.is_success());
 
     // after append entries, check hard state in term 2 and vote for node 1

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
@@ -5,9 +5,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::Vote;
-use openraft::network::RPCOption;
-use openraft::network::RaftNetworkFactory;
-use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
 use openraft::type_config::TypeConfigExt;
@@ -70,9 +67,8 @@ async fn building_snapshot_does_not_block_append() -> Result<()> {
             leader_commit: None,
         };
 
-        let mut cli = router.new_client(1, &()).await;
-        let option = RPCOption::new(Duration::from_millis(1_000));
-        let fu = cli.append_entries(rpc, option);
+        let node = router.get_raft_handle(&1)?;
+        let fu = node.append_entries(rpc);
         let fu = TypeConfig::timeout(Duration::from_millis(500), fu);
         let resp = fu.await??;
         assert!(resp.is_success());

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
@@ -5,9 +5,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::Vote;
-use openraft::network::RPCOption;
-use openraft::network::RaftNetworkFactory;
-use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
 use openraft::type_config::TypeConfigExt;
@@ -75,10 +72,8 @@ async fn building_snapshot_does_not_block_apply() -> Result<()> {
             leader_commit: Some(log_id(1, 0, next)),
         };
 
-        let mut cli = router.new_client(1, &()).await;
-        let option = RPCOption::new(Duration::from_millis(1_000));
-
-        let fu = cli.append_entries(rpc, option);
+        let node = router.get_raft_handle(&1)?;
+        let fu = node.append_entries(rpc);
         let fu = TypeConfig::timeout(Duration::from_millis(500), fu);
         let resp = fu.await??;
         assert!(resp.is_success());


### PR DESCRIPTION

## Changelog

##### refactor: simplify tests to call `append_entries` directly on Raft node
Simplify test code by calling `Raft::append_entries()` directly instead
of going through the network layer. This makes tests cleaner and removes
unnecessary dependencies on network traits.

Changes:
- Use `router.get_raft_handle(&id)?.append_entries(rpc)` instead of
  `router.new_client(id, &()).await.append_entries(rpc, option)`
- Remove unused imports: `Duration`, `RPCOption`, `RaftNetworkFactory`,
  `RaftNetworkV2`

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1626)
<!-- Reviewable:end -->
