### PR TITLE
feat: add `lock_owned()` method returning Arc-based guard

### DIFF
--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -33,6 +33,7 @@ pub use mpsc::MpscWeakSender;
 pub use mpsc::SendError;
 pub use mpsc::TryRecvError;
 pub use mutex::Mutex;
+pub use mutex::OwnedGuard;
 pub use oneshot::Oneshot;
 pub use oneshot::OneshotSender;
 pub use threaded::BoxAny;

--- a/rt/src/mutex.rs
+++ b/rt/src/mutex.rs
@@ -1,12 +1,17 @@
 //! Async mutex trait.
 
+use std::future::Future;
+use std::ops::Deref;
 use std::ops::DerefMut;
+use std::sync::Arc;
 
 use crate::OptionalSend;
 use crate::OptionalSync;
 
 /// Represents an implementation of an asynchronous Mutex.
-pub trait Mutex<T: OptionalSend + 'static>: OptionalSend + OptionalSync {
+pub trait Mutex<T>: OptionalSend + OptionalSync + 'static
+where T: OptionalSend + 'static
+{
     /// Handle to an acquired lock, should release it when dropped.
     type Guard<'a>: DerefMut<Target = T> + OptionalSend
     where Self: 'a;
@@ -18,4 +23,60 @@ pub trait Mutex<T: OptionalSend + 'static>: OptionalSend + OptionalSync {
     /// Locks this Mutex.
     #[track_caller]
     fn lock(&self) -> impl Future<Output = Self::Guard<'_>> + OptionalSend;
+
+    /// Lock this mutex, returning a guard that owns the mutex via Arc.
+    ///
+    /// The guard can be moved, returned from functions, or stored in structs.
+    /// This is provided as a default implementation for convenience.
+    #[must_use]
+    fn lock_owned(self: Arc<Self>) -> impl Future<Output = OwnedGuard<Self, T>> + OptionalSend
+    where Self: Sized {
+        async move {
+            let guard = self.lock().await;
+
+            // SAFETY: OwnedGuard holds the Arc, ensuring mutex outlives the guard.
+            // We transmute the guard to 'static lifetime because its lifetime is
+            // now tied to the Arc in OwnedGuard, not the original borrow.
+            let guard_static = unsafe { std::mem::transmute::<Self::Guard<'_>, Self::Guard<'static>>(guard) };
+
+            OwnedGuard {
+                guard: guard_static,
+                _mutex: self,
+            }
+        }
+    }
+}
+
+/// An owned guard that keeps the mutex alive via Arc.
+///
+/// This guard owns the lock through an `Arc<Mutex>`, allowing it to outlive
+/// the original reference and be moved, returned from functions, or stored in structs.
+pub struct OwnedGuard<M, T>
+where
+    M: Mutex<T>,
+    T: OptionalSend + 'static,
+{
+    guard: M::Guard<'static>,
+    _mutex: Arc<M>,
+}
+
+impl<M, T> Deref for OwnedGuard<M, T>
+where
+    M: Mutex<T>,
+    T: OptionalSend + 'static,
+{
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<M, T> DerefMut for OwnedGuard<M, T>
+where
+    M: Mutex<T>,
+    T: OptionalSend + 'static,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
 }


### PR DESCRIPTION

## Changelog

##### feat: add `lock_owned()` method returning Arc-based guard
Implement an owned mutex guard that holds the lock through an Arc,
allowing guards to be moved, returned from functions, or stored
in structs without lifetime constraints.

Changes:
- Add `Mutex::lock_owned()` method returning `OwnedGuard`
- Add `OwnedGuard<M, T>` type for Arc-based mutex guards
- Export `OwnedGuard` in `rt::lib`
- Add `test_mutex_lock_owned()` test suite

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1638)
<!-- Reviewable:end -->
