### PR TITLE
Fix: allow newer snapshot in `Inflight::Snapshot` ack

### DIFF
--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -181,7 +181,17 @@ impl<NID: NodeId> Inflight<NID> {
                 }
             }
             Inflight::Snapshot { id: _, last_log_id } => {
-                debug_assert_eq!(&upto, last_log_id);
+                // The shipped snapshot may be newer than the one selected at `next_send` time:
+                // the state machine can build a fresher snapshot between boundary selection and
+                // `get_snapshot()`. Accepting `upto >= last_log_id` avoids a panic in that benign
+                // race while still catching an actual regression (a snapshot older than expected
+                // would roll `matching` backward on the follower).
+                debug_assert!(
+                    &upto >= last_log_id,
+                    "snapshot ack must not regress: upto={:?}, expected last_log_id={:?}",
+                    upto,
+                    last_log_id
+                );
                 *self = Inflight::None;
             }
         }


### PR DESCRIPTION
### Fix: allow newer snapshot in `Inflight::Snapshot` ack

A replication snapshot boundary is chosen at `next_send` time from the
engine's cached `snapshot_last_log_id()`, but the state machine can build
a fresher snapshot before `ReplicationCore::stream_snapshot` calls
`get_snapshot()`. When the callback reports the shipped snapshot's actual
`last_log_id`, the old `debug_assert_eq!(&upto, last_log_id)` in
`Inflight::ack` would panic in debug builds, even though the follower
received strictly more data than requested and `matching` advances safely.

Relax the check to `upto >= last_log_id`. This still catches a real
regression — shipping an older snapshot than expected would roll
`matching` backward on the follower — but accepts the benign TOCTOU race.




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1729)
<!-- Reviewable:end -->
