### PR TITLE
chore: upgrade base2histogram from 0.1.1 to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ itertools          = { version = "0.14" }
 futures            = { version = "0.3" }
 futures-channel    = { version = "0.3" }
 futures-util       = { version = "0.3" }
-base2histogram     = { version = "0.1.1" }
+base2histogram     = { version = "0.2.2" }
 lazy_static        = { version = "1.4.0" }
 maplit             = { version = "1.0.2" }
 peel-off           = { version = "0.1.0" }


### PR DESCRIPTION

## Changelog

##### chore: upgrade base2histogram from 0.1.1 to 0.2.2
0.2.2 brings trapezoidal percentile interpolation for more accurate
statistics, runtime-configured log scale width (replacing const
generics), and new bucket inspection APIs. The openraft usage only
touches the stable high-level API (`Histogram::new`, `record`,
`percentile_stats`, `PercentileStats` fields), so no source changes
are needed.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1707)
<!-- Reviewable:end -->
