### PR TITLE
chore: upgrade base2histogram from 0.1.1 to 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ itertools          = { version = "0.14" }
 futures            = { version = "0.3" }
 futures-channel    = { version = "0.3" }
 futures-util       = { version = "0.3" }
-base2histogram     = { version = "0.1.1" }
+base2histogram     = { version = "0.2.3" }
 lazy_static        = { version = "1.4.0" }
 maplit             = { version = "1.0.2" }
 peel-off           = { version = "0.1.0" }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1888,6 +1888,12 @@ where
         }
 
         if self.engine.state.membership_state.effective().voter_ids().count() == 1 {
+            // When a node restart, it may stay in any state but the in progress election(engine.candidate) is
+            // empty.
+            if self.engine.candidate_ref().is_some() {
+                tracing::debug!("skip election, single voter already has an active election in progress");
+                return;
+            }
             tracing::debug!("single voter, elect immediately");
         } else {
             tracing::debug!("multiple voters, check election timeout");


### PR DESCRIPTION

## Changelog

##### chore: upgrade base2histogram from 0.1.1 to 0.2.3
0.2.3 brings trapezoidal percentile interpolation for more accurate
statistics, runtime-configured log scale width (replacing const
generics), and new bucket inspection APIs. The openraft usage only
touches the stable high-level API (`Histogram::new`, `record`,
`percentile_stats`, `PercentileStats` fields), so no source changes
are needed.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1708)
<!-- Reviewable:end -->
