### PR TITLE
chore(deps): update rand requirement in /examples/raft-kv-memstore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ peel-off           = { version = "0.1.0" }
 pretty_assertions  = { version = "1.0.0" }
 proc-macro2        = { version = "1.0" }
 quote              = { version = "1.0" }
-rand               = { version = "0.9" }
+rand               = { version = "0.10" }
 semver             = { version = "1.0.14" }
 serde              = { version = "1.0.114", features = ["derive", "rc"] }
 serde_json         = { version = "1.0.57" }

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use anyerror::AnyError;
 use clap::Parser;
 use openraft_macros::since;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::AsyncRuntime;
 use crate::LogId;

--- a/rt-compio/Cargo.toml
+++ b/rt-compio/Cargo.toml
@@ -19,7 +19,7 @@ compio           = { version = ">=0.14.0", features = ["runtime", "time"] }
 flume            = { version = "0.11.1", default-features = false, features = ["async"] }
 futures          = { version = "0.3" }
 pin-project-lite = { version = "0.2.16" }
-rand             = { version = "0.9" }
+rand             = { version = "0.10" }
 see              = { version = "0.1.1" }
 
 [dev-dependencies]

--- a/rt-monoio/Cargo.toml
+++ b/rt-monoio/Cargo.toml
@@ -20,5 +20,5 @@ openraft-rt = { path = "../rt", version = "0.10.0-alpha.17", features = ["single
 futures-util = { version = "0.3" }
 local-sync   = { version = "0.1.1" }
 monoio       = { version = "0.2.3" }
-rand         = { version = "0.9" }
+rand         = { version = "0.10" }
 tokio        = { version = "1.22", features = ["sync"] }

--- a/rt-tokio/Cargo.toml
+++ b/rt-tokio/Cargo.toml
@@ -16,7 +16,7 @@ description = "Tokio runtime implementation for Openraft"
 openraft-rt  = { path = "../rt", version = "0.10.0-alpha.17" }
 tokio        = { version = "1.39", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time"] }
 futures-util = { version = "0.3" }
-rand         = { version = "0.9", default-features = false, features = ["std", "std_rng"] }
+rand         = { version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 
 [features]
 default = []

--- a/rt/src/testing.rs
+++ b/rt/src/testing.rs
@@ -103,7 +103,7 @@ impl<Rt: AsyncRuntime> Suite<Rt> {
 
     /// Test `thread_rng()` returns a working random number generator.
     pub async fn test_thread_rng() {
-        use rand::Rng;
+        use rand::RngExt;
 
         let mut rng = Rt::thread_rng();
 
@@ -1185,7 +1185,7 @@ impl<Rt: AsyncRuntime> DetsimSuite<Rt> {
 
     /// Same seed produces the same RNG sequence; different seed differs.
     fn test_thread_rng_determinism() {
-        use rand::Rng;
+        use rand::RngExt;
 
         let collect = |seed: u64| -> Vec<u64> {
             Self::new_runtime(seed)
@@ -1202,7 +1202,7 @@ impl<Rt: AsyncRuntime> DetsimSuite<Rt> {
 
     /// Consecutive `thread_rng()` calls produce different values.
     fn test_thread_rng_sequence_advances() {
-        use rand::Rng;
+        use rand::RngExt;
 
         Self::new_runtime(42).block_on(async {
             let v1: u64 = Det::<Rt>::thread_rng().random();
@@ -1213,7 +1213,7 @@ impl<Rt: AsyncRuntime> DetsimSuite<Rt> {
 
     /// A spawned task's RNG differs from the parent's.
     fn test_spawn_seed_differs_from_parent() {
-        use rand::Rng;
+        use rand::RngExt;
 
         Self::new_runtime(42).block_on(async {
             let (tx, rx) = <Det<Rt> as AsyncRuntime>::Oneshot::channel::<u64>();
@@ -1235,7 +1235,7 @@ impl<Rt: AsyncRuntime> DetsimSuite<Rt> {
 
     /// Two separately spawned tasks get different RNG values.
     fn test_two_spawned_tasks_differ() {
-        use rand::Rng;
+        use rand::RngExt;
 
         Self::new_runtime(42).block_on(async {
             let (tx1, rx1) = <Det<Rt> as AsyncRuntime>::Oneshot::channel::<u64>();
@@ -1260,7 +1260,7 @@ impl<Rt: AsyncRuntime> DetsimSuite<Rt> {
 
     /// `scope()` sets the seed for an async future without `block_on`.
     fn test_scope() {
-        use rand::Rng;
+        use rand::RngExt;
 
         Self::new_runtime(0).block_on(async {
             // Same seed produces same value


### PR DESCRIPTION

## Changelog

##### chore(deps): update rand requirement in /examples/raft-kv-memstore
Updates the requirements on [rand](https://github.com/rust-random/rand) to permit the latest version.
- [Release notes](https://github.com/rust-random/rand/releases)
- [Changelog](https://github.com/rust-random/rand/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-random/rand/compare/rand_core-0.9.1...0.10.1)

---
updated-dependencies:
- dependency-name: rand
  dependency-version: 0.10.1
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1725)
<!-- Reviewable:end -->
