### PR TITLE
test: add truncate before append in log test to prevent conflict

### DIFF
--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -674,6 +674,9 @@ where
 
         tracing::info!("--- log terms: [0,1,1,2], last_purged_log_id is None, expect [(0,0),(1,1),(2,3)]");
         {
+            // truncate for new append, otherwise there may be conflict error, due to impl of the store.
+            store.truncate_after(Some(log_id(0, 0, 0))).await?;
+
             append(&mut store, [
                 blank_ent_0::<C>(1, 1),
                 blank_ent_0::<C>(1, 2),


### PR DESCRIPTION

## Changelog

##### test: add truncate before append in log test to prevent conflict
Add `truncate_after()` call before appending entries in the log terms
test to avoid conflict errors that may occur due to store implementation.

Changes:
- Add `truncate_after()` before `append()` in log terms test case

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1649)
<!-- Reviewable:end -->
