### PR TITLE
feat: add `Raft::write_blank()` method to write blank log entries

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1518,7 +1518,7 @@ where
                 self.handle_ensure_linearizable_read(read_policy, tx).await;
             }
             RaftMsg::ClientWrite {
-                app_data,
+                payloads,
                 responders,
                 expected_leader,
             } => {
@@ -1538,8 +1538,7 @@ where
                         return;
                     }
                 }
-                self.runtime_stats.write_batch.record(app_data.len() as u64);
-                let payloads = app_data.into_iter().map(EntryPayload::Normal);
+                self.runtime_stats.write_batch.record(payloads.len() as u64);
                 self.write_entries(payloads, responders);
             }
             RaftMsg::Initialize { members, tx } => {

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -10,6 +10,7 @@ use crate::base::Batch;
 use crate::base::BoxOnce;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::display_ext::DisplayBTreeMapDebugValueExt;
+use crate::entry::EntryPayload;
 use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::error::LinearizableReadError;
@@ -80,7 +81,7 @@ where C: RaftTypeConfig
     },
 
     ClientWrite {
-        app_data: Batch<C::D>,
+        payloads: Batch<EntryPayload<C>>,
         responders: Batch<Option<CoreResponder<C>>>,
         expected_leader: Option<CommittedLeaderIdOf<C>>,
     },

--- a/openraft/src/raft/message/write_request.rs
+++ b/openraft/src/raft/message/write_request.rs
@@ -6,6 +6,7 @@ use crate::RaftTypeConfig;
 use crate::base::Batch;
 use crate::base::BoxFuture;
 use crate::core::raft_msg::RaftMsg;
+use crate::entry::EntryPayload;
 use crate::error::Fatal;
 use crate::raft::raft_inner::RaftInner;
 use crate::raft::responder::core_responder::CoreResponder;
@@ -137,7 +138,7 @@ where C: RaftTypeConfig
         Box::pin(async move {
             self.inner
                 .send_msg(RaftMsg::ClientWrite {
-                    app_data: Batch::from(self.app_data),
+                    payloads: Batch::from(EntryPayload::Normal(self.app_data)),
                     responders: Batch::from(self.responder),
                     expected_leader: self.expected_leader,
                 })


### PR DESCRIPTION

## Changelog

##### feat: add `Raft::write_blank()` method to write blank log entries
Adds a public method allowing clients to write `EntryPayload::Blank` directly.
Blank entries are useful to commit entries from previous terms, advance the
commit index, or act as a barrier.

Changes:
- Add `Raft::write_blank()` public method
- Add integration test for `write_blank()`
- Rename internal `app_data: Batch<C::D>` to `payloads: Batch<EntryPayload<C>>` in `RaftMsg::ClientWrite`
- Update internal `AppApi` methods to accept `EntryPayload<C>` directly
- Update tests to use the new field name

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1648)
<!-- Reviewable:end -->
