### PR TITLE
feat: add `to_type()` method to `RaftLogId` for type conversion

### DIFF
--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -142,6 +142,7 @@ where C: RaftTypeConfig<LeaderId = crate::vote::leader_id_std::LeaderId<C>>
 #[cfg(test)]
 mod tests {
     use crate::declare_raft_types;
+    use crate::log_id::raft_log_id::RaftLogId;
     use crate::vote::leader_id_std::CommittedLeaderId;
 
     declare_raft_types!(pub TestConfig: LeaderId=crate::vote::leader_id_std::LeaderId<Self>, Term=u64);
@@ -159,5 +160,20 @@ mod tests {
         let log_id2 = super::LogId::<TestConfig>::new(CommittedLeaderId::<TestConfig>::new(5), 100);
         assert_eq!(log_id1.index(), log_id2.index());
         assert_eq!(**log_id1.committed_leader_id(), **log_id2.committed_leader_id());
+    }
+
+    #[test]
+    fn test_to_type_log_id_to_tuple() {
+        let log_id = super::LogId::<TestConfig>::new_term_index(5, 100);
+        let tuple: (u64, u64) = log_id.to_type();
+        assert_eq!((5, 100), tuple);
+    }
+
+    #[test]
+    fn test_to_type_tuple_to_log_id() {
+        let tuple: (u64, u64) = (5, 100);
+        let log_id: super::LogId<TestConfig> = tuple.to_type();
+        assert_eq!(100, log_id.index());
+        assert_eq!(5, **log_id.committed_leader_id());
     }
 }

--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -26,6 +26,12 @@ where
 
     /// Returns the index of the log id.
     fn index(&self) -> u64;
+
+    /// Converts this log ID into another type that implements [`RaftLogId`].
+    fn to_type<T>(&self) -> T
+    where T: RaftLogId<C> {
+        T::new(self.committed_leader_id().clone(), self.index())
+    }
 }
 
 impl<C, T> RaftLogId<C> for &T


### PR DESCRIPTION

## Changelog

##### feat: add `to_type()` method to `RaftLogId` for type conversion
Adds a generic conversion method that allows converting any `RaftLogId`
implementation to another type that also implements `RaftLogId`.

Changes:
- Add `to_type<T>()` default method to `RaftLogId` trait
- Add tests for bidirectional conversion between `LogId` and tuple types

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1646)
<!-- Reviewable:end -->
