### PR TITLE
refactor: use full path `types_kv::Request` in example crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ exclude = [
 
     "examples/mem-log",
     "examples/rocksstore",
+    "examples/types-kv",
 
     "examples/raft-kv-memstore",
     "examples/raft-kv-memstore-grpc",

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,26 @@ typos:
 	#typos --write-changes --exclude change-log/ --exclude change-log.md --exclude derived-from-async-raft.md
 	# typos
 
+check:
+	RUSTFLAGS="-D warnings" cargo check
+	RUSTFLAGS="-D warnings" cargo check --manifest-path multiraft/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path rt-compio/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path rt-monoio/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path rt-tokio/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path benchmarks/minimal/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/client-http/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/network-v1-http/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/mem-log/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/types-kv/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/raft-kv-memstore-grpc/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/raft-kv-memstore-single-threaded/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/raft-kv-memstore/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/raft-kv-rocksdb/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/rocksstore/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/multi-raft-kv/Cargo.toml
+
 clean:
 	cargo clean
 	cargo clean --manifest-path multiraft/Cargo.toml

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,6 +38,7 @@ Deprecated:
 - **[network-v1]** - HTTP-based RaftNetwork interface V1 using `reqwest` crate
 
 ### Utilities
+- **[types-kv]** - Shared KV request/response types for example crates
 - **[utils]** - Shared type declarations and utilities
 
 <!-- Reference Links -->
@@ -50,6 +51,7 @@ Deprecated:
 [mem-log]: mem-log/
 [rocksstore]: rocksstore/
 [network-v1]: network-v1-http/
+[types-kv]: types-kv/
 [utils]: utils/
 
 [memstore]: memstore/

--- a/examples/multi-raft-kv/Cargo.toml
+++ b/examples/multi-raft-kv/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 mem-log         = { path = "../mem-log", features = [] }
 openraft        = { path = "../../openraft", default-features = false, features = ["serde", "type-alias"] }
 openraft-multi = { path = "../../multiraft" }
+types-kv       = { path = "../types-kv" }
 
 futures            = { version = "0.3" }
 serde              = { version = "1", features = ["derive"] }

--- a/examples/multi-raft-kv/src/lib.rs
+++ b/examples/multi-raft-kv/src/lib.rs
@@ -4,8 +4,6 @@ use openraft::Config;
 
 use crate::app::Node;
 use crate::router::Router;
-use crate::store::Request;
-use crate::store::Response;
 use crate::store::StateMachineData;
 
 pub mod router;
@@ -24,8 +22,8 @@ pub type GroupId = String;
 openraft::declare_raft_types!(
     /// Declare the type configuration for Multi-Raft K/V store.
     pub TypeConfig:
-        D = Request,
-        R = Response,
+        D = types_kv::Request,
+        R = types_kv::Response,
         // In this example, snapshot is just a copy of the state machine.
         SnapshotData = StateMachineData,
 );

--- a/examples/multi-raft-kv/src/store.rs
+++ b/examples/multi-raft-kv/src/store.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fmt;
 use std::fmt::Debug;
 use std::io;
 use std::sync::Arc;
@@ -19,34 +18,6 @@ use serde::Serialize;
 use crate::typ::*;
 
 pub type LogStore = mem_log::LogStore<TypeConfig>;
-
-/// Application request type
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum Request {
-    Set { key: String, value: String },
-}
-
-impl fmt::Display for Request {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Request::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
-        }
-    }
-}
-
-impl Request {
-    pub fn set(key: impl ToString, value: impl ToString) -> Self {
-        Self::Set {
-            key: key.to_string(),
-            value: value.to_string(),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Response {
-    pub value: Option<String>,
-}
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
@@ -144,18 +115,16 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
             sm.last_applied = Some(entry.log_id);
 
             let response = match entry.payload {
-                EntryPayload::Blank => Response { value: None },
+                EntryPayload::Blank => types_kv::Response::none(),
                 EntryPayload::Normal(ref req) => match req {
-                    Request::Set { key, value, .. } => {
+                    types_kv::Request::Set { key, value, .. } => {
                         sm.data.insert(key.clone(), value.clone());
-                        Response {
-                            value: Some(value.clone()),
-                        }
+                        types_kv::Response::new(value.clone())
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    Response { value: None }
+                    types_kv::Response::none()
                 }
             };
 

--- a/examples/multi-raft-kv/tests/cluster/test_cluster.rs
+++ b/examples/multi-raft-kv/tests/cluster/test_cluster.rs
@@ -15,7 +15,6 @@ use multi_raft_kv::TypeConfig;
 use multi_raft_kv::create_node;
 use multi_raft_kv::groups;
 use multi_raft_kv::router::Router;
-use multi_raft_kv::store::Request;
 use multi_raft_kv::typ;
 use openraft::BasicNode;
 use openraft::async_runtime::WatchReceiver;
@@ -120,18 +119,18 @@ async fn run_test(node1_rafts: &[typ::Raft], node2_rafts: &[typ::Raft], group_id
     println!("\n=== Writing data to each group ===\n");
 
     // users group
-    node1_rafts[0].client_write(Request::set("user:1", "Alice")).await.unwrap();
-    node1_rafts[0].client_write(Request::set("user:2", "Bob")).await.unwrap();
+    node1_rafts[0].client_write(types_kv::Request::set("user:1", "Alice")).await.unwrap();
+    node1_rafts[0].client_write(types_kv::Request::set("user:2", "Bob")).await.unwrap();
     println!("  ✓ Group 'users': wrote user:1=Alice, user:2=Bob");
 
     // orders group
-    node1_rafts[1].client_write(Request::set("order:1001", "pending")).await.unwrap();
-    node1_rafts[1].client_write(Request::set("order:1002", "shipped")).await.unwrap();
+    node1_rafts[1].client_write(types_kv::Request::set("order:1001", "pending")).await.unwrap();
+    node1_rafts[1].client_write(types_kv::Request::set("order:1002", "shipped")).await.unwrap();
     println!("  ✓ Group 'orders': wrote order:1001=pending, order:1002=shipped");
 
     // products group
-    node1_rafts[2].client_write(Request::set("product:A", "Widget")).await.unwrap();
-    node1_rafts[2].client_write(Request::set("product:B", "Gadget")).await.unwrap();
+    node1_rafts[2].client_write(types_kv::Request::set("product:A", "Widget")).await.unwrap();
+    node1_rafts[2].client_write(types_kv::Request::set("product:B", "Gadget")).await.unwrap();
     println!("  ✓ Group 'products': wrote product:A=Widget, product:B=Gadget");
 
     TypeConfig::sleep(Duration::from_millis(500)).await;

--- a/examples/raft-kv-memstore-network-v2/Cargo.toml
+++ b/examples/raft-kv-memstore-network-v2/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 [dependencies]
 mem-log  = { path = "../mem-log", features = [] }
 openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
+types-kv = { path = "../types-kv" }
 
 futures            = { version = "0.3" }
 serde              = { version = "1.0.114", features = ["derive"] }

--- a/examples/raft-kv-memstore-network-v2/src/lib.rs
+++ b/examples/raft-kv-memstore-network-v2/src/lib.rs
@@ -7,8 +7,6 @@ use openraft::Config;
 
 use crate::app::App;
 use crate::router::Router;
-use crate::store::Request;
-use crate::store::Response;
 use crate::store::StateMachineData;
 
 pub mod router;
@@ -23,8 +21,8 @@ pub type NodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
     pub TypeConfig:
-        D = Request,
-        R = Response,
+        D = types_kv::Request,
+        R = types_kv::Response,
         // In this example, snapshot is just a copy of the state machine.
         // And it can be any type.
         SnapshotData = StateMachineData,

--- a/examples/raft-kv-memstore-network-v2/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-network-v2/tests/cluster/test_cluster.rs
@@ -10,7 +10,6 @@ use openraft::type_config::TypeConfigExt;
 use raft_kv_memstore_network_v2::TypeConfig;
 use raft_kv_memstore_network_v2::new_raft;
 use raft_kv_memstore_network_v2::router::Router;
-use raft_kv_memstore_network_v2::store::Request;
 use raft_kv_memstore_network_v2::typ;
 use tracing_subscriber::EnvFilter;
 
@@ -90,9 +89,9 @@ async fn run_test(rafts: &[typ::Raft], router: Router) {
 
     println!("=== write 2 logs");
     {
-        let resp = raft1.client_write(Request::set("foo1", "bar1")).await.unwrap();
+        let resp = raft1.client_write(types_kv::Request::set("foo1", "bar1")).await.unwrap();
         println!("write resp: {:#?}", resp);
-        let resp = raft1.client_write(Request::set("foo2", "bar2")).await.unwrap();
+        let resp = raft1.client_write(types_kv::Request::set("foo2", "bar2")).await.unwrap();
         println!("write resp: {:#?}", resp);
     }
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
@@ -19,6 +19,7 @@ repository = "https://github.com/databendlabs/openraft"
 [dependencies]
 mem-log  = { path = "../mem-log", features = [] }
 openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
+types-kv = { path = "../types-kv" }
 
 bytes              = { version = "1.0" }
 futures            = { version = "0.3" }

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -10,8 +10,6 @@ use openraft::Config;
 
 use crate::app::App;
 use crate::router::Router;
-use crate::store::Request;
-use crate::store::Response;
 
 pub mod router;
 
@@ -25,8 +23,8 @@ pub type NodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
     pub TypeConfig:
-        D = Request,
-        R = Response,
+        D = types_kv::Request,
+        R = types_kv::Response,
         // In this example, snapshot is a path pointing to a file stored in shared storage.
         SnapshotData = String
 );

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fmt;
 use std::io;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -20,33 +19,6 @@ use crate::encode;
 use crate::typ::*;
 
 pub type LogStore = mem_log::LogStore<TypeConfig>;
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum Request {
-    Set { key: String, value: String },
-}
-
-impl fmt::Display for Request {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Request::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
-        }
-    }
-}
-
-impl Request {
-    pub fn set(key: impl ToString, value: impl ToString) -> Self {
-        Self::Set {
-            key: key.to_string(),
-            value: value.to_string(),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Response {
-    pub value: Option<String>,
-}
 
 #[derive(Debug)]
 pub struct StoredSnapshot {
@@ -172,18 +144,16 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
             sm.last_applied = Some(entry.log_id);
 
             let response = match entry.payload {
-                EntryPayload::Blank => Response { value: None },
+                EntryPayload::Blank => types_kv::Response::none(),
                 EntryPayload::Normal(ref req) => match req {
-                    Request::Set { key, value, .. } => {
+                    types_kv::Request::Set { key, value, .. } => {
                         sm.data.insert(key.clone(), value.clone());
-                        Response {
-                            value: Some(value.clone()),
-                        }
+                        types_kv::Response::new(value.clone())
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    Response { value: None }
+                    types_kv::Response::none()
                 }
             };
 

--- a/examples/raft-kv-memstore-opendal-snapshot-data/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/tests/cluster/test_cluster.rs
@@ -11,7 +11,6 @@ use openraft::type_config::TypeConfigExt;
 use raft_kv_memstore_opendal_snapshot_data::TypeConfig;
 use raft_kv_memstore_opendal_snapshot_data::new_raft;
 use raft_kv_memstore_opendal_snapshot_data::router::Router;
-use raft_kv_memstore_opendal_snapshot_data::store::Request;
 use raft_kv_memstore_opendal_snapshot_data::typ;
 use tracing_subscriber::EnvFilter;
 
@@ -95,9 +94,9 @@ async fn run_test(rafts: &[typ::Raft], router: Router) {
 
     println!("=== write 2 logs");
     {
-        let resp = raft1.client_write(Request::set("foo1", "bar1")).await.unwrap();
+        let resp = raft1.client_write(types_kv::Request::set("foo1", "bar1")).await.unwrap();
         println!("write resp: {:#?}", resp);
-        let resp = raft1.client_write(Request::set("foo2", "bar2")).await.unwrap();
+        let resp = raft1.client_write(types_kv::Request::set("foo2", "bar2")).await.unwrap();
         println!("write resp: {:#?}", resp);
     }
 

--- a/examples/raft-kv-memstore/Cargo.toml
+++ b/examples/raft-kv-memstore/Cargo.toml
@@ -25,6 +25,7 @@ mem-log            = { path = "../mem-log", features = [] }
 network-v1-http    = { path = "../network-v1-http" }
 openraft           = { path = "../../openraft", features = ["serde", "type-alias"] }
 openraft-network-v1 = { path = "../../network-v1" }
+types-kv           = { path = "../types-kv" }
 
 actix-web          = { version = "4.0.0-rc.2" }
 clap               = { version = "4.1.11", features = ["derive", "env"] }

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -14,8 +14,6 @@ use crate::app::App;
 use crate::network::api;
 use crate::network::management;
 use crate::network::raft;
-use crate::store::Request;
-use crate::store::Response;
 
 pub mod app;
 pub mod network;
@@ -28,8 +26,8 @@ pub type NodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration for example K/V store.
     pub TypeConfig:
-        D = Request,
-        R = Response,
+        D = types_kv::Request,
+        R = types_kv::Response,
 );
 
 pub type LogStore = store::LogStore;

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -13,7 +13,6 @@ use web::Json;
 
 use crate::TypeConfig;
 use crate::app::App;
-use crate::store::Request;
 
 /**
  * Application API
@@ -25,7 +24,7 @@ use crate::store::Request;
  *  - `POST - /read` attempt to find a value from a given key.
  */
 #[post("/write")]
-pub async fn write(app: Data<App>, req: Json<Request>) -> actix_web::Result<impl Responder> {
+pub async fn write(app: Data<App>, req: Json<types_kv::Request>) -> actix_web::Result<impl Responder> {
     let response = app.raft.client_write(req.0).await.decompose().unwrap();
     Ok(Json(response))
 }

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -13,7 +13,6 @@ use openraft::type_config::TypeConfigExt;
 use openraft::type_config::alias::AsyncRuntimeOf;
 use raft_kv_memstore::TypeConfig;
 use raft_kv_memstore::start_example_raft_node;
-use raft_kv_memstore::store::Request;
 use tracing_subscriber::EnvFilter;
 
 pub fn log_panic(panic: &PanicHookInfo) {
@@ -180,7 +179,7 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
 
     println!("=== write `foo=bar`");
     client
-        .write(&Request::Set {
+        .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "bar".to_string(),
         })
@@ -210,7 +209,7 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
 
     println!("=== read `foo` on node 2");
     client2
-        .write(&Request::Set {
+        .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "wow".to_string(),
         })
@@ -264,7 +263,7 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
 
     println!("=== write `foo=zoo` to node-3");
     client3
-        .write(&Request::Set {
+        .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "zoo".to_string(),
         })

--- a/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs
@@ -5,7 +5,6 @@ use maplit::btreeset;
 use openraft::type_config::TypeConfigExt;
 use raft_kv_memstore::TypeConfig;
 use raft_kv_memstore::start_example_raft_node;
-use raft_kv_memstore::store::Request;
 
 /// Test follower read functionality
 #[test]
@@ -54,7 +53,7 @@ async fn test_follower_read_inner() -> anyhow::Result<()> {
     // Write some data
     println!("=== write test_key=test_value");
     leader
-        .write(&Request::Set {
+        .write(&types_kv::Request::Set {
             key: "test_key".to_string(),
             value: "test_value".to_string(),
         })

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -26,6 +26,7 @@ network-v1-http     = { path = "../network-v1-http" }
 openraft            = { path = "../../openraft", features = ["serde", "type-alias"] }
 openraft-network-v1 = { path = "../../network-v1" }
 openraft-rocksstore = { path = "../rocksstore" }
+types-kv            = { path = "../types-kv" }
 
 actix-web          = { version = "4.0.0-rc.2" }
 clap               = { version = "4.1.11", features = ["derive", "env"] }

--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -15,8 +15,6 @@ use crate::app::App;
 use crate::network::api;
 use crate::network::management;
 use crate::network::raft;
-use crate::store::Request;
-use crate::store::Response;
 use crate::store::new_storage;
 
 pub mod app;
@@ -27,8 +25,8 @@ pub type NodeId = u64;
 
 openraft::declare_raft_types!(
     pub TypeConfig:
-        D = Request,
-        R = Response,
+        D = types_kv::Request,
+        R = types_kv::Response,
 );
 
 pub type LogStore = openraft_rocksstore::log_store::RocksLogStore<TypeConfig>;

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -10,10 +10,9 @@ use web::Json;
 
 use crate::TypeConfig;
 use crate::app::App;
-use crate::store::Request;
 
 #[post("/write")]
-pub async fn write(app: Data<App>, req: Json<Request>) -> actix_web::Result<impl Responder> {
+pub async fn write(app: Data<App>, req: Json<types_kv::Request>) -> actix_web::Result<impl Responder> {
     let response = app.raft.client_write(req.0).await.decompose().unwrap();
     Ok(Json(response))
 }

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -13,7 +13,6 @@ use openraft::type_config::TypeConfigExt;
 use openraft::type_config::alias::AsyncRuntimeOf;
 use raft_kv_rocksdb::TypeConfig;
 use raft_kv_rocksdb::start_example_raft_node;
-use raft_kv_rocksdb::store::Request;
 use tracing_subscriber::EnvFilter;
 
 pub fn log_panic(panic: &PanicHookInfo) {
@@ -172,7 +171,7 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
 
     println!("=== write `foo=bar`");
     leader
-        .write(&Request::Set {
+        .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "bar".to_string(),
         })
@@ -202,7 +201,7 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
 
     println!("=== write `foo=wow` on node 2");
     client2
-        .write(&Request::Set {
+        .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "wow".to_string(),
         })

--- a/examples/rocksstore/Cargo.toml
+++ b/examples/rocksstore/Cargo.toml
@@ -19,6 +19,7 @@ repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
 openraft = { path = "../../openraft", version = "0.10.0", features = ["serde", "type-alias"] }
+types-kv = { path = "../types-kv" }
 
 byteorder  = { version = "1.4.3" }
 futures    = { version = "0.3" }

--- a/examples/rocksstore/src/lib.rs
+++ b/examples/rocksstore/src/lib.rs
@@ -12,7 +12,6 @@ pub mod state_machine;
 #[cfg(test)]
 mod test;
 
-use std::fmt;
 use std::io;
 use std::path::Path;
 use std::sync::Arc;
@@ -21,8 +20,6 @@ use openraft::RaftTypeConfig;
 use rocksdb::ColumnFamilyDescriptor;
 use rocksdb::DB;
 use rocksdb::Options;
-use serde::Deserialize;
-use serde::Serialize;
 
 use crate::log_store::RocksLogStore;
 pub use crate::state_machine::RocksStateMachine;
@@ -32,38 +29,9 @@ pub type RocksNodeId = u64;
 openraft::declare_raft_types!(
     /// Declare the type configuration.
     pub TypeConfig:
-        D = RocksRequest,
-        R = RocksResponse,
+        D = types_kv::Request,
+        R = types_kv::Response,
 );
-
-/**
- * Here you will set the types of request that will interact with the raft nodes.
- * For example the `Set` will be used to write data (key and value) to the raft database.
- * The `AddNode` will append a new node to the current existing shared list of nodes.
- * You will want to add any request that can write data in all nodes here.
- */
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum RocksRequest {
-    Set { key: String, value: String },
-}
-
-impl fmt::Display for RocksRequest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RocksRequest::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
-        }
-    }
-}
-
-/**
- * Here you will define what type of answer you expect from reading the data of a node.
- * In this example it will return a optional value from a given key in
- * the `RocksRequest.Set`.
- */
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RocksResponse {
-    pub value: Option<String>,
-}
 
 /// Create a pair of `RocksLogStore` and `RocksStateMachine` that are backed by a same rocks db
 /// instance.

--- a/examples/types-kv/Cargo.toml
+++ b/examples/types-kv/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "types-kv"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/examples/types-kv/README.md
+++ b/examples/types-kv/README.md
@@ -1,0 +1,8 @@
+# types-kv
+
+Shared KV request/response types for openraft example crates.
+
+## Types
+
+- `Request` - KV store write operations (currently `Set { key, value }`)
+- `Response` - KV store operation results with optional value

--- a/examples/types-kv/src/lib.rs
+++ b/examples/types-kv/src/lib.rs
@@ -1,0 +1,47 @@
+//! Shared KV request/response types for example crates.
+
+use std::fmt;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// A request to the KV store.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Request {
+    Set { key: String, value: String },
+}
+
+impl Request {
+    pub fn set(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Request::Set {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Request::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+        }
+    }
+}
+
+/// A response from the KV store.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Response {
+    pub value: Option<String>,
+}
+
+impl Response {
+    pub fn new(value: impl Into<String>) -> Self {
+        Response {
+            value: Some(value.into()),
+        }
+    }
+
+    pub fn none() -> Self {
+        Response { value: None }
+    }
+}

--- a/network-v1/README.md
+++ b/network-v1/README.md
@@ -1,0 +1,41 @@
+# openraft-network-v1
+
+Legacy `RaftNetwork` v1 trait with chunk-based snapshot transmission.
+
+This crate provides:
+- **`RaftNetwork`**: The legacy v1 network trait using `install_snapshot()` for chunked snapshot transfer
+- **`Adapter`**: Converts a v1 `RaftNetwork` impl to `RaftNetworkV2`
+- **`ChunkedRaft`**: Wraps `Raft` to accept v1 chunk-based `install_snapshot` RPCs
+
+## Components
+
+### Client-side: `Adapter`
+
+Wraps a v1 `RaftNetwork` to provide `RaftNetworkV2`:
+
+```rust
+impl RaftNetwork<C> for MyNetwork {
+    async fn install_snapshot(...) { /* chunk-based */ }
+    async fn append_entries(...) { ... }
+    async fn vote(...) { ... }
+}
+
+impl RaftNetworkFactory<C> for MyFactory {
+    type Network = Adapter<C, MyNetwork>;
+
+    async fn new_client(...) -> Self::Network {
+        Adapter::new(MyNetwork::new(...))
+    }
+}
+```
+
+### Server-side: `ChunkedRaft`
+
+Wraps `Raft` to accept chunk-based snapshot RPCs. Derefs to inner `Raft`:
+
+```rust
+let raft = ChunkedRaft::new(Raft::new(...));
+
+raft.client_write(cmd).await?;      // via Deref
+raft.install_snapshot(req).await?;  // chunk-based
+```


### PR DESCRIPTION

## Changelog

##### refactor: use full path `types_kv::Request` in example crates
Replace re-exports with explicit full paths for `types_kv::Request` and
`types_kv::Response` across all example crates. This makes type origins
explicit at usage sites and avoids potential shadowing issues.

Changes:
- Add `types-kv` to workspace exclude list in `Cargo.toml`
- Add `make check` target to verify all crates including standalone examples
- Replace `pub use types_kv::Request/Response` with direct `types_kv::` paths
- Update `declare_raft_types!` macros to use full paths


##### refactor: migrate example crates to use shared `types-kv`
Update all KV example crates to use the shared `Request` and `Response`
types from `types-kv` instead of defining their own.

Changes:
- Update `raft-kv-memstore` to use `types-kv`
- Update `raft-kv-rocksdb` to use `types-kv`
- Update `raft-kv-memstore-network-v2` to use `types-kv`
- Update `raft-kv-memstore-opendal-snapshot-data` to use `types-kv`
- Update `multi-raft-kv` to use `types-kv`
- Use `Response::new()` and `Response::none()` constructors


##### docs: add types-kv to examples README
Add reference to the new `types-kv` crate in the Utilities section.


##### refactor: extract shared KV types into standalone `types-kv` crate
Extract `Request` and `Response` types from rocksstore into a new
`types-kv` crate for reuse across example crates.

Changes:
- Add `types-kv` crate with `Request` enum and `Response` struct
- Add `Request::set()` constructor for ergonomic request creation
- Add `Response::new()` and `Response::none()` constructors
- Update rocksstore to re-export types from `types-kv`


##### docs: add README for network-v1 crate

##### refactor: move state machine code to separate module in rocksstore
Extract `RocksStateMachine` and related code into `state_machine.rs` for
better code organization.

Changes:
- Create `state_machine.rs` with `RocksStateMachine`, `RaftSnapshotBuilder`
  and `RaftStateMachine` implementations
- Keep type definitions and `new()` factory function in `lib.rs`
- Re-export `RocksStateMachine` from `lib.rs` for backward compatibility

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1628)
<!-- Reviewable:end -->
