### PR TITLE
change: remove Display bound from RaftLogId trait

### DIFF
--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -9,7 +9,7 @@ use crate::type_config::alias::CommittedLeaderIdOf;
 pub(crate) trait RaftLogId<C>
 where
     C: RaftTypeConfig,
-    Self: Eq + Clone + fmt::Debug + fmt::Display,
+    Self: Eq + Clone + fmt::Debug,
 {
     /// Creates a log id proposed by a committed leader `leader_id` at the given index.
     // This is only used internally


### PR DESCRIPTION

## Changelog

##### change: remove Display bound from RaftLogId trait
The Display trait is not actually used by the trait methods.
Removing this bound reduces implementation requirements without
affecting functionality.

Changes:
- Remove `fmt::Display` from `RaftLogId<C>` trait bounds

Upgrade tip:

If you manually implement `RaftLogId` trait, the `Display` bound
is no longer required. Any `Display` implementations can be removed
if they were added solely to satisfy this trait bound.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1640)
<!-- Reviewable:end -->
