### PR TITLE
feat: add `log_id_parts()` method to `RaftLogId` trait

### DIFF
--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -176,4 +176,12 @@ mod tests {
         assert_eq!(100, log_id.index());
         assert_eq!(5, **log_id.committed_leader_id());
     }
+
+    #[test]
+    fn test_log_id_parts() {
+        let log_id = super::LogId::<TestConfig>::new_term_index(5, 100);
+        let (leader_id, index) = log_id.log_id_parts();
+        assert_eq!(5, **leader_id);
+        assert_eq!(100, index);
+    }
 }

--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -32,6 +32,11 @@ where
     where T: RaftLogId<C> {
         T::new(self.committed_leader_id().clone(), self.index())
     }
+
+    /// Returns the parts of this log ID as a tuple of (committed_leader_id, index).
+    fn log_id_parts(&self) -> (&CommittedLeaderIdOf<C>, u64) {
+        (self.committed_leader_id(), self.index())
+    }
 }
 
 impl<C, T> RaftLogId<C> for &T


### PR DESCRIPTION

## Changelog

##### feat: add `log_id_parts()` method to `RaftLogId` trait
Adds a convenience method that returns both the committed_leader_id and
index as a tuple, useful for destructuring in pattern matching.

Changes:
- Add `log_id_parts()` default method to `RaftLogId` trait
- Add unit test for `log_id_parts()`

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1647)
<!-- Reviewable:end -->
