### PR TITLE
refactor: add leader forwarding to gRPC example

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/grpc/app_service.rs
+++ b/examples/raft-kv-memstore-grpc/src/grpc/app_service.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeMap;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use openraft::async_runtime::WatchReceiver;
+use openraft::errors::decompose::DecomposeResult;
 use tonic::Request;
 use tonic::Response;
 use tonic::Status;
+use tonic::metadata::MetadataValue;
 use tracing::debug;
 
 use crate::pb;
@@ -15,30 +18,33 @@ use crate::protobuf::app_service_server::AppService;
 use crate::store::StateMachineStore;
 use crate::typ::*;
 
-/// External API service implementation providing key-value store operations.
-/// This service handles client requests for getting and setting values in the distributed store.
+/// gRPC metadata header used to communicate the leader's endpoint to clients.
 ///
-/// # Responsibilities
-/// - Handle key-value get operations
-/// - Handle key-value set operations
-/// - Ensure consistency through Raft consensus
-///
-/// # Protocol Safety
-/// This service implements the client-facing API and should validate all inputs
-/// before processing them through the Raft consensus protocol.
+/// When a non-leader node receives a write request, it returns `Status::unavailable`
+/// with this header set to the leader's address, so clients can retry against the leader.
+pub const LEADER_ENDPOINT_HEADER: &str = "x-openraft-leader-endpoint";
+
+/// Build a `Status::unavailable` with the leader's endpoint in gRPC metadata,
+/// so the client knows where to retry.
+fn status_forward_to_leader(forward: &ForwardToLeader) -> Status {
+    let mut status = Status::unavailable(format!("{}", forward));
+
+    if let Some(ref node) = forward.leader_node
+        && let Ok(v) = MetadataValue::from_str(&node.rpc_addr)
+    {
+        status.metadata_mut().insert(LEADER_ENDPOINT_HEADER, v);
+    }
+
+    status
+}
+
+/// External API service providing key-value store operations over gRPC.
 pub struct AppServiceImpl {
-    /// The Raft node instance for consensus operations
     raft_node: Raft,
-    /// The state machine store for direct reads
     state_machine_store: Arc<StateMachineStore>,
 }
 
 impl AppServiceImpl {
-    /// Creates a new instance of the API service
-    ///
-    /// # Arguments
-    /// * `raft_node` - The Raft node instance this service will use
-    /// * `state_machine_store` - The state machine store for reading data
     pub fn new(raft_node: Raft, state_machine_store: Arc<StateMachineStore>) -> Self {
         AppServiceImpl {
             raft_node,
@@ -49,142 +55,79 @@ impl AppServiceImpl {
 
 #[tonic::async_trait]
 impl AppService for AppServiceImpl {
-    /// Sets a value for a given key in the distributed store
-    ///
-    /// # Arguments
-    /// * `request` - Contains the key and value to set
-    ///
-    /// # Returns
-    /// * `Ok(Response)` - Success response after the value is set
-    /// * `Err(Status)` - Error status if the set operation fails
     async fn set(&self, request: Request<SetRequest>) -> Result<Response<PbResponse>, Status> {
         let req = request.into_inner();
-        debug!("Processing set request for key: {}", req.key.clone());
+        debug!("Processing set request for key: {}", req.key);
 
-        let res = self
-            .raft_node
-            .client_write(req.clone())
-            .await
-            .map_err(|e| Status::internal(format!("Failed to write to store: {}", e)))?;
+        let res = self.raft_node.client_write(req.clone()).await;
 
-        debug!("Successfully set value for key: {}", req.key);
-        Ok(Response::new(res.data))
+        match res.decompose() {
+            Ok(Ok(resp)) => Ok(Response::new(resp.data)),
+            Ok(Err(ClientWriteError::ForwardToLeader(forward))) => Err(status_forward_to_leader(&forward)),
+            Ok(Err(e)) => Err(Status::internal(e.to_string())),
+            Err(fatal) => Err(Status::internal(fatal.to_string())),
+        }
     }
 
-    /// Gets a value for a given key from the distributed store
-    ///
-    /// # Arguments
-    /// * `request` - Contains the key to retrieve
-    ///
-    /// # Returns
-    /// * `Ok(Response)` - Success response containing the value
-    /// * `Err(Status)` - Error status if the get operation fails
     async fn get(&self, request: Request<GetRequest>) -> Result<Response<PbResponse>, Status> {
         let req = request.into_inner();
         debug!("Processing get request for key: {}", req.key);
 
         let sm = self.state_machine_store.state_machine.lock().await;
-        let value = sm
-            .data
-            .get(&req.key)
-            .ok_or_else(|| Status::internal(format!("Key not found: {}", req.key)))?
-            .to_string();
+        let value = sm.data.get(&req.key).map(|v| v.to_string());
 
-        debug!("Successfully retrieved value for key: {}", req.key);
-        Ok(Response::new(PbResponse { value: Some(value) }))
+        Ok(Response::new(PbResponse { value }))
     }
 
-    /// Initializes a new Raft cluster with the specified nodes
-    ///
-    /// # Arguments
-    /// * `request` - Contains the initial set of nodes for the cluster
-    ///
-    /// # Returns
-    /// * Success response with initialization details
-    /// * Error if initialization fails
     async fn init(&self, request: Request<pb::InitRequest>) -> Result<Response<()>, Status> {
-        debug!("Initializing Raft cluster");
         let req = request.into_inner();
 
-        // Convert nodes into required format
         let nodes_map: BTreeMap<u64, pb::Node> = req.nodes.into_iter().map(|node| (node.node_id, node)).collect();
 
-        // Initialize the cluster
-        let result = self
-            .raft_node
-            .initialize(nodes_map)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to initialize cluster: {}", e)))?;
+        self.raft_node.initialize(nodes_map).await.map_err(|e| Status::internal(e.to_string()))?;
 
-        debug!("Cluster initialization successful");
-        Ok(Response::new(result))
+        Ok(Response::new(()))
     }
 
-    /// Adds a learner node to the Raft cluster
-    ///
-    /// # Arguments
-    /// * `request` - Contains the node information and blocking preference
-    ///
-    /// # Returns
-    /// * Success response with learner addition details
-    /// * Error if the operation fails
     async fn add_learner(
         &self,
         request: Request<pb::AddLearnerRequest>,
     ) -> Result<Response<pb::ClientWriteResponse>, Status> {
         let req = request.into_inner();
-
-        let node = req.node.ok_or_else(|| Status::internal("Node information is required"))?;
-
-        debug!("Adding learner node {}", node.node_id);
+        let node = req.node.ok_or_else(|| Status::invalid_argument("Node information is required"))?;
 
         let raft_node = Node {
             rpc_addr: node.rpc_addr.clone(),
             node_id: node.node_id,
         };
 
-        let result = self
-            .raft_node
-            .add_learner(node.node_id, raft_node, true)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to add learner node: {}", e)))?;
+        let res = self.raft_node.add_learner(node.node_id, raft_node, true).await;
 
-        debug!("Successfully added learner node {}", node.node_id);
-        Ok(Response::new(result.into()))
+        match res.decompose() {
+            Ok(Ok(resp)) => Ok(Response::new(resp.into())),
+            Ok(Err(ClientWriteError::ForwardToLeader(forward))) => Err(status_forward_to_leader(&forward)),
+            Ok(Err(e)) => Err(Status::internal(e.to_string())),
+            Err(fatal) => Err(Status::internal(fatal.to_string())),
+        }
     }
 
-    /// Changes the membership of the Raft cluster
-    ///
-    /// # Arguments
-    /// * `request` - Contains the new member set and retention policy
-    ///
-    /// # Returns
-    /// * Success response with membership change details
-    /// * Error if the operation fails
     async fn change_membership(
         &self,
         request: Request<pb::ChangeMembershipRequest>,
     ) -> Result<Response<pb::ClientWriteResponse>, Status> {
         let req = request.into_inner();
 
-        debug!(
-            "Changing membership. Members: {:?}, Retain: {}",
-            req.members, req.retain
-        );
+        let res = self.raft_node.change_membership(req.members, req.retain).await;
 
-        let result = self
-            .raft_node
-            .change_membership(req.members, req.retain)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to change membership: {}", e)))?;
-
-        debug!("Successfully changed cluster membership");
-        Ok(Response::new(result.into()))
+        match res.decompose() {
+            Ok(Ok(resp)) => Ok(Response::new(resp.into())),
+            Ok(Err(ClientWriteError::ForwardToLeader(forward))) => Err(status_forward_to_leader(&forward)),
+            Ok(Err(e)) => Err(Status::internal(e.to_string())),
+            Err(fatal) => Err(Status::internal(fatal.to_string())),
+        }
     }
 
-    /// Retrieves metrics about the Raft node
     async fn metrics(&self, _request: Request<()>) -> Result<Response<pb::MetricsResponse>, Status> {
-        debug!("Collecting metrics");
         let metrics = self.raft_node.metrics().borrow_watched().clone();
         let resp = pb::MetricsResponse {
             membership: Some(metrics.membership_config.membership().clone().into()),

--- a/examples/raft-kv-memstore-grpc/tests/test_cluster.rs
+++ b/examples/raft-kv-memstore-grpc/tests/test_cluster.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::uninlined_format_args)]
 use std::backtrace::Backtrace;
 use std::panic::PanicHookInfo;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -10,8 +12,10 @@ use openraft::type_config::TypeConfigExt;
 use openraft::type_config::alias::AsyncRuntimeOf;
 use raft_kv_memstore_grpc::TypeConfig;
 use raft_kv_memstore_grpc::app::start_raft_app;
+use raft_kv_memstore_grpc::grpc::app_service::LEADER_ENDPOINT_HEADER;
 use raft_kv_memstore_grpc::protobuf as pb;
 use raft_kv_memstore_grpc::protobuf::app_service_client::AppServiceClient;
+use tonic::Code;
 use tonic::transport::Channel;
 use tracing_subscriber::EnvFilter;
 
@@ -36,8 +40,109 @@ pub fn log_panic(panic: &PanicHookInfo) {
     eprintln!("{}", backtrace);
 }
 
+// --- Forwarding gRPC Client ---
+
+/// A gRPC client that automatically forwards requests to the Raft leader.
+///
+/// When a non-leader node returns `Status::Unavailable` with the
+/// `x-openraft-leader-endpoint` metadata header, this client extracts
+/// the leader address, reconnects, and retries.
+struct GrpcClient {
+    /// Current leader address, shared so it can be updated on forwarding.
+    leader: Arc<Mutex<String>>,
+    inner: AppServiceClient<Channel>,
+}
+
+impl GrpcClient {
+    async fn new(addr: String) -> anyhow::Result<Self> {
+        let inner = connect(&addr).await?;
+        Ok(Self {
+            leader: Arc::new(Mutex::new(addr)),
+            inner,
+        })
+    }
+
+    /// Send a `Set` request, retrying up to 3 times on leader forwarding.
+    async fn set(&mut self, req: pb::SetRequest) -> anyhow::Result<pb::Response> {
+        self.with_forwarding(|c| {
+            let r = req.clone();
+            Box::pin(async move { c.set(r).await })
+        })
+        .await
+    }
+
+    /// Send an `AddLearner` request with forwarding.
+    async fn add_learner(&mut self, req: pb::AddLearnerRequest) -> anyhow::Result<pb::ClientWriteResponse> {
+        self.with_forwarding(|c| {
+            let r = req.clone();
+            Box::pin(async move { c.add_learner(r).await })
+        })
+        .await
+    }
+
+    /// Send a `ChangeMembership` request with forwarding.
+    async fn change_membership(&mut self, req: pb::ChangeMembershipRequest) -> anyhow::Result<pb::ClientWriteResponse> {
+        self.with_forwarding(|c| {
+            let r = req.clone();
+            Box::pin(async move { c.change_membership(r).await })
+        })
+        .await
+    }
+
+    /// Generic retry loop: on `Unavailable` with leader metadata, switch endpoint and retry.
+    async fn with_forwarding<T, F>(&mut self, make_rpc: F) -> anyhow::Result<T>
+    where F: Fn(
+            &mut AppServiceClient<Channel>,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<tonic::Response<T>, tonic::Status>> + Send + '_>,
+        > {
+        let max_retries = 3;
+
+        for _attempt in 0..=max_retries {
+            let result = make_rpc(&mut self.inner).await;
+
+            match result {
+                Ok(resp) => return Ok(resp.into_inner()),
+                Err(status) if status.code() == Code::Unavailable => {
+                    // Extract leader endpoint from gRPC metadata
+                    let leader_addr = status
+                        .metadata()
+                        .get(LEADER_ENDPOINT_HEADER)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+
+                    if let Some(addr) = leader_addr {
+                        println!(">>> forwarding to leader at {}", addr);
+                        *self.leader.lock().unwrap() = addr.clone();
+                        self.inner = connect(&addr).await?;
+                        continue;
+                    }
+
+                    return Err(anyhow::anyhow!(
+                        "Unavailable but no leader endpoint in metadata: {}",
+                        status
+                    ));
+                }
+                Err(status) => {
+                    return Err(anyhow::anyhow!("RPC failed: {}", status));
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("max retries exceeded"))
+    }
+}
+
+async fn connect(addr: &str) -> Result<AppServiceClient<Channel>, tonic::transport::Error> {
+    let channel = Channel::builder(format!("https://{}", addr).parse().unwrap()).connect().await?;
+    Ok(AppServiceClient::new(channel))
+}
+
+// --- Test ---
+
 /// Set up a cluster of 3 nodes.
-/// Write to it and read from it.
+/// Write to it and read from it, including writes to non-leader nodes
+/// to demonstrate automatic leader forwarding.
 #[test]
 fn test_cluster() {
     TypeConfig::run(test_cluster_inner()).unwrap();
@@ -79,19 +184,23 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
     // Wait for server to start up.
     TypeConfig::sleep(Duration::from_millis(200)).await;
 
-    let mut client1 = new_client(get_addr(1)).await?;
+    // Use the forwarding client that automatically retries on leader redirection.
+    let mut client1 = GrpcClient::new(get_addr(1)).await?;
 
     // --- Initialize the target node as a cluster of only one node.
     //     After init(), the single node cluster will be fully functional.
     println!("=== init single node cluster");
     {
+        // init() does not go through the forwarding client because it's only
+        // called on the node that will become the initial leader.
         client1
+            .inner
             .init(pb::InitRequest {
                 nodes: vec![new_node(1)],
             })
             .await?;
 
-        let metrics = client1.metrics(()).await?.into_inner();
+        let metrics = client1.inner.metrics(()).await?.into_inner();
         println!("=== metrics after init: {:?}", metrics);
     }
 
@@ -113,7 +222,7 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
             })
             .await?;
 
-        let metrics = client1.metrics(()).await?.into_inner();
+        let metrics = client1.inner.metrics(()).await?.into_inner();
         println!("=== metrics after add-learner: {:?}", metrics);
         assert_eq!(
             vec![pb::NodeIdSet {
@@ -143,7 +252,7 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
             })
             .await?;
 
-        let metrics = client1.metrics(()).await?.into_inner();
+        let metrics = client1.inner.metrics(()).await?.into_inner();
         println!("=== metrics after change-member: {:?}", metrics);
         assert_eq!(
             vec![pb::NodeIdSet {
@@ -153,7 +262,9 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
         );
     }
 
-    println!("=== write `foo=bar`");
+    // --- Write via the leader (node 1).
+
+    println!("=== write `foo=bar` on leader (node 1)");
     {
         client1
             .set(pb::SetRequest {
@@ -162,30 +273,40 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
             })
             .await?;
 
-        // --- Wait for a while to let the replication get done.
-        TypeConfig::sleep(Duration::from_millis(1_000)).await;
+        TypeConfig::sleep(Duration::from_millis(500)).await;
     }
 
-    println!("=== read `foo` on every node");
+    // --- Write via a non-leader node (node 2).
+    //     This demonstrates leader forwarding: node 2 returns `Unavailable`
+    //     with the leader's endpoint in metadata, and the client retries
+    //     against the leader automatically.
+
+    println!("=== write `qux=quux` on non-leader (node 2), expect auto-forwarding to leader");
     {
-        println!("=== read `foo` on node 1");
-        {
-            let got = client1.get(pb::GetRequest { key: "foo".to_string() }).await?;
-            assert_eq!(Some("bar".to_string()), got.into_inner().value);
-        }
+        let mut client2 = GrpcClient::new(get_addr(2)).await?;
+        client2
+            .set(pb::SetRequest {
+                key: "qux".to_string(),
+                value: "quux".to_string(),
+            })
+            .await?;
 
-        println!("=== read `foo` on node 2");
-        {
-            let mut client2 = new_client(get_addr(2)).await?;
-            let got = client2.get(pb::GetRequest { key: "foo".to_string() }).await?;
-            assert_eq!(Some("bar".to_string()), got.into_inner().value);
-        }
+        TypeConfig::sleep(Duration::from_millis(500)).await;
+    }
 
-        println!("=== read `foo` on node 3");
-        {
-            let mut client3 = new_client(get_addr(3)).await?;
-            let got = client3.get(pb::GetRequest { key: "foo".to_string() }).await?;
-            assert_eq!(Some("bar".to_string()), got.into_inner().value);
+    // --- Read from every node to verify replication.
+
+    println!("=== read `foo` and `qux` on every node");
+    {
+        for node_id in [1, 2, 3] {
+            println!("=== read on node {}", node_id);
+            let mut client = connect(&get_addr(node_id)).await?;
+
+            let got_foo = client.get(pb::GetRequest { key: "foo".to_string() }).await?;
+            assert_eq!(Some("bar".to_string()), got_foo.into_inner().value);
+
+            let got_qux = client.get(pb::GetRequest { key: "qux".to_string() }).await?;
+            assert_eq!(Some("quux".to_string()), got_qux.into_inner().value);
         }
     }
 
@@ -200,7 +321,7 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
 
         TypeConfig::sleep(Duration::from_millis(2_000)).await;
 
-        let metrics = client1.metrics(()).await?.into_inner();
+        let metrics = client1.inner.metrics(()).await?.into_inner();
         println!("=== metrics after change-membership to {{3}}: {:?}", metrics);
         assert_eq!(
             vec![pb::NodeIdSet {
@@ -211,12 +332,6 @@ async fn test_cluster_inner() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-async fn new_client(addr: String) -> Result<AppServiceClient<Channel>, tonic::transport::Error> {
-    let channel = Channel::builder(format!("https://{}", addr).parse().unwrap()).connect().await?;
-    let client = AppServiceClient::new(channel);
-    Ok(client)
 }
 
 fn new_node(node_id: u64) -> pb::Node {


### PR DESCRIPTION

## Changelog

##### refactor: add leader forwarding to gRPC example
Handle `ForwardToLeader` errors properly in the gRPC kv-memstore
example, so writes to non-leader nodes are automatically redirected
to the current leader instead of failing with a generic internal error.

Server side: use `decompose()` to match `ForwardToLeader` and return
`Status::unavailable` with the leader's address in a gRPC metadata
header (`x-openraft-leader-endpoint`).

Client side (test): add a `GrpcClient` wrapper that extracts the
leader endpoint from error metadata and retries, similar to the HTTP
example's `send_with_forwarding()`.

The test now writes via a non-leader node (node 2) to exercise and
verify the forwarding path.

- Fix: #1716

Thanks to @gtema for reporting the issue and pointing out that the
gRPC example was incomplete without forwarding support.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1717)
<!-- Reviewable:end -->
