### PR TITLE
fix: clear replication backoff after success in stream session

### DIFF
--- a/openraft/src/replication/backoff_consumer.rs
+++ b/openraft/src/replication/backoff_consumer.rs
@@ -1,0 +1,73 @@
+//! Read-only consumer handle for the shared [`Backoff`] owned by
+//! [`BackoffState`](crate::replication::backoff_state::BackoffState).
+//!
+//! The request-stream generator in
+//! [`StreamState`](crate::replication::stream_state::StreamState) samples the next
+//! delay before emitting each AppendEntries request. It does not — and must not —
+//! enable, disable, or replace the backoff itself; only `BackoffState` does that,
+//! maintaining the invariants described in
+//! [issue #1723](https://github.com/databendlabs/openraft/issues/1723).
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::network::Backoff;
+
+/// Fallback delay used when the [`Backoff`] iterator is exhausted.
+const EXHAUSTED_BACKOFF_DELAY: Duration = Duration::from_millis(500);
+
+/// Read-only handle to the backoff shared with the request-stream generator.
+///
+/// Exposes exactly one operation — [`next_delay`](Self::next_delay) — so the consumer
+/// cannot enable, disable, or replace the backoff. Constructed only by
+/// [`BackoffState::consumer`](crate::replication::backoff_state::BackoffState::consumer).
+#[derive(Clone)]
+pub(crate) struct BackoffConsumer {
+    pub(crate) inner: Arc<Mutex<Option<Backoff>>>,
+}
+
+impl BackoffConsumer {
+    /// Returns the next delay to wait before emitting the next request, or `None`
+    /// if backoff is not currently enabled. Advances the iterator when enabled.
+    pub(crate) fn next_delay(&self) -> Option<Duration> {
+        let mut guard = self.inner.lock().unwrap();
+        let backoff = guard.as_mut()?;
+        Some(backoff.next().unwrap_or(EXHAUSTED_BACKOFF_DELAY))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::network::Backoff;
+    use crate::replication::backoff_state::BackoffState;
+
+    fn constant_200ms_backoff() -> Backoff {
+        Backoff::new(std::iter::repeat(Duration::from_millis(200)))
+    }
+
+    /// The consumer yields a delay only while backoff is enabled on the owning
+    /// `BackoffState`, and returns `None` once the state clears it.
+    #[test]
+    fn samples_delay_only_when_enabled() {
+        let mut state = BackoffState::new();
+        let consumer = state.consumer();
+
+        assert_eq!(consumer.next_delay(), None, "disabled: no delay");
+
+        state.on_error(100);
+        state.reconcile(constant_200ms_backoff);
+
+        assert_eq!(
+            consumer.next_delay(),
+            Some(Duration::from_millis(200)),
+            "enabled: yields configured delay"
+        );
+
+        state.on_success();
+
+        assert_eq!(consumer.next_delay(), None, "after success: no delay");
+    }
+}

--- a/openraft/src/replication/backoff_state.rs
+++ b/openraft/src/replication/backoff_state.rs
@@ -1,0 +1,190 @@
+//! Backoff state for replication.
+//!
+//! Owns the two pieces of state that together decide whether a replication session
+//! should throttle outgoing requests after transient RPC errors:
+//!
+//! - `rank`: accumulated error weight, reset on success.
+//! - `inner`: the active [`Backoff`] iterator. Handed to the request-stream generator as a
+//!   [`BackoffConsumer`] so the consumer can sample the next delay without being able to enable or
+//!   disable the backoff itself.
+//!
+//! Both pieces must be cleared on success; otherwise a stale [`Backoff`] left over
+//! from a prior error throttles every subsequent request in the same stream session
+//! until the session ends (see
+//! [issue #1723](https://github.com/databendlabs/openraft/issues/1723)).
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use crate::RaftTypeConfig;
+use crate::errors::RPCError;
+use crate::network::Backoff;
+use crate::replication::backoff_consumer::BackoffConsumer;
+
+/// Error-rank threshold above which backoff is enabled.
+const BACKOFF_RANK_THRESHOLD: u64 = 20;
+
+/// Coordinates rank accumulation and the shared [`Backoff`] iterator for a
+/// replication session.
+///
+/// Owned by `ReplicationCore`. The request-stream generator receives a read-only
+/// [`BackoffConsumer`] that can only sample delays.
+pub(crate) struct BackoffState {
+    rank: u64,
+    inner: Arc<Mutex<Option<Backoff>>>,
+}
+
+impl BackoffState {
+    pub(crate) fn new() -> Self {
+        Self {
+            rank: 0,
+            inner: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Returns a consumer handle that can only sample the current backoff delay.
+    pub(crate) fn consumer(&self) -> BackoffConsumer {
+        BackoffConsumer {
+            inner: self.inner.clone(),
+        }
+    }
+
+    /// Called when a replication RPC succeeds: clears both `rank` and `inner`.
+    ///
+    /// Clearing `inner` here is critical — the outer main loop cannot run while a
+    /// stream session is active, so this is the only opportunity to drop the stale
+    /// [`Backoff`] before the next RPC in the same session reads it.
+    ///
+    /// Fast path: `rank == 0` implies `inner` is already `None` (invariant maintained
+    /// by every writer in this module), so we skip the lock on the common hot path of
+    /// successive successes.
+    pub(crate) fn on_success(&mut self) {
+        if self.rank == 0 {
+            return;
+        }
+        self.rank = 0;
+        *self.inner.lock().unwrap() = None;
+    }
+
+    /// Called when a replication RPC fails; `weight` is the error's backoff rank.
+    pub(crate) fn on_error(&mut self, weight: u64) {
+        self.rank += weight;
+    }
+
+    /// Dispatches to [`Self::on_success`] or [`Self::on_error`] based on the RPC
+    /// outcome, extracting the error weight from [`RPCError::backoff_rank`].
+    pub(crate) fn observe<T, C>(&mut self, result: &Result<T, RPCError<C>>)
+    where C: RaftTypeConfig {
+        match result {
+            Ok(_) => self.on_success(),
+            Err(e) => self.on_error(e.backoff_rank()),
+        }
+    }
+
+    /// Reconciles `inner` with `rank` before starting a new stream session:
+    /// - If `rank` exceeds the threshold, enables backoff (if not already active).
+    /// - Otherwise, clears backoff.
+    pub(crate) fn reconcile(&self, backoff_factory: impl FnOnce() -> Backoff) {
+        let mut inner = self.inner.lock().unwrap();
+        if self.rank > BACKOFF_RANK_THRESHOLD {
+            if inner.is_none() {
+                *inner = Some(backoff_factory());
+            }
+        } else {
+            *inner = None;
+        }
+    }
+
+    #[cfg(test)]
+    fn is_enabled(&self) -> bool {
+        self.inner.lock().unwrap().is_some()
+    }
+
+    #[cfg(test)]
+    fn rank(&self) -> u64 {
+        self.rank
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn make_test_backoff() -> Backoff {
+        Backoff::new(std::iter::repeat(Duration::from_millis(200)))
+    }
+
+    #[test]
+    fn on_error_accumulates_rank_and_reconcile_enables_backoff() {
+        let mut state = BackoffState::new();
+        assert!(!state.is_enabled());
+        assert_eq!(state.rank(), 0);
+
+        // An `Unreachable` error contributes weight 100, which exceeds the threshold.
+        state.on_error(100);
+        state.reconcile(make_test_backoff);
+
+        assert!(state.is_enabled(), "backoff should be enabled after error > threshold");
+        assert_eq!(state.rank(), 100);
+    }
+
+    /// Reproduces issue #1723.
+    ///
+    /// During an active stream session, `on_success` is called on every successful
+    /// response, but `reconcile` is only called in the outer main loop and does not
+    /// run until the stream session ends. If `on_success` does not itself clear
+    /// `inner`, the shared [`Backoff`] remains `Some` indefinitely and every
+    /// subsequent request pays the full backoff sleep.
+    ///
+    /// The invariant this test asserts: **after a successful RPC, the state is
+    /// fully reset — both `rank` and `inner` — without relying on an external
+    /// reconciliation step.**
+    #[test]
+    fn on_success_clears_backoff_without_external_reconcile() {
+        let mut state = BackoffState::new();
+
+        // 1. Errors accumulate and backoff is enabled (via reconcile at the top of the main loop before a
+        //    stream session starts).
+        state.on_error(100);
+        state.reconcile(make_test_backoff);
+        assert!(state.is_enabled(), "precondition: backoff is enabled");
+
+        // 2. A successful response is received inside the stream session — the only signal that reaches the
+        //    backoff state during the session is on_success.
+        state.on_success();
+
+        assert_eq!(state.rank(), 0, "rank must be reset on success");
+        assert!(
+            !state.is_enabled(),
+            "backoff must be cleared on success, not left for an external reconcile call \
+             that does not run during an active stream session"
+        );
+    }
+
+    /// `observe` dispatches to `on_success` or `on_error` based on the [`Result`]
+    /// variant, using [`RPCError::backoff_rank`] to determine the error weight.
+    #[test]
+    fn observe_dispatches_to_on_success_or_on_error() {
+        use crate::engine::testing::UTConfig;
+        use crate::errors::Unreachable;
+
+        let mut state = BackoffState::new();
+
+        // Err arm: accumulates rank using the error's `backoff_rank` (100 for Unreachable).
+        let err: Result<(), RPCError<UTConfig>> = Err(RPCError::Unreachable(Unreachable::<UTConfig>::from_string("x")));
+        state.observe(&err);
+        assert_eq!(state.rank(), 100, "err arm: rank accumulated from Unreachable weight");
+
+        // Bring backoff into the enabled state before the Ok arm.
+        state.reconcile(make_test_backoff);
+        assert!(state.is_enabled(), "precondition: backoff is enabled");
+
+        // Ok arm: clears rank and inner (the fix for issue #1723).
+        let ok: Result<(), RPCError<UTConfig>> = Ok(());
+        state.observe(&ok);
+        assert_eq!(state.rank(), 0, "ok arm: rank reset");
+        assert!(!state.is_enabled(), "ok arm: inner cleared");
+    }
+}

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -1,5 +1,7 @@
 //! Replication stream.
 
+mod backoff_consumer;
+pub(crate) mod backoff_state;
 pub(crate) mod event_watcher;
 pub(crate) mod inflight_append;
 pub(crate) mod inflight_append_queue;
@@ -40,7 +42,6 @@ use crate::display_ext::display_instant::DisplayInstantExt;
 use crate::errors::RPCError;
 use crate::errors::ReplicationClosed;
 use crate::log_id_range::LogIdRange;
-use crate::network::Backoff;
 use crate::network::NetBackoff;
 use crate::network::NetStreamAppend;
 use crate::network::RPCOption;
@@ -49,6 +50,7 @@ use crate::raft::AppendEntriesRequest;
 use crate::raft::StreamAppendError;
 use crate::raft::StreamAppendResult;
 use crate::raft_state::IOId;
+use crate::replication::backoff_state::BackoffState;
 use crate::replication::event_watcher::EventWatcher;
 use crate::replication::inflight_append_queue::InflightAppendQueue;
 use crate::replication::replication_context::ReplicationContext;
@@ -93,10 +95,14 @@ where
     /// The log replication state tracking progress and matching logs for the follower.
     replication_progress: ReplicationProgress<C>,
 
-    backoff_rank: u64,
-
-    /// Shared backoff state for rate-limiting retries on persistent errors.
-    backoff: Arc<std::sync::Mutex<Option<Backoff>>>,
+    /// Backoff state for rate-limiting retries on persistent errors.
+    ///
+    /// Encapsulates both the accumulated error rank and the shared backoff iterator
+    /// handed to [`StreamState`] via
+    /// [`BackoffState::consumer`](crate::replication::backoff_state::BackoffState::consumer).
+    /// See [issue #1723](https://github.com/databendlabs/openraft/issues/1723) for the
+    /// invariant these two pieces must maintain together.
+    backoff_state: BackoffState,
 }
 
 impl<C, N, LS> ReplicationCore<C, N, LS>
@@ -126,7 +132,7 @@ where
             progress.remote_matched.display()
         );
 
-        let backoff = Arc::new(std::sync::Mutex::new(None));
+        let backoff_state = BackoffState::new();
 
         let this = Self {
             replication_context: replication_context.clone(),
@@ -137,14 +143,13 @@ where
                 payload: None,
                 inflight_id: None,
                 leader_committed: None,
-                backoff: backoff.clone(),
+                backoff_consumer: backoff_state.consumer(),
             })),
             inflight_id: None,
             event_watcher,
             network: Some(network),
             replication_progress: progress,
-            backoff_rank: 0,
-            backoff: backoff.clone(),
+            backoff_state,
             next_action: None,
         };
 
@@ -206,11 +211,9 @@ where
                 return Err(ReplicationClosed::new("Leader changed"));
             }
 
-            if self.backoff_rank > 20 {
-                self.enable_backoff(&mut network);
-            } else {
-                self.disable_backoff();
-            }
+            // Kept separate from `on_error` because only this scope holds a reference
+            // to `network`, which is needed to construct the `Backoff` iterator.
+            self.backoff_state.reconcile(|| network.backoff());
 
             if self.next_action.is_none() {
                 self.drain_events().await?;
@@ -256,7 +259,7 @@ where
             let resp_strm = match resp_strm_res {
                 Ok(resp_strm) => resp_strm,
                 Err(rpc_err) => {
-                    self.backoff_rank += rpc_err.backoff_rank();
+                    self.backoff_state.on_error(rpc_err.backoff_rank());
                     self.send_progress_error(rpc_err, "initiate-stream-replication").await;
 
                     continue;
@@ -289,15 +292,11 @@ where
         while let Some(rpc_res) = resp_strm.next().await {
             tracing::debug!("AppendEntries RPC response: {:?}", rpc_res);
 
+            self.backoff_state.observe(&rpc_res);
             let append_res = match rpc_res {
-                Ok(stream_append_res) => {
-                    self.backoff_rank = 0;
-                    stream_append_res
-                }
+                Ok(stream_append_res) => stream_append_res,
                 Err(rpc_err) => {
-                    self.backoff_rank += rpc_err.backoff_rank();
                     self.send_progress_error(rpc_err, "stream-replication").await;
-
                     return Err("RPCError");
                 }
             };
@@ -337,20 +336,6 @@ where
             }
         }
         Ok(())
-    }
-
-    /// Enables backoff for retries when errors persist.
-    fn enable_backoff(&self, network: &mut N::Network) {
-        let mut backoff = self.backoff.lock().unwrap();
-        if backoff.is_none() {
-            *backoff = Some(network.backoff());
-        }
-    }
-
-    /// Disables backoff after successful communication.
-    fn disable_backoff(&self) {
-        let mut backoff = self.backoff.lock().unwrap();
-        *backoff = None;
     }
 
     /// Send the error result to RaftCore.

--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-use std::sync::Mutex;
 use std::time::Duration;
 
 use display_more::DisplayOptionExt;
@@ -16,10 +14,10 @@ use crate::entry::RaftEntry;
 use crate::entry::raft_entry_ext::RaftEntryExt;
 use crate::errors::StorageIOResult;
 use crate::log_id_range::LogIdRange;
-use crate::network::Backoff;
 use crate::progress::inflight_id::InflightId;
 use crate::raft::AppendEntriesRequest;
 use crate::raft_state::IOId;
+use crate::replication::backoff_consumer::BackoffConsumer;
 use crate::replication::event_watcher::EventWatcher;
 use crate::replication::payload::Payload;
 use crate::replication::replication_context::ReplicationContext;
@@ -56,9 +54,11 @@ where
     /// The leader's committed log id to send in AppendEntries requests.
     pub(crate) leader_committed: Option<LogIdOf<C>>,
 
-    /// The backoff policy if an [`Unreachable`](`crate::error::Unreachable`) error is returned.
-    /// It will be reset to `None` when a successful response is received.
-    pub(crate) backoff: Arc<Mutex<Option<Backoff>>>,
+    /// Read-only handle to the shared backoff state, sampled before each request.
+    ///
+    /// The consumer can only query the next delay; only `ReplicationCore` (via its
+    /// owned `BackoffState`) enables or clears the backoff.
+    pub(crate) backoff_consumer: BackoffConsumer,
 }
 
 impl<C, LS> StreamState<C, LS>
@@ -184,11 +184,8 @@ where
 
     /// Waits for the backoff duration if backoff is enabled, or returns immediately.
     async fn backoff_if_enabled(&mut self) {
-        let sleep_duration = {
-            let mut backoff = self.backoff.lock().unwrap();
-            let Some(backoff) = &mut *backoff else { return };
-
-            backoff.next().unwrap_or_else(|| Duration::from_millis(500))
+        let Some(sleep_duration) = self.backoff_consumer.next_delay() else {
+            return;
         };
 
         let sleep = C::sleep(sleep_duration);

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -8,6 +8,7 @@ mod t10_append_entries_partial_success;
 mod t20_empty_log_entries;
 mod t50_append_entries_backoff;
 mod t50_append_entries_backoff_rejoin;
+mod t51_backoff_cleared_after_success;
 mod t60_feature_loosen_follower_log_revert;
 mod t61_allow_follower_log_revert;
 mod t62_follower_clear_restart_recover;

--- a/tests/tests/replication/t51_backoff_cleared_after_success.rs
+++ b/tests/tests/replication/t51_backoff_cleared_after_success.rs
@@ -1,0 +1,114 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::RPCTypes;
+use openraft::errors::RPCError;
+use openraft::errors::Unreachable;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// Regression test for [issue #1723](https://github.com/databendlabs/openraft/issues/1723):
+/// backoff must be cleared on the first successful RPC inside a stream replication
+/// session, not left for the outer main loop to clear — the outer loop does not run
+/// while a session is alive.
+///
+/// Reproducing the bug in a test is subtle because the 0.10 engine, after any error,
+/// issues a short "commit-update" bounded session (`LogIdRange` with an empty range)
+/// *before* the long pipeline session resumes. That single-RPC bounded session
+/// absorbs the one backoff sleep, then the main loop runs and clears the backoff
+/// because `rank` was reset to 0 on that success. By the time the long pipeline
+/// session starts, the backoff is already gone.
+///
+/// This test defeats that masking by injecting **two** transient errors:
+///   - Error 1 ends the active pipeline session; `rank = 100`; main loop enables backoff.
+///   - Error 2 kills the bounded commit-update session; `rank = 200`; main loop keeps backoff
+///     enabled.
+///   - The next session is a long-lived pipeline (`LogsSince`). It starts with `rank = 200` and
+///     `Backoff = Some(...)`. Its first RPC succeeds and resets `rank = 0`, but the bug leaves
+///     `Backoff` in place. Every subsequent RPC (one per client write, since quorum = 2 in this
+///     2-node cluster) pays the ~200ms sleep until the session ends.
+///
+/// Writing `n = 10` entries serially therefore takes roughly `n * 200ms = 2000ms`
+/// with the bug versus tens of ms without.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn backoff_cleared_after_success_in_stream() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            heartbeat_interval: 5_000,
+            election_timeout_min: 10_000,
+            election_timeout_max: 10_001,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing 2-node cluster");
+    router.new_cluster(btreeset! {0, 1}, btreeset! {}).await?;
+
+    // Inject two transient `Unreachable` errors on AppendEntries to node 1. See the
+    // doc comment above for why two are needed.
+    let failures_remaining = Arc::new(AtomicU64::new(2));
+    {
+        let failures_remaining = failures_remaining.clone();
+        router
+            .set_rpc_pre_hook(RPCTypes::AppendEntries, move |_router, _req, _id, target| {
+                let should_fail = target == 1 && failures_remaining.load(Ordering::SeqCst) > 0;
+                let res = if should_fail {
+                    failures_remaining.fetch_sub(1, Ordering::SeqCst);
+                    Err(RPCError::Unreachable(Unreachable::<TypeConfig>::from_string(
+                        "transient",
+                    )))
+                } else {
+                    Ok(())
+                };
+                Box::pin(futures::future::ready(res))
+            })
+            .await;
+    }
+
+    tracing::info!("--- write one entry to trigger both injected errors");
+    router.client_request_many(0, "trigger", 1).await?;
+
+    // Give the replication task time to consume both errors and enter the long
+    // pipeline session with backoff enabled.
+    TypeConfig::sleep(Duration::from_millis(300)).await;
+
+    assert_eq!(
+        failures_remaining.load(Ordering::SeqCst),
+        0,
+        "precondition: both injected errors must have been consumed"
+    );
+
+    let n: u64 = 10;
+    tracing::info!("--- write {} entries and time commit latency", n);
+    let start = TypeConfig::now();
+    router.client_request_many(0, "after", n as usize).await?;
+    let elapsed = TypeConfig::now() - start;
+
+    tracing::info!("--- {} post-recovery writes committed in {:?}", n, elapsed);
+
+    // With the bug: each commit waits ~200ms for the throttled follower, so n serial
+    // writes take on the order of n * 200ms = 2000ms (plus commit-update RPCs).
+    // Without the bug: writes complete in tens of ms.
+    assert!(
+        elapsed < Duration::from_millis(1_000),
+        "{} post-recovery writes took {:?}; backoff is stuck after success \
+         (expected < 1000ms, buggy behavior is ~{}ms)",
+        n,
+        elapsed,
+        n * 200,
+    );
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### fix: clear replication backoff after success in stream session
Thanks to @AustenSchunk for reporting this bug (#1723) with a
precise root-cause analysis that made the fix straightforward.

Cause:

Backoff state was split across two pieces that were updated in
different scopes and never coordinated:

  1. `ReplicationCore::backoff_rank` — a counter incremented on
     every RPC error and reset to 0 on every successful response.
     Both updates happen inside the stream response-handling loop.

  2. `Arc<Mutex<Option<Backoff>>>` — the shared `Backoff` iterator
     sampled by `StreamState::backoff_if_enabled` before each
     request. This was only created by `enable_backoff()` and
     only cleared by `disable_backoff()`, both called from the
     outer main loop.

In `LogsSince` (pipeline) mode the outer main loop does not
iterate while a stream session is alive — `handle_response_stream`
consumes responses in a `while let` loop while the request-stream
generator concurrently emits requests. `disable_backoff` therefore
never runs between sessions. So after a transient error spike
followed by recovery:

  - `backoff_rank` is reset to 0 on the first successful response.
  - The `Backoff` object remains `Some(...)` indefinitely.
  - Every subsequent request sleeps for ~200ms before being sent.
  - The throttle persists until the session ends for unrelated
    reasons (network error, cancellation, higher vote).

Fix:

Encapsulate both pieces behind a new `BackoffState` type that
maintains the invariant `rank == 0 => inner == None`. `on_success`
now clears both `rank` and the shared iterator in one place, so
reconciliation no longer depends on the outer loop. `StreamState`
receives a read-only `BackoffConsumer` handle that can only sample
the next delay — it cannot enable, disable, or replace the
backoff, so the ownership of these transitions is clear in the
type system.

Changes:
- Add `BackoffState` owning both the rank counter and the shared
  `Backoff` iterator; expose `reconcile` for the main loop and
  `observe`/`on_error`/`on_success` for the response sites
- Add `BackoffConsumer` as the read-only handle given to
  `StreamState`
- Regression test `t51_backoff_cleared_after_success` injects two
  transient errors to defeat the bounded commit-update session the
  engine issues after an error (a single error is absorbed by that
  bounded session, masking the bug) and asserts post-recovery
  writes complete in < 1s

- Fix: #1723

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1727)
<!-- Reviewable:end -->
