### PR TITLE
feat: implement truncate_after for RaftLogStorage

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -2116,14 +2116,14 @@ where
                 self.log_store.purge(upto.clone()).await.sto_write_logs()?;
                 self.engine.state.io_state_mut().update_purged(Some(upto));
             }
-            Command::TruncateLog { since } => {
-                self.log_store.truncate(since.clone()).await.sto_write_logs()?;
+            Command::TruncateLog { after } => {
+                self.log_store.truncate_after(after.clone()).await.sto_write_logs()?;
 
                 // Inform clients waiting for logs to be applied.
                 let leader_id = self.current_leader();
                 let leader_node = self.get_leader_node(leader_id.clone());
 
-                for (log_index, tx) in self.client_responders.drain_from(since.index()) {
+                for (log_index, tx) in self.client_responders.drain_from(after.next_index()) {
                     tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
                         leader_id: leader_id.clone(),
                         leader_node: leader_node.clone(),

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -138,9 +138,9 @@ where C: RaftTypeConfig
     /// Purge log from the beginning to `upto`, inclusive.
     PurgeLog { upto: LogIdOf<C> },
 
-    /// Delete logs that have conflicted with the leader from a follower/learner since log id
-    /// `since`, inclusive.
-    TruncateLog { since: LogIdOf<C> },
+    /// Delete logs that have conflicted with the leader from a follower/learner after log id
+    /// `after`, exclusive.
+    TruncateLog { after: Option<LogIdOf<C>> },
 
     /// A command sent to state machine worker [`sm::worker::Worker`].
     ///
@@ -211,7 +211,7 @@ where C: RaftTypeConfig
             Command::SaveVote { vote } => write!(f, "SaveVote: {}", vote),
             Command::SendVote { vote_req } => write!(f, "SendVote: {}", vote_req),
             Command::PurgeLog { upto } => write!(f, "PurgeLog: upto: {}", upto),
-            Command::TruncateLog { since } => write!(f, "TruncateLog: since: {}", since),
+            Command::TruncateLog { after } => write!(f, "TruncateLog: since: {}", after.display()),
             Command::StateMachine { command } => write!(f, "StateMachine: command: {}", command),
             Command::Respond { when, resp } => write!(f, "Respond: when: {}, resp: {}", when.display(), resp),
         }
@@ -246,7 +246,7 @@ where
             (Command::SaveVote { vote },                       Command::SaveVote { vote: b })                                        => vote == b,
             (Command::SendVote { vote_req },                   Command::SendVote { vote_req: b }, )                                  => vote_req == b,
             (Command::PurgeLog { upto },                       Command::PurgeLog { upto: b })                                        => upto == b,
-            (Command::TruncateLog { since },                   Command::TruncateLog { since: b }, )                                  => since == b,
+            (Command::TruncateLog { after },                   Command::TruncateLog { after: b }, )                                  => after == b,
             (Command::Respond { when, resp: send },            Command::Respond { when: b_when, resp: b })                           => send == b && when == b_when,
             (Command::StateMachine { command },                Command::StateMachine { command: b })                                 => command == b,
             (Command::CloseReplicationStreams,                 Command::CloseReplicationStreams)                                     => true,

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -277,7 +277,9 @@ mod tests {
         assert_eq!(cmd.name(), CommandName::PurgeLog);
 
         // TruncateLog
-        let cmd: Command<C> = Command::TruncateLog { since: log_id(1, 0, 1) };
+        let cmd: Command<C> = Command::TruncateLog {
+            after: Some(log_id(1, 0, 1)),
+        };
         assert_eq!(cmd.name(), CommandName::TruncateLog);
 
         // Respond - skip as it requires a oneshot sender

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -244,7 +244,9 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::TruncateLog { since: log_id(2, 1, 4) },
+            Command::TruncateLog {
+                after: Some(log_id(2, 1, 3))
+            },
             Command::from(sm::Command::install_full_snapshot(
                 Snapshot {
                     meta: SnapshotMeta {

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -71,7 +71,9 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::TruncateLog { since: log_id(2, 1, 3) },
+            Command::TruncateLog {
+                after: Some(log_id(2, 1, 2))
+            },
         ],
         eng.output.take_commands()
     );
@@ -98,7 +100,9 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
 
     assert_eq!(
-        vec![Command::TruncateLog { since: log_id(4, 1, 4) }],
+        vec![Command::TruncateLog {
+            after: Some(log_id(2, 1, 3))
+        }],
         eng.output.take_commands()
     );
 
@@ -115,7 +119,9 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
     assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(&[log_id(2, 1, 3), log_id(4, 1, 4)], eng.state.log_ids.key_log_ids());
     assert_eq!(
-        vec![Command::TruncateLog { since: log_id(4, 1, 5) }],
+        vec![Command::TruncateLog {
+            after: Some(log_id(4, 1, 4))
+        }],
         eng.output.take_commands()
     );
 
@@ -132,7 +138,9 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
     assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(&[log_id(2, 1, 3), log_id(4, 1, 5)], eng.state.log_ids.key_log_ids());
     assert_eq!(
-        vec![Command::TruncateLog { since: log_id(4, 1, 6) }],
+        vec![Command::TruncateLog {
+            after: Some(log_id(4, 1, 5))
+        }],
         eng.output.take_commands()
     );
 
@@ -184,7 +192,9 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::TruncateLog { since: log_id(4, 1, 4) },
+            Command::TruncateLog {
+                after: Some(log_id(2, 1, 3))
+            },
         ],
         eng.output.take_commands()
     );

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -175,7 +175,9 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::CloseReplicationStreams,
-            Command::TruncateLog { since: log_id(1, 1, 2) },
+            Command::TruncateLog {
+                after: Some(log_id(1, 1, 1))
+            },
         ],
         eng.output.take_commands()
     );
@@ -217,7 +219,9 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::CloseReplicationStreams,
-            Command::TruncateLog { since: log_id(1, 1, 2) },
+            Command::TruncateLog {
+                after: Some(log_id(1, 1, 1))
+            },
             Command::AppendEntries {
                 committed_vote: Vote::new(2, 1).into_committed(),
                 entries: [blank_ent(2, 1, 2)].into()
@@ -317,7 +321,9 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::CloseReplicationStreams,
-            Command::TruncateLog { since: log_id(2, 1, 3) },
+            Command::TruncateLog {
+                after: Some(log_id(1, 1, 2))
+            },
             Command::AppendEntries {
                 committed_vote: Vote::new(2, 1).into_committed(),
                 entries: [Entry::new_membership(log_id(3, 1, 3), m34())].into()


### PR DESCRIPTION

## Changelog

##### feat: implement truncate_after for RaftLogStorage
Implement the new `truncate_after` method that provides clearer semantics
than the deprecated `truncate` method:
- `truncate_after(Some(log_id))` truncates from log_id onwards (inclusive)
- `truncate_after(None)` deletes all logs

The default implementation delegates to the deprecated `truncate` method.

Changes:
- Add `#[since]` attribute to `truncate_after`
- Implement `truncate_after` with proper None handling for deleting all logs
- Update `raft_core.rs` to use `truncate_after` instead of deprecated `truncate`
- Add tests: `delete_logs_after_11`, `delete_logs_after_0`, `delete_logs_after_none`
- Add `#[allow(deprecated)]` to tests using deprecated `truncate`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1644)
<!-- Reviewable:end -->
