### PR TITLE
feat: add OpenTelemetry metrics integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
 ]
 exclude = [
     "benchmarks/minimal",
+    "metrics-otel",
 
     "examples/client-http",
     "examples/network-v1-http",
@@ -87,7 +88,6 @@ exclude = [
     "examples/raft-kv-memstore-network-v2",
     "examples/raft-kv-memstore-opendal-snapshot-data",
     "examples/raft-kv-rocksdb",
-
     "examples/multi-raft-kv",
 
     "rt-monoio",

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ check:
 	RUSTFLAGS="-D warnings" cargo check --manifest-path rt-compio/Cargo.toml
 	RUSTFLAGS="-D warnings" cargo check --manifest-path rt-monoio/Cargo.toml
 	RUSTFLAGS="-D warnings" cargo check --manifest-path rt-tokio/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo check --manifest-path metrics-otel/Cargo.toml
 	RUSTFLAGS="-D warnings" cargo check --manifest-path benchmarks/minimal/Cargo.toml
 	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/client-http/Cargo.toml
 	RUSTFLAGS="-D warnings" cargo check --manifest-path examples/network-v1-http/Cargo.toml
@@ -171,6 +172,7 @@ clean:
 	cargo clean --manifest-path rt-compio/Cargo.toml
 	cargo clean --manifest-path rt-monoio/Cargo.toml
 	cargo clean --manifest-path rt-tokio/Cargo.toml
+	cargo clean --manifest-path metrics-otel/Cargo.toml
 	cargo clean --manifest-path benchmarks/minimal/Cargo.toml
 	cargo clean --manifest-path examples/client-http/Cargo.toml
 	cargo clean --manifest-path examples/network-v1-http/Cargo.toml

--- a/metrics-otel/Cargo.toml
+++ b/metrics-otel/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "openraft-metrics-otel"
+version = "0.1.0"
+edition = "2024"
+authors = [
+    "Databend Authors <opensource@datafuselabs.com>",
+]
+description = "OpenTelemetry metrics integration for Openraft"
+documentation = "https://docs.rs/openraft-metrics-otel"
+homepage = "https://github.com/databendlabs/openraft"
+keywords = ["raft", "consensus", "opentelemetry", "metrics"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/databendlabs/openraft"
+
+[dependencies]
+openraft = { path = "../openraft", version = "0.10.0" }
+opentelemetry = "0.30.0"

--- a/metrics-otel/TODO.md
+++ b/metrics-otel/TODO.md
@@ -1,0 +1,43 @@
+# Future Metrics TODO
+
+Metrics that could be added to `MetricsRecorder` when OpenRaft provides the necessary instrumentation points.
+
+## Latency / Timing
+
+- `record_election_duration(duration_ms)` - Time from election start to becoming leader
+- `record_replication_latency(peer_id, duration_ms)` - Replication round-trip time per peer
+- `record_commit_latency(duration_ms)` - Time from log append to commit
+- `record_storage_append_latency(duration_ms)` - Storage append duration
+- `record_storage_read_latency(duration_ms)` - Storage read duration
+- `record_snapshot_build_duration(duration_ms)` - Time to build snapshot
+- `record_snapshot_apply_duration(duration_ms)` - Time to apply snapshot
+
+## State Transitions
+
+- `record_state_transition(from_state, to_state)` - Track state changes with labels
+- `increment_election_started()` - Elections initiated
+- `increment_election_won()` - Elections won
+- `increment_election_lost()` - Elections lost (timeout or lost to another candidate)
+
+## Errors
+
+- `increment_storage_error()` - Storage operation failures
+- `increment_network_error(peer_id)` - Network failures per peer
+- `increment_vote_rejected()` - Vote rejections received
+- `increment_append_rejected()` - AppendEntries rejections
+
+## Replication Health
+
+- `set_replication_lag(peer_id, lag_entries)` - Replication lag per peer
+- `record_replication_rpc_rate(peer_id, rpc_count)` - RPCs per second per peer
+- `record_replication_entry_rate(peer_id, entry_count)` - Entries replicated per second per peer
+
+## Membership
+
+- `set_membership_size(voters, learners)` - Current cluster membership size
+- `increment_membership_change()` - Membership configuration changes
+
+## Resource Usage
+
+- `set_log_cache_size(bytes)` - In-memory log cache size
+- `set_pending_proposals(count)` - Pending client proposals

--- a/metrics-otel/src/lib.rs
+++ b/metrics-otel/src/lib.rs
@@ -1,0 +1,303 @@
+//! OpenTelemetry metrics integration for Openraft.
+//!
+//! This crate provides an implementation of the [`MetricsRecorder`] trait
+//! from openraft, allowing applications to export Raft metrics to any
+//! OTEL-compatible backend (Prometheus, Jaeger, OTLP, etc.).
+//!
+//! # Usage
+//!
+//! 1. Add this crate to your `Cargo.toml`:
+//!    ```toml
+//!    [dependencies]
+//!    openraft = "0.10"
+//!    openraft-metrics-otel = "0.1"
+//!    opentelemetry = "0.30"
+//!    opentelemetry_sdk = "0.30"  # For configuring exporters
+//!    ```
+//!
+//! 2. Configure the OpenTelemetry SDK in your application:
+//!    ```rust,ignore
+//!    use opentelemetry_sdk::metrics::MeterProvider;
+//!
+//!    let meter_provider = MeterProvider::builder()
+//!        .with_reader(/* your exporter */)
+//!        .build();
+//!
+//!    opentelemetry::global::set_meter_provider(meter_provider);
+//!    ```
+//!
+//! 3. Install the recorder in your Raft instance:
+//!    ```rust,ignore
+//!    use std::sync::Arc;
+//!    use openraft_metrics_otel::Instruments;
+//!
+//!    let raft = Raft::new(...).await?;
+//!    raft.set_metrics_recorder(Some(Arc::new(Instruments::new()))).await?;
+//!    ```
+//!
+//! # Metrics
+//!
+//! The following metrics are exported:
+//!
+//! ## Histograms
+//! - `openraft.log.apply.batch_size` - Distribution of log entry counts in Apply commands
+//! - `openraft.storage.append.batch_size` - Distribution of log entry counts when appending
+//! - `openraft.replication.batch_size` - Distribution of log entry counts in replication RPCs
+//! - `openraft.write.batch_size` - Distribution of client write entries merged together
+//!
+//! ## Gauges
+//!
+//! - `openraft.term.current` - Current Raft term
+//! - `openraft.log.index.last` - Index of last log entry
+//! - `openraft.log.index.applied` - Index of last applied log entry
+//! - `openraft.snapshot.index` - Index of last snapshot
+//! - `openraft.log.index.purged` - Index of last purged log entry
+//! - `openraft.server.state` - Server state (0=Learner, 1=Follower, 2=Candidate, 3=Leader)
+//!
+//! ## Counters
+//!
+//! - `openraft.operation.vote.total` - Vote operations
+//! - `openraft.operation.heartbeat.total` - Heartbeat operations
+//! - `openraft.operation.append.total` - Append entries operations
+//!
+//! [`MetricsRecorder`]: openraft::metrics::MetricsRecorder
+
+use openraft::metrics::MetricsRecorder;
+use opentelemetry::global;
+use opentelemetry::metrics::Counter;
+use opentelemetry::metrics::Gauge;
+use opentelemetry::metrics::Histogram;
+use opentelemetry::metrics::Meter;
+
+const METER_NAME: &str = "openraft";
+
+/// OpenTelemetry instruments for recording Raft metrics.
+///
+/// This struct holds references to all OTEL instruments used by openraft.
+/// It implements the [`MetricsRecorder`] trait for inline metrics recording
+/// during Raft operations.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use openraft_metrics_otel::Instruments;
+///
+/// let recorder = Arc::new(Instruments::new());
+/// raft.set_metrics_recorder(Some(recorder)).await?;
+/// ```
+///
+/// [`MetricsRecorder`]: openraft::metrics::MetricsRecorder
+#[derive(Debug, Clone)]
+pub struct Instruments {
+    #[allow(dead_code)]
+    meter: Meter,
+
+    // Histograms for performance metrics
+    apply_batch_size: Histogram<u64>,
+    storage_append_batch_size: Histogram<u64>,
+    replicate_batch_size: Histogram<u64>,
+    write_batch_size: Histogram<u64>,
+
+    // Gauges for runtime state
+    current_term: Gauge<u64>,
+    last_log_index: Gauge<u64>,
+    applied_index: Gauge<u64>,
+    snapshot_index: Gauge<u64>,
+    purged_index: Gauge<u64>,
+    server_state: Gauge<u64>,
+
+    // Counters for operations
+    vote_total: Counter<u64>,
+    heartbeat_total: Counter<u64>,
+    append_total: Counter<u64>,
+}
+
+impl Instruments {
+    /// Creates a new set of OpenTelemetry instruments.
+    ///
+    /// This uses the global meter provider configured by the application.
+    /// Make sure to configure the OpenTelemetry SDK before calling this.
+    pub fn new() -> Self {
+        let meter = global::meter(METER_NAME);
+
+        let apply_batch_size = meter
+            .u64_histogram("openraft.log.apply.batch_size")
+            .with_description("Distribution of log entry counts in Apply commands")
+            .build();
+
+        let storage_append_batch_size = meter
+            .u64_histogram("openraft.storage.append.batch_size")
+            .with_description("Distribution of log entry counts when appending to storage")
+            .build();
+
+        let replicate_batch_size = meter
+            .u64_histogram("openraft.replication.batch_size")
+            .with_description("Distribution of log entry counts in replication RPCs")
+            .build();
+
+        let write_batch_size = meter
+            .u64_histogram("openraft.write.batch_size")
+            .with_description("Distribution of client write entries merged together")
+            .build();
+
+        let current_term = meter.u64_gauge("openraft.term.current").with_description("Current Raft term").build();
+
+        let last_log_index =
+            meter.u64_gauge("openraft.log.index.last").with_description("Index of last log entry").build();
+
+        let applied_index = meter
+            .u64_gauge("openraft.log.index.applied")
+            .with_description("Index of last applied log entry")
+            .build();
+
+        let snapshot_index =
+            meter.u64_gauge("openraft.snapshot.index").with_description("Index of last snapshot").build();
+
+        let purged_index =
+            meter.u64_gauge("openraft.log.index.purged").with_description("Index of last purged log entry").build();
+
+        let server_state = meter
+            .u64_gauge("openraft.server.state")
+            .with_description("Server state (0=Learner, 1=Follower, 2=Candidate, 3=Leader)")
+            .build();
+
+        let vote_total = meter
+            .u64_counter("openraft.operation.vote.total")
+            .with_description("Total vote requests sent or received")
+            .build();
+
+        let heartbeat_total = meter
+            .u64_counter("openraft.operation.heartbeat.total")
+            .with_description("Total heartbeats sent")
+            .build();
+
+        let append_total = meter
+            .u64_counter("openraft.operation.append.total")
+            .with_description("Total append entries operations")
+            .build();
+
+        Self {
+            meter,
+            apply_batch_size,
+            storage_append_batch_size,
+            replicate_batch_size,
+            write_batch_size,
+            current_term,
+            last_log_index,
+            applied_index,
+            snapshot_index,
+            purged_index,
+            server_state,
+            vote_total,
+            heartbeat_total,
+            append_total,
+        }
+    }
+}
+
+impl Default for Instruments {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Implements the MetricsRecorder trait for inline metrics recording.
+///
+/// This allows Instruments to be installed in RaftCore for automatic
+/// metrics collection during Raft operations.
+impl MetricsRecorder for Instruments {
+    fn record_apply_batch(&self, entry_count: u64) {
+        self.apply_batch_size.record(entry_count, &[]);
+    }
+
+    fn record_append_batch(&self, entry_count: u64) {
+        self.storage_append_batch_size.record(entry_count, &[]);
+    }
+
+    fn record_replicate_batch(&self, entry_count: u64) {
+        self.replicate_batch_size.record(entry_count, &[]);
+    }
+
+    fn record_write_batch(&self, entry_count: u64) {
+        self.write_batch_size.record(entry_count, &[]);
+    }
+
+    fn set_current_term(&self, term: u64) {
+        self.current_term.record(term, &[]);
+    }
+
+    fn set_last_log_index(&self, index: u64) {
+        self.last_log_index.record(index, &[]);
+    }
+
+    fn set_applied_index(&self, index: u64) {
+        self.applied_index.record(index, &[]);
+    }
+
+    fn set_snapshot_index(&self, index: u64) {
+        self.snapshot_index.record(index, &[]);
+    }
+
+    fn set_purged_index(&self, index: u64) {
+        self.purged_index.record(index, &[]);
+    }
+
+    fn set_server_state(&self, state: u8) {
+        self.server_state.record(state as u64, &[]);
+    }
+
+    fn increment_vote(&self) {
+        self.vote_total.add(1, &[]);
+    }
+
+    fn increment_heartbeat(&self) {
+        self.heartbeat_total.add(1, &[]);
+    }
+
+    fn increment_append(&self) {
+        self.append_total.add(1, &[]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instruments_all_methods() {
+        let instruments = Instruments::new();
+
+        // Histograms
+        instruments.record_apply_batch(10);
+        instruments.record_append_batch(5);
+        instruments.record_replicate_batch(8);
+        instruments.record_write_batch(3);
+
+        // Gauges
+        instruments.set_current_term(42);
+        instruments.set_last_log_index(100);
+        instruments.set_applied_index(99);
+        instruments.set_snapshot_index(50);
+        instruments.set_purged_index(25);
+        instruments.set_server_state(3); // Leader
+
+        // Counters
+        instruments.increment_vote();
+        instruments.increment_heartbeat();
+        instruments.increment_append();
+    }
+
+    #[test]
+    fn test_instruments_default() {
+        let instruments = Instruments::default();
+        instruments.record_apply_batch(1);
+    }
+
+    #[test]
+    fn test_instruments_clone() {
+        let instruments = Instruments::new();
+        let cloned = instruments.clone();
+        cloned.record_apply_batch(1);
+    }
+}

--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -10,12 +10,13 @@ pub enum ExternalCommandName {
     TriggerTransferLeader,
     AllowNextRevert,
     StateMachineCommand,
+    SetMetricsRecorder,
 }
 
 impl ExternalCommandName {
     /// Total number of variants.
     #[allow(dead_code)]
-    pub const COUNT: usize = 8;
+    pub const COUNT: usize = 9;
 
     /// All variants in canonical order.
     #[allow(dead_code)]
@@ -28,6 +29,7 @@ impl ExternalCommandName {
         ExternalCommandName::TriggerTransferLeader,
         ExternalCommandName::AllowNextRevert,
         ExternalCommandName::StateMachineCommand,
+        ExternalCommandName::SetMetricsRecorder,
     ];
 
     /// Returns the index of this variant for array-based storage.
@@ -42,6 +44,7 @@ impl ExternalCommandName {
             ExternalCommandName::TriggerTransferLeader => 5,
             ExternalCommandName::AllowNextRevert => 6,
             ExternalCommandName::StateMachineCommand => 7,
+            ExternalCommandName::SetMetricsRecorder => 8,
         }
     }
 
@@ -56,6 +59,7 @@ impl ExternalCommandName {
             ExternalCommandName::TriggerTransferLeader => "Ext::TriggerTransferLeader",
             ExternalCommandName::AllowNextRevert => "Ext::AllowNextRevert",
             ExternalCommandName::StateMachineCommand => "Ext::StateMachineCommand",
+            ExternalCommandName::SetMetricsRecorder => "Ext::SetMetricsRecorder",
         }
     }
 }
@@ -89,7 +93,7 @@ pub enum RaftMsgName {
 
 impl RaftMsgName {
     /// Total number of variants (including expanded ExternalCommand variants).
-    pub const COUNT: usize = 19;
+    pub const COUNT: usize = 20;
 
     /// All variants in canonical order.
     ///
@@ -113,6 +117,7 @@ impl RaftMsgName {
         RaftMsgName::ExternalCommand(ExternalCommandName::TriggerTransferLeader),
         RaftMsgName::ExternalCommand(ExternalCommandName::AllowNextRevert),
         RaftMsgName::ExternalCommand(ExternalCommandName::StateMachineCommand),
+        RaftMsgName::ExternalCommand(ExternalCommandName::SetMetricsRecorder),
         RaftMsgName::GetRuntimeStats,
     ];
 

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -32,6 +32,7 @@ mod raft_metrics;
 mod wait;
 
 mod metric_display;
+pub mod recorder;
 mod serde_instant;
 mod wait_condition;
 #[cfg(test)]
@@ -43,6 +44,8 @@ pub use metric::Metric;
 pub use raft_metrics::RaftDataMetrics;
 pub use raft_metrics::RaftMetrics;
 pub use raft_metrics::RaftServerMetrics;
+pub use recorder::MetricsRecorder;
+pub use recorder::forward_metrics;
 pub use serde_instant::SerdeInstant;
 pub use wait::Wait;
 pub use wait::WaitError;

--- a/openraft/src/metrics/recorder.rs
+++ b/openraft/src/metrics/recorder.rs
@@ -1,0 +1,136 @@
+//! Metrics recording trait for external metrics collection.
+//!
+//! This module defines the [`MetricsRecorder`] trait that allows applications
+//! to plug in custom metrics collection backends. The trait provides a minimal
+//! interface for recording Raft internal events.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use openraft::metrics::MetricsRecorder;
+//!
+//! #[derive(Debug)]
+//! struct MyRecorder;
+//!
+//! impl MetricsRecorder for MyRecorder {
+//!     fn record_apply_batch(&self, entry_count: u64) { /* ... */ }
+//!     fn record_append_batch(&self, entry_count: u64) { /* ... */ }
+//!     fn record_write_batch(&self, entry_count: u64) { /* ... */ }
+//!     fn set_current_term(&self, term: u64) { /* ... */ }
+//!     fn set_last_log_index(&self, index: u64) { /* ... */ }
+//!     fn set_applied_index(&self, index: u64) { /* ... */ }
+//!     fn set_snapshot_index(&self, index: u64) { /* ... */ }
+//!     fn set_purged_index(&self, index: u64) { /* ... */ }
+//!     fn set_server_state(&self, state: u8) { /* ... */ }
+//!     fn increment_vote(&self) { /* ... */ }
+//!     fn increment_heartbeat(&self) { /* ... */ }
+//!     fn increment_append(&self) { /* ... */ }
+//! }
+//!
+//! // Install in Raft instance
+//! raft.set_metrics_recorder(Some(Arc::new(MyRecorder)));
+//! ```
+
+use crate::RaftTypeConfig;
+use crate::core::ServerState;
+use crate::metrics::RaftMetrics;
+use crate::vote::RaftTerm;
+
+/// Trait for recording Raft metrics to external systems.
+///
+/// Implement this trait to collect metrics from Raft internals and export them
+/// to your preferred metrics backend (e.g., Prometheus, OpenTelemetry, StatsD).
+///
+/// All methods are called from the RaftCore task and should return quickly to
+/// avoid blocking Raft operations.
+pub trait MetricsRecorder: Send + Sync + std::fmt::Debug {
+    // --- Histograms (batch sizes) ---
+
+    /// Record a batch of log entries being applied to the state machine.
+    fn record_apply_batch(&self, entry_count: u64);
+
+    /// Record a batch of log entries being appended to storage.
+    fn record_append_batch(&self, entry_count: u64);
+
+    /// Record a batch of client write entries merged together.
+    fn record_write_batch(&self, entry_count: u64);
+
+    // --- Gauges (current state) ---
+
+    /// Set the current Raft term.
+    fn set_current_term(&self, term: u64);
+
+    /// Set the index of the last log entry.
+    fn set_last_log_index(&self, index: u64);
+
+    /// Set the index of the last applied log entry.
+    fn set_applied_index(&self, index: u64);
+
+    /// Set the index of the last snapshot.
+    fn set_snapshot_index(&self, index: u64);
+
+    /// Set the index of the last purged log entry.
+    fn set_purged_index(&self, index: u64);
+
+    /// Set the server state.
+    ///
+    /// States: 0=Learner, 1=Follower, 2=Candidate, 3=Leader, 4=Shutdown
+    fn set_server_state(&self, state: u8);
+
+    // --- Counters (operations) ---
+
+    /// Increment the vote operation counter.
+    fn increment_vote(&self);
+
+    /// Increment the heartbeat operation counter.
+    fn increment_heartbeat(&self);
+
+    /// Increment the append entries operation counter.
+    fn increment_append(&self);
+}
+
+/// Forward gauge metrics from `RaftMetrics` to a `MetricsRecorder`.
+///
+/// This helper function extracts the relevant fields from `RaftMetrics` and
+/// calls the corresponding setter methods on the recorder. It only forwards
+/// gauge metrics (current state values), not counters or histograms.
+///
+/// # Example
+///
+/// ```ignore
+/// use openraft::metrics::{RaftMetrics, MetricsRecorder, forward_metrics};
+///
+/// fn on_metrics_update<C: RaftTypeConfig>(metrics: &RaftMetrics<C>, recorder: &dyn MetricsRecorder) {
+///     forward_metrics(metrics, recorder);
+/// }
+/// ```
+pub fn forward_metrics<C: RaftTypeConfig>(metrics: &RaftMetrics<C>, recorder: &dyn MetricsRecorder) {
+    if let Some(term) = metrics.current_term.as_u64() {
+        recorder.set_current_term(term);
+    }
+
+    if let Some(index) = metrics.last_log_index {
+        recorder.set_last_log_index(index);
+    }
+
+    if let Some(ref applied) = metrics.last_applied {
+        recorder.set_applied_index(applied.index());
+    }
+
+    if let Some(ref snapshot) = metrics.snapshot {
+        recorder.set_snapshot_index(snapshot.index());
+    }
+
+    if let Some(ref purged) = metrics.purged {
+        recorder.set_purged_index(purged.index());
+    }
+
+    recorder.set_server_state(match metrics.state {
+        ServerState::Learner => 0,
+        ServerState::Follower => 1,
+        ServerState::Candidate => 2,
+        ServerState::Leader => 3,
+        ServerState::Shutdown => 4,
+    });
+}

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -109,6 +109,7 @@ use crate::error::LinearizableReadError;
 use crate::error::RaftError;
 use crate::error::into_raft_result::IntoRaftResult;
 use crate::membership::IntoNodes;
+use crate::metrics::MetricsRecorder;
 use crate::metrics::RaftDataMetrics;
 use crate::metrics::RaftMetrics;
 use crate::metrics::RaftServerMetrics;
@@ -525,6 +526,8 @@ where C: RaftTypeConfig
             runtime_stats: RuntimeStats::new(),
             shared_replicate_batch,
 
+            metrics_recorder: None,
+
             span: core_span,
         };
 
@@ -773,6 +776,40 @@ where C: RaftTypeConfig
     /// ```
     pub fn trigger(&self) -> Trigger<'_, C> {
         Trigger::new(self.inner.as_ref())
+    }
+
+    /// Set or unset a custom metrics recorder for exporting Raft metrics.
+    ///
+    /// This allows applications to plug in their own metrics collection backends
+    /// (e.g., OpenTelemetry, Prometheus, StatsD) at runtime. The recorder will
+    /// receive metrics events from RaftCore as they occur.
+    ///
+    /// Pass `Some(recorder)` to enable metrics recording, or `None` to disable it.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use std::sync::Arc;
+    /// use openraft::metrics::MetricsRecorder;
+    ///
+    /// struct MyRecorder;
+    /// impl MetricsRecorder for MyRecorder {
+    ///     fn record_apply_batch(&self, entry_count: u64) { /* ... */ }
+    ///     fn record_append_batch(&self, entry_count: u64) { /* ... */ }
+    /// }
+    ///
+    /// // Enable metrics recording
+    /// raft.set_metrics_recorder(Some(Arc::new(MyRecorder))).await?;
+    ///
+    /// // Disable metrics recording
+    /// raft.set_metrics_recorder(None).await?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Fatal`] error if RaftCore is shut down or has a storage error.
+    pub async fn set_metrics_recorder(&self, recorder: Option<Arc<dyn MetricsRecorder>>) -> Result<(), Fatal<C>> {
+        self.inner.send_external_command(ExternalCommand::SetMetricsRecorder { recorder }).await
     }
 
     /// Submit an AppendEntries RPC to this Raft node.

--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -110,7 +110,8 @@ where
             entries,
         };
 
-        self.replication_context.replicate_batch.record(payload.entries.len() as u64);
+        let entry_count = payload.entries.len() as u64;
+        self.replication_context.replicate_batch.record(entry_count);
 
         tracing::debug!("next_request: AppendEntries: {}", payload);
 

--- a/openraft/src/vote/raft_term/mod.rs
+++ b/openraft/src/vote/raft_term/mod.rs
@@ -12,7 +12,7 @@ use crate::base::OptionalFeatures;
 /// A term is a logical clock in Raft that is used to detect obsolete information,
 /// such as old leaders. It must be totally ordered and monotonically increasing.
 ///
-/// Common implementations are provided for standard integer types like `u64`, `i64`, etc.
+/// Common implementations are provided for standard integer types like `u64`, `u32`, etc.
 #[since(version = "0.10.0")]
 pub trait RaftTerm
 where Self: OptionalFeatures + Ord + Debug + Display + Copy + Default + 'static
@@ -21,4 +21,11 @@ where Self: OptionalFeatures + Ord + Debug + Display + Copy + Default + 'static
     ///
     /// Must satisfy: `self < self.next()`
     fn next(&self) -> Self;
+
+    /// Convert to u64 for metrics recording.
+    ///
+    /// Returns `None` if the term cannot be represented as u64.
+    /// Implementors must explicitly choose whether their term type
+    /// can be converted to u64 for metrics purposes.
+    fn as_u64(&self) -> Option<u64>;
 }

--- a/openraft/src/vote/raft_term/raft_term_impls.rs
+++ b/openraft/src/vote/raft_term/raft_term_impls.rs
@@ -1,22 +1,41 @@
 use crate::vote::RaftTerm;
 
-macro_rules! impl_raft_term {
+/// Implement RaftTerm for types that infallibly convert to u64.
+macro_rules! impl_raft_term_infallible {
     ($($t:ty),*) => {
         $(
             impl RaftTerm for $t {
                 fn next(&self) -> Self {
                     self + 1
                 }
+
+                fn as_u64(&self) -> Option<u64> {
+                    Some((*self).into())
+                }
             }
         )*
     }
 }
 
-impl_raft_term!(
-    u8, u16, u32, u64, u128, //
-    i8, i16, i32, i64, i128, //
-    usize, isize
-);
+/// Implement RaftTerm for types that may fail to convert to u64.
+macro_rules! impl_raft_term_fallible {
+    ($($t:ty),*) => {
+        $(
+            impl RaftTerm for $t {
+                fn next(&self) -> Self {
+                    self + 1
+                }
+
+                fn as_u64(&self) -> Option<u64> {
+                    (*self).try_into().ok()
+                }
+            }
+        )*
+    }
+}
+
+impl_raft_term_infallible!(u8, u16, u32, u64);
+impl_raft_term_fallible!(u128, i8, i16, i32, i64, i128, usize, isize);
 
 #[cfg(test)]
 mod tests {
@@ -30,7 +49,6 @@ mod tests {
         assert_eq!(1_u32.next(), 2_u32);
         assert_eq!(1_u64.next(), 2_u64);
         assert_eq!(1_u128.next(), 2_u128);
-        assert_eq!(1_usize.next(), 2_usize);
 
         // Test signed integers
         assert_eq!(1_i8.next(), 2_i8);
@@ -38,17 +56,36 @@ mod tests {
         assert_eq!(1_i32.next(), 2_i32);
         assert_eq!(1_i64.next(), 2_i64);
         assert_eq!(1_i128.next(), 2_i128);
-        assert_eq!(1_isize.next(), 2_isize);
 
         // Test default values
         assert_eq!(u8::default().next(), 1_u8);
-        assert_eq!(i8::default().next(), 1_i8);
-        assert_eq!(usize::default().next(), 1_usize);
-        assert_eq!(isize::default().next(), 1_isize);
+        assert_eq!(u64::default().next(), 1_u64);
+        assert_eq!(i64::default().next(), 1_i64);
 
         // Test boundary cases
         assert_eq!(254_u8.next(), 255_u8);
-        assert_eq!(126_i8.next(), 127_i8);
-        assert_eq!((-2_i8).next(), -1_i8);
+    }
+
+    #[test]
+    fn test_as_u64() {
+        // Infallible conversions
+        assert_eq!(1_u8.as_u64(), Some(1));
+        assert_eq!(255_u8.as_u64(), Some(255));
+        assert_eq!(1_u16.as_u64(), Some(1));
+        assert_eq!(1_u32.as_u64(), Some(1));
+        assert_eq!(1_u64.as_u64(), Some(1));
+        assert_eq!(u64::MAX.as_u64(), Some(u64::MAX));
+
+        // Fallible conversions - positive values
+        assert_eq!(1_i8.as_u64(), Some(1));
+        assert_eq!(1_i64.as_u64(), Some(1));
+        assert_eq!(1_u128.as_u64(), Some(1));
+
+        // Fallible conversions - negative values return None
+        assert_eq!((-1_i8).as_u64(), None);
+        assert_eq!((-1_i64).as_u64(), None);
+
+        // Fallible conversions - overflow returns None
+        assert_eq!((u64::MAX as u128 + 1).as_u64(), None);
     }
 }

--- a/tests/tests/metrics/main.rs
+++ b/tests/tests/metrics/main.rs
@@ -9,6 +9,7 @@ mod fixtures;
 
 mod t10_current_leader;
 mod t10_leader_last_ack;
+mod t10_metrics_recorder;
 mod t10_purged;
 mod t10_server_metrics_and_data_metrics;
 mod t20_metrics_state_machine_consistency;

--- a/tests/tests/metrics/t10_metrics_recorder.rs
+++ b/tests/tests/metrics/t10_metrics_recorder.rs
@@ -1,0 +1,299 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::metrics::MetricsRecorder;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// A simple MetricsRecorder implementation for testing.
+///
+/// Captures all metric calls so they can be verified in tests.
+#[derive(Debug, Default)]
+pub struct TestRecorder {
+    // Histograms (sum of all recorded values)
+    pub apply_batch_total: AtomicU64,
+    pub append_batch_total: AtomicU64,
+    pub write_batch_total: AtomicU64,
+
+    // Gauges (last recorded value)
+    pub current_term: AtomicU64,
+    pub last_log_index: AtomicU64,
+    pub applied_index: AtomicU64,
+    pub snapshot_index: AtomicU64,
+    pub purged_index: AtomicU64,
+    pub server_state: AtomicU64,
+
+    // Counters
+    pub vote_count: AtomicU64,
+    pub heartbeat_count: AtomicU64,
+    pub append_count: AtomicU64,
+}
+
+impl MetricsRecorder for TestRecorder {
+    fn record_apply_batch(&self, n: u64) {
+        self.apply_batch_total.fetch_add(n, Ordering::Relaxed);
+    }
+
+    fn record_append_batch(&self, n: u64) {
+        self.append_batch_total.fetch_add(n, Ordering::Relaxed);
+    }
+
+    fn record_write_batch(&self, n: u64) {
+        self.write_batch_total.fetch_add(n, Ordering::Relaxed);
+    }
+
+    fn set_current_term(&self, v: u64) {
+        self.current_term.store(v, Ordering::Relaxed);
+    }
+
+    fn set_last_log_index(&self, v: u64) {
+        self.last_log_index.store(v, Ordering::Relaxed);
+    }
+
+    fn set_applied_index(&self, v: u64) {
+        self.applied_index.store(v, Ordering::Relaxed);
+    }
+
+    fn set_snapshot_index(&self, v: u64) {
+        self.snapshot_index.store(v, Ordering::Relaxed);
+    }
+
+    fn set_purged_index(&self, v: u64) {
+        self.purged_index.store(v, Ordering::Relaxed);
+    }
+
+    fn set_server_state(&self, v: u8) {
+        self.server_state.store(v as u64, Ordering::Relaxed);
+    }
+
+    fn increment_vote(&self) {
+        self.vote_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn increment_heartbeat(&self) {
+        self.heartbeat_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn increment_append(&self) {
+        self.append_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Test that all MetricsRecorder methods are called during normal Raft operations.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn test_metrics_recorder_all_fields() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            snapshot_policy: openraft::SnapshotPolicy::LogsSinceLast(5),
+            max_in_snapshot_log_to_keep: 0,
+            purge_batch_size: 1,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    // Create and install the recorder on the leader
+    let recorder = Arc::new(TestRecorder::default());
+    let leader_id = router.leader().expect("cluster should have a leader");
+    let leader = router.get_raft_handle(&leader_id)?;
+    leader.set_metrics_recorder(Some(recorder.clone())).await?;
+
+    // --- Trigger client writes ---
+    // This should trigger:
+    // - record_write_batch (leader batching client writes)
+    // - record_append_batch (leader appending to log)
+    // - record_apply_batch (applying to state machine)
+    // - record_replicate_batch (leader replicating to followers)
+    tracing::info!(log_index, "--- write 10 client requests");
+    log_index += router.client_request_many(leader_id, "test", 10).await?;
+
+    // Wait for all nodes to apply - this ensures replication completed
+    for node_id in [0, 1, 2] {
+        router.wait(&node_id, timeout()).applied_index(Some(log_index), "applied").await?;
+    }
+
+    // --- Trigger heartbeat ---
+    // This should trigger increment_heartbeat
+    tracing::info!(log_index, "--- trigger heartbeat");
+    leader.trigger().heartbeat().await?;
+
+    // --- Trigger snapshot ---
+    // This should trigger set_snapshot_index
+    tracing::info!(log_index, "--- trigger snapshot");
+    leader.trigger().snapshot().await?;
+    router.wait(&leader_id, timeout()).snapshot(log_id(1, leader_id, log_index), "snapshot").await?;
+
+    // --- Trigger purge ---
+    // This should trigger set_purged_index
+    tracing::info!(log_index, "--- trigger purge");
+    leader.trigger().purge_log(log_index).await?;
+    router.wait(&leader_id, timeout()).purged(Some(log_id(1, leader_id, log_index)), "purged").await?;
+
+    // Wait a bit for metrics to be recorded
+    TypeConfig::sleep(Duration::from_millis(100)).await;
+
+    // --- Verify metrics ---
+    tracing::info!("--- verifying metrics");
+
+    // Histograms: should have recorded some batches
+    let write_batch = recorder.write_batch_total.load(Ordering::Relaxed);
+    let append_batch = recorder.append_batch_total.load(Ordering::Relaxed);
+    let apply_batch = recorder.apply_batch_total.load(Ordering::Relaxed);
+
+    tracing::info!(write_batch, append_batch, apply_batch, "histogram metrics");
+
+    assert!(write_batch > 0, "write_batch should be recorded, got {}", write_batch);
+    assert!(
+        append_batch > 0,
+        "append_batch should be recorded, got {}",
+        append_batch
+    );
+    assert!(apply_batch > 0, "apply_batch should be recorded, got {}", apply_batch);
+
+    // Gauges: should reflect current state
+    let term = recorder.current_term.load(Ordering::Relaxed);
+    let last_log = recorder.last_log_index.load(Ordering::Relaxed);
+    let applied = recorder.applied_index.load(Ordering::Relaxed);
+    let snapshot = recorder.snapshot_index.load(Ordering::Relaxed);
+    let purged = recorder.purged_index.load(Ordering::Relaxed);
+    let server_state = recorder.server_state.load(Ordering::Relaxed);
+
+    tracing::info!(term, last_log, applied, snapshot, purged, server_state, "gauge metrics");
+
+    assert!(term >= 1, "current_term should be at least 1, got {}", term);
+    assert!(last_log > 0, "last_log_index should be > 0, got {}", last_log);
+    assert!(applied > 0, "applied_index should be > 0, got {}", applied);
+    assert!(snapshot > 0, "snapshot_index should be > 0, got {}", snapshot);
+    assert!(purged > 0, "purged_index should be > 0, got {}", purged);
+    assert_eq!(
+        server_state, 3,
+        "server_state should be Leader (3), got {}",
+        server_state
+    );
+
+    // Counters: should have counted operations
+    let heartbeat = recorder.heartbeat_count.load(Ordering::Relaxed);
+
+    tracing::info!(heartbeat, "counter metrics");
+
+    assert!(heartbeat > 0, "heartbeat_count should be > 0, got {}", heartbeat);
+
+    // Note: vote_count and append_count are incremented on followers receiving RPCs,
+    // not on the leader. We only installed the recorder on the leader.
+
+    Ok(())
+}
+
+/// Test that MetricsRecorder on followers captures append entries and vote operations.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn test_metrics_recorder_on_follower() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    // Install recorder on follower (node 1)
+    let recorder = Arc::new(TestRecorder::default());
+    let follower = router.get_raft_handle(&1)?;
+    follower.set_metrics_recorder(Some(recorder.clone())).await?;
+
+    // Write some entries from leader
+    let leader_id = router.leader().expect("cluster should have a leader");
+    tracing::info!(log_index, "--- write 5 client requests");
+    log_index += router.client_request_many(leader_id, "test", 5).await?;
+
+    // Wait for follower to receive and apply
+    router.wait(&1, timeout()).applied_index(Some(log_index), "follower applied").await?;
+
+    // Trigger an election from another node to test vote_count
+    // Node 2 will send vote requests to node 1 (which has our recorder)
+    tracing::info!("--- trigger election on node 2 to test vote_count");
+    let node2 = router.get_raft_handle(&2)?;
+    node2.trigger().elect().await?;
+
+    // Wait a bit for vote to be processed
+    TypeConfig::sleep(Duration::from_millis(200)).await;
+
+    // Verify follower metrics
+    let append_count = recorder.append_count.load(Ordering::Relaxed);
+    let append_batch = recorder.append_batch_total.load(Ordering::Relaxed);
+    let apply_batch = recorder.apply_batch_total.load(Ordering::Relaxed);
+    let vote_count = recorder.vote_count.load(Ordering::Relaxed);
+    let term = recorder.current_term.load(Ordering::Relaxed);
+    let last_log = recorder.last_log_index.load(Ordering::Relaxed);
+    let applied = recorder.applied_index.load(Ordering::Relaxed);
+    let server_state = recorder.server_state.load(Ordering::Relaxed);
+
+    tracing::info!(
+        append_count,
+        append_batch,
+        apply_batch,
+        vote_count,
+        term,
+        last_log,
+        applied,
+        server_state,
+        "follower metrics"
+    );
+
+    assert!(
+        append_count > 0,
+        "follower should receive append entries RPCs, got {}",
+        append_count
+    );
+    assert!(
+        append_batch > 0,
+        "follower should record append batches, got {}",
+        append_batch
+    );
+    assert!(
+        apply_batch > 0,
+        "follower should record apply batches, got {}",
+        apply_batch
+    );
+    assert!(
+        vote_count > 0,
+        "follower should receive vote requests, got {}",
+        vote_count
+    );
+    assert!(term >= 1, "current_term should be at least 1, got {}", term);
+    assert!(last_log > 0, "last_log_index should be > 0, got {}", last_log);
+    assert!(applied > 0, "applied_index should be > 0, got {}", applied);
+    // Server state could be Follower(1) or Candidate(2) depending on election timing
+    assert!(
+        server_state == 1 || server_state == 2,
+        "server_state should be Follower(1) or Candidate(2), got {}",
+        server_state
+    );
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2000))
+}


### PR DESCRIPTION

## Changelog

##### feat: add OpenTelemetry metrics integration
Add pluggable metrics support via the `MetricsRecorder` trait, allowing
applications to export Raft metrics to custom backends. Includes an
OpenTelemetry implementation in a separate crate.

Changes:
- Add `MetricsRecorder` trait for pluggable metrics backends
- Create `openraft-metrics-otel` crate with OpenTelemetry implementation
- Add `Raft::set_metrics_recorder()` to install/uninstall recorders at runtime
- Add histogram methods: `record_apply_batch()`, `record_append_batch()`, `record_replicate_batch()`, `record_write_batch()`
- Add gauge methods: `set_current_term()`, `set_last_log_index()`, `set_applied_index()`, `set_snapshot_index()`, `set_purged_index()`, `set_server_state()`
- Add counter methods: `increment_vote()`, `increment_heartbeat()`, `increment_append()`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1631)
<!-- Reviewable:end -->
