### PR TITLE
change: replace `RaftLogStorage::truncate()` with `truncate_after()`

### DIFF
--- a/benchmarks/minimal/src/store.rs
+++ b/benchmarks/minimal/src/store.rs
@@ -233,9 +233,14 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn truncate(&mut self, log_id: LogIdOf<TypeConfig>) -> Result<(), io::Error> {
+    async fn truncate_after(&mut self, last_log_id: Option<LogIdOf<TypeConfig>>) -> Result<(), io::Error> {
+        let start_index = match last_log_id {
+            Some(log_id) => log_id.index() + 1,
+            None => 0,
+        };
+
         let mut log = self.log.write().await;
-        log.split_off(&log_id.index());
+        log.split_off(&start_index);
 
         Ok(())
     }

--- a/examples/raft-kv-memstore-single-threaded/src/store.rs
+++ b/examples/raft-kv-memstore-single-threaded/src/store.rs
@@ -333,11 +333,16 @@ impl RaftLogStorage<TypeConfig> for Rc<LogStore> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn truncate(&mut self, log_id: LogId) -> Result<(), io::Error> {
-        tracing::debug!("delete_log: [{:?}, +oo)", log_id);
+    async fn truncate_after(&mut self, last_log_id: Option<LogId>) -> Result<(), io::Error> {
+        tracing::debug!("truncate_after: ({:?}, +oo)", last_log_id);
+
+        let start_index = match last_log_id {
+            Some(log_id) => log_id.index() + 1,
+            None => 0,
+        };
 
         let mut log = self.log.borrow_mut();
-        let keys = log.range(log_id.index()..).map(|(k, _v)| *k).collect::<Vec<_>>();
+        let keys = log.range(start_index..).map(|(k, _v)| *k).collect::<Vec<_>>();
         for key in keys {
             log.remove(&key);
         }

--- a/examples/rocksstore/src/log_store.rs
+++ b/examples/rocksstore/src/log_store.rs
@@ -187,10 +187,15 @@ where C: RaftTypeConfig
         Ok(())
     }
 
-    async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), io::Error> {
-        tracing::debug!("truncate: [{:?}, +oo)", log_id);
+    async fn truncate_after(&mut self, last_log_id: Option<LogIdOf<C>>) -> Result<(), io::Error> {
+        tracing::debug!("truncate_after: ({:?}, +oo)", last_log_id);
 
-        let from = id_to_bin(log_id.index());
+        let start_index = match last_log_id {
+            Some(log_id) => log_id.index() + 1,
+            None => 0,
+        };
+
+        let from = id_to_bin(start_index);
         let to = id_to_bin(u64::MAX);
         self.db.delete_range_cf(self.cf_logs(), &from, &to).map_err(|e| io::Error::other(e.to_string()))?;
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -2116,14 +2116,14 @@ where
                 self.log_store.purge(upto.clone()).await.sto_write_logs()?;
                 self.engine.state.io_state_mut().update_purged(Some(upto));
             }
-            Command::TruncateLog { since } => {
-                self.log_store.truncate(since.clone()).await.sto_write_logs()?;
+            Command::TruncateLog { after } => {
+                self.log_store.truncate_after(after.clone()).await.sto_write_logs()?;
 
                 // Inform clients waiting for logs to be applied.
                 let leader_id = self.current_leader();
                 let leader_node = self.get_leader_node(leader_id.clone());
 
-                for (log_index, tx) in self.client_responders.drain_from(since.index()) {
+                for (log_index, tx) in self.client_responders.drain_from(after.next_index()) {
                     tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
                         leader_id: leader_id.clone(),
                         leader_node: leader_node.clone(),

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -135,7 +135,7 @@ Follow the links to method documentations to see the details.
 |            |                           | ↳ [`try_get_log_entries()`]  | get a range of logs                   |
 |            | [`get_log_state()`]       | [`LogState`]                 | get first/last log id                 |
 | Write log: | [`append()`]              | ()                           | append logs                           |
-| Write log: | [`truncate()`]            | ()                           | delete logs `[index, +oo)`            |
+| Write log: | [`truncate_after()`]      | ()                           | delete logs `(index, +oo)`            |
 | Write log: | [`purge()`]               | ()                           | purge logs `(-oo, index]`             |
 | Vote:      | [`save_vote()`]           | ()                           | save vote                             |
 
@@ -481,7 +481,7 @@ Additionally, two test scripts for setting up a cluster are available:
 [`RaftLogStorage`]:                     `crate::storage::RaftLogStorage`
 [`RaftLogStorage::LogReader`]:          `crate::storage::RaftLogStorage::LogReader`
 [`append()`]:                           `crate::storage::RaftLogStorage::append`
-[`truncate()`]:                         `crate::storage::RaftLogStorage::truncate`
+[`truncate_after()`]:                   `crate::storage::RaftLogStorage::truncate_after`
 [`purge()`]:                            `crate::storage::RaftLogStorage::purge`
 [`save_vote()`]:                        `crate::storage::RaftLogStorage::save_vote`
 [`get_log_state()`]:                    `crate::storage::RaftLogStorage::get_log_state`

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -138,9 +138,9 @@ where C: RaftTypeConfig
     /// Purge log from the beginning to `upto`, inclusive.
     PurgeLog { upto: LogIdOf<C> },
 
-    /// Delete logs that have conflicted with the leader from a follower/learner since log id
-    /// `since`, inclusive.
-    TruncateLog { since: LogIdOf<C> },
+    /// Delete logs that have conflicted with the leader from a follower/learner after log id
+    /// `after`, exclusive.
+    TruncateLog { after: Option<LogIdOf<C>> },
 
     /// A command sent to state machine worker [`sm::worker::Worker`].
     ///
@@ -211,7 +211,7 @@ where C: RaftTypeConfig
             Command::SaveVote { vote } => write!(f, "SaveVote: {}", vote),
             Command::SendVote { vote_req } => write!(f, "SendVote: {}", vote_req),
             Command::PurgeLog { upto } => write!(f, "PurgeLog: upto: {}", upto),
-            Command::TruncateLog { since } => write!(f, "TruncateLog: since: {}", since),
+            Command::TruncateLog { after } => write!(f, "TruncateLog: since: {}", after.display()),
             Command::StateMachine { command } => write!(f, "StateMachine: command: {}", command),
             Command::Respond { when, resp } => write!(f, "Respond: when: {}, resp: {}", when.display(), resp),
         }
@@ -246,7 +246,7 @@ where
             (Command::SaveVote { vote },                       Command::SaveVote { vote: b })                                        => vote == b,
             (Command::SendVote { vote_req },                   Command::SendVote { vote_req: b }, )                                  => vote_req == b,
             (Command::PurgeLog { upto },                       Command::PurgeLog { upto: b })                                        => upto == b,
-            (Command::TruncateLog { since },                   Command::TruncateLog { since: b }, )                                  => since == b,
+            (Command::TruncateLog { after },                   Command::TruncateLog { after: b }, )                                  => after == b,
             (Command::Respond { when, resp: send },            Command::Respond { when: b_when, resp: b })                           => send == b && when == b_when,
             (Command::StateMachine { command },                Command::StateMachine { command: b })                                 => command == b,
             (Command::CloseReplicationStreams,                 Command::CloseReplicationStreams)                                     => true,

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -277,7 +277,9 @@ mod tests {
         assert_eq!(cmd.name(), CommandName::PurgeLog);
 
         // TruncateLog
-        let cmd: Command<C> = Command::TruncateLog { since: log_id(1, 0, 1) };
+        let cmd: Command<C> = Command::TruncateLog {
+            after: Some(log_id(1, 0, 1)),
+        };
         assert_eq!(cmd.name(), CommandName::TruncateLog);
 
         // Respond - skip as it requires a oneshot sender

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -244,7 +244,9 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::TruncateLog { since: log_id(2, 1, 4) },
+            Command::TruncateLog {
+                after: Some(log_id(2, 1, 3))
+            },
             Command::from(sm::Command::install_full_snapshot(
                 Snapshot {
                     meta: SnapshotMeta {

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -71,7 +71,9 @@ fn test_truncate_logs_since_3() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::TruncateLog { since: log_id(2, 1, 3) },
+            Command::TruncateLog {
+                after: Some(log_id(2, 1, 2))
+            },
         ],
         eng.output.take_commands()
     );
@@ -98,7 +100,9 @@ fn test_truncate_logs_since_4() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
 
     assert_eq!(
-        vec![Command::TruncateLog { since: log_id(4, 1, 4) }],
+        vec![Command::TruncateLog {
+            after: Some(log_id(2, 1, 3))
+        }],
         eng.output.take_commands()
     );
 
@@ -115,7 +119,9 @@ fn test_truncate_logs_since_5() -> anyhow::Result<()> {
     assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(&[log_id(2, 1, 3), log_id(4, 1, 4)], eng.state.log_ids.key_log_ids());
     assert_eq!(
-        vec![Command::TruncateLog { since: log_id(4, 1, 5) }],
+        vec![Command::TruncateLog {
+            after: Some(log_id(4, 1, 4))
+        }],
         eng.output.take_commands()
     );
 
@@ -132,7 +138,9 @@ fn test_truncate_logs_since_6() -> anyhow::Result<()> {
     assert_eq!(None, eng.state.log_ids.purged());
     assert_eq!(&[log_id(2, 1, 3), log_id(4, 1, 5)], eng.state.log_ids.key_log_ids());
     assert_eq!(
-        vec![Command::TruncateLog { since: log_id(4, 1, 6) }],
+        vec![Command::TruncateLog {
+            after: Some(log_id(4, 1, 5))
+        }],
         eng.output.take_commands()
     );
 
@@ -184,7 +192,9 @@ fn test_truncate_logs_revert_effective_membership() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             //
-            Command::TruncateLog { since: log_id(4, 1, 4) },
+            Command::TruncateLog {
+                after: Some(log_id(2, 1, 3))
+            },
         ],
         eng.output.take_commands()
     );

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -175,7 +175,9 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::CloseReplicationStreams,
-            Command::TruncateLog { since: log_id(1, 1, 2) },
+            Command::TruncateLog {
+                after: Some(log_id(1, 1, 1))
+            },
         ],
         eng.output.take_commands()
     );
@@ -217,7 +219,9 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::CloseReplicationStreams,
-            Command::TruncateLog { since: log_id(1, 1, 2) },
+            Command::TruncateLog {
+                after: Some(log_id(1, 1, 1))
+            },
             Command::AppendEntries {
                 committed_vote: Vote::new(2, 1).into_committed(),
                 entries: [blank_ent(2, 1, 2)].into()
@@ -317,7 +321,9 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
                 vote: Vote::new_committed(2, 1)
             },
             Command::CloseReplicationStreams,
-            Command::TruncateLog { since: log_id(2, 1, 3) },
+            Command::TruncateLog {
+                after: Some(log_id(1, 1, 2))
+            },
             Command::AppendEntries {
                 committed_vote: Vote::new(2, 1).into_committed(),
                 entries: [Entry::new_membership(log_id(3, 1, 3), m34())].into()

--- a/openraft/src/raft_state/io_state/io_id.rs
+++ b/openraft/src/raft_state/io_state/io_id.rs
@@ -20,7 +20,7 @@ use crate::vote::ref_vote::RefVote;
 /// Uniquely identifies a monotonic increasing I/O operation to [`RaftLogStorage`].
 ///
 /// Includes only IOs that make progress: [`save_vote()`] and [`append()`].
-/// Operations like [`purge()`] and [`truncate()`] are excluded as they remove logs.
+/// Operations like [`purge()`] and [`truncate_after()`] are excluded as they remove logs.
 ///
 /// For details on when to use `IOId` vs [`LogIOId`], see: [`IOId`
 /// documentation](crate::docs::data::io_id).
@@ -28,7 +28,7 @@ use crate::vote::ref_vote::RefVote;
 /// [`RaftLogStorage`]: `crate::storage::RaftLogStorage`
 /// [`save_vote()`]: `crate::storage::RaftLogStorage::save_vote()`
 /// [`append()`]: `crate::storage::RaftLogStorage::append()`
-/// [`truncate()`]: `crate::storage::RaftLogStorage::truncate()`
+/// [`truncate_after()`]: `crate::storage::RaftLogStorage::truncate_after()`
 /// [`purge()`]: `crate::storage::RaftLogStorage::purge()`
 /// [`LogIOId`]: crate::raft_state::io_state::log_io_id::LogIOId
 #[derive(Debug, Clone)]

--- a/openraft/src/storage/v2/raft_log_storage.rs
+++ b/openraft/src/storage/v2/raft_log_storage.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 
 use crate::OptionalSend;
 use crate::OptionalSync;
@@ -108,12 +109,15 @@ where C: RaftTypeConfig
         I: IntoIterator<Item = C::Entry> + OptionalSend,
         I::IntoIter: OptionalSend;
 
-    /// Truncate logs since `log_id`, inclusive
+    /// Truncate logs after `last_log_id`, exclusive
     ///
     /// ### To ensure correctness:
     ///
-    /// - It must not leave a **hole** in logs.
-    async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), io::Error>;
+    /// - It must not leave a **hole** in logs: It is OK if the truncation is not done in
+    ///   transaction, but it must not leave a **hole** in logs. In other words, a non-transactional
+    ///   truncation removes log entries from the end backward to this `last_log_id`.
+    #[since(version = "0.10.0")]
+    async fn truncate_after(&mut self, last_log_id: Option<LogIdOf<C>>) -> Result<(), io::Error>;
 
     /// Purge logs up to `log_id`, inclusive
     ///

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -163,8 +163,10 @@ where
         run_test(builder, Self::purge_logs_upto_0).await?;
         run_test(builder, Self::purge_logs_upto_5).await?;
         run_test(builder, Self::purge_logs_upto_20).await?;
-        run_test(builder, Self::delete_logs_since_11).await?;
-        run_test(builder, Self::delete_logs_since_0).await?;
+        run_test(builder, Self::delete_logs_after_11).await?;
+        run_test(builder, Self::delete_logs_after_5).await?;
+        run_test(builder, Self::delete_logs_after_0).await?;
+        run_test(builder, Self::delete_logs_after_none).await?;
         run_test(builder, Self::append_to_log).await?;
         run_test(builder, Self::snapshot_meta).await?;
         run_test(builder, Self::snapshot_meta_optional).await?;
@@ -1409,12 +1411,12 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_11(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
-        tracing::info!("--- delete [11, +oo)");
+    pub async fn delete_logs_after_11(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
+        tracing::info!("--- delete (11, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.truncate(log_id_0(1, 11)).await?;
+        store.truncate_after(Some(log_id_0(1, 11))).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 11);
@@ -1429,12 +1431,54 @@ where
         Ok(())
     }
 
-    pub async fn delete_logs_since_0(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
-        tracing::info!("--- delete [0, +oo)");
+    /// Test truncating in the middle of the log: keep logs 0-5, delete logs 6-10.
+    pub async fn delete_logs_after_5(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
+        tracing::info!("--- delete (5, +oo)");
 
         Self::feed_10_logs_vote_self(&mut store).await?;
 
-        store.truncate(log_id_0(0, 0)).await?;
+        store.truncate_after(Some(log_id_0(1, 5))).await?;
+
+        let logs = store.try_get_log_entries(0..100).await?;
+        assert_eq!(logs.len(), 6); // logs 0-5 remain
+
+        assert_eq!(
+            LogState {
+                last_purged_log_id: None,
+                last_log_id: Some(log_id_0(1, 5)),
+            },
+            store.get_log_state().await?
+        );
+        Ok(())
+    }
+
+    pub async fn delete_logs_after_0(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
+        tracing::info!("--- delete (0, +oo)");
+
+        Self::feed_10_logs_vote_self(&mut store).await?;
+
+        store.truncate_after(Some(log_id_0(0, 0))).await?;
+
+        let logs = store.try_get_log_entries(0..100).await?;
+        assert_eq!(logs.len(), 1); // log at index 0 remains
+
+        assert_eq!(
+            LogState {
+                last_purged_log_id: None,
+                last_log_id: Some(log_id_0(0, 0)),
+            },
+            store.get_log_state().await?
+        );
+
+        Ok(())
+    }
+
+    pub async fn delete_logs_after_none(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
+        tracing::info!("--- delete all logs");
+
+        Self::feed_10_logs_vote_self(&mut store).await?;
+
+        store.truncate_after(None).await?;
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 0);


### PR DESCRIPTION

## Changelog

##### change: replace `RaftLogStorage::truncate()` with `truncate_after()`
Replace the `truncate()` method with `truncate_after()` in the `RaftLogStorage`
trait to provide clearer log truncation semantics. The new method takes
`Option<LogId>` and keeps logs up to and including the given log id.

Changes:
- Replace `truncate()` with `truncate_after()` in `RaftLogStorage` trait
- Update all store implementations to use the new method
- Update internal raft_core to use `truncate_after()`
- Add `delete_logs_after_5` test for mid-log truncation coverage

Upgrade tip:

If you implement `RaftLogStorage`, replace your `truncate()` implementation
with `truncate_after()`. The key semantic difference:

- `truncate(log_id)`: deleted logs from `log_id.index()` onwards (inclusive)
- `truncate_after(last_log_id)`: deletes logs after `last_log_id` (exclusive)

Update your implementation:
```rust
// Before:
async fn truncate(&mut self, log_id: LogId) -> Result<(), io::Error> {
    delete_from(log_id.index()..);
}

// After:
async fn truncate_after(&mut self, last_log_id: Option<LogId>) -> Result<(), io::Error> {
    let start = last_log_id.map(|id| id.index() + 1).unwrap_or(0);
    delete_from(start..);
}
```

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1645)
<!-- Reviewable:end -->
