### PR TITLE
feat: make RaftLogId trait public

### DIFF
--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -39,8 +39,8 @@ use std::fmt::Formatter;
 pub use log_id_option_ext::LogIdOptionExt;
 pub use log_index_option_ext::LogIndexOptionExt;
 
+pub use self::raft_log_id::RaftLogId;
 use crate::RaftTypeConfig;
-use crate::log_id::raft_log_id::RaftLogId;
 use crate::type_config::alias::CommittedLeaderIdOf;
 
 /// The identity of a raft log.

--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -6,7 +6,7 @@ use crate::type_config::alias::CommittedLeaderIdOf;
 /// Log id is the globally unique identifier of a log entry.
 ///
 /// Equal log id means the same log entry.
-pub(crate) trait RaftLogId<C>
+pub trait RaftLogId<C>
 where
     C: RaftTypeConfig,
     Self: Eq + Clone + fmt::Debug,


### PR DESCRIPTION

## Changelog

##### feat: make RaftLogId trait public
Export the RaftLogId trait to allow users to implement log ID behavior
for custom types. This enables applications to define their own log ID
representations that integrate with Openraft's log management.

Changes:
- Change RaftLogId visibility from pub(crate) to pub
- Add public re-export of RaftLogId from log_id module

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1643)
<!-- Reviewable:end -->
