### PR TITLE
refactor: simplify more tests to call Raft methods directly

### DIFF
--- a/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
@@ -11,9 +11,6 @@ use openraft::Membership;
 use openraft::RaftLogReader;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
-use openraft::network::RPCOption;
-use openraft::network::RaftNetworkFactory;
-use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
@@ -87,9 +84,9 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 }],
                 leader_commit: Some(log_id(0, 0, 0)),
             };
-            let option = RPCOption::new(Duration::from_millis(1_000));
 
-            router.new_client(1, &()).await.append_entries(req, option).await?;
+            let node = router.get_raft_handle(&1)?;
+            node.append_entries(req).await?;
 
             tracing::info!(log_index, "--- check that learner membership is affected");
             {


### PR DESCRIPTION

## Changelog

##### refactor: simplify more tests to call Raft methods directly
Continue simplifying tests by calling Raft methods directly instead of
going through the network layer.

Changes:
- `t10_see_higher_vote.rs`: use `Raft::vote()` directly
- `t31_snapshot_overrides_membership.rs`: use `Raft::append_entries()` directly
- `t33_snapshot_delete_conflict_logs.rs`: use `Raft::append_entries()` and
  `Raft::install_full_snapshot()` directly
- Remove unused imports: `RPCOption`, `RaftNetworkFactory`, `RaftNetworkV2`

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1627)
<!-- Reviewable:end -->
