### PR TITLE
feat: include log stage latency percentiles in RuntimeStatsDisplay

### DIFF
--- a/openraft/src/core/runtime_stats/display_mode.rs
+++ b/openraft/src/core/runtime_stats/display_mode.rs
@@ -1,7 +1,4 @@
-#[cfg(doc)]
-use crate::core::runtime_stats::RuntimeStatsDisplay;
-
-/// Display mode for [`RuntimeStatsDisplay`].
+/// Display mode for [`RuntimeStatsDisplay`](super::RuntimeStatsDisplay).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DisplayMode {
     /// Compact single-line format (default).

--- a/openraft/src/core/runtime_stats/log_stage/histograms.rs
+++ b/openraft/src/core/runtime_stats/log_stage/histograms.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use base2histogram::Histogram;
+use base2histogram::PercentileStats;
 
 /// Stage-to-stage duration histograms in microseconds.
 ///
@@ -27,6 +28,19 @@ impl LogStageHistograms {
             committed_to_applied: Histogram::new(),
             proposed_to_applied: Histogram::new(),
         }
+    }
+}
+
+impl LogStageHistograms {
+    pub(crate) fn percentile_stats_array(&self) -> [(&'static str, PercentileStats); 6] {
+        [
+            ("1:proposed→received", self.proposed_to_received.percentile_stats()),
+            ("2:received→submitted", self.received_to_submitted.percentile_stats()),
+            ("3:submitted→persisted", self.submitted_to_persisted.percentile_stats()),
+            ("4:persisted→committed", self.persisted_to_committed.percentile_stats()),
+            ("5:committed→applied", self.committed_to_applied.percentile_stats()),
+            ("1~5:proposed→applied", self.proposed_to_applied.percentile_stats()),
+        ]
     }
 }
 

--- a/openraft/src/core/runtime_stats/log_stage/histograms.rs
+++ b/openraft/src/core/runtime_stats/log_stage/histograms.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use base2histogram::AsciiChart;
 use base2histogram::Histogram;
 use base2histogram::PercentileStats;
 
@@ -41,6 +42,17 @@ impl LogStageHistograms {
             ("5:committed→applied", self.committed_to_applied.percentile_stats()),
             ("1~5:proposed→applied", self.proposed_to_applied.percentile_stats()),
         ]
+    }
+
+    /// Build a stacked ASCII chart of all stage-to-stage latency histograms.
+    #[allow(dead_code)]
+    pub(crate) fn ascii_chart(&self) -> AsciiChart {
+        AsciiChart::new()
+            .add("1:proposed→received", self.proposed_to_received.clone())
+            .add("2:received→submitted", self.received_to_submitted.clone())
+            .add("3:submitted→persisted", self.submitted_to_persisted.clone())
+            .add("4:persisted→committed", self.persisted_to_committed.clone())
+            .add("5:committed→applied", self.committed_to_applied.clone())
     }
 }
 

--- a/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
+++ b/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
@@ -30,49 +30,14 @@ impl<I> fmt::Display for LogStages<I>
 where I: Instant
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut prev_proposed = None;
-
-        for (i, seg) in self.segments().enumerate() {
-            if i > 0 {
+        let mut first = true;
+        for line in self.display_lines() {
+            if !first {
                 writeln!(f)?;
             }
-
-            let proposed = seg.values[Stage::Proposed.index()];
-            let delta = prev_proposed.map(|prev| proposed.saturating_duration_since(prev)).unwrap_or_default();
-            let stages = [
-                ("proposed", seg.values[Stage::Proposed.index()]),
-                ("received", seg.values[Stage::Received.index()]),
-                ("submitted", seg.values[Stage::Submitted.index()]),
-                ("persisted", seg.values[Stage::Persisted.index()]),
-                ("committed", seg.values[Stage::Committed.index()]),
-                ("applied", seg.values[Stage::Applied.index()]),
-            ];
-
-            write!(
-                f,
-                "[{},{}): {} +{:.2?}; ",
-                seg.range.start,
-                seg.range.end,
-                proposed.display(),
-                delta,
-            )?;
-
-            let mut prev = proposed;
-            let mut cumulative = Duration::default();
-            for (j, (name, at)) in stages.into_iter().enumerate() {
-                if j > 0 {
-                    write!(f, ", ")?;
-                }
-
-                let step = at.saturating_duration_since(prev);
-                cumulative += step;
-                write!(f, "{} +{:.2?} ({:.2?})", name, step, cumulative)?;
-                prev = at;
-            }
-
-            prev_proposed = Some(proposed);
+            write!(f, "{}", line)?;
+            first = false;
         }
-
         Ok(())
     }
 }
@@ -122,6 +87,57 @@ where I: Instant
     /// Iterate segments within the intersection range where all stages have data.
     pub fn segments(&self) -> SegmentIter<'_, u64, I, { Stage::COUNT }> {
         self.inner.segments(self.begin)
+    }
+
+    /// Returns an iterator of formatted lines, one per segment.
+    ///
+    /// Each line shows the log index range, the proposed timestamp, the
+    /// inter-batch gap, and per-stage step/cumulative durations.
+    pub fn display_lines(&self) -> impl Iterator<Item = String> + '_ {
+        use std::fmt::Write;
+
+        let mut prev_proposed: Option<I> = None;
+
+        self.segments().map(move |seg| {
+            let proposed = seg.values[Stage::Proposed.index()];
+            let delta = prev_proposed.map(|p| proposed.saturating_duration_since(p)).unwrap_or_default();
+
+            let mut line = String::new();
+            write!(
+                line,
+                "[{},{}): {} +{:.2?}; ",
+                seg.range.start,
+                seg.range.end,
+                proposed.display(),
+                delta
+            )
+            .unwrap();
+
+            let mut prev = proposed;
+            let mut cumulative = Duration::default();
+            for (j, (name, at)) in [
+                ("proposed", seg.values[Stage::Proposed.index()]),
+                ("received", seg.values[Stage::Received.index()]),
+                ("submitted", seg.values[Stage::Submitted.index()]),
+                ("persisted", seg.values[Stage::Persisted.index()]),
+                ("committed", seg.values[Stage::Committed.index()]),
+                ("applied", seg.values[Stage::Applied.index()]),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                if j > 0 {
+                    write!(line, ", ").unwrap();
+                }
+                let step = at.saturating_duration_since(prev);
+                cumulative += step;
+                write!(line, "{} +{:.2?} ({:.2?})", name, step, cumulative).unwrap();
+                prev = at;
+            }
+
+            prev_proposed = Some(proposed);
+            line
+        })
     }
 
     /// Compute stage-to-stage duration histograms from all segments.

--- a/openraft/src/core/runtime_stats/runtime_stats.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats.rs
@@ -214,6 +214,7 @@ where C: RaftTypeConfig
             command_counts: self.command_counts.clone(),
             raft_msg_counts: self.raft_msg_counts.clone(),
             notification_counts: self.notification_counts.clone(),
+            log_stage_percentiles: self.log_stage_histograms.percentile_stats_array(),
         }
     }
 }

--- a/openraft/src/core/runtime_stats/runtime_stats.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats.rs
@@ -199,7 +199,7 @@ where C: RaftTypeConfig
     ///
     /// Use builder methods like `.human_readable()` to change the display mode.
     #[allow(dead_code)]
-    pub fn display(&self) -> RuntimeStatsDisplay {
+    pub fn display(&self) -> RuntimeStatsDisplay<C> {
         RuntimeStatsDisplay {
             mode: DisplayMode::default(),
             apply_batch: self.apply_batch.percentile_stats(),
@@ -215,6 +215,8 @@ where C: RaftTypeConfig
             raft_msg_counts: self.raft_msg_counts.clone(),
             notification_counts: self.notification_counts.clone(),
             log_stage_percentiles: self.log_stage_histograms.percentile_stats_array(),
+            log_stage_histograms: self.log_stage_histograms.clone(),
+            log_stages: self.log_stage.clone(),
         }
     }
 }

--- a/openraft/src/core/runtime_stats/runtime_stats_display.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats_display.rs
@@ -10,19 +10,23 @@ use tabled::settings::Style;
 #[cfg(feature = "runtime-stats")]
 use tabled::settings::object::Columns;
 
+use crate::RaftTypeConfig;
 use crate::core::NotificationName;
 use crate::core::raft_msg::RaftMsgName;
-#[cfg(doc)]
-use crate::core::runtime_stats::RuntimeStats;
 use crate::core::runtime_stats::display_mode::DisplayMode;
+use crate::core::runtime_stats::log_stage::LogStageHistograms;
+use crate::core::runtime_stats::log_stage::LogStages;
 use crate::engine::CommandName;
+use crate::type_config::alias::InstantOf;
 
 /// Precomputed display data for [`RuntimeStats`].
 ///
 /// All values are computed upfront so `Display::fmt()` is cheap.
 /// Use [`DisplayMode`] to control the output format.
 #[allow(dead_code)]
-pub struct RuntimeStatsDisplay {
+pub struct RuntimeStatsDisplay<C>
+where C: RaftTypeConfig
+{
     pub(crate) mode: DisplayMode,
     pub(crate) apply_batch: PercentileStats,
     pub(crate) append_batch: PercentileStats,
@@ -37,10 +41,14 @@ pub struct RuntimeStatsDisplay {
     pub(crate) raft_msg_counts: Vec<u64>,
     pub(crate) notification_counts: Vec<u64>,
     pub(crate) log_stage_percentiles: [(&'static str, PercentileStats); 6],
+    pub(crate) log_stage_histograms: LogStageHistograms,
+    pub(crate) log_stages: LogStages<InstantOf<C>>,
 }
 
 #[allow(dead_code)]
-impl RuntimeStatsDisplay {
+impl<C> RuntimeStatsDisplay<C>
+where C: RaftTypeConfig
+{
     /// Set the display mode.
     pub fn mode(mut self, mode: DisplayMode) -> Self {
         self.mode = mode;
@@ -63,7 +71,9 @@ impl RuntimeStatsDisplay {
     }
 }
 
-impl fmt::Display for RuntimeStatsDisplay {
+impl<C> fmt::Display for RuntimeStatsDisplay<C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.mode {
             DisplayMode::Compact => self.fmt_compact(f),
@@ -73,7 +83,9 @@ impl fmt::Display for RuntimeStatsDisplay {
     }
 }
 
-impl RuntimeStatsDisplay {
+impl<C> RuntimeStatsDisplay<C>
+where C: RaftTypeConfig
+{
     fn fmt_compact(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -189,6 +201,14 @@ impl RuntimeStatsDisplay {
                     "    {:>22}: n={} p50={} p90={} p99={} p99.9={}",
                     name, stats.samples, stats.p50, stats.p90, stats.p99, stats.p99_9,
                 )?;
+            }
+        }
+
+        let mut lines = self.log_stages.display_lines().peekable();
+        if lines.peek().is_some() {
+            writeln!(f, "  log_stage_segments:")?;
+            for line in lines {
+                writeln!(f, "    {}", line)?;
             }
         }
 
@@ -344,7 +364,11 @@ impl RuntimeStatsDisplay {
             table.with(Style::rounded());
             table.with(Alignment::right());
             table.modify(Columns::first(), Alignment::left());
-            write!(f, "{}", table)?;
+            writeln!(f, "{}", table)?;
+
+            let chart = self.log_stage_histograms.ascii_chart();
+            writeln!(f, "Log Stage Latency Distribution (us):")?;
+            write!(f, "{}", chart.detailed())?;
         }
 
         Ok(())
@@ -386,5 +410,323 @@ impl RuntimeStatsDisplay {
             result.push(c);
         }
         result.chars().rev().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base2histogram::PercentileStats;
+
+    use super::*;
+    use crate::engine::testing::UTConfig;
+
+    type C = UTConfig<()>;
+
+    const EMPTY_STATS: PercentileStats = PercentileStats {
+        samples: 0,
+        p0_1: 0,
+        p1: 0,
+        p5: 0,
+        p10: 0,
+        p50: 0,
+        p90: 0,
+        p99: 0,
+        p99_9: 0,
+    };
+
+    fn sample_stats(samples: u64, p50: u64, p99: u64) -> PercentileStats {
+        PercentileStats {
+            samples,
+            p0_1: 1,
+            p1: 2,
+            p5: 5,
+            p10: 10,
+            p50,
+            p90: p99 - 1,
+            p99,
+            p99_9: p99 + 1,
+        }
+    }
+
+    fn make_display(
+        apply_batch: PercentileStats,
+        command_counts: Vec<u64>,
+        log_stage: [(&'static str, PercentileStats); 6],
+    ) -> RuntimeStatsDisplay<C> {
+        RuntimeStatsDisplay {
+            mode: DisplayMode::default(),
+            apply_batch,
+            append_batch: EMPTY_STATS,
+            replicate_batch: EMPTY_STATS,
+            raft_msg_per_run: EMPTY_STATS,
+            write_batch: EMPTY_STATS,
+            raft_msg_budget: EMPTY_STATS,
+            notification_budget: EMPTY_STATS,
+            raft_msg_usage_permille: EMPTY_STATS,
+            notification_usage_permille: EMPTY_STATS,
+            command_counts,
+            raft_msg_counts: vec![0; RaftMsgName::COUNT],
+            notification_counts: vec![0; NotificationName::COUNT],
+            log_stage_percentiles: log_stage,
+            log_stage_histograms: LogStageHistograms::new(),
+            log_stages: LogStages::new(1, 0),
+        }
+    }
+
+    fn empty_log_stages() -> [(&'static str, PercentileStats); 6] {
+        [
+            ("1:proposed→received", EMPTY_STATS),
+            ("2:received→submitted", EMPTY_STATS),
+            ("3:submitted→persisted", EMPTY_STATS),
+            ("4:persisted→committed", EMPTY_STATS),
+            ("5:committed→applied", EMPTY_STATS),
+            ("1~5:proposed→applied", EMPTY_STATS),
+        ]
+    }
+
+    #[test]
+    fn test_compact_empty() {
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        let s = format!("{}", d.compact());
+
+        assert!(s.starts_with("RuntimeStats {"));
+        assert!(s.ends_with("} }"));
+        assert!(s.contains("commands: {}"));
+        assert!(s.contains("log_stages(us): {}"));
+    }
+
+    #[test]
+    fn test_compact_with_data() {
+        let mut cmds = vec![0u64; CommandName::COUNT];
+        cmds[0] = 42;
+
+        let mut stages = empty_log_stages();
+        stages[0].1 = sample_stats(10, 100, 500);
+
+        let d = make_display(sample_stats(5, 50, 200), cmds, stages);
+        let s = format!("{}", d.compact());
+        println!("{s}");
+
+        assert!(s.contains("apply_batch: [samples: 5"));
+        assert!(s.contains("1:proposed→received: [samples: 10"));
+    }
+
+    #[test]
+    fn test_multiline_empty() {
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        let s = format!("{}", d.multiline());
+
+        assert!(s.contains("RuntimeStats:"));
+        assert!(s.contains("apply_batch:"));
+        assert!(s.contains("log_stages(us):"));
+        // No log stage entries when all empty
+        assert!(!s.contains("proposed→received"));
+    }
+
+    #[test]
+    fn test_multiline_with_log_stages() {
+        let mut stages = empty_log_stages();
+        stages[0].1 = sample_stats(100, 50, 200);
+        stages[5].1 = sample_stats(100, 120, 800);
+
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], stages);
+        let s = format!("{}", d.multiline());
+
+        println!("{s}");
+
+        assert!(s.contains("1:proposed→received"));
+        assert!(s.contains("n=100"));
+        assert!(s.contains("p50=50"));
+        assert!(s.contains("p99=200"));
+        assert!(s.contains("1~5:proposed→applied"));
+        assert!(s.contains("p50=120"));
+        // Stages with 0 samples are omitted
+        assert!(!s.contains("2:received→submitted"));
+    }
+
+    #[test]
+    fn test_multiline_with_log_stage_segments() {
+        use std::time::Duration;
+
+        use crate::type_config::TypeConfigExt;
+
+        // Build 3 batches of log entries with realistic stage timestamps:
+        //   batch 1: log [0,10), proposed at t=0ms
+        //   batch 2: log [10,20), proposed at t=5ms
+        //   batch 3: log [20,30), proposed at t=12ms
+        let base = C::now();
+        let t = |ms: u64| -> InstantOf<C> { base + Duration::from_millis(ms) };
+
+        let mut log_stages = LogStages::<InstantOf<C>>::new(10, 0);
+
+        // Batch 1: fast path — small queue delay, quick persist/commit/apply
+        log_stages.proposed(10, t(0));
+        log_stages.received(10, t(1));
+        log_stages.submitted(10, t(1));
+        log_stages.persisted(10, t(3));
+        log_stages.committed(10, t(4));
+        log_stages.applied(10, t(5));
+
+        // Batch 2: moderate — slightly slower persist and replication
+        log_stages.proposed(20, t(5));
+        log_stages.received(20, t(6));
+        log_stages.submitted(20, t(7));
+        log_stages.persisted(20, t(10));
+        log_stages.committed(20, t(12));
+        log_stages.applied(20, t(13));
+
+        // Batch 3: slow — storage stall causes higher latency
+        log_stages.proposed(30, t(12));
+        log_stages.received(30, t(13));
+        log_stages.submitted(30, t(14));
+        log_stages.persisted(30, t(22));
+        log_stages.committed(30, t(25));
+        log_stages.applied(30, t(28));
+
+        let mut d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        d.log_stages = log_stages;
+
+        let s = format!("{}", d.multiline());
+        println!("{s}");
+
+        assert!(s.contains("log_stage_segments:"));
+        // 3 segments
+        assert!(s.contains("[0,10):"));
+        assert!(s.contains("[10,20):"));
+        assert!(s.contains("[20,30):"));
+        // Stage names and durations present
+        assert!(s.contains("proposed +"));
+        assert!(s.contains("persisted +"));
+        assert!(s.contains("applied +"));
+    }
+
+    #[test]
+    fn test_multiline_no_segments_when_empty() {
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        let s = format!("{}", d.multiline());
+
+        assert!(!s.contains("log_stage_segments:"));
+    }
+
+    #[test]
+    fn test_multiline_with_counts() {
+        let mut cmds = vec![0u64; CommandName::COUNT];
+        cmds[0] = 7;
+
+        let d = make_display(EMPTY_STATS, cmds, empty_log_stages());
+        let s = format!("{}", d.multiline());
+
+        assert!(s.contains("commands:"));
+        assert!(s.contains(": 7"));
+    }
+
+    #[cfg(feature = "runtime-stats")]
+    #[test]
+    fn test_mode_builder() {
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        let compact = format!("{}", d.compact());
+
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        let multiline = format!("{}", d.multiline());
+
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        let human = format!("{}", d.human_readable());
+
+        assert!(compact.starts_with("RuntimeStats {"));
+        assert!(multiline.starts_with("RuntimeStats:"));
+        assert!(human.contains("Batch Sizes:"));
+        assert_ne!(compact, multiline);
+        assert_ne!(multiline, human);
+    }
+
+    #[cfg(feature = "runtime-stats")]
+    #[test]
+    fn test_human_readable_empty() {
+        let d = make_display(EMPTY_STATS, vec![0; CommandName::COUNT], empty_log_stages());
+        let s = format!("{}", d.human_readable());
+
+        assert!(s.contains("Batch Sizes:"));
+        assert!(s.contains("Budget & Utilization:"));
+        // No command/message/notification/log-stage tables when all counts are zero
+        assert!(!s.contains("Commands:"));
+        assert!(!s.contains("Raft Messages:"));
+        assert!(!s.contains("Notifications:"));
+        assert!(!s.contains("Log Stage Latencies"));
+    }
+
+    #[cfg(feature = "runtime-stats")]
+    #[test]
+    fn test_human_readable_with_data() {
+        let mut cmds = vec![0u64; CommandName::COUNT];
+        cmds[0] = 1_234;
+
+        let mut msgs = vec![0u64; RaftMsgName::COUNT];
+        msgs[0] = 56;
+
+        let mut stages = empty_log_stages();
+        stages[0].1 = sample_stats(100, 50, 200);
+        stages[5].1 = sample_stats(100, 120, 800);
+
+        // Build histograms where each stage follows a log-normal distribution
+        // (Gaussian on the log scale) with a different center.
+        // 7 geometrically-spaced bucket values; each stage peaks at a
+        // different position and tapers symmetrically on the log axis.
+        //
+        // values(us):            8   20   50  120  300  700 1500
+        // 1:proposed→received   20   12    5    2    1    1    1  (peak@8)
+        // 2:received→submitted   8   20   12    5    2    1    1  (peak@20)
+        // 5:committed→applied    1    2    8   20   12    5    1  (peak@120)
+        // 4:persisted→committed  1    1    2    8   20   12    5  (peak@300)
+        // 3:submitted→persisted  1    1    1    2    8   20   12  (peak@700)
+        let mut hist = LogStageHistograms::new();
+        let values: [u64; 7] = [8, 20, 50, 120, 300, 700, 1500];
+        let counts: [&[u64; 7]; 5] = [
+            &[20, 12, 5, 2, 1, 1, 1],
+            &[8, 20, 12, 5, 2, 1, 1],
+            &[1, 1, 1, 2, 8, 20, 12],
+            &[1, 1, 2, 8, 20, 12, 5],
+            &[1, 2, 8, 20, 12, 5, 1],
+        ];
+        let fields = [
+            &mut hist.proposed_to_received,
+            &mut hist.received_to_submitted,
+            &mut hist.submitted_to_persisted,
+            &mut hist.persisted_to_committed,
+            &mut hist.committed_to_applied,
+        ];
+        for (field, stage_counts) in fields.into_iter().zip(counts) {
+            for (&v, &n) in values.iter().zip(stage_counts) {
+                field.record_n(v, n);
+            }
+        }
+        for (i, &v) in values.iter().enumerate() {
+            let total: u64 = counts.iter().map(|c| c[i]).sum();
+            hist.proposed_to_applied.record_n(v, total);
+        }
+
+        let mut d = make_display(sample_stats(10, 30, 150), cmds, stages);
+        d.raft_msg_counts = msgs;
+        d.log_stage_histograms = hist;
+        let s = format!("{}", d.human_readable());
+        println!("{s}");
+
+        // Batch sizes table
+        assert!(s.contains("Batch Sizes:"));
+        assert!(s.contains("Apply"));
+
+        // Counts tables
+        assert!(s.contains("Commands:"));
+        assert!(s.contains("1,234"));
+        assert!(s.contains("Raft Messages:"));
+
+        // Log stage percentile table
+        assert!(s.contains("Log Stage Latencies (us):"));
+        assert!(s.contains("1:proposed→received"));
+        assert!(s.contains("1~5:proposed→applied"));
+        // ASCII chart
+        assert!(s.contains("Log Stage Latency Distribution (us):"));
+        assert!(s.contains("1:proposed→received"));
+        // Chart contains bar characters
+        assert!(s.contains('█'));
     }
 }

--- a/openraft/src/core/runtime_stats/runtime_stats_display.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats_display.rs
@@ -36,6 +36,7 @@ pub struct RuntimeStatsDisplay {
     pub(crate) command_counts: Vec<u64>,
     pub(crate) raft_msg_counts: Vec<u64>,
     pub(crate) notification_counts: Vec<u64>,
+    pub(crate) log_stage_percentiles: [(&'static str, PercentileStats); 6],
 }
 
 #[allow(dead_code)]
@@ -128,6 +129,19 @@ impl RuntimeStatsDisplay {
             }
         }
 
+        write!(f, "}}, log_stages(us): {{")?;
+
+        let mut first = true;
+        for (name, stats) in &self.log_stage_percentiles {
+            if stats.samples > 0 {
+                if !first {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}: {}", name, stats)?;
+                first = false;
+            }
+        }
+
         write!(f, "}} }}")
     }
 
@@ -164,6 +178,17 @@ impl RuntimeStatsDisplay {
             let count = self.notification_counts[i];
             if count > 0 {
                 writeln!(f, "    {}: {}", name, count)?;
+            }
+        }
+
+        writeln!(f, "  log_stages(us):")?;
+        for (name, stats) in &self.log_stage_percentiles {
+            if stats.samples > 0 {
+                writeln!(
+                    f,
+                    "    {:>22}: n={} p50={} p90={} p99={} p99.9={}",
+                    name, stats.samples, stats.p50, stats.p90, stats.p99, stats.p99_9,
+                )?;
             }
         }
 
@@ -291,6 +316,34 @@ impl RuntimeStatsDisplay {
             let mut table = builder.build();
             table.with(Style::rounded());
             table.modify(Columns::last(), Alignment::right());
+            writeln!(f, "{}", table)?;
+        }
+
+        // Log stage latencies table (microseconds)
+        let mut builder = Builder::default();
+        builder.push_record(["", "#Samples", "P0.1", "P1", "P5", "P10", "P50", "P90", "P99", "P99.9"]);
+        for (name, stats) in &self.log_stage_percentiles {
+            if stats.samples > 0 {
+                builder.push_record([
+                    name.to_string(),
+                    Self::format_count(stats.samples),
+                    stats.p0_1.to_string(),
+                    stats.p1.to_string(),
+                    stats.p5.to_string(),
+                    stats.p10.to_string(),
+                    stats.p50.to_string(),
+                    stats.p90.to_string(),
+                    stats.p99.to_string(),
+                    stats.p99_9.to_string(),
+                ]);
+            }
+        }
+        if builder.count_records() > 1 {
+            writeln!(f, "Log Stage Latencies (us):")?;
+            let mut table = builder.build();
+            table.with(Style::rounded());
+            table.with(Alignment::right());
+            table.modify(Columns::first(), Alignment::left());
             write!(f, "{}", table)?;
         }
 

--- a/tests/tests/metrics/t60_runtime_stats.rs
+++ b/tests/tests/metrics/t60_runtime_stats.rs
@@ -127,5 +127,7 @@ async fn runtime_stats_log_stage_counts_batched_entries_per_entry() -> Result<()
     assert_eq!(after[4], log_stage_histograms.committed_to_applied.total());
     assert_eq!(after[5], log_stage_histograms.proposed_to_applied.total());
 
+    println!("{}", runtime_stats.display());
+
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### feat: include log stage latency percentiles in RuntimeStatsDisplay
Log stage histograms (proposed→received, received→submitted, etc.)
track per-entry latencies in microseconds across 6 lifecycle phases.
Previously these were only available via `LogStageHistograms::Display`
but not included in `RuntimeStatsDisplay`. Now all three display modes
(compact, multiline, human-readable) render log stage percentiles
when samples are present.

Changes:
- Add `percentile_stats_array()` on `LogStageHistograms`, returning
  a fixed `[_; 6]` array to avoid allocation
- Phase names are indexed (`1:proposed→received` .. `5:committed→applied`,
  `1~5:proposed→applied`) to indicate pipeline order

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1709)
<!-- Reviewable:end -->
